### PR TITLE
[feat] Add provider resource cache management

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -17,6 +17,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
             selectedSettingsProviderId = preferences.getString(KEY_SELECTED_SETTINGS_PROVIDER_ID, null),
             providerLoginMode = enumValue(KEY_PROVIDER_LOGIN_MODE, ProviderLoginMode.WebView),
             providerCookieInputs = readCookieInputs(),
+            audioCacheLimitMb = preferences.getInt(KEY_AUDIO_CACHE_LIMIT_MB, DEFAULT_AUDIO_CACHE_LIMIT_MB),
+            imageCacheLimitMb = preferences.getInt(KEY_IMAGE_CACHE_LIMIT_MB, DEFAULT_IMAGE_CACHE_LIMIT_MB),
         )
     }
 
@@ -30,6 +32,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putNullableString(KEY_SELECTED_SETTINGS_PROVIDER_ID, settings.selectedSettingsProviderId)
                 .putString(KEY_PROVIDER_LOGIN_MODE, settings.providerLoginMode.name)
                 .putString(KEY_PROVIDER_COOKIE_INPUTS, cookieInputsJson(settings.providerCookieInputs))
+                .putInt(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb)
+                .putInt(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb)
                 .apply()
         }
     }
@@ -79,5 +83,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_SELECTED_SETTINGS_PROVIDER_ID = "selected_settings_provider_id"
         private const val KEY_PROVIDER_LOGIN_MODE = "provider_login_mode"
         private const val KEY_PROVIDER_COOKIE_INPUTS = "provider_cookie_inputs"
