### PR TITLE
[feat] Add provider switches and new music sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ shell ready for the same bridge.
 
 ## Android
 
-The Android build packages Python through Chaquopy. The default provider list is
-stored in `androidApp/src/main/assets/providers.json` and enables `fuo_netease`.
+The Android build packages Python through Chaquopy. Provider packages are
+bundled in the APK, while the runtime enabled provider list is controlled from
+Settings. The default enabled provider is NetEase only.
 
 ```bash
 ./gradlew :androidApp:assembleDebug
@@ -33,11 +34,12 @@ XCFramework still needs to be added to the Xcode project before device builds.
 
 ## Provider Extension
 
-Add a Python package dependency and append a provider module to
-`providers.json`, for example:
+Add a Python package dependency, register the provider in the Android bridge,
+and expose it from Settings. The fallback asset keeps NetEase as the only
+default provider:
 
 ```json
 {
-  "enabled": ["fuo_netease", "fuo_qqmusic"]
+  "enabled": ["netease"]
 }
 ```

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -45,15 +45,36 @@ chaquopy {
         version = "3.12"
         configuredBuildPython?.let { buildPython(it) }
         pip {
+            options("--no-deps")
             install(feelUOwnSource)
             install("https://files.pythonhosted.org/packages/1c/70/cf356c9096d401ad63acbe686b51f1d50d491e9afb478e704c574ab17606/fuo_netease-1.0.8.tar.gz")
             install("fuo-qqmusic==1.0.16")
+            install("feeluown-bilibili==0.5.5")
+            install("fuo-ytmusic==0.4.18")
+            install("attrs")
             install("beautifulsoup4")
+            install("babel")
+            install("cachetools")
+            install("certifi")
+            install("charset-normalizer")
+            install("fluent-runtime==0.4.0")
+            install("fluent.syntax")
+            install("idna")
+            install("janus")
             install("marshmallow==3.26.2")
             install("mutagen")
+            install("packaging")
             install("pydantic==1.10.26")
             install("pycryptodome==3.21.0")
+            install("pytz")
+            install("qasync")
             install("requests")
+            install("soupsieve")
+            install("tomlkit")
+            install("typing-extensions")
+            install("urllib3")
+            install("yt-dlp")
+            install("ytmusicapi")
         }
     }
 }

--- a/androidApp/src/main/assets/providers.json
+++ b/androidApp/src/main/assets/providers.json
@@ -1,3 +1,3 @@
 {
-  "enabled": ["fuo_netease", "fuo_qqmusic"]
+  "enabled": ["netease"]
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -24,6 +24,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
             selectedSettingsProviderId = preferences.getString(KEY_SELECTED_SETTINGS_PROVIDER_ID, null),
             providerLoginMode = enumValue(KEY_PROVIDER_LOGIN_MODE, ProviderLoginMode.WebView),
             providerCookieInputs = readCookieInputs(),
+            providerHeaderInputs = readHeaderInputs(),
+            enabledProviderIds = readStringSet(KEY_ENABLED_PROVIDER_IDS).ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS },
             audioCacheLimitMb = preferences.getInt(KEY_AUDIO_CACHE_LIMIT_MB, DEFAULT_AUDIO_CACHE_LIMIT_MB),
             imageCacheLimitMb = preferences.getInt(KEY_IMAGE_CACHE_LIMIT_MB, DEFAULT_IMAGE_CACHE_LIMIT_MB),
             wifiAudioQualityPolicy = enumValue(KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
@@ -51,6 +53,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putNullableString(KEY_SELECTED_SETTINGS_PROVIDER_ID, settings.selectedSettingsProviderId)
                 .putString(KEY_PROVIDER_LOGIN_MODE, settings.providerLoginMode.name)
                 .putString(KEY_PROVIDER_COOKIE_INPUTS, cookieInputsJson(settings.providerCookieInputs))
+                .putString(KEY_PROVIDER_HEADER_INPUTS, headerInputsJson(settings.providerHeaderInputs))
+                .putStringSet(KEY_ENABLED_PROVIDER_IDS, settings.enabledProviderIds)
                 .putInt(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb)
                 .putInt(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb)
                 .putString(KEY_WIFI_AUDIO_QUALITY_POLICY, settings.wifiAudioQualityPolicy.name)
@@ -103,6 +107,43 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         return json.toString()
     }
 
+    private fun readHeaderInputs(): Map<String, ProviderHeaderInput> {
+        val raw = preferences.getString(KEY_PROVIDER_HEADER_INPUTS, null).orEmpty()
+        if (raw.isBlank()) return emptyMap()
+        return runCatching {
+            val json = JSONObject(raw)
+            buildMap {
+                val keys = json.keys()
+                while (keys.hasNext()) {
+                    val providerId = keys.next()
+                    val value = json.optJSONObject(providerId) ?: continue
+                    val input = ProviderHeaderInput(
+                        authorization = value.optString("authorization"),
+                        cookie = value.optString("cookie"),
+                    )
+                    if (providerId.isNotBlank() && (input.authorization.isNotBlank() || input.cookie.isNotBlank())) {
+                        put(providerId, input)
+                    }
+                }
+            }
+        }.getOrDefault(emptyMap())
+    }
+
+    private fun headerInputsJson(inputs: Map<String, ProviderHeaderInput>): String {
+        val json = JSONObject()
+        inputs.forEach { (providerId, input) ->
+            if (providerId.isNotBlank() && (input.authorization.isNotBlank() || input.cookie.isNotBlank())) {
+                json.put(
+                    providerId,
+                    JSONObject()
+                        .put("authorization", input.authorization)
+                        .put("cookie", input.cookie),
+                )
+            }
+        }
+        return json.toString()
+    }
+
     private fun readStringSet(key: String): Set<String> {
         return preferences.getStringSet(key, emptySet()).orEmpty().filter { it.isNotBlank() }.toSet()
     }
@@ -122,6 +163,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_SELECTED_SETTINGS_PROVIDER_ID = "selected_settings_provider_id"
         private const val KEY_PROVIDER_LOGIN_MODE = "provider_login_mode"
         private const val KEY_PROVIDER_COOKIE_INPUTS = "provider_cookie_inputs"
+        private const val KEY_PROVIDER_HEADER_INPUTS = "provider_header_inputs"
+        private const val KEY_ENABLED_PROVIDER_IDS = "enabled_provider_ids"
         private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
         private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
         private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
 import org.json.JSONObject
 
 class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
@@ -26,6 +27,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
             providerCookieInputs = readCookieInputs(),
             providerHeaderInputs = readHeaderInputs(),
             enabledProviderIds = readStringSet(KEY_ENABLED_PROVIDER_IDS).ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS },
+            providerOrderIds = readStringList(KEY_PROVIDER_ORDER_IDS).ifEmpty { DEFAULT_PROVIDER_ORDER_IDS },
             audioCacheLimitMb = preferences.getInt(KEY_AUDIO_CACHE_LIMIT_MB, DEFAULT_AUDIO_CACHE_LIMIT_MB),
             imageCacheLimitMb = preferences.getInt(KEY_IMAGE_CACHE_LIMIT_MB, DEFAULT_IMAGE_CACHE_LIMIT_MB),
             wifiAudioQualityPolicy = enumValue(KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
@@ -55,6 +57,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putString(KEY_PROVIDER_COOKIE_INPUTS, cookieInputsJson(settings.providerCookieInputs))
                 .putString(KEY_PROVIDER_HEADER_INPUTS, headerInputsJson(settings.providerHeaderInputs))
                 .putStringSet(KEY_ENABLED_PROVIDER_IDS, settings.enabledProviderIds)
+                .putString(KEY_PROVIDER_ORDER_IDS, stringListJson(settings.providerOrderIds))
                 .putInt(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb)
                 .putInt(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb)
                 .putString(KEY_WIFI_AUDIO_QUALITY_POLICY, settings.wifiAudioQualityPolicy.name)
@@ -148,6 +151,23 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         return preferences.getStringSet(key, emptySet()).orEmpty().filter { it.isNotBlank() }.toSet()
     }
 
+    private fun readStringList(key: String): List<String> {
+        val raw = preferences.getString(key, null).orEmpty()
+        if (raw.isBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            List(array.length()) { index -> array.optString(index) }
+                .filter { it.isNotBlank() }
+                .distinct()
+        }.getOrDefault(emptyList())
+    }
+
+    private fun stringListJson(values: List<String>): String {
+        val array = JSONArray()
+        values.filter { it.isNotBlank() }.distinct().forEach { array.put(it) }
+        return array.toString()
+    }
+
     private fun android.content.SharedPreferences.Editor.putNullableString(key: String, value: String?) =
         if (value == null) remove(key) else putString(key, value)
 
@@ -165,6 +185,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_PROVIDER_COOKIE_INPUTS = "provider_cookie_inputs"
         private const val KEY_PROVIDER_HEADER_INPUTS = "provider_header_inputs"
         private const val KEY_ENABLED_PROVIDER_IDS = "enabled_provider_ids"
+        private const val KEY_PROVIDER_ORDER_IDS = "provider_order_ids"
         private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
         private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
         private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -100,7 +100,7 @@ class AndroidFuoCoreBridge(
                     )
                     .toString()
                 JSONObject(raw).toPayload(track).also {
-                    Log.d(TAG, "resolve done title=${it.title}")
+                    Log.d(TAG, it.resolveLog(trackId))
                 }
             } catch (throwable: Throwable) {
                 Log.e(TAG, "resolve failed trackId=$trackId", throwable)
@@ -296,18 +296,40 @@ class AndroidFuoCoreBridge(
         )
     }
 
-    private fun JSONObject.toPayload(track: MusicTrack): PlaybackPayload = PlaybackPayload(
-        url = getString("url"),
-        title = optString("title").ifBlank { track.title },
-        artists = optString("artists").ifBlank { track.artists },
-        album = optString("album").ifBlank { track.album },
-        source = optString("source").ifBlank { track.source },
-        headers = optJSONObject("headers").toStringMap(),
-        coverUrl = optString("cover_url").takeIf { it.isNotBlank() } ?: track.coverUrl,
-        durationMs = optLong("duration_ms").takeIf { it > 0 } ?: track.durationMs,
-        lyrics = optString("lyrics").takeIf { it.isNotBlank() },
-        audioQuality = optString("audio_quality").takeIf { it.isNotBlank() },
-    )
+    private fun JSONObject.toPayload(track: MusicTrack): PlaybackPayload {
+        val smartReplacement = optBoolean("smart_replacement", false)
+        return PlaybackPayload(
+            url = getString("url"),
+            title = optString("title").ifBlank { track.title },
+            artists = optString("artists").ifBlank { track.artists },
+            album = optString("album").ifBlank { track.album },
+            source = optString("source").ifBlank { track.source },
+            headers = optJSONObject("headers").toStringMap(),
+            coverUrl = optString("cover_url").takeIf { it.isNotBlank() } ?: track.coverUrl,
+            durationMs = optLong("duration_ms").takeIf { it > 0 } ?: track.durationMs,
+            lyrics = optString("lyrics").takeIf { it.isNotBlank() },
+            audioQuality = optString("audio_quality").takeIf { it.isNotBlank() },
+            providerName = optString("replacement_provider_name")
+                .takeIf { smartReplacement && it.isNotBlank() }
+                ?: optString("provider_name").takeIf { it.isNotBlank() }
+                ?: track.providerName,
+            isSmartReplacement = smartReplacement,
+            originalTitle = optString("original_title").takeIf { smartReplacement && it.isNotBlank() },
+            originalProviderName = optString("original_provider_name").takeIf { smartReplacement && it.isNotBlank() },
+            replacementStrategy = optString("standby_strategy").takeIf { smartReplacement && it.isNotBlank() },
+            replacementScore = optDouble("standby_score").takeIf { smartReplacement && has("standby_score") },
+        )
+    }
+
+    private fun PlaybackPayload.resolveLog(trackId: String): String {
+        if (!isSmartReplacement) {
+            return "resolve done trackId=$trackId title=$title source=$source quality=${audioQuality.orEmpty()}"
+        }
+        return "resolve done smartReplacement trackId=$trackId strategy=${replacementStrategy.orEmpty()} " +
+            "score=${replacementScore?.toString().orEmpty()} " +
+            "original=${originalProviderName.orEmpty()}:${originalTitle.orEmpty()} " +
+            "replacement=${providerName.orEmpty()}:$title source=$source quality=${audioQuality.orEmpty()}"
+    }
 
     private fun JSONObject.toAuthState(providerId: String): ProviderAuthState = ProviderAuthState(
         providerId = optString("provider_id").ifBlank { providerId },

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -17,23 +17,33 @@ class AndroidFuoCoreBridge(
     @Volatile
     private var bridge: PyObject? = null
     @Volatile
+    private var enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS
+    @Volatile
     private var wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY
     @Volatile
     private var cellularAudioQualityPolicy: AudioQualityPolicy = DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY
 
     override suspend fun initialize() {
+        updateEnabledProviders(enabledProviderIds)
+    }
+
+    override suspend fun availableProviders(): List<ProviderInfo> = AVAILABLE_PROVIDERS
+
+    override suspend fun updateEnabledProviders(providerIds: Set<String>) {
+        val nextProviderIds = providerIds
+            .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
+            .intersect(AVAILABLE_PROVIDERS.map { it.providerId }.toSet())
+            .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
         withContext(Dispatchers.IO) {
-            if (bridge != null) return@withContext
             synchronized(this@AndroidFuoCoreBridge) {
-                if (bridge != null) return@synchronized
+                if (bridge != null && enabledProviderIds == nextProviderIds) return@synchronized
                 try {
-                    Log.d(TAG, "initialize start")
-                    val providers = context.assets.open("providers.json")
-                        .bufferedReader()
-                        .use { it.readText() }
-                    bridge = Python.getInstance()
+                    Log.d(TAG, "initialize start providers=$nextProviderIds")
+                    val nextBridge = Python.getInstance()
                         .getModule("fuo_mobile.bridge")
-                        .callAttr("create_bridge", providers)
+                        .callAttr("create_bridge", enabledProvidersJson(nextProviderIds))
+                    bridge = nextBridge
+                    enabledProviderIds = nextProviderIds
                     Log.d(TAG, "initialize done")
                 } catch (throwable: Throwable) {
                     Log.e(TAG, "initialize failed", throwable)
@@ -120,6 +130,16 @@ class AndroidFuoCoreBridge(
         }
     }
 
+    override suspend fun loginWithHeaders(providerId: String, authorization: String, cookie: String): ProviderAuthState {
+        initialize()
+        return withContext(Dispatchers.IO) {
+            val raw = requireNotNull(bridge)
+                .callAttr("provider_login_with_headers", providerId, authorization, cookie)
+                .toString()
+            JSONObject(raw).toAuthState(providerId)
+        }
+    }
+
     override suspend fun logout(providerId: String): ProviderAuthState {
         initialize()
         return withContext(Dispatchers.IO) {
@@ -196,6 +216,7 @@ class AndroidFuoCoreBridge(
             providerId = providerId,
             providerName = optString("provider_name").ifBlank { providerId },
             loginConfig = optJSONObject("login_config")?.toLoginConfig(),
+            supportedLoginModes = optJSONArray("login_modes").toLoginModes(),
         )
     }
 
@@ -314,6 +335,14 @@ class AndroidFuoCoreBridge(
         }
     }
 
+    private fun JSONArray?.toLoginModes(): Set<ProviderLoginMode> {
+        if (this == null) return setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie)
+        return List(length()) { index -> optString(index) }
+            .mapNotNull { raw -> runCatching { ProviderLoginMode.valueOf(raw) }.getOrNull() }
+            .toSet()
+            .ifEmpty { setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie) }
+    }
+
     private fun JSONObject?.toStringMap(): Map<String, String> {
         if (this == null) return emptyMap()
         val keys = keys()
@@ -327,5 +356,46 @@ class AndroidFuoCoreBridge(
 
     private companion object {
         private const val TAG = "FuoCoreBridge"
+
+        private val AVAILABLE_PROVIDERS = listOf(
+            ProviderInfo(
+                providerId = "netease",
+                providerName = "网易云音乐",
+                loginConfig = ProviderLoginConfig(
+                    loginUrl = "https://music.163.com",
+                    cookieKeyGroups = listOf(listOf("MUSIC_U")),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "qqmusic",
+                providerName = "QQ 音乐",
+                loginConfig = ProviderLoginConfig(
+                    loginUrl = "https://y.qq.com",
+                    cookieKeyGroups = listOf(
+                        listOf("qqmusic_key", "wxuin", "qm_keyst"),
+                        listOf("qqmusic_key", "uin", "qm_keyst"),
+                    ),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "bilibili",
+                providerName = "哔哩哔哩",
+                loginConfig = ProviderLoginConfig(
+                    loginUrl = "https://www.bilibili.com",
+                    cookieKeyGroups = listOf(listOf("SESSDATA", "bili_jct")),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "ytmusic",
+                providerName = "YouTube Music",
+                supportedLoginModes = setOf(ProviderLoginMode.Headers),
+            ),
+        )
+
+        private fun enabledProvidersJson(providerIds: Set<String>): String {
+            val array = JSONArray()
+            providerIds.forEach { array.put(it) }
+            return JSONObject().put("enabled", array).toString()
+        }
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -165,6 +165,9 @@ class AndroidNativeAudioEngine(
             .put("local_uri", track.localUri ?: "")
             .put("provider_id", track.providerId ?: "")
             .put("provider_name", track.providerName ?: "")
+            .put("smart_replacement", track.isSmartReplacement)
+            .put("original_title", track.originalTitle ?: "")
+            .put("original_provider_name", track.originalProviderName ?: "")
             .put("url", url)
             .put("title", title)
             .put("artists", artists)
@@ -196,6 +199,9 @@ class AndroidNativeAudioEngine(
             lyrics = mediaMetadata.extras?.getString("lyrics")?.takeIf { it.isNotBlank() },
             providerId = mediaMetadata.extras?.getString("provider_id")?.takeIf { it.isNotBlank() },
             providerName = mediaMetadata.extras?.getString("provider_name")?.takeIf { it.isNotBlank() },
+            isSmartReplacement = mediaMetadata.extras?.getBoolean("smart_replacement") ?: false,
+            originalTitle = mediaMetadata.extras?.getString("original_title")?.takeIf { it.isNotBlank() },
+            originalProviderName = mediaMetadata.extras?.getString("original_provider_name")?.takeIf { it.isNotBlank() },
         )
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -107,6 +107,9 @@ class FuoPlaybackService : MediaSessionService() {
             putString("local_uri", payload.optString("local_uri"))
             putString("provider_id", payload.optString("provider_id"))
             putString("provider_name", payload.optString("provider_name"))
+            putBoolean("smart_replacement", payload.optBoolean("smart_replacement", false))
+            putString("original_title", payload.optString("original_title"))
+            putString("original_provider_name", payload.optString("original_provider_name"))
             putString("lyrics", payload.optString("lyrics"))
             putString("audio_quality", payload.optString("audio_quality"))
         }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
@@ -177,6 +177,12 @@ class ProviderWebLoginActivity : Activity() {
                 "ptlogin2.qq.com",
                 "qq.com",
             )
+            "bilibili" -> listOf(
+                "www.bilibili.com",
+                "api.bilibili.com",
+                "passport.bilibili.com",
+                "bilibili.com",
+            )
             else -> emptyList()
         }
     }

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -977,9 +977,36 @@ class FuoMobileBridge:
     def _select_media(self, song, audio_select_policy: str):
         provider = self.app.library.get(getattr(song, "source", ""))
         if provider is not None and isinstance(provider, SupportsSongMultiQuality):
-            media, quality = provider.song_select_media(song, audio_select_policy)
+            try:
+                media, quality = provider.song_select_media(song, audio_select_policy)
+            except MediaNotFound:
+                refreshed_song = self._refresh_song_for_media_retry(song, provider)
+                if refreshed_song is None:
+                    raise
+                media, quality = provider.song_select_media(refreshed_song, audio_select_policy)
+                song = refreshed_song
+            self._tracks[f"{getattr(song, 'source', '')}:{getattr(song, 'identifier', '')}"] = song
             return media, getattr(quality, "value", str(quality)).upper()
         return self.app.library.song_prepare_media(song, audio_select_policy), ""
+
+    def _refresh_song_for_media_retry(self, song, provider):
+        source = getattr(song, "source", "")
+        identifier = getattr(song, "identifier", "")
+        if source != "netease" or not identifier:
+            return None
+        try:
+            song.cache_set("q_media_mapping", None, ttl=-1)
+        except Exception as exc:  # pylint: disable=broad-except
+            bridge_log(f"netease media cache clear failed track={song_log_label(song)} error={exc}")
+        refreshed_song = None
+        try:
+            refreshed_song = provider.song_get(identifier)
+            refreshed_song.cache_set("q_media_mapping", None, ttl=-1)
+        except Exception as exc:  # pylint: disable=broad-except
+            bridge_log(f"netease song refresh failed track={song_log_label(song)} error={exc}")
+        retry_song = refreshed_song or song
+        bridge_log(f"netease media retry track={song_log_label(retry_song)}")
+        return retry_song
 
     def _payload_from_media(self, song, media: Media, quality: str) -> Dict[str, Any]:
         payload = media_to_payload(media, song_to_metadata(song, self.app.library))

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -882,6 +882,10 @@ class FuoMobileBridge:
         try:
             media, quality = self._select_media(song, audio_select_policy)
         except MediaNotFound as exc:
+            bridge_log(
+                "media not found "
+                f"track={song_log_label(song)} allow_standby={allow_standby} policy={audio_select_policy}"
+            )
             if allow_standby:
                 standby_payload = self._prepare_standby_payload(song, audio_select_policy)
                 if standby_payload is not None:
@@ -894,8 +898,11 @@ class FuoMobileBridge:
         source = getattr(song, "source", "")
         source_in = [provider_id for provider_id in self.provider_registry.provider_ids if provider_id != source]
         if not source_in:
+            bridge_log(f"standby skipped no source track={song_log_label(song)}")
             return None
-        bridge_log(f"standby start song={getattr(song, 'title', '')} source_in={source_in}")
+        bridge_log(
+            f"standby start track={song_log_label(song)} source_in={source_in} policy={audio_select_policy}"
+        )
         try:
             standby_list = asyncio.run(
                 self.app.library.a_list_song_standby_v2(
@@ -906,21 +913,23 @@ class FuoMobileBridge:
                 )
             )
         except Exception as exc:  # pylint: disable=broad-except
-            bridge_log(f"standby failed: {exc}")
+            bridge_log(f"standby failed track={song_log_label(song)} error={exc}")
             return self._prepare_search_standby_payload(song, audio_select_policy, source_in)
         if not standby_list:
-            bridge_log("standby empty")
+            bridge_log(f"standby empty track={song_log_label(song)}")
             return self._prepare_search_standby_payload(song, audio_select_policy, source_in)
         standby, _ = standby_list[0]
         self._tracks[f"{getattr(standby, 'source', '')}:{getattr(standby, 'identifier', '')}"] = standby
         bridge_log(
-            f"standby selected source={getattr(standby, 'source', '')} title={display(standby, 'title')}"
+            f"standby selected origin={song_log_label(song)} replacement={song_log_label(standby)}"
         )
         try:
             media, quality = self._select_media(standby, audio_select_policy)
         except MediaNotFound:
+            bridge_log(f"standby selected media not found replacement={song_log_label(standby)}")
             return self._prepare_search_standby_payload(song, audio_select_policy, source_in)
-        return self._payload_from_media(standby, media, quality)
+        payload = self._payload_from_media(standby, media, quality)
+        return self._mark_standby_payload(payload, song, standby, "library", None)
 
     def _prepare_search_standby_payload(
         self,
@@ -931,6 +940,7 @@ class FuoMobileBridge:
         candidates = []
         seen = set()
         for query in standby_queries(song):
+            bridge_log(f"search standby query track={song_log_label(song)} query={query} source_in={source_in}")
             for result in self.app.library.search(query, type_in=[SearchType.so], source_in=source_in):
                 for standby in read_models(getattr(result, "songs", []) or [], limit=10):
                     key = (getattr(standby, "source", ""), getattr(standby, "identifier", ""))
@@ -939,22 +949,29 @@ class FuoMobileBridge:
                     seen.add(key)
                     score = standby_score(song, standby)
                     if score >= 0.55:
+                        bridge_log(
+                            f"search standby candidate score={score:.2f} replacement={song_log_label(standby)}"
+                        )
                         candidates.append((score, standby))
         if not candidates:
-            bridge_log("search standby empty")
+            bridge_log(f"search standby empty track={song_log_label(song)}")
             return None
         for score, standby in sorted(candidates, key=lambda item: item[0], reverse=True)[:8]:
             try:
                 media, quality = self._select_media(standby, audio_select_policy)
             except MediaNotFound:
+                bridge_log(
+                    f"search standby candidate media not found score={score:.2f} replacement={song_log_label(standby)}"
+                )
                 continue
             self._tracks[f"{getattr(standby, 'source', '')}:{getattr(standby, 'identifier', '')}"] = standby
             bridge_log(
-                "search standby selected "
-                f"score={score:.2f} source={getattr(standby, 'source', '')} title={display(standby, 'title')}"
+                f"search standby selected score={score:.2f} "
+                f"origin={song_log_label(song)} replacement={song_log_label(standby)}"
             )
-            return self._payload_from_media(standby, media, quality)
-        bridge_log("search standby media empty")
+            payload = self._payload_from_media(standby, media, quality)
+            return self._mark_standby_payload(payload, song, standby, "search", score)
+        bridge_log(f"search standby media empty track={song_log_label(song)} candidates={len(candidates)}")
         return None
 
     def _select_media(self, song, audio_select_policy: str):
@@ -968,13 +985,55 @@ class FuoMobileBridge:
         payload = media_to_payload(media, song_to_metadata(song, self.app.library))
         if quality:
             payload["audio_quality"] = quality
-        cover = normalize_image_url(self.app.library.model_get_cover(song))
+        cover = self._get_cover(song)
         if cover:
             payload["cover_url"] = cover
         lyrics = self._get_lyrics(song)
         if lyrics:
             payload["lyrics"] = lyrics
         return payload
+
+    def _mark_standby_payload(
+        self,
+        payload: Dict[str, Any],
+        origin,
+        standby,
+        strategy: str,
+        score: Optional[float],
+    ) -> Dict[str, Any]:
+        origin_provider = provider_name(self.app.library.get(getattr(origin, "source", "")))
+        standby_provider = provider_name(self.app.library.get(getattr(standby, "source", "")))
+        payload.update(
+            {
+                "smart_replacement": True,
+                "standby_strategy": strategy,
+                "original_id": f"{getattr(origin, 'source', '')}:{getattr(origin, 'identifier', '')}",
+                "original_title": display(origin, "title"),
+                "original_artists": display_artists(origin),
+                "original_source": getattr(origin, "source", ""),
+                "original_provider_name": origin_provider,
+                "replacement_id": f"{getattr(standby, 'source', '')}:{getattr(standby, 'identifier', '')}",
+                "replacement_title": display(standby, "title"),
+                "replacement_artists": display_artists(standby),
+                "replacement_source": getattr(standby, "source", ""),
+                "replacement_provider_name": standby_provider,
+            }
+        )
+        if score is not None:
+            payload["standby_score"] = round(score, 2)
+        bridge_log(
+            f"standby payload ready strategy={strategy} "
+            f"origin={song_log_label(origin)} replacement={song_log_label(standby)} "
+            f"quality={payload.get('audio_quality', '')}"
+        )
+        return payload
+
+    def _get_cover(self, song) -> str:
+        try:
+            return normalize_image_url(self.app.library.model_get_cover(song))
+        except Exception as exc:  # pylint: disable=broad-except
+            bridge_log(f"cover lookup failed: {exc}")
+            return ""
 
     def _get_lyrics(self, song) -> str:
         try:
@@ -1093,6 +1152,7 @@ def song_to_metadata(song, library: Library) -> Dict[str, Any]:
         "artists": data["artists"],
         "album": data["album"],
         "source": data["source"],
+        "provider_name": data["provider_name"],
         "duration_ms": data["duration_ms"],
         "cover_url": data["cover_url"],
     }
@@ -1136,6 +1196,7 @@ def media_to_payload(media: Media, metadata: Optional[Dict[str, Any]] = None) ->
         "artists": metadata.get("artists", ""),
         "album": metadata.get("album", ""),
         "source": metadata.get("source", ""),
+        "provider_name": metadata.get("provider_name", ""),
         "headers": dict(media.http_headers or {}),
         "cover_url": normalize_image_url(metadata.get("cover_url", "")),
         "duration_ms": metadata.get("duration_ms", 0),
@@ -1247,6 +1308,14 @@ def provider_name(provider) -> str:
     if provider is None:
         return ""
     return getattr(provider, "name", getattr(provider, "identifier", ""))
+
+
+def song_log_label(song) -> str:
+    source = getattr(song, "source", "")
+    identifier = getattr(song, "identifier", "")
+    title = display(song, "title")
+    artists = display_artists(song)
+    return f"{source}:{identifier} title={title} artists={artists}"
 
 
 def duration_ms(song) -> int:

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -162,6 +162,14 @@ class MobileAppContext:
         self.last_message = str(msg)
 
 
+PROVIDER_MODULES = {
+    "netease": "fuo_netease",
+    "qqmusic": "fuo_qqmusic",
+    "bilibili": "fuo_bilibili",
+    "ytmusic": "fuo_ytmusic",
+}
+
+
 class ProviderRegistry:
     def __init__(self, app: MobileAppContext, enabled: List[str]):
         self.app = app
@@ -169,7 +177,8 @@ class ProviderRegistry:
         self.provider_ids: List[str] = []
 
     def load(self):
-        for module_name in self.enabled:
+        for provider_or_module in self.enabled:
+            module_name = PROVIDER_MODULES.get(provider_or_module, provider_or_module)
             module = __import__(module_name)
             if not hasattr(module, "enable"):
                 raise RuntimeError(f"provider module has no enable(app): {module_name}")
@@ -345,6 +354,90 @@ FEATURE_DEFS = {
             "action": "current_user_fav_create_albums_rd",
         },
     ],
+    "bilibili": [
+        {
+            "id": "bilibili_user_playlists",
+            "title": "我的歌单",
+            "category": "MinePlaylists",
+            "content_type": "Playlists",
+            "requires_login": True,
+            "action": "current_user_list_playlists",
+        },
+        {
+            "id": "bilibili_favorite_playlists",
+            "title": "收藏歌单",
+            "category": "MineFavoritePlaylists",
+            "content_type": "Playlists",
+            "requires_login": True,
+            "action": "current_user_fav_create_playlists_rd",
+        },
+    ],
+    "ytmusic": [
+        {
+            "id": "ytmusic_daily_songs",
+            "title": "每日推荐歌曲",
+            "category": "Recommend",
+            "content_type": "Songs",
+            "requires_login": False,
+            "action": "rec_list_daily_songs",
+        },
+        {
+            "id": "ytmusic_daily_playlists",
+            "title": "推荐歌单",
+            "category": "Recommend",
+            "content_type": "Playlists",
+            "requires_login": False,
+            "action": "rec_list_daily_playlists",
+        },
+        {
+            "id": "ytmusic_toplists",
+            "title": "排行榜",
+            "category": "Music",
+            "content_type": "Playlists",
+            "requires_login": False,
+            "action": "toplist_list",
+        },
+        {
+            "id": "ytmusic_user_playlists",
+            "title": "我的歌单",
+            "category": "MinePlaylists",
+            "content_type": "Playlists",
+            "requires_login": True,
+            "action": "current_user_list_playlists",
+        },
+        {
+            "id": "ytmusic_favorite_songs",
+            "title": "收藏歌曲",
+            "category": "Mine",
+            "content_type": "Songs",
+            "requires_login": True,
+            "action": "current_user_fav_create_songs_rd",
+        },
+        {
+            "id": "ytmusic_favorite_playlists",
+            "title": "收藏歌单",
+            "category": "MineFavoritePlaylists",
+            "content_type": "Playlists",
+            "requires_login": True,
+            "action": "current_user_fav_create_playlists_rd",
+        },
+        {
+            "id": "ytmusic_favorite_artists",
+            "title": "收藏歌手",
+            "category": "Mine",
+            "content_type": "Artists",
+            "requires_login": True,
+            "action": "current_user_fav_create_artists_rd",
+        },
+        {
+            "id": "ytmusic_favorite_albums",
+            "title": "收藏专辑",
+            "category": "Mine",
+            "content_type": "Albums",
+            "requires_login": True,
+            "action": "current_user_fav_create_albums_rd",
+        },
+    ],
 }
 
 LOGIN_CONFIGS = {
@@ -359,12 +452,23 @@ LOGIN_CONFIGS = {
             ["qqmusic_key", "uin", "qm_keyst"],
         ],
     },
+    "bilibili": {
+        "login_url": "https://www.bilibili.com",
+        "cookie_key_groups": [["SESSDATA", "bili_jct"]],
+    },
+}
+
+LOGIN_MODES = {
+    "netease": ["WebView", "Cookie"],
+    "qqmusic": ["WebView", "Cookie"],
+    "bilibili": ["WebView", "Cookie"],
+    "ytmusic": ["Headers"],
 }
 
 
 class FuoMobileBridge:
     def __init__(self, providers_json: str):
-        providers = json.loads(providers_json or "{}").get("enabled") or ["fuo_netease"]
+        providers = json.loads(providers_json or "{}").get("enabled") or ["netease"]
         library = Library(
             MobileConfig.PROVIDERS_STANDBY,
             MobileConfig.ENABLE_AI_STANDBY_MATCHER,
@@ -429,7 +533,10 @@ class FuoMobileBridge:
         cookies = parse_cookies(cookies_json)
         if not isinstance(cookies, dict) or not cookies:
             raise RuntimeError("cookies must be a non-empty JSON object")
-        if hasattr(provider, "get_user_from_cookies"):
+        if provider_id == "bilibili":
+            provider._api.from_cookiedict(cookies)
+            user = provider.user_info()
+        elif hasattr(provider, "get_user_from_cookies"):
             user = provider.get_user_from_cookies(cookies)
         elif hasattr(provider, "try_get_user_from_cookies"):
             user, err = provider.try_get_user_from_cookies(cookies)
@@ -439,6 +546,27 @@ class FuoMobileBridge:
             raise RuntimeError(f"provider does not support cookies login: {provider_id}")
         provider.auth(user)
         self._save_login(provider_id, user, cookies)
+        return json.dumps(provider_auth_state(provider, user), ensure_ascii=False)
+
+    def provider_login_with_headers(self, provider_id: str, authorization: str, cookie: str) -> str:
+        if provider_id != "ytmusic":
+            raise RuntimeError(f"provider does not support header login: {provider_id}")
+        auth = (authorization or "").strip()
+        cookie_value = (cookie or "").strip()
+        if not auth or not cookie_value:
+            raise RuntimeError("authorization and cookie must be non-empty")
+        provider = self._get_provider(provider_id)
+        from fuo_ytmusic.consts import HEADER_FILE
+        from fuo_ytmusic.headerfile import write_headerfile
+
+        write_headerfile(auth, cookie_value, HEADER_FILE)
+        user = provider.try_get_user_with_headerfile()
+        if user is None:
+            raise RuntimeError("get user with ytmusic headers failed")
+        provider.auth(user)
+        current_user_changed = getattr(provider, "current_user_changed", None)
+        if current_user_changed is not None:
+            current_user_changed.emit(user)
         return json.dumps(provider_auth_state(provider, user), ensure_ascii=False)
 
     def provider_logout(self, provider_id: str) -> str:
@@ -636,6 +764,10 @@ class FuoMobileBridge:
             from fuo_qqmusic.login import write_cookies
 
             write_cookies(user, cookies)
+        elif provider_id == "bilibili":
+            from fuo_bilibili.login import dump_user_cookies
+
+            dump_user_cookies(cookies)
 
     def _delete_saved_login(self, provider_id: str) -> None:
         if provider_id == "netease":
@@ -648,6 +780,20 @@ class FuoMobileBridge:
 
             if os.path.exists(USER_INFO_FILE):
                 os.remove(USER_INFO_FILE)
+        elif provider_id == "bilibili":
+            from fuo_bilibili.const import PLUGIN_API_COOKIEJAR_FILE, PLUGIN_API_COOKIEDICT_FILE
+
+            for path in (PLUGIN_API_COOKIEJAR_FILE, PLUGIN_API_COOKIEDICT_FILE):
+                if os.path.exists(path):
+                    os.remove(path)
+        elif provider_id == "ytmusic":
+            from fuo_ytmusic.consts import HEADER_FILE
+            from fuo_ytmusic.headerfile import YtdlpCookiefileManager
+
+            cookiefile = YtdlpCookiefileManager(HEADER_FILE).cookiefile_path
+            for path in (HEADER_FILE, cookiefile):
+                if path is not None and os.path.exists(path):
+                    os.remove(path)
 
     def _clear_provider_auth(self, provider_id: str, provider) -> None:
         try:
@@ -663,6 +809,12 @@ class FuoMobileBridge:
             LoginController._api = provider.api
         elif provider_id == "qqmusic":
             provider.api.set_cookies(None)
+        elif provider_id == "bilibili":
+            from fuo_bilibili.api import BilibiliApi
+
+            provider._api = BilibiliApi()
+        elif provider_id == "ytmusic":
+            provider._user = None
         current_user_changed = getattr(provider, "current_user_changed", None)
         if current_user_changed is not None:
             current_user_changed.emit(None)
@@ -689,8 +841,20 @@ class FuoMobileBridge:
                 user, err = provider.try_get_user_from_cookies(cookies)
                 if user is None:
                     bridge_log(f"restore login skipped provider_id={provider_id}: {err}")
+        elif provider_id == "bilibili":
+            from fuo_bilibili.login import load_user_cookies
+
+            cookies = load_user_cookies()
+            if cookies:
+                provider._api.from_cookiedict(cookies)
+                user = provider.user_info()
+        elif provider_id == "ytmusic":
+            user = provider.try_get_user_with_headerfile()
         if user is not None:
             provider.auth(user)
+            current_user_changed = getattr(provider, "current_user_changed", None)
+            if current_user_changed is not None:
+                current_user_changed.emit(user)
             bridge_log(f"restore login ok provider_id={provider_id} user={getattr(user, 'name', '')}")
 
     def _prepare_payload(self, song, audio_select_policy: str, allow_standby: bool) -> Dict[str, Any]:
@@ -824,6 +988,7 @@ def provider_info(provider) -> Dict[str, Any]:
         "provider_id": provider_id,
         "provider_name": provider_name(provider),
         "login_config": LOGIN_CONFIGS.get(provider_id),
+        "login_modes": LOGIN_MODES.get(provider_id, ["WebView", "Cookie"]),
     }
 
 

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -56,6 +56,14 @@ def _patch_pydantic_v1() -> None:
 
         pydantic.model_validator = model_validator
 
+    if not hasattr(pydantic, "field_validator"):
+        from pydantic import validator
+
+        def field_validator(*fields, mode="after", **kwargs):
+            return validator(*fields, pre=(mode == "before"), allow_reuse=True)
+
+        pydantic.field_validator = field_validator
+
     if not hasattr(pydantic, "model_serializer"):
         def model_serializer(*args, **kwargs):
             def decorator(func):
@@ -183,7 +191,10 @@ class ProviderRegistry:
             if not hasattr(module, "enable"):
                 raise RuntimeError(f"provider module has no enable(app): {module_name}")
             if hasattr(module, "init_config"):
-                module.init_config(Config(module_name))
+                config_name = self._config_name(provider_or_module, module_name, module)
+                provider_config = Config(config_name)
+                module.init_config(provider_config)
+                setattr(self.app.config, config_name, provider_config)
             before = {provider.identifier for provider in self.app.library.list()}
             self._enable_without_auto_login(module)
             provider = getattr(module, "provider", None)
@@ -193,6 +204,16 @@ class ProviderRegistry:
             else:
                 after = [provider.identifier for provider in self.app.library.list()]
                 self.provider_ids.extend(provider_id for provider_id in after if provider_id not in before)
+
+    def _config_name(self, provider_or_module: str, module_name: str, module) -> str:
+        if provider_or_module in PROVIDER_MODULES:
+            return provider_or_module
+        provider_id = getattr(module, "__identifier__", "")
+        if provider_id:
+            return provider_id
+        if module_name.startswith("fuo_"):
+            return module_name.removeprefix("fuo_")
+        return module_name
 
     def _enable_without_auto_login(self, module):
         import feeluown.library.library as library_module

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -90,7 +90,7 @@ def _patch_feeluown_models_for_pydantic_v1() -> None:
     import pydantic
     import feeluown.library.models as models
 
-    if hasattr(pydantic, "field_validator"):
+    if hasattr(pydantic.BaseModel, "model_rebuild"):
         return
 
     refs = {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -1316,12 +1316,27 @@ private fun SettingsScreen(
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
     onLogoutProvider: (ProviderInfo) -> Unit,
 ) {
+    var loginProviderId by remember { mutableStateOf<String?>(null) }
+    val loginProvider = controller.orderedProviders().firstOrNull { it.providerId == loginProviderId }
+    LaunchedEffect(loginProviderId, controller.providers) {
+        if (loginProviderId != null && loginProvider == null) {
+            loginProviderId = null
+        }
+    }
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text("设置") },
+                title = { Text(loginProvider?.providerName ?: "设置") },
                 navigationIcon = {
-                    IconButton(onClick = controller::closeSettings) {
+                    IconButton(
+                        onClick = {
+                            if (loginProvider != null) {
+                                loginProviderId = null
+                            } else {
+                                controller.closeSettings()
+                            }
+                        },
+                    ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                     }
                 },
@@ -1336,32 +1351,35 @@ private fun SettingsScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            ProviderSwitchPanel(controller)
-            if (controller.providers.isEmpty()) {
-                ProviderContentMessage("音源正在初始化")
+            if (loginProvider != null) {
+                ProviderLoginPanel(
+                    controller = controller,
+                    provider = loginProvider,
+                    onOpenProviderWebLogin = onOpenProviderWebLogin,
+                    onLogoutProvider = onLogoutProvider,
+                )
             } else {
-                controller.orderedProviders().forEach { provider ->
-                    ProviderLoginPanel(
-                        controller = controller,
-                        provider = provider,
-                        onOpenProviderWebLogin = onOpenProviderWebLogin,
-                        onLogoutProvider = onLogoutProvider,
-                    )
+                ProviderSwitchPanel(
+                    controller = controller,
+                    onOpenProviderLogin = { provider -> loginProviderId = provider.providerId },
+                )
+                AudioQualitySettingsPanel(controller)
+                PlaybackPolicySettingsPanel(controller)
+                LocalMusicScanSettingsPanel(controller)
+                CacheSettingsPanel(controller)
+                if (controller.isDebugLogViewerAvailable) {
+                    DebugSettingsPanel(controller)
                 }
-            }
-            AudioQualitySettingsPanel(controller)
-            PlaybackPolicySettingsPanel(controller)
-            LocalMusicScanSettingsPanel(controller)
-            CacheSettingsPanel(controller)
-            if (controller.isDebugLogViewerAvailable) {
-                DebugSettingsPanel(controller)
             }
         }
     }
 }
 
 @Composable
-private fun ProviderSwitchPanel(controller: FuoPlayerController) {
+private fun ProviderSwitchPanel(
+    controller: FuoPlayerController,
+    onOpenProviderLogin: (ProviderInfo) -> Unit,
+) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surfaceVariant,
@@ -1381,6 +1399,8 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
             } else {
                 val orderedProviders = controller.orderedAvailableProviders()
                 orderedProviders.forEachIndexed { index, provider ->
+                    val isEnabled = controller.isProviderEnabled(provider.providerId)
+                    val authState = controller.authStateFor(provider)
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -1393,7 +1413,7 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
                                 fontWeight = FontWeight.Medium,
                             )
                             Text(
-                                text = if (controller.isProviderEnabled(provider.providerId)) "已启用" else "未启用",
+                                text = providerStatusText(isEnabled, authState),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -1411,12 +1431,17 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
                             ) {
                                 Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "下移${provider.providerName}")
                             }
+                            TextButton(
+                                enabled = !controller.isLoading && isEnabled,
+                                onClick = { onOpenProviderLogin(provider) },
+                            ) {
+                                Text(if (authState.isLoggedIn) "管理" else "登录")
+                            }
                         }
                         Checkbox(
-                            checked = controller.isProviderEnabled(provider.providerId),
+                            checked = isEnabled,
                             enabled = !controller.isLoading &&
-                                (controller.isProviderEnabled(provider.providerId) && controller.enabledProviderIds.size > 1 ||
-                                    !controller.isProviderEnabled(provider.providerId)),
+                                (isEnabled && controller.enabledProviderIds.size > 1 || !isEnabled),
                             onCheckedChange = { controller.onProviderEnabledChange(provider.providerId, it) },
                         )
                     }
@@ -1424,6 +1449,12 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
             }
         }
     }
+}
+
+private fun providerStatusText(isEnabled: Boolean, authState: ProviderAuthState): String {
+    val enabledText = if (isEnabled) "已启用" else "未启用"
+    val loginText = if (isEnabled && authState.isLoggedIn) "已登录" else "未登录"
+    return "$enabledText · $loginText"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -1336,29 +1337,10 @@ private fun SettingsScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             ProviderSwitchPanel(controller)
-            Text(
-                text = "Provider 登录",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold,
-            )
             if (controller.providers.isEmpty()) {
-                ProviderContentMessage("Provider 正在初始化")
+                ProviderContentMessage("音源正在初始化")
             } else {
-                if (controller.providers.size > 1) {
-                    Row(
-                        modifier = Modifier.horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        controller.providers.forEach { provider ->
-                            FilterChip(
-                                selected = controller.selectedSettingsProviderId == provider.providerId,
-                                onClick = { controller.onSettingsProviderChange(provider.providerId) },
-                                label = { Text(provider.providerName) },
-                            )
-                        }
-                    }
-                }
-                controller.selectedSettingsProvider()?.let { provider ->
+                controller.orderedProviders().forEach { provider ->
                     ProviderLoginPanel(
                         controller = controller,
                         provider = provider,
@@ -1390,14 +1372,15 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
-                text = "Provider 开关",
+                text = "音源",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
             if (controller.availableProviders.isEmpty()) {
-                ProviderContentMessage("Provider 正在初始化")
+                ProviderContentMessage("音源正在初始化")
             } else {
-                controller.availableProviders.forEach { provider ->
+                val orderedProviders = controller.orderedAvailableProviders()
+                orderedProviders.forEachIndexed { index, provider ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -1414,6 +1397,20 @@ private fun ProviderSwitchPanel(controller: FuoPlayerController) {
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
+                        }
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            IconButton(
+                                enabled = !controller.isLoading && index > 0,
+                                onClick = { controller.moveProvider(provider.providerId, -1) },
+                            ) {
+                                Icon(Icons.Filled.KeyboardArrowUp, contentDescription = "上移${provider.providerName}")
+                            }
+                            IconButton(
+                                enabled = !controller.isLoading && index < orderedProviders.lastIndex,
+                                onClick = { controller.moveProvider(provider.providerId, 1) },
+                            ) {
+                                Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "下移${provider.providerName}")
+                            }
                         }
                         Checkbox(
                             checked = controller.isProviderEnabled(provider.providerId),
@@ -2922,7 +2919,7 @@ private fun sourceLabel(track: MusicTrack, downloadState: DownloadState?): Strin
     }
     return listOfNotNull(
         when (track.sourceType) {
-            TrackSourceType.Provider -> track.providerName ?: track.source.ifBlank { "Provider" }
+            TrackSourceType.Provider -> track.providerName ?: track.source.ifBlank { "音源" }
             TrackSourceType.LocalMediaStore -> "本地"
             TrackSourceType.Downloaded -> track.providerName ?: "FeelUOwn"
         },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -1335,6 +1335,7 @@ private fun SettingsScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            ProviderSwitchPanel(controller)
             Text(
                 text = "Provider 登录",
                 style = MaterialTheme.typography.titleLarge,
@@ -1377,6 +1378,57 @@ private fun SettingsScreen(
     }
 }
 
+@Composable
+private fun ProviderSwitchPanel(controller: FuoPlayerController) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Provider 开关",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (controller.availableProviders.isEmpty()) {
+                ProviderContentMessage("Provider 正在初始化")
+            } else {
+                controller.availableProviders.forEach { provider ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = provider.providerName,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium,
+                            )
+                            Text(
+                                text = if (controller.isProviderEnabled(provider.providerId)) "已启用" else "未启用",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Checkbox(
+                            checked = controller.isProviderEnabled(provider.providerId),
+                            enabled = !controller.isLoading &&
+                                (controller.isProviderEnabled(provider.providerId) && controller.enabledProviderIds.size > 1 ||
+                                    !controller.isProviderEnabled(provider.providerId)),
+                            onCheckedChange = { controller.onProviderEnabledChange(provider.providerId, it) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ProviderLoginPanel(
@@ -1386,6 +1438,15 @@ private fun ProviderLoginPanel(
     onLogoutProvider: (ProviderInfo) -> Unit,
 ) {
     val authState = controller.authStateFor(provider)
+    val supportedLoginModes = listOf(
+        ProviderLoginMode.WebView,
+        ProviderLoginMode.Cookie,
+        ProviderLoginMode.Headers,
+    ).filter { it in provider.supportedLoginModes }
+    val activeLoginMode = supportedLoginModes
+        .firstOrNull { it == controller.providerLoginMode }
+        ?: supportedLoginModes.firstOrNull()
+        ?: ProviderLoginMode.Cookie
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surfaceVariant,
@@ -1418,23 +1479,20 @@ private fun ProviderLoginPanel(
                 }
                 return@Column
             }
-            SingleChoiceSegmentedButtonRow {
-                SegmentedButton(
-                    selected = controller.providerLoginMode == ProviderLoginMode.WebView,
-                    onClick = { controller.onProviderLoginModeChange(ProviderLoginMode.WebView) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                ) {
-                    Text("WebView")
-                }
-                SegmentedButton(
-                    selected = controller.providerLoginMode == ProviderLoginMode.Cookie,
-                    onClick = { controller.onProviderLoginModeChange(ProviderLoginMode.Cookie) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                ) {
-                    Text("复制 Cookie")
+            if (supportedLoginModes.size > 1) {
+                SingleChoiceSegmentedButtonRow {
+                    supportedLoginModes.forEachIndexed { index, mode ->
+                        SegmentedButton(
+                            selected = activeLoginMode == mode,
+                            onClick = { controller.onProviderLoginModeChange(mode) },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = supportedLoginModes.size),
+                        ) {
+                            Text(mode.label())
+                        }
+                    }
                 }
             }
-            when (controller.providerLoginMode) {
+            when (activeLoginMode) {
                 ProviderLoginMode.WebView -> {
                     Button(
                         enabled = !controller.isLoading && provider.loginConfig != null,
@@ -1470,9 +1528,43 @@ private fun ProviderLoginPanel(
                         Text(if (controller.isLoading) "登录中" else "登录")
                     }
                 }
+                ProviderLoginMode.Headers -> {
+                    val headerInput = controller.providerHeaderInputFor(provider.providerId)
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = headerInput.authorization,
+                        onValueChange = { controller.onProviderHeaderAuthorizationChange(provider.providerId, it) },
+                        placeholder = { Text("Authorization") },
+                        singleLine = true,
+                    )
+                    TextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 120.dp),
+                        value = headerInput.cookie,
+                        onValueChange = { controller.onProviderHeaderCookieChange(provider.providerId, it) },
+                        placeholder = { Text("Cookie") },
+                        minLines = 4,
+                        maxLines = 8,
+                    )
+                    Button(
+                        enabled = !controller.isLoading,
+                        onClick = { controller.loginProviderWithHeaders(provider.providerId) },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
+                        Spacer(Modifier.size(8.dp))
+                        Text(if (controller.isLoading) "登录中" else "登录")
+                    }
+                }
             }
         }
     }
+}
+
+private fun ProviderLoginMode.label(): String = when (this) {
+    ProviderLoginMode.WebView -> "WebView"
+    ProviderLoginMode.Cookie -> "复制 Cookie"
+    ProviderLoginMode.Headers -> "Headers"
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -2645,6 +2645,11 @@ private fun PlayerInfoTags(track: MusicTrack?, audioQuality: String?) {
     ) {
         if (track != null) {
             InfoTag(sourceLabel(track, null))
+            if (track.isSmartReplacement) {
+                track.originalProviderName?.takeIf { it.isNotBlank() }?.let {
+                    InfoTag("原：$it")
+                }
+            }
         }
         audioQuality?.takeIf { it.isNotBlank() }?.let {
             InfoTag(it.uppercase())
@@ -2954,6 +2959,7 @@ private fun sourceLabel(track: MusicTrack, downloadState: DownloadState?): Strin
             TrackSourceType.LocalMediaStore -> "本地"
             TrackSourceType.Downloaded -> track.providerName ?: "FeelUOwn"
         },
+        "智能替换".takeIf { track.isSmartReplacement },
         state,
     ).joinToString(" · ")
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -12,6 +12,7 @@ enum class TrackSourceType {
 enum class ProviderLoginMode {
     WebView,
     Cookie,
+    Headers,
 }
 
 enum class AudioQualityPolicy(
@@ -42,6 +43,8 @@ data class AppSettings(
     val selectedSettingsProviderId: String? = null,
     val providerLoginMode: ProviderLoginMode = ProviderLoginMode.WebView,
     val providerCookieInputs: Map<String, String> = emptyMap(),
+    val providerHeaderInputs: Map<String, ProviderHeaderInput> = emptyMap(),
+    val enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS,
     val audioCacheLimitMb: Int = DEFAULT_AUDIO_CACHE_LIMIT_MB,
     val imageCacheLimitMb: Int = DEFAULT_IMAGE_CACHE_LIMIT_MB,
     val wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY,
@@ -49,9 +52,15 @@ data class AppSettings(
     val unavailablePlaybackPolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
 )
 
+data class ProviderHeaderInput(
+    val authorization: String = "",
+    val cookie: String = "",
+)
+
 const val DEFAULT_AUDIO_CACHE_LIMIT_MB = 512
 const val DEFAULT_IMAGE_CACHE_LIMIT_MB = 128
 const val DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS = 0
+val DEFAULT_ENABLED_PROVIDER_IDS = setOf("netease")
 val DEFAULT_WIFI_AUDIO_QUALITY_POLICY = AudioQualityPolicy.High
 val DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY = AudioQualityPolicy.Standard
 val DEFAULT_UNAVAILABLE_PLAYBACK_POLICY = UnavailablePlaybackPolicy.SmartReplace
@@ -147,6 +156,7 @@ data class ProviderInfo(
     val providerId: String,
     val providerName: String,
     val loginConfig: ProviderLoginConfig? = null,
+    val supportedLoginModes: Set<ProviderLoginMode> = setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie),
 )
 
 enum class ProviderFeatureCategory {
@@ -210,6 +220,8 @@ data class ProviderContentSection(
 
 interface ProviderMusicRepository {
     suspend fun initialize()
+    suspend fun availableProviders(): List<ProviderInfo> = providers()
+    suspend fun updateEnabledProviders(providerIds: Set<String>) = Unit
     suspend fun providers(): List<ProviderInfo>
     suspend fun search(keyword: String, providerId: String? = null): List<MusicTrack>
     suspend fun resolve(
@@ -218,6 +230,9 @@ interface ProviderMusicRepository {
     ): PlaybackPayload
     suspend fun authState(providerId: String): ProviderAuthState
     suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState
+    suspend fun loginWithHeaders(providerId: String, authorization: String, cookie: String): ProviderAuthState {
+        throw UnsupportedOperationException("provider does not support header login: $providerId")
+    }
     suspend fun logout(providerId: String): ProviderAuthState
     suspend fun updateAudioQualityPolicies(wifiPolicy: AudioQualityPolicy, cellularPolicy: AudioQualityPolicy)
     suspend fun features(): List<ProviderFeature>

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -45,6 +45,7 @@ data class AppSettings(
     val providerCookieInputs: Map<String, String> = emptyMap(),
     val providerHeaderInputs: Map<String, ProviderHeaderInput> = emptyMap(),
     val enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS,
+    val providerOrderIds: List<String> = DEFAULT_PROVIDER_ORDER_IDS,
     val audioCacheLimitMb: Int = DEFAULT_AUDIO_CACHE_LIMIT_MB,
     val imageCacheLimitMb: Int = DEFAULT_IMAGE_CACHE_LIMIT_MB,
     val wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY,
@@ -61,6 +62,7 @@ const val DEFAULT_AUDIO_CACHE_LIMIT_MB = 512
 const val DEFAULT_IMAGE_CACHE_LIMIT_MB = 128
 const val DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS = 0
 val DEFAULT_ENABLED_PROVIDER_IDS = setOf("netease")
+val DEFAULT_PROVIDER_ORDER_IDS = listOf("netease", "qqmusic", "bilibili", "ytmusic")
 val DEFAULT_WIFI_AUDIO_QUALITY_POLICY = AudioQualityPolicy.High
 val DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY = AudioQualityPolicy.Standard
 val DEFAULT_UNAVAILABLE_PLAYBACK_POLICY = UnavailablePlaybackPolicy.SmartReplace

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -91,6 +91,9 @@ data class MusicTrack(
     val lyrics: String? = null,
     val providerId: String? = null,
     val providerName: String? = null,
+    val isSmartReplacement: Boolean = false,
+    val originalTitle: String? = null,
+    val originalProviderName: String? = null,
 )
 
 data class PlaybackPayload(
@@ -104,6 +107,12 @@ data class PlaybackPayload(
     val durationMs: Long? = null,
     val lyrics: String? = null,
     val audioQuality: String? = null,
+    val providerName: String? = null,
+    val isSmartReplacement: Boolean = false,
+    val originalTitle: String? = null,
+    val originalProviderName: String? = null,
+    val replacementStrategy: String? = null,
+    val replacementScore: Double? = null,
 )
 
 enum class PlayerStatus {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -1162,8 +1162,16 @@ class FuoPlayerController(
                     ?: providerRepository.resolve(playbackTrack, unavailablePlaybackPolicy)
                 if (requestSerial != playRequestSerial) return@playRequest
                 val playableTrack = playbackTrack.copy(
+                    title = payload.title.ifBlank { playbackTrack.title },
+                    artists = payload.artists.ifBlank { playbackTrack.artists },
+                    album = payload.album.ifBlank { playbackTrack.album },
+                    source = payload.source.ifBlank { playbackTrack.source },
                     coverUrl = payload.coverUrl ?: playbackTrack.coverUrl,
                     durationMs = payload.durationMs ?: playbackTrack.durationMs,
+                    providerName = payload.providerName ?: playbackTrack.providerName,
+                    isSmartReplacement = payload.isSmartReplacement,
+                    originalTitle = payload.originalTitle,
+                    originalProviderName = payload.originalProviderName,
                 )
                 queue = sourceQueue.mapIndexed { itemIndex, item ->
                     if (itemIndex == index) playableTrack else item
@@ -1314,6 +1322,10 @@ class FuoPlayerController(
             durationMs = durationMs,
             lyrics = lyrics,
             audioQuality = null,
+            providerName = providerName,
+            isSmartReplacement = isSmartReplacement,
+            originalTitle = originalTitle,
+            originalProviderName = originalProviderName,
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -61,6 +61,8 @@ class FuoPlayerController(
         private set
     var enabledProviderIds by mutableStateOf(DEFAULT_ENABLED_PROVIDER_IDS)
         private set
+    var providerOrderIds by mutableStateOf(DEFAULT_PROVIDER_ORDER_IDS)
+        private set
     var recommendSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
         private set
     var musicSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
@@ -232,6 +234,10 @@ class FuoPlayerController(
 
     fun isProviderEnabled(providerId: String): Boolean = providerId in enabledProviderIds
 
+    fun orderedAvailableProviders(): List<ProviderInfo> = availableProviders.sortedProvidersByOrder()
+
+    fun orderedProviders(): List<ProviderInfo> = providers.sortedProvidersByOrder()
+
     fun selectedSettingsProvider(): ProviderInfo? {
         return providers.firstOrNull { it.providerId == selectedSettingsProviderId } ?: providers.firstOrNull()
     }
@@ -371,26 +377,42 @@ class FuoPlayerController(
             enabledProviderIds - providerId
         }
         if (next.isEmpty()) {
-            message = "至少保留一个 Provider"
+            message = "至少保留一个音源"
             return
         }
         enabledProviderIds = next
         persistSettings()
         scope.launch {
             isLoading = true
-            message = "正在更新 Provider"
+            message = "正在更新音源"
             runCatching {
                 providerRepository.updateEnabledProviders(enabledProviderIds)
                 clearProviderContent()
                 refreshProviderCatalog()
             }.onSuccess {
-                message = "Provider 已更新"
+                message = "音源已更新"
                 refreshHomeContent(homeSection)
             }.onFailure {
                 setError(it)
             }
             isLoading = false
         }
+    }
+
+    fun moveProvider(providerId: String, offset: Int) {
+        val availableIds = availableProviders.map { it.providerId }.toSet()
+        val orderedIds = normalizedProviderOrder(availableIds).toMutableList()
+        val index = orderedIds.indexOf(providerId)
+        val targetIndex = (index + offset).coerceIn(0, orderedIds.lastIndex)
+        if (index < 0 || index == targetIndex) return
+        val moved = orderedIds.removeAt(index)
+        orderedIds.add(targetIndex, moved)
+        providerOrderIds = orderedIds
+        availableProviders = availableProviders.sortedProvidersByOrder()
+        providers = providers.sortedProvidersByOrder()
+        providerFeatures = providerFeatures.sortedFeaturesByOrder()
+        reorderProviderContent()
+        persistSettings()
     }
 
     fun onProviderLoginModeChange(value: ProviderLoginMode) {
@@ -660,7 +682,7 @@ class FuoPlayerController(
                             runCatching { providerRepository.loadFeature(feature) }
                                 .getOrElse { ProviderContentSection(feature, errorMessage = it.message ?: "加载失败") }
                         }
-                    }
+                    }.sortedSectionsByOrder()
                 }
             }.onSuccess {
                 if (section == HomeSection.Recommend) {
@@ -722,7 +744,7 @@ class FuoPlayerController(
                     runCatching { providerRepository.loadFeature(feature) }
                         .getOrElse { ProviderContentSection(feature, errorMessage = it.message ?: "加载失败") }
                 }
-            }
+            }.sortedSectionsByOrder()
         }
     }
 
@@ -1031,8 +1053,13 @@ class FuoPlayerController(
 
     private suspend fun refreshProviderCatalog() {
         val loadedAvailableProviders = providerRepository.availableProviders()
-        availableProviders = loadedAvailableProviders
         val availableProviderIds = loadedAvailableProviders.map { it.providerId }.toSet()
+        val normalizedProviderOrderIds = normalizedProviderOrder(availableProviderIds)
+        if (normalizedProviderOrderIds != providerOrderIds) {
+            providerOrderIds = normalizedProviderOrderIds
+            persistSettings()
+        }
+        availableProviders = loadedAvailableProviders.sortedProvidersByOrder()
         if (availableProviderIds.isNotEmpty()) {
             val normalizedEnabledProviderIds = enabledProviderIds.intersect(availableProviderIds)
                 .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS.intersect(availableProviderIds) }
@@ -1043,7 +1070,7 @@ class FuoPlayerController(
                 providerRepository.updateEnabledProviders(enabledProviderIds)
             }
         }
-        val loadedProviders = providerRepository.providers()
+        val loadedProviders = providerRepository.providers().sortedProvidersByOrder()
         providers = loadedProviders
         val providerIds = loadedProviders.map { it.providerId }.toSet()
         if (selectedSettingsProviderId !in providerIds) {
@@ -1062,7 +1089,7 @@ class FuoPlayerController(
                 isLoggedIn = false,
             ))
         }
-        providerFeatures = providerRepository.features()
+        providerFeatures = providerRepository.features().sortedFeaturesByOrder()
         refreshProviderAuthStates()
     }
 
@@ -1078,6 +1105,14 @@ class FuoPlayerController(
         selectedFeatureTracks = emptyList()
         selectedPlaylistTracks = emptyList()
         selectedMediaItemTracks = emptyList()
+    }
+
+    private fun reorderProviderContent() {
+        recommendSections = recommendSections.sortedSectionsByOrder()
+        musicSections = musicSections.sortedSectionsByOrder()
+        mineSections = mineSections.sortedSectionsByOrder()
+        minePlaylistSections = minePlaylistSections.sortedSectionsByOrder()
+        mineFavoritePlaylistSections = mineFavoritePlaylistSections.sortedSectionsByOrder()
     }
 
     private fun refreshAllProviderAuthStates() {
@@ -1293,6 +1328,28 @@ class FuoPlayerController(
             ?: providerId
     }
 
+    private fun normalizedProviderOrder(availableProviderIds: Set<String>): List<String> {
+        val orderedIds = (providerOrderIds + DEFAULT_PROVIDER_ORDER_IDS + availableProviderIds)
+            .filter { it in availableProviderIds }
+            .distinct()
+        return orderedIds.ifEmpty { availableProviderIds.toList() }
+    }
+
+    private fun providerOrderIndex(providerId: String): Int {
+        val normalizedOrder = (providerOrderIds + DEFAULT_PROVIDER_ORDER_IDS).distinct()
+        val index = normalizedOrder.indexOf(providerId)
+        return if (index >= 0) index else Int.MAX_VALUE
+    }
+
+    private fun List<ProviderInfo>.sortedProvidersByOrder(): List<ProviderInfo> =
+        sortedWith(compareBy<ProviderInfo> { providerOrderIndex(it.providerId) }.thenBy { it.providerName })
+
+    private fun List<ProviderFeature>.sortedFeaturesByOrder(): List<ProviderFeature> =
+        sortedWith(compareBy<ProviderFeature> { providerOrderIndex(it.providerId) }.thenBy { it.id })
+
+    private fun List<ProviderContentSection>.sortedSectionsByOrder(): List<ProviderContentSection> =
+        sortedWith(compareBy<ProviderContentSection> { providerOrderIndex(it.feature.providerId) }.thenBy { it.feature.id })
+
     private fun ProviderFeature.isDeferredHomeFeature(): Boolean {
         return category == ProviderFeatureCategory.Recommend &&
             (id.endsWith("_daily_songs") || isDynamicQueueFeature())
@@ -1315,6 +1372,7 @@ class FuoPlayerController(
         providerCookieInputs = settings.providerCookieInputs
         providerHeaderInputs = settings.providerHeaderInputs
         enabledProviderIds = settings.enabledProviderIds.ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
+        providerOrderIds = settings.providerOrderIds.ifEmpty { DEFAULT_PROVIDER_ORDER_IDS }
         audioCacheLimitMb = settings.audioCacheLimitMb
         imageCacheLimitMb = settings.imageCacheLimitMb
         wifiAudioQualityPolicy = settings.wifiAudioQualityPolicy
@@ -1336,6 +1394,7 @@ class FuoPlayerController(
             providerCookieInputs = providerCookieInputs,
             providerHeaderInputs = providerHeaderInputs,
             enabledProviderIds = enabledProviderIds,
+            providerOrderIds = providerOrderIds,
             audioCacheLimitMb = audioCacheLimitMb,
             imageCacheLimitMb = imageCacheLimitMb,
             wifiAudioQualityPolicy = wifiAudioQualityPolicy,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -47,6 +47,8 @@ class FuoPlayerController(
     private val debugLogRepository: DebugLogRepository = NoOpDebugLogRepository,
     private val scope: CoroutineScope,
 ) {
+    var availableProviders by mutableStateOf<List<ProviderInfo>>(emptyList())
+        private set
     var providers by mutableStateOf<List<ProviderInfo>>(emptyList())
         private set
     var providerFeatures by mutableStateOf<List<ProviderFeature>>(emptyList())
@@ -54,6 +56,10 @@ class FuoPlayerController(
     var providerAuthStates by mutableStateOf<Map<String, ProviderAuthState>>(emptyMap())
         private set
     var providerCookieInputs by mutableStateOf<Map<String, String>>(emptyMap())
+        private set
+    var providerHeaderInputs by mutableStateOf<Map<String, ProviderHeaderInput>>(emptyMap())
+        private set
+    var enabledProviderIds by mutableStateOf(DEFAULT_ENABLED_PROVIDER_IDS)
         private set
     var recommendSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
         private set
@@ -170,6 +176,7 @@ class FuoPlayerController(
             updateAudioQualityPolicies()
             resourceCacheRepository.refreshUsage()
             runCatching {
+                providerRepository.updateEnabledProviders(enabledProviderIds)
                 providerRepository.initialize()
                 refreshProviderCatalog()
                 downloadRepository.load()
@@ -220,6 +227,10 @@ class FuoPlayerController(
     }
 
     fun cookieInputFor(providerId: String): String = providerCookieInputs[providerId].orEmpty()
+
+    fun providerHeaderInputFor(providerId: String): ProviderHeaderInput = providerHeaderInputs[providerId] ?: ProviderHeaderInput()
+
+    fun isProviderEnabled(providerId: String): Boolean = providerId in enabledProviderIds
 
     fun selectedSettingsProvider(): ProviderInfo? {
         return providers.firstOrNull { it.providerId == selectedSettingsProviderId } ?: providers.firstOrNull()
@@ -336,9 +347,50 @@ class FuoPlayerController(
         persistSettings()
     }
 
+    fun onProviderHeaderAuthorizationChange(providerId: String, value: String) {
+        val input = providerHeaderInputFor(providerId).copy(authorization = value)
+        providerHeaderInputs = providerHeaderInputs + (providerId to input)
+        persistSettings()
+    }
+
+    fun onProviderHeaderCookieChange(providerId: String, value: String) {
+        val input = providerHeaderInputFor(providerId).copy(cookie = value)
+        providerHeaderInputs = providerHeaderInputs + (providerId to input)
+        persistSettings()
+    }
+
     fun onSettingsProviderChange(providerId: String) {
         selectedSettingsProviderId = providerId
         persistSettings()
+    }
+
+    fun onProviderEnabledChange(providerId: String, enabled: Boolean) {
+        val next = if (enabled) {
+            enabledProviderIds + providerId
+        } else {
+            enabledProviderIds - providerId
+        }
+        if (next.isEmpty()) {
+            message = "至少保留一个 Provider"
+            return
+        }
+        enabledProviderIds = next
+        persistSettings()
+        scope.launch {
+            isLoading = true
+            message = "正在更新 Provider"
+            runCatching {
+                providerRepository.updateEnabledProviders(enabledProviderIds)
+                clearProviderContent()
+                refreshProviderCatalog()
+            }.onSuccess {
+                message = "Provider 已更新"
+                refreshHomeContent(homeSection)
+            }.onFailure {
+                setError(it)
+            }
+            isLoading = false
+        }
     }
 
     fun onProviderLoginModeChange(value: ProviderLoginMode) {
@@ -418,6 +470,38 @@ class FuoPlayerController(
         }
     }
 
+    fun loginProviderWithHeaders(providerId: String) {
+        val input = providerHeaderInputFor(providerId)
+        val authorization = input.authorization.trim()
+        val cookie = input.cookie.trim()
+        val providerName = providerName(providerId)
+        if (authorization.isEmpty() || cookie.isEmpty()) {
+            message = "请输入 $providerName Authorization 和 Cookie"
+            return
+        }
+        scope.launch {
+            isLoading = true
+            message = "正在登录 $providerName"
+            runCatching { providerRepository.loginWithHeaders(providerId, authorization, cookie) }
+                .onSuccess {
+                    providerAuthStates = providerAuthStates + (providerId to it)
+                    persistSettings()
+                    message = if (it.isLoggedIn) {
+                        "${it.providerName} 已登录：${it.userName.orEmpty()}"
+                    } else {
+                        "${it.providerName} 未登录"
+                    }
+                    if (homeSection == HomeSection.Mine && mineSection != MineSection.LocalMusic) {
+                        refreshActiveMineProviderContent()
+                    } else {
+                        refreshHomeContent(homeSection)
+                    }
+                }
+                .onFailure { setError(it) }
+            isLoading = false
+        }
+    }
+
     fun logoutProvider(providerId: String) {
         val providerName = providerName(providerId)
         scope.launch {
@@ -427,6 +511,7 @@ class FuoPlayerController(
                 .onSuccess {
                     providerAuthStates = providerAuthStates + (providerId to it)
                     providerCookieInputs = providerCookieInputs - providerId
+                    providerHeaderInputs = providerHeaderInputs - providerId
                     persistSettings()
                     message = "${it.providerName} 已退出登录"
                     if (homeSection == HomeSection.Mine && mineSection != MineSection.LocalMusic) {
@@ -945,6 +1030,19 @@ class FuoPlayerController(
     }
 
     private suspend fun refreshProviderCatalog() {
+        val loadedAvailableProviders = providerRepository.availableProviders()
+        availableProviders = loadedAvailableProviders
+        val availableProviderIds = loadedAvailableProviders.map { it.providerId }.toSet()
+        if (availableProviderIds.isNotEmpty()) {
+            val normalizedEnabledProviderIds = enabledProviderIds.intersect(availableProviderIds)
+                .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS.intersect(availableProviderIds) }
+                .ifEmpty { setOf(loadedAvailableProviders.first().providerId) }
+            if (normalizedEnabledProviderIds != enabledProviderIds) {
+                enabledProviderIds = normalizedEnabledProviderIds
+                persistSettings()
+                providerRepository.updateEnabledProviders(enabledProviderIds)
+            }
+        }
         val loadedProviders = providerRepository.providers()
         providers = loadedProviders
         val providerIds = loadedProviders.map { it.providerId }.toSet()
@@ -966,6 +1064,20 @@ class FuoPlayerController(
         }
         providerFeatures = providerRepository.features()
         refreshProviderAuthStates()
+    }
+
+    private fun clearProviderContent() {
+        recommendSections = emptyList()
+        musicSections = emptyList()
+        mineSections = emptyList()
+        minePlaylistSections = emptyList()
+        mineFavoritePlaylistSections = emptyList()
+        selectedFeature = null
+        selectedPlaylist = null
+        selectedMediaItem = null
+        selectedFeatureTracks = emptyList()
+        selectedPlaylistTracks = emptyList()
+        selectedMediaItemTracks = emptyList()
     }
 
     private fun refreshAllProviderAuthStates() {
@@ -1176,7 +1288,9 @@ class FuoPlayerController(
     }
 
     private fun providerName(providerId: String): String {
-        return providers.firstOrNull { it.providerId == providerId }?.providerName ?: providerId
+        return providers.firstOrNull { it.providerId == providerId }?.providerName
+            ?: availableProviders.firstOrNull { it.providerId == providerId }?.providerName
+            ?: providerId
     }
 
     private fun ProviderFeature.isDeferredHomeFeature(): Boolean {
@@ -1199,6 +1313,8 @@ class FuoPlayerController(
         selectedSettingsProviderId = settings.selectedSettingsProviderId
         providerLoginMode = settings.providerLoginMode
         providerCookieInputs = settings.providerCookieInputs
+        providerHeaderInputs = settings.providerHeaderInputs
+        enabledProviderIds = settings.enabledProviderIds.ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
         audioCacheLimitMb = settings.audioCacheLimitMb
         imageCacheLimitMb = settings.imageCacheLimitMb
         wifiAudioQualityPolicy = settings.wifiAudioQualityPolicy
@@ -1218,6 +1334,8 @@ class FuoPlayerController(
             selectedSettingsProviderId = selectedSettingsProviderId,
             providerLoginMode = providerLoginMode,
             providerCookieInputs = providerCookieInputs,
+            providerHeaderInputs = providerHeaderInputs,
+            enabledProviderIds = enabledProviderIds,
             audioCacheLimitMb = audioCacheLimitMb,
             imageCacheLimitMb = imageCacheLimitMb,
             wifiAudioQualityPolicy = wifiAudioQualityPolicy,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -709,6 +709,13 @@ class FuoPlayerControllerTest {
                 localMusicMinDurationSeconds = 30,
                 providerLoginMode = ProviderLoginMode.Cookie,
                 providerCookieInputs = mapOf("netease" to """{"MUSIC_U":"saved"}"""),
+                providerHeaderInputs = mapOf(
+                    "ytmusic" to ProviderHeaderInput(
+                        authorization = "SAPISIDHASH saved",
+                        cookie = "SID=saved",
+                    ),
+                ),
+                enabledProviderIds = setOf("netease", "ytmusic"),
                 audioCacheLimitMb = 256,
                 imageCacheLimitMb = 64,
                 wifiAudioQualityPolicy = AudioQualityPolicy.Highest,
@@ -743,6 +750,11 @@ class FuoPlayerControllerTest {
             assertEquals(LocalMusicScanSettings(setOf("Podcasts/"), 30), local.lastSettings)
             assertEquals(ProviderLoginMode.Cookie, controller.providerLoginMode)
             assertEquals("""{"MUSIC_U":"saved"}""", controller.cookieInputFor("netease"))
+            assertEquals(setOf("netease", "ytmusic"), controller.enabledProviderIds)
+            assertEquals(
+                ProviderHeaderInput("SAPISIDHASH saved", "SID=saved"),
+                controller.providerHeaderInputFor("ytmusic"),
+            )
             assertEquals(256, controller.audioCacheLimitMb)
             assertEquals(64, controller.imageCacheLimitMb)
             assertEquals(CacheLimit(256L * 1024L * 1024L, 64L * 1024L * 1024L), cache.lastLimit)
@@ -754,6 +766,8 @@ class FuoPlayerControllerTest {
 
             controller.onProviderLoginModeChange(ProviderLoginMode.WebView)
             controller.onProviderCookiesChange("netease", """{"MUSIC_U":"draft"}""")
+            controller.onProviderHeaderAuthorizationChange("ytmusic", "SAPISIDHASH draft")
+            controller.onProviderHeaderCookieChange("ytmusic", "SID=draft")
             controller.onMineSectionChange(MineSection.Favorites)
             controller.onLocalMusicDirectoryEnabledChange("Podcasts/", enabled = true)
             controller.onLocalMusicMinDurationChange(60)
@@ -766,6 +780,11 @@ class FuoPlayerControllerTest {
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
             assertEquals("""{"MUSIC_U":"draft"}""", store.saved.providerCookieInputs["netease"])
+            assertEquals(
+                ProviderHeaderInput("SAPISIDHASH draft", "SID=draft"),
+                store.saved.providerHeaderInputs["ytmusic"],
+            )
+            assertEquals(setOf("netease", "ytmusic"), store.saved.enabledProviderIds)
             assertEquals(MineSection.Favorites, store.saved.mineSection)
             assertEquals(emptySet(), store.saved.excludedLocalMusicDirectoryIds)
             assertEquals(60, store.saved.localMusicMinDurationSeconds)
@@ -778,6 +797,49 @@ class FuoPlayerControllerTest {
             assertEquals(UnavailablePlaybackPolicy.SmartReplace, store.saved.unavailablePlaybackPolicy)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Standard, provider.lastCellularAudioQualityPolicy)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun providerSwitchesDefaultToNeteaseAndPersistChanges() = runTest {
+        val store = FakeSettingsStore()
+        val provider = FakeProviderRepository(emptyList())
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = store,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertEquals(setOf("netease"), controller.enabledProviderIds)
+            assertEquals(listOf("netease"), controller.providers.map { it.providerId })
+            assertEquals(listOf("netease", "qqmusic", "bilibili", "ytmusic"), controller.availableProviders.map { it.providerId })
+            assertEquals(setOf("netease"), provider.lastEnabledProviderIds)
+
+            controller.onProviderEnabledChange("ytmusic", enabled = true)
+            advanceUntilIdle()
+
+            assertEquals(setOf("netease", "ytmusic"), controller.enabledProviderIds)
+            assertEquals(listOf("netease", "ytmusic"), controller.providers.map { it.providerId })
+            assertEquals(setOf("netease", "ytmusic"), store.saved.enabledProviderIds)
+            assertEquals(setOf("netease", "ytmusic"), provider.lastEnabledProviderIds)
+
+            controller.onSearchProviderChange("ytmusic")
+            controller.onProviderEnabledChange("ytmusic", enabled = false)
+            advanceUntilIdle()
+
+            assertEquals(setOf("netease"), controller.enabledProviderIds)
+            assertEquals(listOf("netease"), controller.providers.map { it.providerId })
+            assertEquals(SearchScope.All, controller.searchScope)
+            assertEquals(null, controller.selectedSearchProviderId)
         } finally {
             controllerScope.cancel()
         }
@@ -879,11 +941,23 @@ class FuoPlayerControllerTest {
         private val additionalFeatureTracks: Map<String, List<MusicTrack>> = emptyMap(),
         private val resolveFailures: Set<String> = emptySet(),
         private val resolveHandler: (suspend (MusicTrack, UnavailablePlaybackPolicy) -> PlaybackPayload)? = null,
+        private val availableProviderInfos: List<ProviderInfo> = listOf(
+            ProviderInfo(providerId = "netease", providerName = "网易云音乐"),
+            ProviderInfo(providerId = "qqmusic", providerName = "QQ 音乐"),
+            ProviderInfo(providerId = "bilibili", providerName = "哔哩哔哩"),
+            ProviderInfo(
+                providerId = "ytmusic",
+                providerName = "YouTube Music",
+                supportedLoginModes = setOf(ProviderLoginMode.Headers),
+            ),
+        ),
         initialIsLoggedIn: Boolean = true,
     ) : ProviderMusicRepository {
         private var isLoggedIn = initialIsLoggedIn
+        private var enabledProviderIds = DEFAULT_ENABLED_PROVIDER_IDS
         var resolveCount = 0
         var logoutCount = 0
+        var lastEnabledProviderIds: Set<String>? = null
         var lastWifiAudioQualityPolicy: AudioQualityPolicy? = null
         var lastCellularAudioQualityPolicy: AudioQualityPolicy? = null
         val loadedFeatureIds = mutableListOf<String>()
@@ -892,9 +966,15 @@ class FuoPlayerControllerTest {
 
         override suspend fun initialize() = Unit
 
-        override suspend fun providers(): List<ProviderInfo> = listOf(
-            ProviderInfo(providerId = "netease", providerName = "网易云音乐"),
-        )
+        override suspend fun availableProviders(): List<ProviderInfo> = availableProviderInfos
+
+        override suspend fun updateEnabledProviders(providerIds: Set<String>) {
+            enabledProviderIds = providerIds
+            lastEnabledProviderIds = providerIds
+        }
+
+        override suspend fun providers(): List<ProviderInfo> =
+            availableProviderInfos.filter { it.providerId in enabledProviderIds }
 
         override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> = tracks
 
@@ -924,6 +1004,11 @@ class FuoPlayerControllerTest {
             )
 
         override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState {
+            isLoggedIn = true
+            return authState(providerId)
+        }
+
+        override suspend fun loginWithHeaders(providerId: String, authorization: String, cookie: String): ProviderAuthState {
             isLoggedIn = true
             return authState(providerId)
         }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -46,6 +46,53 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun smartReplacementPayloadUpdatesCurrentPlaybackTrack() = runTest {
+        val origin = providerTrack("provider:1", "First")
+        val provider = FakeProviderRepository(
+            listOf(origin),
+            resolveHandler = { track, _ ->
+                PlaybackPayload(
+                    url = "https://example.com/replacement.mp3",
+                    title = "Replacement",
+                    artists = "Other Artist",
+                    album = "Other Album",
+                    source = "qqmusic",
+                    providerName = "QQ 音乐",
+                    isSmartReplacement = true,
+                    originalTitle = track.title,
+                    originalProviderName = track.providerName,
+                )
+            },
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onQueryChange("first")
+            controller.onSearchScopeChange(SearchScope.Provider)
+            advanceUntilIdle()
+            controller.playFromSearch(0)
+            advanceUntilIdle()
+
+            assertEquals("Replacement", engine.lastTrack?.title)
+            assertEquals("QQ 音乐", engine.lastTrack?.providerName)
+            assertEquals(true, engine.lastTrack?.isSmartReplacement)
+            assertEquals("First", engine.lastTrack?.originalTitle)
+            assertEquals("网易云音乐", engine.lastTrack?.originalProviderName)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun nextUsesKotlinQueueOrder() = runTest {
         val tracks = listOf(
             providerTrack("provider:1", "First"),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -716,6 +716,7 @@ class FuoPlayerControllerTest {
                     ),
                 ),
                 enabledProviderIds = setOf("netease", "ytmusic"),
+                providerOrderIds = listOf("ytmusic", "netease", "qqmusic", "bilibili"),
                 audioCacheLimitMb = 256,
                 imageCacheLimitMb = 64,
                 wifiAudioQualityPolicy = AudioQualityPolicy.Highest,
@@ -751,6 +752,7 @@ class FuoPlayerControllerTest {
             assertEquals(ProviderLoginMode.Cookie, controller.providerLoginMode)
             assertEquals("""{"MUSIC_U":"saved"}""", controller.cookieInputFor("netease"))
             assertEquals(setOf("netease", "ytmusic"), controller.enabledProviderIds)
+            assertEquals(listOf("ytmusic", "netease"), controller.providers.map { it.providerId })
             assertEquals(
                 ProviderHeaderInput("SAPISIDHASH saved", "SID=saved"),
                 controller.providerHeaderInputFor("ytmusic"),
@@ -785,6 +787,7 @@ class FuoPlayerControllerTest {
                 store.saved.providerHeaderInputs["ytmusic"],
             )
             assertEquals(setOf("netease", "ytmusic"), store.saved.enabledProviderIds)
+            assertEquals(listOf("ytmusic", "netease", "qqmusic", "bilibili"), store.saved.providerOrderIds)
             assertEquals(MineSection.Favorites, store.saved.mineSection)
             assertEquals(emptySet(), store.saved.excludedLocalMusicDirectoryIds)
             assertEquals(60, store.saved.localMusicMinDurationSeconds)
@@ -832,6 +835,12 @@ class FuoPlayerControllerTest {
             assertEquals(setOf("netease", "ytmusic"), store.saved.enabledProviderIds)
             assertEquals(setOf("netease", "ytmusic"), provider.lastEnabledProviderIds)
 
+            controller.moveProvider("ytmusic", -3)
+            advanceUntilIdle()
+
+            assertEquals(listOf("ytmusic", "netease"), controller.providers.map { it.providerId })
+            assertEquals(listOf("ytmusic", "netease", "qqmusic", "bilibili"), store.saved.providerOrderIds)
+
             controller.onSearchProviderChange("ytmusic")
             controller.onProviderEnabledChange("ytmusic", enabled = false)
             advanceUntilIdle()
@@ -840,6 +849,58 @@ class FuoPlayerControllerTest {
             assertEquals(listOf("netease"), controller.providers.map { it.providerId })
             assertEquals(SearchScope.All, controller.searchScope)
             assertEquals(null, controller.selectedSearchProviderId)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun providerSectionsFollowConfiguredOrder() = runTest {
+        val neteaseFeature = ProviderFeature(
+            id = "netease_recommend",
+            providerId = "netease",
+            providerName = "网易云音乐",
+            title = "网易推荐",
+            category = ProviderFeatureCategory.Recommend,
+            contentType = ProviderContentType.Playlists,
+            requiresLogin = false,
+        )
+        val ytmusicFeature = ProviderFeature(
+            id = "ytmusic_recommend",
+            providerId = "ytmusic",
+            providerName = "YouTube Music",
+            title = "YT 推荐",
+            category = ProviderFeatureCategory.Recommend,
+            contentType = ProviderContentType.Playlists,
+            requiresLogin = false,
+        )
+        val store = FakeSettingsStore(
+            AppSettings(
+                enabledProviderIds = setOf("netease", "ytmusic"),
+                providerOrderIds = listOf("ytmusic", "netease", "qqmusic", "bilibili"),
+            ),
+        )
+        val provider = FakeProviderRepository(
+            tracks = emptyList(),
+            features = listOf(neteaseFeature, ytmusicFeature),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = store,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("ytmusic_recommend", "netease_recommend"),
+                controller.recommendSections.map { it.feature.id },
+            )
         } finally {
             controllerScope.cancel()
         }


### PR DESCRIPTION
## Summary
- add runtime provider switches with NetEase as the only default enabled provider
- package and integrate optional Bilibili and YouTube Music providers while keeping QQ Music optional
- add Bilibili cookie/WebView login and YouTube Music Authorization + Cookie header login

## Validation
- `./gradlew :shared:allTests`
- `./gradlew :androidApp:assembleDebug`
- `python3 -m py_compile androidApp/src/main/python/fuo_mobile/bridge.py`
- `git diff --check`