+        private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
+        private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidResourceCacheRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidResourceCacheRepository.kt
@@ -1,0 +1,37 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+class AndroidResourceCacheRepository(
+    context: Context,
+) : ResourceCacheRepository {
+    private val appContext = context.applicationContext
+    private val mutableUsage = MutableStateFlow(CacheUsage())
+
+    override val usage: StateFlow<CacheUsage> = mutableUsage.asStateFlow()
+
+    override suspend fun refreshUsage() {
+        mutableUsage.value = withContext(Dispatchers.IO) {
+            AndroidResourceCache.usage(appContext)
+        }
+    }
+
+    override suspend fun clearAll() {
+        withContext(Dispatchers.IO) {
+            AndroidResourceCache.clearAll(appContext)
+            mutableUsage.value = CacheUsage()
+        }
+    }
+
+    override suspend fun updateLimit(limit: CacheLimit) {
+        withContext(Dispatchers.IO) {
+            AndroidResourceCache.updateLimit(appContext, limit)
+            mutableUsage.value = AndroidResourceCache.usage(appContext)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -29,6 +29,10 @@ class FuoEvolveApplication : PyApplication() {
         AndroidAppSettingsStore(applicationContext)
     }
 
+    private val resourceCacheRepository: AndroidResourceCacheRepository by lazy {
+        AndroidResourceCacheRepository(applicationContext)
+    }
+
     val controller: FuoPlayerController by lazy {
         FuoPlayerController(
             providerRepository = providerRepository,
@@ -36,6 +40,7 @@ class FuoEvolveApplication : PyApplication() {
             downloadRepository = downloadRepository,
             playbackEngine = playbackEngine,
             settingsStore = settingsStore,
+            resourceCacheRepository = resourceCacheRepository,
             scope = appScope,
         )
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.session.MediaSession
@@ -80,9 +81,17 @@ class FuoPlaybackService : MediaSessionService() {
             )
             .build()
 
+        val url = payload.getString("url")
         val headers = payload.optJSONObject("headers").toStringMap()
         val httpFactory = DefaultHttpDataSource.Factory().setDefaultRequestProperties(headers)
-        val sourceFactory = DefaultDataSource.Factory(this, httpFactory)
+        val upstreamFactory = DefaultDataSource.Factory(this, httpFactory)
+        val sourceFactory = if (url.isRemoteUrl()) {
+            CacheDataSource.Factory()
+                .setCache(AndroidResourceCache.audioCache(this))
+                .setUpstreamDataSourceFactory(upstreamFactory)
+        } else {
+            upstreamFactory
+        }
         val source = ProgressiveMediaSource.Factory(sourceFactory).createMediaSource(mediaItem)
 
         player?.run {
@@ -101,6 +110,11 @@ class FuoPlaybackService : MediaSessionService() {
             result[key] = optString(key)
         }
         return result
+    }
+
+    private fun String.isRemoteUrl(): Boolean {
+        val scheme = Uri.parse(this).scheme
+        return scheme == "http" || scheme == "https"
     }
 
     companion object {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -35,6 +35,9 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
         }
+        androidMain.dependencies {
+            implementation(libs.androidx.media3.datasource)
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/AndroidResourceCache.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/AndroidResourceCache.kt
@@ -1,0 +1,155 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import android.net.Uri
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import java.io.File
+import java.net.URL
+import java.security.MessageDigest
+
+object AndroidResourceCache {
+    private const val PREFS_NAME = "fuo_resource_cache"
+    private const val KEY_AUDIO_LIMIT_BYTES = "audio_limit_bytes"
+    private const val KEY_IMAGE_LIMIT_BYTES = "image_limit_bytes"
+    private const val CACHE_ROOT = "fuo_provider_cache"
+    private const val AUDIO_DIR = "audio"
+    private const val IMAGE_DIR = "images"
+    private const val IMAGE_EXTENSION = ".img"
+
+    private val lock = Any()
+    private var audioCache: SimpleCache? = null
+    private var audioCacheLimitBytes: Long = 0
+
+    fun audioCache(context: Context): SimpleCache {
+        val limit = limit(context).audioMaxBytes
+        synchronized(lock) {
+            audioCache?.takeIf { audioCacheLimitBytes == limit }?.let { return it }
+            audioCache?.release()
+            audioCacheLimitBytes = limit
+            return SimpleCache(
+                audioDir(context).apply { mkdirs() },
+                LeastRecentlyUsedCacheEvictor(limit),
+            ).also { audioCache = it }
+        }
+    }
+
+    fun usage(context: Context): CacheUsage {
+        val audioBytes = synchronized(lock) {
+            audioCache?.cacheSpace ?: audioDir(context).sizeBytes()
+        }
+        return CacheUsage(
+            audioBytes = audioBytes,
+            imageBytes = imageDir(context).sizeBytes(),
+        )
+    }
+
+    fun updateLimit(context: Context, limit: CacheLimit) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putLong(KEY_AUDIO_LIMIT_BYTES, limit.audioMaxBytes)
+            .putLong(KEY_IMAGE_LIMIT_BYTES, limit.imageMaxBytes)
+            .apply()
+        synchronized(lock) {
+            if (audioCache != null && audioCacheLimitBytes != limit.audioMaxBytes) {
+                audioCache?.release()
+                audioCache = null
+                audioCacheLimitBytes = 0
+            }
+        }
+        trimImages(context)
+    }
+
+    fun clearAll(context: Context) {
+        synchronized(lock) {
+            audioCache?.release()
+            audioCache = null
+            audioCacheLimitBytes = 0
+        }
+        audioDir(context).deleteRecursively()
+        imageDir(context).deleteRecursively()
+        rootDir(context).mkdirs()
+    }
+
+    fun cachedImage(context: Context, imageUrl: String): File? {
+        val uri = Uri.parse(imageUrl)
+        if (uri.scheme !in setOf("http", "https")) return null
+        val target = File(imageDir(context).apply { mkdirs() }, "${sha256(imageUrl)}$IMAGE_EXTENSION")
+        if (target.exists() && target.length() > 0L) {
+            target.setLastModified(System.currentTimeMillis())
+            return target
+        }
+        val temp = File(target.parentFile, "${target.name}.tmp")
+        return runCatching {
+            URL(imageUrl).openConnection().run {
+                connectTimeout = 15_000
+                readTimeout = 20_000
+                getInputStream().use { input ->
+                    temp.outputStream().use { output -> input.copyTo(output) }
+                }
+            }
+            if (temp.length() <= 0L) {
+                temp.delete()
+                null
+            } else {
+                if (target.exists()) target.delete()
+                if (temp.renameTo(target)) {
+                    target.setLastModified(System.currentTimeMillis())
+                    trimImages(context)
+                    target
+                } else {
+                    temp.delete()
+                    null
+                }
+            }
+        }.getOrNull()
+    }
+
+    private fun trimImages(context: Context) {
+        val maxBytes = limit(context).imageMaxBytes
+        if (maxBytes <= 0L) {
+            imageDir(context).deleteRecursively()
+            return
+        }
+        val files = imageDir(context).listFiles()?.filter { it.isFile }.orEmpty()
+        var total = files.sumOf { it.length() }
+        files.sortedBy { it.lastModified() }.forEach { file ->
+            if (total <= maxBytes) return
+            val size = file.length()
+            if (file.delete()) total -= size
+        }
+    }
+
+    private fun limit(context: Context): CacheLimit {
+        val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return CacheLimit(
+            audioMaxBytes = preferences.getLong(
+                KEY_AUDIO_LIMIT_BYTES,
+                DEFAULT_AUDIO_CACHE_LIMIT_MB.toLong() * 1024L * 1024L,
+            ),
+            imageMaxBytes = preferences.getLong(
+                KEY_IMAGE_LIMIT_BYTES,
+                DEFAULT_IMAGE_CACHE_LIMIT_MB.toLong() * 1024L * 1024L,
+            ),
+        )
+    }
+
+    private fun rootDir(context: Context): File = File(context.cacheDir, CACHE_ROOT)
+
+    private fun audioDir(context: Context): File = File(rootDir(context), AUDIO_DIR)
+
+    private fun imageDir(context: Context): File = File(rootDir(context), IMAGE_DIR)
+
+    private fun File.sizeBytes(): Long {
+        if (!exists()) return 0L
+        if (isFile) return length()
+        return walkTopDown()
+            .filter { it.isFile }
+            .sumOf { it.length() }
+    }
+
+    private fun sha256(value: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(value.encodeToByteArray())
+        return bytes.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformCoverArt.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformCoverArt.android.kt
@@ -72,11 +72,15 @@ private fun loadDirectCover(context: Context, imageUrl: String): ImageBitmap? {
     val uri = Uri.parse(imageUrl)
     val bitmap = when (uri.scheme) {
         "content", "file" -> context.contentResolver.openInputStream(uri)?.use(BitmapFactory::decodeStream)
-        "http", "https" -> URL(imageUrl).openStream().use(BitmapFactory::decodeStream)
+        "http", "https" -> loadCachedRemoteCover(context, imageUrl)
         else -> null
     }
     return bitmap?.asImageBitmap()
 }
+
+private fun loadCachedRemoteCover(context: Context, imageUrl: String) =
+    AndroidResourceCache.cachedImage(context, imageUrl)?.let { BitmapFactory.decodeFile(it.path) }
+        ?: URL(imageUrl).openStream().use(BitmapFactory::decodeStream)
 
 private fun loadEmbeddedCover(context: Context, imageUrl: String): ImageBitmap? {
     val uri = Uri.parse(imageUrl)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -898,6 +898,7 @@ private fun SettingsScreen(
                     )
                 }
             }
+            CacheSettingsPanel(controller)
         }
     }
 }
@@ -985,6 +986,85 @@ private fun ProviderLoginPanel(
                         Text(if (controller.isLoading) "登录中" else "登录")
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CacheSettingsPanel(controller: FuoPlayerController) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "缓存",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "音乐 ${formatBytes(controller.cacheUsage.audioBytes)} · 图片 ${formatBytes(controller.cacheUsage.imageBytes)} · 总计 ${formatBytes(controller.cacheUsage.totalBytes)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            CacheLimitRow(
+                title = "音乐缓存",
+                selected = controller.audioCacheLimitMb,
+                options = listOf(128, 256, 512, 1024, 2048),
+                onSelect = controller::onAudioCacheLimitChange,
+            )
+            CacheLimitRow(
+                title = "图片缓存",
+                selected = controller.imageCacheLimitMb,
+                options = listOf(32, 64, 128, 256, 512),
+                onSelect = controller::onImageCacheLimitChange,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = controller::refreshResourceCacheUsage) {
+                    Icon(Icons.Filled.Refresh, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("刷新")
+                }
+                Button(
+                    enabled = !controller.isLoading,
+                    onClick = controller::clearResourceCache,
+                ) {
+                    Icon(Icons.Filled.Delete, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("清空缓存")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CacheLimitRow(
+    title: String,
+    selected: Int,
+    options: List<Int>,
+    onSelect: (Int) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "$title：${formatCacheLimit(selected)}",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            options.forEach { value ->
+                FilterChip(
+                    selected = selected == value,
+                    onClick = { onSelect(value) },
+                    label = { Text(formatCacheLimit(value)) },
+                )
             }
         }
     }
@@ -1705,6 +1785,23 @@ private fun formatPlayCount(value: Long): String {
         value >= 100_000_000 -> "${value / 100_000_000} 亿次播放"
         value >= 10_000 -> "${value / 10_000} 万次播放"
         else -> "$value 次播放"
+    }
+}
+
+private fun formatBytes(value: Long): String {
+    return when {
+        value >= 1024L * 1024L * 1024L -> "${value / (1024L * 1024L * 1024L)} GB"
+        value >= 1024L * 1024L -> "${value / (1024L * 1024L)} MB"
+        value >= 1024L -> "${value / 1024L} KB"
+        else -> "$value B"
+    }
+}
+
+private fun formatCacheLimit(value: Int): String {
+    return if (value >= 1024 && value % 1024 == 0) {
+        "${value / 1024}GB"
+    } else {
+        "${value}MB"
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 enum class TrackSourceType {
@@ -21,7 +22,12 @@ data class AppSettings(
     val selectedSettingsProviderId: String? = null,
     val providerLoginMode: ProviderLoginMode = ProviderLoginMode.WebView,
     val providerCookieInputs: Map<String, String> = emptyMap(),
+    val audioCacheLimitMb: Int = DEFAULT_AUDIO_CACHE_LIMIT_MB,
+    val imageCacheLimitMb: Int = DEFAULT_IMAGE_CACHE_LIMIT_MB,
 )
+
+const val DEFAULT_AUDIO_CACHE_LIMIT_MB = 512
+const val DEFAULT_IMAGE_CACHE_LIMIT_MB = 128
 
 data class MusicTrack(
     val id: String,
@@ -182,4 +188,35 @@ object NoOpAppSettingsStore : AppSettingsStore {
     override suspend fun load(): AppSettings = AppSettings()
 
     override suspend fun save(settings: AppSettings) = Unit
+}
+
+data class CacheUsage(
+    val audioBytes: Long = 0,
+    val imageBytes: Long = 0,
+) {
+    val totalBytes: Long
+        get() = audioBytes + imageBytes
+}
+
+data class CacheLimit(
+    val audioMaxBytes: Long,
+    val imageMaxBytes: Long,
+)
+
+interface ResourceCacheRepository {
+    val usage: StateFlow<CacheUsage>
+    suspend fun refreshUsage()
+    suspend fun clearAll()
+    suspend fun updateLimit(limit: CacheLimit)
+}
+
+object NoOpResourceCacheRepository : ResourceCacheRepository {
+    private val mutableUsage = MutableStateFlow(CacheUsage())
+    override val usage: StateFlow<CacheUsage> = mutableUsage
+
+    override suspend fun refreshUsage() = Unit
+
+    override suspend fun clearAll() = Unit
+
+    override suspend fun updateLimit(limit: CacheLimit) = Unit
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -34,6 +34,7 @@ class FuoPlayerController(
     private val downloadRepository: DownloadRepository,
     private val playbackEngine: PlaybackEngine,
     private val settingsStore: AppSettingsStore = NoOpAppSettingsStore,
+    private val resourceCacheRepository: ResourceCacheRepository = NoOpResourceCacheRepository,
     private val scope: CoroutineScope,
 ) {
     var providers by mutableStateOf<List<ProviderInfo>>(emptyList())
@@ -94,6 +95,12 @@ class FuoPlayerController(
         private set
     var playbackState by mutableStateOf(PlaybackState())
         private set
+    var cacheUsage by mutableStateOf(CacheUsage())
+        private set
+    var audioCacheLimitMb by mutableStateOf(DEFAULT_AUDIO_CACHE_LIMIT_MB)
+        private set
+    var imageCacheLimitMb by mutableStateOf(DEFAULT_IMAGE_CACHE_LIMIT_MB)
+        private set
     val canNavigateBack: Boolean
         get() = isFullPlayerOpen ||
             isSettingsOpen ||
@@ -107,8 +114,10 @@ class FuoPlayerController(
 
     init {
         scope.launch {
-            runCatching { settingsStore.load() }
-                .onSuccess { applySettings(it) }
+            val loadedSettings = runCatching { settingsStore.load() }
+            loadedSettings.onSuccess { applySettings(it) }
+            updateResourceCacheLimit()
+            resourceCacheRepository.refreshUsage()
             runCatching {
                 providerRepository.initialize()
                 refreshProviderCatalog()
@@ -124,6 +133,11 @@ class FuoPlayerController(
         scope.launch {
             downloadRepository.states.collect {
                 downloadStates = it
+            }
+        }
+        scope.launch {
+            resourceCacheRepository.usage.collect {
+                cacheUsage = it
             }
         }
         scope.launch {
@@ -223,6 +237,7 @@ class FuoPlayerController(
     fun openSettings() {
         isSettingsOpen = true
         refreshAllProviderAuthStates()
+        refreshResourceCacheUsage()
     }
 
     fun closeSettings() {
@@ -242,6 +257,47 @@ class FuoPlayerController(
     fun onProviderLoginModeChange(value: ProviderLoginMode) {
         providerLoginMode = value
         persistSettings()
+    }
+
+    fun onAudioCacheLimitChange(value: Int) {
+        audioCacheLimitMb = value
+        persistSettings()
+        scope.launch {
+            updateResourceCacheLimit()
+            resourceCacheRepository.refreshUsage()
+        }
+    }
+
+    fun onImageCacheLimitChange(value: Int) {
+        imageCacheLimitMb = value
+        persistSettings()
+        scope.launch {
+            updateResourceCacheLimit()
+            resourceCacheRepository.refreshUsage()
+        }
+    }
+
+    fun refreshResourceCacheUsage() {
+        scope.launch {
+            runCatching { resourceCacheRepository.refreshUsage() }
+                .onFailure { setError(it) }
+        }
+    }
+
+    fun clearResourceCache() {
+        scope.launch {
+            isLoading = true
+            message = "正在清空缓存"
+            runCatching {
+                resourceCacheRepository.clearAll()
+                resourceCacheRepository.refreshUsage()
+            }.onSuccess {
+                message = "缓存已清空"
+            }.onFailure {
+                setError(it)
+            }
+            isLoading = false
+        }
     }
 
     fun loginProviderWithCookies(providerId: String, cookiesJson: String) {
@@ -698,6 +754,8 @@ class FuoPlayerController(
         selectedSettingsProviderId = settings.selectedSettingsProviderId
         providerLoginMode = settings.providerLoginMode
         providerCookieInputs = settings.providerCookieInputs
+        audioCacheLimitMb = settings.audioCacheLimitMb
+        imageCacheLimitMb = settings.imageCacheLimitMb
     }
 
     private fun persistSettings() {
@@ -709,10 +767,21 @@ class FuoPlayerController(
             selectedSettingsProviderId = selectedSettingsProviderId,
             providerLoginMode = providerLoginMode,
             providerCookieInputs = providerCookieInputs,
+            audioCacheLimitMb = audioCacheLimitMb,
+            imageCacheLimitMb = imageCacheLimitMb,
         )
         scope.launch {
             settingsStore.save(settings)
         }
+    }
+
+    private suspend fun updateResourceCacheLimit() {
+        resourceCacheRepository.updateLimit(
+            CacheLimit(
+                audioMaxBytes = audioCacheLimitMb.mbToBytes(),
+                imageMaxBytes = imageCacheLimitMb.mbToBytes(),
+            ),
+        )
     }
 
     private fun setError(throwable: Throwable) {
@@ -725,4 +794,6 @@ class FuoPlayerController(
     }
 
     private fun Int.floorMod(size: Int): Int = ((this % size) + size) % size
+
+    private fun Int.mbToBytes(): Long = this.toLong() * 1024L * 1024L
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -229,8 +229,11 @@ class FuoPlayerControllerTest {
                 localMusicViewMode = LocalMusicViewMode.Album,
                 providerLoginMode = ProviderLoginMode.Cookie,
                 providerCookieInputs = mapOf("netease" to """{"MUSIC_U":"saved"}"""),
+                audioCacheLimitMb = 256,
+                imageCacheLimitMb = 64,
             ),
         )
+        val cache = FakeResourceCacheRepository()
         val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
         try {
             val controller = FuoPlayerController(
@@ -239,6 +242,7 @@ class FuoPlayerControllerTest {
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
                 settingsStore = store,
+                resourceCacheRepository = cache,
                 scope = controllerScope,
             )
 
@@ -248,13 +252,54 @@ class FuoPlayerControllerTest {
             assertEquals(LocalMusicViewMode.Album, controller.localMusicViewMode)
             assertEquals(ProviderLoginMode.Cookie, controller.providerLoginMode)
             assertEquals("""{"MUSIC_U":"saved"}""", controller.cookieInputFor("netease"))
+            assertEquals(256, controller.audioCacheLimitMb)
+            assertEquals(64, controller.imageCacheLimitMb)
+            assertEquals(CacheLimit(256L * 1024L * 1024L, 64L * 1024L * 1024L), cache.lastLimit)
 
             controller.onProviderLoginModeChange(ProviderLoginMode.WebView)
             controller.onProviderCookiesChange("netease", """{"MUSIC_U":"draft"}""")
+            controller.onAudioCacheLimitChange(1024)
+            controller.onImageCacheLimitChange(256)
             advanceUntilIdle()
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
             assertEquals("""{"MUSIC_U":"draft"}""", store.saved.providerCookieInputs["netease"])
+            assertEquals(1024, store.saved.audioCacheLimitMb)
+            assertEquals(256, store.saved.imageCacheLimitMb)
+            assertEquals(CacheLimit(1024L * 1024L * 1024L, 256L * 1024L * 1024L), cache.lastLimit)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun clearResourceCacheRefreshesUsageAndMessage() = runTest {
+        val cache = FakeResourceCacheRepository(
+            CacheUsage(
+                audioBytes = 10L * 1024L * 1024L,
+                imageBytes = 2L * 1024L * 1024L,
+            ),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                resourceCacheRepository = cache,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            assertEquals(12L * 1024L * 1024L, controller.cacheUsage.totalBytes)
+
+            controller.clearResourceCache()
+            advanceUntilIdle()
+
+            assertEquals(1, cache.clearCount)
+            assertEquals(CacheUsage(), controller.cacheUsage)
+            assertEquals("缓存已清空", controller.message)
         } finally {
             controllerScope.cancel()
         }
@@ -384,6 +429,26 @@ class FuoPlayerControllerTest {
 
         override suspend fun save(settings: AppSettings) {
             saved = settings
+        }
+    }
+
+    private class FakeResourceCacheRepository(
+        initialUsage: CacheUsage = CacheUsage(),
+    ) : ResourceCacheRepository {
+        private val mutableUsage = MutableStateFlow(initialUsage)
+        override val usage = mutableUsage
+        var lastLimit: CacheLimit? = null
+        var clearCount = 0
+
+        override suspend fun refreshUsage() = Unit
+
+        override suspend fun clearAll() {
+            clearCount += 1
+            mutableUsage.value = CacheUsage()
+        }
+
+        override suspend fun updateLimit(limit: CacheLimit) {
+            lastLimit = limit
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add shared cache settings/state contracts and controller actions for provider resource cache management.
- Add Android transparent cache support for remote provider audio via Media3 `CacheDataSource` and remote cover images via disk LRU files.
- Add settings UI to view audio/image/total cache usage, adjust cache limits, refresh usage, and clear transparent cache without deleting downloaded music.

## Validation

- `./gradlew :shared:allTests`
- `./gradlew :androidApp:assembleDebug`
- `git diff --check`