### PR TITLE
[feat] Implement playback queue

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -45,6 +45,14 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 KEY_SMART_REPLACEMENT_MIN_SCORE,
                 DEFAULT_SMART_REPLACEMENT_MIN_SCORE.toFloat(),
             ).toDouble(),
+            smartReplacementUseOriginalMetadata = preferences.getBoolean(
+                KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA,
+                false,
+            ),
+            smartReplacementUseOriginalLyrics = preferences.getBoolean(
+                KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS,
+                false,
+            ),
         )
     }
 
@@ -72,6 +80,11 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putString(KEY_UNAVAILABLE_PLAYBACK_POLICY, settings.unavailablePlaybackPolicy.name)
                 .putStringSet(KEY_SMART_REPLACEMENT_PROVIDER_IDS, settings.smartReplacementProviderIds)
                 .putFloat(KEY_SMART_REPLACEMENT_MIN_SCORE, settings.smartReplacementMinScore.toFloat())
+                .putBoolean(
+                    KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA,
+                    settings.smartReplacementUseOriginalMetadata,
+                )
+                .putBoolean(KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS, settings.smartReplacementUseOriginalLyrics)
                 .apply()
         }
     }
@@ -203,5 +216,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"
         private const val KEY_SMART_REPLACEMENT_PROVIDER_IDS = "smart_replacement_provider_ids"
         private const val KEY_SMART_REPLACEMENT_MIN_SCORE = "smart_replacement_min_score"
+        private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA = "smart_replacement_use_original_metadata"
+        private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS = "smart_replacement_use_original_lyrics"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -302,6 +302,8 @@ class AndroidFuoCoreBridge(
             durationMs = optLong("duration_ms").takeIf { it > 0 },
             providerId = id,
             providerName = optString("provider_name").ifBlank { source }.takeIf { it.isNotBlank() },
+            artistItemId = optString("artist_item_id").takeIf { it.isNotBlank() },
+            albumItemId = optString("album_item_id").takeIf { it.isNotBlank() },
         )
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -86,6 +86,8 @@ class AndroidFuoCoreBridge(
         unavailablePolicy: UnavailablePlaybackPolicy,
         smartReplacementProviderIds: Set<String>,
         smartReplacementMinScore: Double,
+        smartReplacementUseOriginalMetadata: Boolean,
+        smartReplacementUseOriginalLyrics: Boolean,
     ): PlaybackPayload {
         initialize()
         return withContext(Dispatchers.IO) {
@@ -106,6 +108,8 @@ class AndroidFuoCoreBridge(
                         unavailablePolicy == UnavailablePlaybackPolicy.SmartReplace,
                         smartReplacementProviderIdsJson(smartReplacementProviderIds),
                         smartReplacementMinScore,
+                        smartReplacementUseOriginalMetadata,
+                        smartReplacementUseOriginalLyrics,
                     )
                     .toString()
                 JSONObject(raw).toPayload(track).also {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
+    private val preferences = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
+        preferences.getString(KEY_QUEUE_SNAPSHOT, null)
+            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
+            ?: PlaybackQueueSnapshot()
+    }
+
+    override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+        withContext(Dispatchers.IO) {
+            preferences.edit()
+                .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
+                .apply()
+        }
+    }
+
+    private companion object {
+        private const val PREFS_NAME = "fuo_playback_queue"
+        private const val KEY_QUEUE_SNAPSHOT = "queue_snapshot"
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -30,6 +30,10 @@ class FuoEvolveApplication : PyApplication() {
         AndroidAppSettingsStore(applicationContext)
     }
 
+    private val playbackQueueStore: AndroidPlaybackQueueStore by lazy {
+        AndroidPlaybackQueueStore(applicationContext)
+    }
+
     private val resourceCacheRepository: AndroidResourceCacheRepository by lazy {
         AndroidResourceCacheRepository(applicationContext)
     }
@@ -45,6 +49,7 @@ class FuoEvolveApplication : PyApplication() {
             downloadRepository = downloadRepository,
             playbackEngine = playbackEngine,
             settingsStore = settingsStore,
+            playbackQueueStore = playbackQueueStore,
             resourceCacheRepository = resourceCacheRepository,
             debugLogRepository = debugLogRepository,
             scope = appScope,

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -548,6 +548,8 @@ class FuoMobileBridge:
         allow_standby: bool = True,
         standby_provider_ids_json: str = "",
         standby_min_score: float = 0.55,
+        standby_use_origin_metadata: bool = False,
+        standby_use_origin_lyrics: bool = False,
     ) -> str:
         song = self._tracks.get(track_id)
         if song is None:
@@ -556,7 +558,15 @@ class FuoMobileBridge:
         policy = audio_select_policy or self.app.config.AUDIO_SELECT_POLICY
         standby_provider_ids = parse_provider_ids(standby_provider_ids_json)
         min_score = normalize_standby_min_score(standby_min_score)
-        payload = self._prepare_payload(song, policy, allow_standby, standby_provider_ids, min_score)
+        payload = self._prepare_payload(
+            song,
+            policy,
+            allow_standby,
+            standby_provider_ids,
+            min_score,
+            standby_use_origin_metadata,
+            standby_use_origin_lyrics,
+        )
         return json.dumps(payload, ensure_ascii=False)
 
     def play(self, track_id: str) -> str:
@@ -938,6 +948,8 @@ class FuoMobileBridge:
         allow_standby: bool,
         standby_provider_ids: Optional[List[str]],
         standby_min_score: float,
+        standby_use_origin_metadata: bool,
+        standby_use_origin_lyrics: bool,
     ) -> Dict[str, Any]:
         try:
             media, quality = self._select_media(song, audio_select_policy)
@@ -952,6 +964,8 @@ class FuoMobileBridge:
                     audio_select_policy,
                     standby_provider_ids,
                     standby_min_score,
+                    standby_use_origin_metadata,
+                    standby_use_origin_lyrics,
                 )
                 if standby_payload is not None:
                     return standby_payload
@@ -965,6 +979,8 @@ class FuoMobileBridge:
         audio_select_policy: str,
         standby_provider_ids: Optional[List[str]],
         standby_min_score: float,
+        standby_use_origin_metadata: bool,
+        standby_use_origin_lyrics: bool,
     ) -> Optional[Dict[str, Any]]:
         source = getattr(song, "source", "")
         provider_ids = standby_provider_ids or self.provider_registry.provider_ids
@@ -991,10 +1007,24 @@ class FuoMobileBridge:
             )
         except Exception as exc:  # pylint: disable=broad-except
             bridge_log(f"standby failed track={song_log_label(song)} error={exc}")
-            return self._prepare_search_standby_payload(song, audio_select_policy, source_in, standby_min_score)
+            return self._prepare_search_standby_payload(
+                song,
+                audio_select_policy,
+                source_in,
+                standby_min_score,
+                standby_use_origin_metadata,
+                standby_use_origin_lyrics,
+            )
         if not standby_list:
             bridge_log(f"standby empty track={song_log_label(song)}")
-            return self._prepare_search_standby_payload(song, audio_select_policy, source_in, standby_min_score)
+            return self._prepare_search_standby_payload(
+                song,
+                audio_select_policy,
+                source_in,
+                standby_min_score,
+                standby_use_origin_metadata,
+                standby_use_origin_lyrics,
+            )
         candidates = []
         for standby, _ in standby_list:
             score = standby_score(song, standby)
@@ -1002,7 +1032,14 @@ class FuoMobileBridge:
                 candidates.append((score, standby))
         if not candidates:
             bridge_log(f"standby no scored candidates track={song_log_label(song)}")
-            return self._prepare_search_standby_payload(song, audio_select_policy, source_in, standby_min_score)
+            return self._prepare_search_standby_payload(
+                song,
+                audio_select_policy,
+                source_in,
+                standby_min_score,
+                standby_use_origin_metadata,
+                standby_use_origin_lyrics,
+            )
         for score, standby in sorted(candidates, key=lambda item: item[0], reverse=True):
             self._tracks[f"{getattr(standby, 'source', '')}:{getattr(standby, 'identifier', '')}"] = standby
             bridge_log(
@@ -1017,9 +1054,24 @@ class FuoMobileBridge:
                 )
                 continue
             payload = self._payload_from_media(standby, media, quality)
-            return self._mark_standby_payload(payload, song, standby, "library", score)
+            return self._mark_standby_payload(
+                payload,
+                song,
+                standby,
+                "library",
+                score,
+                standby_use_origin_metadata,
+                standby_use_origin_lyrics,
+            )
         bridge_log(f"standby scored media empty track={song_log_label(song)} candidates={len(candidates)}")
-        return self._prepare_search_standby_payload(song, audio_select_policy, source_in, standby_min_score)
+        return self._prepare_search_standby_payload(
+            song,
+            audio_select_policy,
+            source_in,
+            standby_min_score,
+            standby_use_origin_metadata,
+            standby_use_origin_lyrics,
+        )
 
     def _prepare_search_standby_payload(
         self,
@@ -1027,6 +1079,8 @@ class FuoMobileBridge:
         audio_select_policy: str,
         source_in: List[str],
         standby_min_score: float,
+        standby_use_origin_metadata: bool,
+        standby_use_origin_lyrics: bool,
     ) -> Optional[Dict[str, Any]]:
         candidates = []
         seen = set()
@@ -1061,7 +1115,15 @@ class FuoMobileBridge:
                 f"origin={song_log_label(song)} replacement={song_log_label(standby)}"
             )
             payload = self._payload_from_media(standby, media, quality)
-            return self._mark_standby_payload(payload, song, standby, "search", score)
+            return self._mark_standby_payload(
+                payload,
+                song,
+                standby,
+                "search",
+                score,
+                standby_use_origin_metadata,
+                standby_use_origin_lyrics,
+            )
         bridge_log(f"search standby media empty track={song_log_label(song)} candidates={len(candidates)}")
         return None
 
@@ -1122,6 +1184,8 @@ class FuoMobileBridge:
         standby,
         strategy: str,
         score: Optional[float],
+        use_origin_metadata: bool = False,
+        use_origin_lyrics: bool = False,
     ) -> Dict[str, Any]:
         origin_provider = provider_name(self.app.library.get(getattr(origin, "source", "")))
         standby_provider = provider_name(self.app.library.get(getattr(standby, "source", "")))
@@ -1143,6 +1207,12 @@ class FuoMobileBridge:
         )
         if score is not None:
             payload["standby_score"] = round(score, 2)
+        if use_origin_metadata:
+            apply_origin_metadata(payload, song_to_metadata(origin, self.app.library))
+        if use_origin_lyrics:
+            origin_lyrics = self._get_lyrics(origin)
+            if origin_lyrics:
+                payload["lyrics"] = origin_lyrics
         bridge_log(
             f"standby payload ready strategy={strategy} "
             f"origin={song_log_label(origin)} replacement={song_log_label(standby)} "
@@ -1320,6 +1390,16 @@ def song_to_metadata(song, library: Library) -> Dict[str, Any]:
         "duration_ms": data["duration_ms"],
         "cover_url": data["cover_url"],
     }
+
+
+def apply_origin_metadata(payload: Dict[str, Any], metadata: Dict[str, Any]) -> None:
+    for key in ("title", "artists", "album", "source", "provider_name", "cover_url"):
+        value = metadata.get(key)
+        if value:
+            payload[key] = value
+    duration = metadata.get("duration_ms", 0)
+    if duration:
+        payload["duration_ms"] = duration
 
 
 def playlist_to_dict(playlist, library: Library) -> Dict[str, Any]:

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -1304,6 +1304,8 @@ def song_to_dict(song, library: Library) -> Dict[str, Any]:
         "provider_name": provider_name(library.get(source)),
         "duration_ms": duration_ms(song),
         "cover_url": normalize_image_url(display(song, "pic_url")),
+        "artist_item_id": first_artist_item_id(song),
+        "album_item_id": album_item_id(song),
     }
 
 
@@ -1401,6 +1403,25 @@ def display_album(song) -> str:
     if album is None:
         return ""
     return display(album, "name")
+
+
+def first_artist_item_id(song) -> str:
+    source = getattr(song, "source", "")
+    artists = getattr(song, "artists", []) or []
+    artist = artists[0] if artists else None
+    identifier = getattr(artist, "identifier", "") if artist is not None else ""
+    if source and identifier:
+        return f"artist:{source}:{identifier}"
+    return ""
+
+
+def album_item_id(song) -> str:
+    source = getattr(song, "source", "")
+    album = getattr(song, "album", None)
+    identifier = getattr(album, "identifier", "") if album is not None else ""
+    if source and identifier:
+        return f"album:{source}:{identifier}"
+    return ""
 
 
 def standby_queries(song) -> List[str]:

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -1706,6 +1706,38 @@ private fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
                         enabled = !controller.isLoading,
                     )
                 }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        modifier = Modifier.weight(1f),
+                        text = "使用原曲信息",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Checkbox(
+                        checked = controller.smartReplacementUseOriginalMetadata,
+                        enabled = !controller.isLoading,
+                        onCheckedChange = controller::onSmartReplacementUseOriginalMetadataChange,
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        modifier = Modifier.weight(1f),
+                        text = "使用原曲歌词",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Checkbox(
+                        checked = controller.smartReplacementUseOriginalLyrics,
+                        enabled = !controller.isLoading,
+                        onCheckedChange = controller::onSmartReplacementUseOriginalLyricsChange,
+                    )
+                }
                 controller.orderedProviders().forEach { provider ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -51,18 +51,25 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.RemoveCircleOutline
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -506,8 +513,11 @@ private fun ProviderContentHomeSection(
                                     track = track,
                                     downloadState = controller.downloadStates[track.id],
                                     onClick = { controller.playFromFeature(contentSection.feature.id, index) },
+                                    onAddToUpNext = { controller.addToUpNext(track) },
                                     onDownload = { controller.download(track) },
                                     onDeleteDownload = { controller.deleteDownload(track) },
+                                    onOpenArtist = { controller.openTrackArtist(track) },
+                                    onOpenAlbum = { controller.openTrackAlbum(track) },
                                 )
                                 HorizontalDivider()
                             }
@@ -1265,8 +1275,11 @@ private fun LocalMusicSection(controller: FuoPlayerController, modifier: Modifie
                             track = track,
                             downloadState = controller.downloadStates[track.id],
                             onClick = { controller.playLocalTrack(track, displayTracks) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
                             onDownload = { controller.download(track) },
                             onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
                         )
                         HorizontalDivider()
                     }
@@ -2144,8 +2157,11 @@ private fun ProviderFeatureScreen(controller: FuoPlayerController, feature: Prov
                             track = track,
                             downloadState = controller.downloadStates[track.id],
                             onClick = { controller.playFromSelectedFeature(index) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
                             onDownload = { controller.download(track) },
                             onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
                         )
                         HorizontalDivider()
                     }
@@ -2243,8 +2259,11 @@ private fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: Pr
                             track = track,
                             downloadState = controller.downloadStates[track.id],
                             onClick = { controller.playFromSelectedPlaylist(index) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
                             onDownload = { controller.download(track) },
                             onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
                         )
                         HorizontalDivider()
                     }
@@ -2347,8 +2366,11 @@ private fun ProviderMediaItemScreen(controller: FuoPlayerController, item: Provi
                             track = track,
                             downloadState = controller.downloadStates[track.id],
                             onClick = { controller.playFromSelectedMediaItem(index) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
                             onDownload = { controller.download(track) },
                             onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
                         )
                         HorizontalDivider()
                     }
@@ -2437,8 +2459,11 @@ private fun SearchScreen(controller: FuoPlayerController) {
                             track = track,
                             downloadState = controller.downloadStates[track.id],
                             onClick = { controller.playFromSearch(index) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
                             onDownload = { controller.download(track) },
                             onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
                         )
                         HorizontalDivider()
                     }
@@ -2490,8 +2515,11 @@ private fun TrackRow(
     track: MusicTrack,
     downloadState: DownloadState?,
     onClick: () -> Unit,
+    onAddToUpNext: () -> Unit,
     onDownload: () -> Unit,
     onDeleteDownload: () -> Unit,
+    onOpenArtist: () -> Unit,
+    onOpenAlbum: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -2524,7 +2552,15 @@ private fun TrackRow(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        TrackAction(track, downloadState, onDownload, onDeleteDownload)
+        TrackAction(
+            track = track,
+            downloadState = downloadState,
+            onAddToUpNext = onAddToUpNext,
+            onDownload = onDownload,
+            onDeleteDownload = onDeleteDownload,
+            onOpenArtist = onOpenArtist,
+            onOpenAlbum = onOpenAlbum,
+        )
     }
 }
 
@@ -2546,27 +2582,78 @@ private fun CoverBox(
 private fun TrackAction(
     track: MusicTrack,
     downloadState: DownloadState?,
+    onAddToUpNext: () -> Unit,
     onDownload: () -> Unit,
     onDeleteDownload: () -> Unit,
+    onOpenArtist: () -> Unit,
+    onOpenAlbum: () -> Unit,
 ) {
-    when {
-        track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Downloaded -> {
-            IconButton(onClick = onDeleteDownload) {
-                Icon(Icons.Filled.Delete, contentDescription = "删除下载")
-            }
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(Icons.Filled.MoreVert, contentDescription = "更多操作")
         }
-        track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Downloading -> {
-            Text("下载中", style = MaterialTheme.typography.labelMedium)
-        }
-        track.sourceType == TrackSourceType.Provider -> {
-            IconButton(onClick = onDownload) {
-                Icon(Icons.Filled.Download, contentDescription = "下载")
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("接下来播放") },
+                leadingIcon = { Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    onAddToUpNext()
+                },
+            )
+            when {
+                track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Downloading -> {
+                    DropdownMenuItem(
+                        text = { Text("下载中") },
+                        leadingIcon = { Icon(Icons.Filled.Download, contentDescription = null) },
+                        enabled = false,
+                        onClick = {},
+                    )
+                }
+                (track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Downloaded) ||
+                    track.sourceType == TrackSourceType.Downloaded -> {
+                    DropdownMenuItem(
+                        text = { Text("删除下载") },
+                        leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+                        onClick = {
+                            expanded = false
+                            onDeleteDownload()
+                        },
+                    )
+                }
+                track.sourceType == TrackSourceType.Provider -> {
+                    DropdownMenuItem(
+                        text = { Text("下载") },
+                        leadingIcon = { Icon(Icons.Filled.Download, contentDescription = null) },
+                        onClick = {
+                            expanded = false
+                            onDownload()
+                        },
+                    )
+                }
             }
-        }
-        track.sourceType == TrackSourceType.Downloaded -> {
-            IconButton(onClick = onDeleteDownload) {
-                Icon(Icons.Filled.Delete, contentDescription = "删除下载")
-            }
+            DropdownMenuItem(
+                text = { Text("查看歌手") },
+                leadingIcon = { Icon(Icons.Filled.Person, contentDescription = null) },
+                enabled = track.artists.isNotBlank(),
+                onClick = {
+                    expanded = false
+                    onOpenArtist()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("查看专辑") },
+                leadingIcon = { Icon(Icons.Filled.Album, contentDescription = null) },
+                enabled = track.album.isNotBlank(),
+                onClick = {
+                    expanded = false
+                    onOpenAlbum()
+                },
+            )
         }
     }
 }
@@ -2706,6 +2793,11 @@ private fun FullPlayer(controller: FuoPlayerController) {
                     onPrevious = controller::previous,
                     onToggle = controller::toggle,
                     onNext = controller::next,
+                    shuffleEnabled = controller.isShuffleEnabled,
+                    repeatEnabled = controller.isRepeatEnabled,
+                    shuffleAvailable = !controller.isFmQueueActive,
+                    onShuffle = controller::toggleShuffle,
+                    onRepeat = controller::toggleRepeat,
                 )
             }
             QueueBottomSheet(controller)
@@ -2855,12 +2947,28 @@ private fun PlayerControls(
     onNext: () -> Unit,
     modifier: Modifier = Modifier,
     compact: Boolean = false,
+    shuffleEnabled: Boolean = false,
+    repeatEnabled: Boolean = true,
+    shuffleAvailable: Boolean = true,
+    onShuffle: (() -> Unit)? = null,
+    onRepeat: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier.animateContentSize(animationSpec = tween(220)),
         horizontalArrangement = if (compact) Arrangement.spacedBy(8.dp) else Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (!compact && onShuffle != null) {
+            RoundControlButton(
+                imageVector = Icons.Filled.Shuffle,
+                contentDescription = if (shuffleAvailable) "随机播放" else "私人 FM 使用顺序播放",
+                onClick = onShuffle,
+                size = 44.dp,
+                iconSize = 24.dp,
+                selected = shuffleEnabled,
+                enabled = shuffleAvailable,
+            )
+        }
         RoundControlButton(
             imageVector = Icons.Filled.SkipPrevious,
             contentDescription = "上一首",
@@ -2883,6 +2991,16 @@ private fun PlayerControls(
             size = if (compact) 44.dp else 48.dp,
             iconSize = if (compact) 24.dp else 26.dp,
         )
+        if (!compact && onRepeat != null) {
+            RoundControlButton(
+                imageVector = Icons.Filled.Repeat,
+                contentDescription = "循环播放",
+                onClick = onRepeat,
+                size = 44.dp,
+                iconSize = 24.dp,
+                selected = repeatEnabled,
+            )
+        }
     }
 }
 
@@ -2894,13 +3012,22 @@ private fun RoundControlButton(
     size: androidx.compose.ui.unit.Dp = 48.dp,
     iconSize: androidx.compose.ui.unit.Dp = 26.dp,
     prominent: Boolean = false,
+    selected: Boolean = false,
+    enabled: Boolean = true,
 ) {
     Surface(
         modifier = Modifier
             .size(size)
-            .clickable(onClick = onClick),
-        color = if (prominent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = if (prominent) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+            .clickable(enabled = enabled, onClick = onClick),
+        color = when {
+            prominent || selected -> MaterialTheme.colorScheme.primary
+            else -> MaterialTheme.colorScheme.surfaceVariant
+        },
+        contentColor = when {
+            prominent || selected -> MaterialTheme.colorScheme.onPrimary
+            enabled -> MaterialTheme.colorScheme.onSurfaceVariant
+            else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+        },
         tonalElevation = if (prominent) 3.dp else 1.dp,
         shape = RoundedCornerShape(50),
     ) {
@@ -3008,10 +3135,29 @@ private fun LyricsPanel(state: PlaybackState, modifier: Modifier) {
 
 @Composable
 private fun QueueList(controller: FuoPlayerController, modifier: Modifier) {
+    val upNextCount = controller.displayUpNextCount
     LazyColumn(
         modifier = modifier,
     ) {
+        if (upNextCount > 0) {
+            item(key = "queue-section-up-next") {
+                Text(
+                    text = "接下来播放",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 6.dp, bottom = 4.dp),
+                )
+            }
+        }
         itemsIndexed(controller.playbackState.queue, key = { _, item -> item.id }) { index, track ->
+            if (index == upNextCount && index > 0) {
+                Text(
+                    text = "主队列",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 10.dp, bottom = 4.dp),
+                )
+            }
             val isCurrent = index == controller.playbackState.queueIndex
             val isUnavailable = track.isUnavailable
             val titleColor = when {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -99,6 +99,8 @@ data class MusicTrack(
     val originalTitle: String? = null,
     val originalProviderName: String? = null,
     val isUnavailable: Boolean = false,
+    val artistItemId: String? = null,
+    val albumItemId: String? = null,
 )
 
 data class PlaybackPayload(
@@ -147,6 +149,171 @@ data class PlaybackState(
     val audioQuality: String? = null,
     val errorMessage: String? = null,
 )
+
+data class PlaybackQueueSnapshot(
+    val mainQueue: List<MusicTrack> = emptyList(),
+    val originalMainQueue: List<MusicTrack> = emptyList(),
+    val upNextQueue: List<MusicTrack> = emptyList(),
+    val queueIndex: Int = -1,
+    val shuffleEnabled: Boolean = false,
+    val repeatEnabled: Boolean = true,
+    val isFmQueue: Boolean = false,
+    val shuffleBeforeFm: Boolean? = null,
+)
+
+interface PlaybackQueueStore {
+    suspend fun load(): PlaybackQueueSnapshot
+    suspend fun save(snapshot: PlaybackQueueSnapshot)
+}
+
+object NoOpPlaybackQueueStore : PlaybackQueueStore {
+    override suspend fun load(): PlaybackQueueSnapshot = PlaybackQueueSnapshot()
+
+    override suspend fun save(snapshot: PlaybackQueueSnapshot) = Unit
+}
+
+object PlaybackQueueCodec {
+    fun encode(snapshot: PlaybackQueueSnapshot): String {
+        return buildList {
+            add("v1")
+            add(
+                listOf(
+                    snapshot.queueIndex.toString(),
+                    snapshot.shuffleEnabled.toString(),
+                    snapshot.repeatEnabled.toString(),
+                    snapshot.isFmQueue.toString(),
+                    snapshot.shuffleBeforeFm?.toString().orEmpty(),
+                ).joinToString("\t")
+            )
+            addTracks("main", snapshot.mainQueue)
+            addTracks("original", snapshot.originalMainQueue)
+            addTracks("upNext", snapshot.upNextQueue)
+        }.joinToString("\n")
+    }
+
+    fun decode(raw: String): PlaybackQueueSnapshot {
+        val lines = raw.lineSequence().filter { it.isNotBlank() }.toList()
+        if (lines.size < 2 || lines.first() != "v1") return PlaybackQueueSnapshot()
+        val flags = lines[1].split("\t")
+        val tracksBySection = lines.drop(2)
+            .mapNotNull { line ->
+                val fields = line.split("\t")
+                if (fields.size < 2 || fields[0] != "track") return@mapNotNull null
+                decodeTrack(fields.drop(2))?.let { track -> fields[1] to track }
+            }
+            .groupBy({ it.first }, { it.second })
+        return PlaybackQueueSnapshot(
+            mainQueue = tracksBySection["main"].orEmpty(),
+            originalMainQueue = tracksBySection["original"].orEmpty(),
+            upNextQueue = tracksBySection["upNext"].orEmpty(),
+            queueIndex = flags.getOrNull(0)?.toIntOrNull() ?: -1,
+            shuffleEnabled = flags.getOrNull(1)?.toBooleanStrictOrNull() ?: false,
+            repeatEnabled = flags.getOrNull(2)?.toBooleanStrictOrNull() ?: true,
+            isFmQueue = flags.getOrNull(3)?.toBooleanStrictOrNull() ?: false,
+            shuffleBeforeFm = flags.getOrNull(4)?.takeIf { it.isNotBlank() }?.toBooleanStrictOrNull(),
+        )
+    }
+
+    private fun MutableList<String>.addTracks(section: String, tracks: List<MusicTrack>) {
+        tracks.forEach { track ->
+            add((listOf("track", section) + encodeTrack(track)).joinToString("\t"))
+        }
+    }
+
+    private fun encodeTrack(track: MusicTrack): List<String> = listOf(
+        track.id,
+        track.title,
+        track.artists,
+        track.album,
+        track.source,
+        track.sourceType.name,
+        track.coverUrl.orEmpty(),
+        track.durationMs?.toString().orEmpty(),
+        track.localUri.orEmpty(),
+        track.lyrics.orEmpty(),
+        track.providerId.orEmpty(),
+        track.providerName.orEmpty(),
+        track.isSmartReplacement.toString(),
+        track.originalTitle.orEmpty(),
+        track.originalProviderName.orEmpty(),
+        track.isUnavailable.toString(),
+        track.artistItemId.orEmpty(),
+        track.albumItemId.orEmpty(),
+    ).map(::escape)
+
+    private fun decodeTrack(fields: List<String>): MusicTrack? {
+        if (fields.size < 18) return null
+        return runCatching {
+            MusicTrack(
+                id = unescape(fields[0]),
+                title = unescape(fields[1]),
+                artists = unescape(fields[2]),
+                album = unescape(fields[3]),
+                source = unescape(fields[4]),
+                sourceType = TrackSourceType.valueOf(unescape(fields[5])),
+                coverUrl = unescape(fields[6]).ifBlank { null },
+                durationMs = unescape(fields[7]).toLongOrNull(),
+                localUri = unescape(fields[8]).ifBlank { null },
+                lyrics = unescape(fields[9]).ifBlank { null },
+                providerId = unescape(fields[10]).ifBlank { null },
+                providerName = unescape(fields[11]).ifBlank { null },
+                isSmartReplacement = unescape(fields[12]).toBooleanStrictOrNull() ?: false,
+                originalTitle = unescape(fields[13]).ifBlank { null },
+                originalProviderName = unescape(fields[14]).ifBlank { null },
+                isUnavailable = unescape(fields[15]).toBooleanStrictOrNull() ?: false,
+                artistItemId = unescape(fields[16]).ifBlank { null },
+                albumItemId = unescape(fields[17]).ifBlank { null },
+            )
+        }.getOrNull()
+    }
+
+    private fun escape(value: String): String = buildString {
+        value.forEach { char ->
+            when (char) {
+                '%' -> append("%25")
+                '\t' -> append("%09")
+                '\n' -> append("%0A")
+                '\r' -> append("%0D")
+                else -> append(char)
+            }
+        }
+    }
+
+    private fun unescape(value: String): String {
+        val result = StringBuilder()
+        var index = 0
+        while (index < value.length) {
+            if (value[index] == '%' && index + 2 < value.length) {
+                when (value.substring(index + 1, index + 3)) {
+                    "25" -> {
+                        result.append('%')
+                        index += 3
+                    }
+                    "09" -> {
+                        result.append('\t')
+                        index += 3
+                    }
+                    "0A" -> {
+                        result.append('\n')
+                        index += 3
+                    }
+                    "0D" -> {
+                        result.append('\r')
+                        index += 3
+                    }
+                    else -> {
+                        result.append(value[index])
+                        index += 1
+                    }
+                }
+            } else {
+                result.append(value[index])
+                index += 1
+            }
+        }
+        return result.toString()
+    }
+}
 
 sealed class DownloadState {
     data object NotDownloaded : DownloadState()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -54,6 +54,8 @@ data class AppSettings(
     val unavailablePlaybackPolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
     val smartReplacementProviderIds: Set<String> = emptySet(),
     val smartReplacementMinScore: Double = DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
+    val smartReplacementUseOriginalMetadata: Boolean = false,
+    val smartReplacementUseOriginalLyrics: Boolean = false,
 )
 
 data class ProviderHeaderInput(
@@ -412,6 +414,8 @@ interface ProviderMusicRepository {
         unavailablePolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
         smartReplacementProviderIds: Set<String> = emptySet(),
         smartReplacementMinScore: Double = DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
+        smartReplacementUseOriginalMetadata: Boolean = false,
+        smartReplacementUseOriginalLyrics: Boolean = false,
     ): PlaybackPayload
     suspend fun authState(providerId: String): ProviderAuthState
     suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -50,6 +50,7 @@ class FuoPlayerController(
     private val downloadRepository: DownloadRepository,
     private val playbackEngine: PlaybackEngine,
     private val settingsStore: AppSettingsStore = NoOpAppSettingsStore,
+    private val playbackQueueStore: PlaybackQueueStore = NoOpPlaybackQueueStore,
     private val resourceCacheRepository: ResourceCacheRepository = NoOpResourceCacheRepository,
     private val debugLogRepository: DebugLogRepository = NoOpDebugLogRepository,
     private val scope: CoroutineScope,
@@ -168,6 +169,14 @@ class FuoPlayerController(
         private set
     val isDebugLogViewerAvailable: Boolean
         get() = debugLogRepository.isAvailable
+    val isShuffleEnabled: Boolean
+        get() = shuffleEnabled
+    val isRepeatEnabled: Boolean
+        get() = repeatEnabled
+    val isFmQueueActive: Boolean
+        get() = isFmQueue
+    val displayUpNextCount: Int
+        get() = (if (currentUpNextTrack != null) 1 else 0) + upNextQueue.size
     val canNavigateBack: Boolean
         get() = isFullPlayerOpen ||
             isDebugLogOpen ||
@@ -177,9 +186,17 @@ class FuoPlayerController(
             selectedMediaItem != null ||
             selectedPlaylist != null
 
-    private var queue: List<MusicTrack> = emptyList()
-    private var queueIndex: Int = -1
+    private var mainQueue: List<MusicTrack> = emptyList()
+    private var originalMainQueue: List<MusicTrack> = emptyList()
+    private var upNextQueue: List<MusicTrack> = emptyList()
+    private var mainQueueIndex: Int = -1
+    private var currentUpNextTrack: MusicTrack? = null
+    private var currentIsUpNext: Boolean = false
     private var queueFeature: ProviderFeature? = null
+    private var shuffleEnabled: Boolean = false
+    private var repeatEnabled: Boolean = true
+    private var isFmQueue: Boolean = false
+    private var shuffleBeforeFm: Boolean? = null
     private var appendQueueFeatureTask: Deferred<Int>? = null
     private var lastEndedTrackId: String? = null
     private var autoAdvanceEligibleTrackId: String? = null
@@ -189,6 +206,8 @@ class FuoPlayerController(
         scope.launch {
             val loadedSettings = runCatching { settingsStore.load() }
             loadedSettings.onSuccess { applySettings(it) }
+            runCatching { playbackQueueStore.load() }
+                .onSuccess { restorePlaybackQueue(it) }
             updateLocalMusicScanSettings()
             updateResourceCacheLimit()
             updateAudioQualityPolicies()
@@ -218,7 +237,7 @@ class FuoPlayerController(
         }
         scope.launch {
             playbackEngine.state.collect { engineState ->
-                val queueTrackId = queue.getOrNull(queueIndex)?.id
+                val queueTrackId = currentQueueTrack()?.id
                 when (engineState.status) {
                     PlayerStatus.Playing -> {
                         autoAdvanceEligibleTrackId = queueTrackId ?: engineState.currentTrack?.id
@@ -241,9 +260,9 @@ class FuoPlayerController(
                     }
                 }
                 playbackState = engineState.copy(
-                    queue = queue,
-                    queueIndex = queueIndex,
-                    currentTrack = queue.getOrNull(queueIndex) ?: engineState.currentTrack,
+                    queue = displayQueue(),
+                    queueIndex = displayQueueIndex(),
+                    currentTrack = currentQueueTrack() ?: engineState.currentTrack,
                 )
             }
         }
@@ -732,6 +751,21 @@ class FuoPlayerController(
         }
     }
 
+    private fun searchTrackText(text: String, providerId: String?) {
+        val keyword = text.trim()
+        if (keyword.isBlank()) {
+            message = "没有可搜索的信息"
+            return
+        }
+        query = keyword
+        if (providerId != null && providers.any { it.providerId == providerId }) {
+            searchScope = SearchScope.Provider
+            selectedSearchProviderId = providerId
+        }
+        isSearchOpen = true
+        search()
+    }
+
     fun refreshHomeContent(section: HomeSection = homeSection) {
         if (section == HomeSection.Mine) {
             refreshActiveMineSection()
@@ -1044,8 +1078,21 @@ class FuoPlayerController(
     }
 
     fun playQueueIndex(index: Int) {
-        val track = queue.getOrNull(index) ?: return
-        play(track, queue, index, queueFeature)
+        val pendingOffset = if (currentUpNextTrack != null) 1 else 0
+        val pendingEnd = pendingOffset + upNextQueue.size
+        when {
+            currentUpNextTrack != null && index == 0 -> currentUpNextTrack?.let {
+                startPlayback(it)
+            }
+            index in pendingOffset until pendingEnd -> {
+                val upNextIndex = index - pendingOffset
+                playUpNextIndex(upNextIndex)
+            }
+            else -> {
+                val mainIndex = index - pendingEnd
+                playMainIndex(mainIndex)
+            }
+        }
     }
 
     fun toggle() {
@@ -1059,28 +1106,52 @@ class FuoPlayerController(
     }
 
     fun next() {
-        if (queue.isEmpty()) return
+        if (currentIsUpNext) {
+            currentUpNextTrack = null
+            currentIsUpNext = false
+            persistPlaybackQueue()
+        }
+        if (upNextQueue.isNotEmpty()) {
+            playUpNextIndex(0)
+            return
+        }
+        if (mainQueue.isEmpty()) return
         val feature = queueFeature
-        if (feature != null && queueIndex >= queue.lastIndex) {
+        if (feature != null && mainQueueIndex >= mainQueue.lastIndex) {
             scope.launch {
-                val nextIndex = queue.size
+                val nextIndex = mainQueue.size
                 val appendedCount = appendFeatureQueue(feature)
                 if (appendedCount > 0 && queueFeature == feature) {
-                    playQueueIndex(nextIndex)
+                    playMainIndex(nextIndex)
                 } else if (queueFeature == feature) {
                     message = "${feature.title} 暂无后续歌曲"
                 }
             }
             return
         }
-        val nextIndex = (queueIndex + 1).floorMod(queue.size)
-        playQueueIndex(nextIndex)
+        val nextIndex = mainQueueIndex + 1
+        if (nextIndex < mainQueue.size) {
+            playMainIndex(nextIndex)
+        } else if (repeatEnabled) {
+            playMainIndex(0)
+        }
     }
 
     fun previous() {
-        if (queue.isEmpty()) return
-        val previousIndex = (queueIndex - 1).floorMod(queue.size)
-        playQueueIndex(previousIndex)
+        if (currentIsUpNext) {
+            currentUpNextTrack = null
+            currentIsUpNext = false
+            persistPlaybackQueue()
+            playMainIndex(mainQueueIndex.coerceAtLeast(0))
+            return
+        }
+        if (mainQueue.isEmpty()) return
+        val previousIndex = mainQueueIndex - 1
+        if (previousIndex >= 0) {
+            playMainIndex(previousIndex)
+        } else if (repeatEnabled) {
+            playMainIndex(mainQueue.lastIndex)
+        }
     }
 
     fun seekTo(positionMs: Long) {
@@ -1100,16 +1171,56 @@ class FuoPlayerController(
     }
 
     fun removeFromQueue(track: MusicTrack) {
-        val index = queue.indexOfFirst { it.id == track.id }
-        if (index < 0) return
-        queue = queue.filterIndexed { currentIndex, _ -> currentIndex != index }
-        queueIndex = when {
-            queue.isEmpty() -> -1
-            index < queueIndex -> queueIndex - 1
-            index == queueIndex -> queueIndex.coerceAtMost(queue.lastIndex)
-            else -> queueIndex
+        if (currentUpNextTrack?.id == track.id) {
+            currentUpNextTrack = null
+            currentIsUpNext = false
+            updatePlaybackQueueState()
+            persistPlaybackQueue()
+            return
         }
-        playbackState = playbackState.copy(queue = queue, queueIndex = queueIndex)
+        val upNextIndex = upNextQueue.indexOfFirst { it.id == track.id }
+        if (upNextIndex >= 0) {
+            upNextQueue = upNextQueue.filterIndexed { index, _ -> index != upNextIndex }
+            updatePlaybackQueueState()
+            persistPlaybackQueue()
+            return
+        }
+        val mainIndex = mainQueue.indexOfFirst { it.id == track.id }
+        if (mainIndex < 0) return
+        mainQueue = mainQueue.filterIndexed { index, _ -> index != mainIndex }
+        originalMainQueue = originalMainQueue.filterNot { it.id == track.id }
+        mainQueueIndex = when {
+            mainQueue.isEmpty() -> -1
+            mainIndex < mainQueueIndex -> mainQueueIndex - 1
+            mainIndex == mainQueueIndex -> mainQueueIndex.coerceAtMost(mainQueue.lastIndex)
+            else -> mainQueueIndex
+        }
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
+    }
+
+    fun addToUpNext(track: MusicTrack) {
+        upNextQueue = upNextQueue + track
+        message = "已加入接下来播放：${track.title}"
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
+    }
+
+    fun toggleShuffle() {
+        if (isFmQueue) return
+        if (shuffleEnabled) {
+            disableShuffle()
+        } else {
+            enableShuffle()
+        }
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
+    }
+
+    fun toggleRepeat() {
+        repeatEnabled = !repeatEnabled
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
     }
 
     fun download(track: MusicTrack) {
@@ -1133,6 +1244,46 @@ class FuoPlayerController(
                 }
                 .onFailure { setError(it) }
         }
+    }
+
+    fun openTrackArtist(track: MusicTrack) {
+        val artistName = track.artists.substringBefore("·").substringBefore(",").trim()
+        val providerId = track.source.takeIf { it.isNotBlank() }
+        val providerName = track.providerName ?: providerId.orEmpty()
+        val itemId = track.artistItemId
+        if (!itemId.isNullOrBlank() && providerId != null && artistName.isNotBlank()) {
+            openMediaItem(
+                ProviderMediaItem(
+                    id = itemId,
+                    title = artistName,
+                    providerId = providerId,
+                    providerName = providerName,
+                    type = ProviderMediaItemType.Artist,
+                )
+            )
+            return
+        }
+        searchTrackText(artistName.ifBlank { track.artists }, providerId)
+    }
+
+    fun openTrackAlbum(track: MusicTrack) {
+        val albumName = track.album.trim()
+        val providerId = track.source.takeIf { it.isNotBlank() }
+        val providerName = track.providerName ?: providerId.orEmpty()
+        val itemId = track.albumItemId
+        if (!itemId.isNullOrBlank() && providerId != null && albumName.isNotBlank()) {
+            openMediaItem(
+                ProviderMediaItem(
+                    id = itemId,
+                    title = albumName,
+                    providerId = providerId,
+                    providerName = providerName,
+                    type = ProviderMediaItemType.Album,
+                )
+            )
+            return
+        }
+        searchTrackText(albumName, providerId)
     }
 
     private suspend fun refreshProviderCatalog() {
@@ -1226,21 +1377,28 @@ class FuoPlayerController(
         sourceFeature: ProviderFeature? = null,
         skippedUnavailableCount: Int = 0,
     ) {
+        if (skippedUnavailableCount == 0) {
+            replaceMainQueue(sourceQueue, index, sourceFeature)
+        }
+        playMainIndex(index, skippedUnavailableCount)
+    }
+
+    private fun startPlayback(
+        track: MusicTrack,
+        skippedUnavailableCount: Int = 0,
+    ) {
         val requestSerial = ++playRequestSerial
         val playbackTrack = track.preferDownloaded()
-        queue = sourceQueue.mapIndexed { itemIndex, item ->
-            if (itemIndex == index) playbackTrack else item
-        }
-        queueIndex = index
-        queueFeature = sourceFeature
+        updateCurrentTrack(playbackTrack)
         playbackState = playbackState.copy(
             status = PlayerStatus.Loading,
             currentTrack = playbackTrack,
-            queue = queue,
-            queueIndex = queueIndex,
+            queue = displayQueue(),
+            queueIndex = displayQueueIndex(),
             positionMs = 0,
             errorMessage = null,
         )
+        persistPlaybackQueue()
         playbackEngine.prepareLoading(playbackTrack)
         scope.launch playRequest@{
             isLoading = true
@@ -1267,25 +1425,22 @@ class FuoPlayerController(
                     originalProviderName = payload.originalProviderName,
                     isUnavailable = false,
                 )
-                queue = sourceQueue.mapIndexed { itemIndex, item ->
-                    if (itemIndex == index) playableTrack else item
-                }
-                queueIndex = index
-                queueFeature = sourceFeature
+                updateCurrentTrack(playableTrack)
                 playbackEngine.play(playableTrack, payload)
                 playbackState = playbackState.copy(
                     status = PlayerStatus.Loading,
                     currentTrack = playableTrack,
-                    queue = queue,
-                    queueIndex = queueIndex,
+                    queue = displayQueue(),
+                    queueIndex = displayQueueIndex(),
                     lyrics = payload.lyrics,
                     audioQuality = payload.audioQuality,
                 )
+                persistPlaybackQueue()
                 message = "${playableTrack.title} - ${playableTrack.artists}"
                 prefetchFeatureQueueIfNeeded()
             }.onFailure {
                 if (requestSerial != playRequestSerial) return@playRequest
-                if (!skipUnavailableTrack(track, sourceQueue, index, sourceFeature, skippedUnavailableCount, it)) {
+                if (!skipUnavailableTrack(track, skippedUnavailableCount, it)) {
                     setError(it)
                 }
             }
@@ -1298,6 +1453,49 @@ class FuoPlayerController(
     private fun playFirst(sourceQueue: List<MusicTrack>, sourceFeature: ProviderFeature? = null) {
         val track = sourceQueue.firstOrNull() ?: return
         play(track, sourceQueue, 0, sourceFeature)
+    }
+
+    private fun replaceMainQueue(sourceQueue: List<MusicTrack>, index: Int, sourceFeature: ProviderFeature?) {
+        val normalizedIndex = index.coerceIn(0, sourceQueue.lastIndex)
+        val enteringFm = sourceFeature?.isDynamicQueueFeature() == true
+        val restoreShuffle = if (isFmQueue && !enteringFm) shuffleBeforeFm else null
+        if (enteringFm && !isFmQueue) {
+            shuffleBeforeFm = shuffleEnabled
+            shuffleEnabled = false
+        } else if (!enteringFm && restoreShuffle != null) {
+            shuffleEnabled = restoreShuffle
+            shuffleBeforeFm = null
+        }
+        isFmQueue = enteringFm
+        queueFeature = sourceFeature
+        currentUpNextTrack = null
+        currentIsUpNext = false
+        originalMainQueue = emptyList()
+        mainQueue = sourceQueue
+        mainQueueIndex = normalizedIndex
+        if (shuffleEnabled && !enteringFm) {
+            enableShuffle()
+        }
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
+    }
+
+    private fun playMainIndex(index: Int, skippedUnavailableCount: Int = 0) {
+        val track = mainQueue.getOrNull(index) ?: return
+        currentUpNextTrack = null
+        currentIsUpNext = false
+        mainQueueIndex = index
+        startPlayback(track, skippedUnavailableCount)
+    }
+
+    private fun playUpNextIndex(index: Int) {
+        val track = upNextQueue.getOrNull(index) ?: return
+        upNextQueue = upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
+        currentUpNextTrack = track
+        currentIsUpNext = true
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
+        startPlayback(track)
     }
 
     private fun loadFeatureAndPlayAll(feature: ProviderFeature) {
@@ -1340,8 +1538,9 @@ class FuoPlayerController(
 
     private fun prefetchFeatureQueueIfNeeded() {
         val feature = queueFeature ?: return
-        if (queueIndex < 0) return
-        val remaining = queue.size - queueIndex
+        if (currentIsUpNext || upNextQueue.isNotEmpty()) return
+        if (mainQueueIndex < 0) return
+        val remaining = mainQueue.size - mainQueueIndex
         if (remaining <= DYNAMIC_QUEUE_PREFETCH_REMAINING) {
             scope.launch {
                 appendFeatureQueue(feature)
@@ -1370,11 +1569,12 @@ class FuoPlayerController(
                 providerRepository.loadMoreFeatureTracks(feature)
             }
             if (queueFeature != feature) return 0
-            val seenQueueIds = queue.mapTo(mutableSetOf()) { it.id }
+            val seenQueueIds = mainQueue.mapTo(mutableSetOf()) { it.id }
             val newTracks = tracks.filter { seenQueueIds.add(it.id) }
             if (newTracks.isNotEmpty()) {
-                queue = queue + newTracks
-                playbackState = playbackState.copy(queue = queue, queueIndex = queueIndex)
+                mainQueue = mainQueue + newTracks
+                updatePlaybackQueueState()
+                persistPlaybackQueue()
                 if (selectedFeature == feature) {
                     val seenSelectedIds = selectedFeatureTracks.mapTo(mutableSetOf()) { it.id }
                     val newSelectedTracks = newTracks.filter { seenSelectedIds.add(it.id) }
@@ -1421,6 +1621,103 @@ class FuoPlayerController(
             originalTitle = originalTitle,
             originalProviderName = originalProviderName,
         )
+    }
+
+    private fun currentQueueTrack(): MusicTrack? {
+        return if (currentIsUpNext) currentUpNextTrack else mainQueue.getOrNull(mainQueueIndex)
+    }
+
+    private fun displayQueue(): List<MusicTrack> {
+        return buildList {
+            currentUpNextTrack?.let { add(it) }
+            addAll(upNextQueue)
+            addAll(mainQueue)
+        }
+    }
+
+    private fun displayQueueIndex(): Int {
+        return when {
+            currentIsUpNext && currentUpNextTrack != null -> 0
+            mainQueueIndex >= 0 -> (if (currentUpNextTrack != null) 1 else 0) + upNextQueue.size + mainQueueIndex
+            else -> -1
+        }
+    }
+
+    private fun updateCurrentTrack(track: MusicTrack) {
+        if (currentIsUpNext) {
+            currentUpNextTrack = track
+        } else if (mainQueueIndex in mainQueue.indices) {
+            mainQueue = mainQueue.mapIndexed { index, item -> if (index == mainQueueIndex) track else item }
+            originalMainQueue = originalMainQueue.map { item -> if (item.id == track.id) track else item }
+        }
+    }
+
+    private fun updatePlaybackQueueState() {
+        playbackState = playbackState.copy(
+            queue = displayQueue(),
+            queueIndex = displayQueueIndex(),
+            currentTrack = currentQueueTrack() ?: playbackState.currentTrack,
+        )
+    }
+
+    private fun restorePlaybackQueue(snapshot: PlaybackQueueSnapshot) {
+        mainQueue = snapshot.mainQueue
+        originalMainQueue = snapshot.originalMainQueue
+        upNextQueue = snapshot.upNextQueue
+        mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex)
+        shuffleEnabled = snapshot.shuffleEnabled
+        repeatEnabled = snapshot.repeatEnabled
+        isFmQueue = snapshot.isFmQueue
+        shuffleBeforeFm = snapshot.shuffleBeforeFm
+        currentUpNextTrack = null
+        currentIsUpNext = false
+        playbackState = playbackState.copy(
+            currentTrack = mainQueue.getOrNull(mainQueueIndex),
+            queue = displayQueue(),
+            queueIndex = displayQueueIndex(),
+        )
+    }
+
+    private fun persistPlaybackQueue() {
+        val snapshot = PlaybackQueueSnapshot(
+            mainQueue = mainQueue,
+            originalMainQueue = originalMainQueue,
+            upNextQueue = upNextQueue,
+            queueIndex = mainQueueIndex,
+            shuffleEnabled = shuffleEnabled,
+            repeatEnabled = repeatEnabled,
+            isFmQueue = isFmQueue,
+            shuffleBeforeFm = shuffleBeforeFm,
+        )
+        scope.launch {
+            playbackQueueStore.save(snapshot)
+        }
+    }
+
+    private fun enableShuffle() {
+        if (isFmQueue || mainQueue.size <= 1) {
+            shuffleEnabled = !isFmQueue
+            return
+        }
+        val current = currentQueueTrack()
+        originalMainQueue = if (originalMainQueue.isEmpty()) mainQueue else originalMainQueue
+        val currentInMain = current?.let { track -> mainQueue.firstOrNull { it.id == track.id } }
+        val shuffledRest = mainQueue.filterNot { it.id == currentInMain?.id }.shuffled()
+        mainQueue = listOfNotNull(currentInMain) + shuffledRest
+        mainQueueIndex = currentInMain?.let { 0 } ?: mainQueueIndex.coerceIn(0, mainQueue.lastIndex)
+        shuffleEnabled = true
+    }
+
+    private fun disableShuffle() {
+        val current = currentQueueTrack()
+        if (originalMainQueue.isNotEmpty()) {
+            mainQueue = originalMainQueue
+            mainQueueIndex = current?.let { track -> mainQueue.indexOfFirst { it.id == track.id } }
+                ?.takeIf { it >= 0 }
+                ?: mainQueueIndex.coerceIn(-1, mainQueue.lastIndex)
+        }
+        originalMainQueue = emptyList()
+        shuffleEnabled = false
     }
 
     private fun mergeResults(local: List<MusicTrack>, provider: List<MusicTrack>): List<MusicTrack> {
@@ -1570,36 +1867,36 @@ class FuoPlayerController(
 
     private fun skipUnavailableTrack(
         track: MusicTrack,
-        sourceQueue: List<MusicTrack>,
-        index: Int,
-        sourceFeature: ProviderFeature?,
         skippedUnavailableCount: Int,
         throwable: Throwable,
     ): Boolean {
         if (!shouldSkipUnavailable(throwable)) {
             return false
         }
-        val skippedQueue = sourceQueue.mapIndexed { itemIndex, item ->
-            if (itemIndex == index) item.copy(isUnavailable = true) else item
-        }
-        queue = skippedQueue
+        updateCurrentTrack(track.copy(isUnavailable = true))
         playbackState = playbackState.copy(
-            queue = queue,
-            queueIndex = index,
-            currentTrack = queue.getOrNull(index),
+            queue = displayQueue(),
+            queueIndex = displayQueueIndex(),
+            currentTrack = currentQueueTrack(),
         )
-        if (skippedQueue.size <= 1 || skippedUnavailableCount >= skippedQueue.lastIndex) {
+        persistPlaybackQueue()
+        val playableCount = upNextQueue.size + mainQueue.size
+        if (playableCount <= 1 || skippedUnavailableCount >= playableCount) {
             return false
         }
-        val nextIndex = (index + 1).floorMod(skippedQueue.size)
         message = "已跳过不可用资源：${track.title}"
-        play(
-            track = skippedQueue[nextIndex],
-            sourceQueue = skippedQueue,
-            index = nextIndex,
-            sourceFeature = sourceFeature,
-            skippedUnavailableCount = skippedUnavailableCount + 1,
-        )
+        if (upNextQueue.isNotEmpty()) {
+            playUpNextIndex(0)
+        } else {
+            val nextIndex = mainQueueIndex + 1
+            if (nextIndex < mainQueue.size) {
+                playMainIndex(nextIndex, skippedUnavailableCount + 1)
+            } else if (repeatEnabled) {
+                playMainIndex(0, skippedUnavailableCount + 1)
+            } else {
+                return false
+            }
+        }
         return true
     }
 
@@ -1620,8 +1917,6 @@ class FuoPlayerController(
         return text.contains("media not found", ignoreCase = true) ||
             text.contains("MediaNotFound", ignoreCase = true)
     }
-
-    private fun Int.floorMod(size: Int): Int = ((this % size) + size) % size
 
     private fun Int.mbToBytes(): Long = this.toLong() * 1024L * 1024L
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -163,6 +163,10 @@ class FuoPlayerController(
         private set
     var smartReplacementMinScore by mutableStateOf(DEFAULT_SMART_REPLACEMENT_MIN_SCORE)
         private set
+    var smartReplacementUseOriginalMetadata by mutableStateOf(false)
+        private set
+    var smartReplacementUseOriginalLyrics by mutableStateOf(false)
+        private set
     var debugLogLines by mutableStateOf<List<String>>(emptyList())
         private set
     var debugLogError by mutableStateOf<String?>(null)
@@ -650,6 +654,16 @@ class FuoPlayerController(
 
     fun onSmartReplacementMinScoreChange(value: Double) {
         smartReplacementMinScore = value.coerceIn(0.0, 1.0)
+        persistSettings()
+    }
+
+    fun onSmartReplacementUseOriginalMetadataChange(value: Boolean) {
+        smartReplacementUseOriginalMetadata = value
+        persistSettings()
+    }
+
+    fun onSmartReplacementUseOriginalLyricsChange(value: Boolean) {
+        smartReplacementUseOriginalLyrics = value
         persistSettings()
     }
 
@@ -1410,6 +1424,8 @@ class FuoPlayerController(
                         unavailablePlaybackPolicy,
                         selectedSmartReplacementProviderIds(),
                         smartReplacementMinScore,
+                        smartReplacementUseOriginalMetadata,
+                        smartReplacementUseOriginalLyrics,
                     )
                 if (requestSerial != playRequestSerial) return@playRequest
                 val playableTrack = playbackTrack.copy(
@@ -1784,6 +1800,8 @@ class FuoPlayerController(
         unavailablePlaybackPolicy = settings.unavailablePlaybackPolicy
         smartReplacementProviderIds = settings.smartReplacementProviderIds
         smartReplacementMinScore = settings.smartReplacementMinScore.coerceIn(0.0, 1.0)
+        smartReplacementUseOriginalMetadata = settings.smartReplacementUseOriginalMetadata
+        smartReplacementUseOriginalLyrics = settings.smartReplacementUseOriginalLyrics
     }
 
     private fun persistSettings() {
@@ -1809,6 +1827,8 @@ class FuoPlayerController(
             unavailablePlaybackPolicy = unavailablePlaybackPolicy,
             smartReplacementProviderIds = smartReplacementProviderIds,
             smartReplacementMinScore = smartReplacementMinScore,
+            smartReplacementUseOriginalMetadata = smartReplacementUseOriginalMetadata,
+            smartReplacementUseOriginalLyrics = smartReplacementUseOriginalLyrics,
         )
         scope.launch {
             settingsStore.save(settings)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1254,6 +1254,216 @@ class FuoPlayerControllerTest {
         }
     }
 
+    @Test
+    fun restoresPersistedQueueWithoutAutoPlay() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val upNext = providerTrack("provider:3", "Third")
+        val queueStore = FakePlaybackQueueStore(
+            PlaybackQueueSnapshot(
+                mainQueue = tracks,
+                upNextQueue = listOf(upNext),
+                queueIndex = 1,
+                shuffleEnabled = true,
+                repeatEnabled = false,
+            ),
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                playbackQueueStore = queueStore,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertEquals("provider:2", controller.playbackState.currentTrack?.id)
+            assertEquals(listOf("provider:3", "provider:1", "provider:2"), controller.playbackState.queue.map { it.id })
+            assertEquals(2, controller.playbackState.queueIndex)
+            assertEquals(true, controller.isShuffleEnabled)
+            assertEquals(false, controller.isRepeatEnabled)
+            assertEquals(null, engine.lastTrack)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun disablingShuffleRestoresOriginalMainQueue() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+            providerTrack("provider:3", "Third"),
+            providerTrack("provider:4", "Fourth"),
+        )
+        val queueStore = FakePlaybackQueueStore()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(tracks),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                playbackQueueStore = queueStore,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.toggleShuffle()
+            advanceUntilIdle()
+
+            assertEquals(true, controller.isShuffleEnabled)
+            assertEquals(tracks.map { it.id }, queueStore.saved.originalMainQueue.map { it.id })
+
+            controller.toggleShuffle()
+            advanceUntilIdle()
+
+            assertEquals(false, controller.isShuffleEnabled)
+            assertEquals(tracks.map { it.id }, controller.playbackState.queue.map { it.id })
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun upNextQueuePlaysBeforeMainQueueAndThenReturns() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val upNext = providerTrack("provider:3", "Third")
+        val provider = FakeProviderRepository(tracks + upNext)
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.addToUpNext(upNext)
+            controller.next()
+            advanceUntilIdle()
+
+            assertEquals("provider:3", engine.lastTrack?.id)
+
+            controller.next()
+            advanceUntilIdle()
+
+            assertEquals("provider:2", engine.lastTrack?.id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun repeatDisabledStopsAtMainQueueEnd() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(tracks),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.toggleRepeat()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.next()
+            advanceUntilIdle()
+            controller.next()
+            advanceUntilIdle()
+
+            assertEquals(false, controller.isRepeatEnabled)
+            assertEquals("provider:2", engine.lastTrack?.id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun privateFmTemporarilyDisablesShuffleAndRestoresAfterExit() = runTest {
+        val radioFeature = ProviderFeature(
+            id = "netease_radio",
+            providerId = "netease",
+            providerName = "网易云音乐",
+            title = "私人 FM",
+            category = ProviderFeatureCategory.Recommend,
+            contentType = ProviderContentType.Songs,
+            requiresLogin = true,
+        )
+        val normalTracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val radioTracks = listOf(
+            providerTrack("provider:3", "Radio One"),
+            providerTrack("provider:4", "Radio Two"),
+        )
+        val provider = FakeProviderRepository(
+            tracks = normalTracks,
+            features = listOf(radioFeature),
+            featureSections = mapOf(radioFeature.id to ProviderContentSection(radioFeature, tracks = radioTracks)),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(normalTracks)
+            advanceUntilIdle()
+            controller.toggleShuffle()
+            advanceUntilIdle()
+            assertEquals(true, controller.isShuffleEnabled)
+
+            controller.openFeature(radioFeature)
+            advanceUntilIdle()
+            controller.playAllFromSelectedFeature()
+            advanceUntilIdle()
+
+            assertEquals(true, controller.isFmQueueActive)
+            assertEquals(false, controller.isShuffleEnabled)
+            assertEquals(radioTracks.map { it.id }, controller.playbackState.queue.map { it.id })
+
+            controller.playAllLocalTracks(normalTracks)
+            advanceUntilIdle()
+
+            assertEquals(false, controller.isFmQueueActive)
+            assertEquals(true, controller.isShuffleEnabled)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
     private fun providerTrack(id: String, title: String): MusicTrack = MusicTrack(
         id = id,
         title = title,
@@ -1493,6 +1703,17 @@ class FuoPlayerControllerTest {
 
         override suspend fun save(settings: AppSettings) {
             saved = settings
+        }
+    }
+
+    private class FakePlaybackQueueStore(initial: PlaybackQueueSnapshot = PlaybackQueueSnapshot()) : PlaybackQueueStore {
+        var saved = initial
+            private set
+
+        override suspend fun load(): PlaybackQueueSnapshot = saved
+
+        override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+            saved = snapshot
         }
     }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -50,7 +50,7 @@ class FuoPlayerControllerTest {
         val origin = providerTrack("provider:1", "First")
         val provider = FakeProviderRepository(
             listOf(origin),
-            resolveHandler = { track, _, _, _ ->
+            resolveHandler = { track, _, _, _, _, _ ->
                 PlaybackPayload(
                     url = "https://example.com/replacement.mp3",
                     title = "Replacement",
@@ -156,6 +156,40 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun smartReplacementUsesOriginalSourceOptions() = runTest {
+        val provider = FakeProviderRepository(listOf(providerTrack("provider:1", "First")))
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                settingsStore = FakeSettingsStore(
+                    AppSettings(
+                        smartReplacementUseOriginalMetadata = true,
+                        smartReplacementUseOriginalLyrics = true,
+                    ),
+                ),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onQueryChange("first")
+            controller.onSearchScopeChange(SearchScope.Provider)
+            advanceUntilIdle()
+            controller.playFromSearch(0)
+            advanceUntilIdle()
+
+            assertEquals(true, provider.lastSmartReplacementUseOriginalMetadata)
+            assertEquals(true, provider.lastSmartReplacementUseOriginalLyrics)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun nextUsesKotlinQueueOrder() = runTest {
         val tracks = listOf(
             providerTrack("provider:1", "First"),
@@ -201,7 +235,7 @@ class FuoPlayerControllerTest {
         }
         val provider = FakeProviderRepository(
             tracks = tracks,
-            resolveHandler = { track, _, _, _ -> payloads.getValue(track.id).await() },
+            resolveHandler = { track, _, _, _, _, _ -> payloads.getValue(track.id).await() },
         )
         val engine = FakePlaybackEngine()
         val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -254,7 +288,7 @@ class FuoPlayerControllerTest {
         }
         val provider = FakeProviderRepository(
             tracks = tracks,
-            resolveHandler = { track, _, _, _ -> payloads.getValue(track.id).await() },
+            resolveHandler = { track, _, _, _, _, _ -> payloads.getValue(track.id).await() },
         )
         val engine = FakePlaybackEngine()
         val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -987,6 +1021,8 @@ class FuoPlayerControllerTest {
                 wifiAudioQualityPolicy = AudioQualityPolicy.Highest,
                 cellularAudioQualityPolicy = AudioQualityPolicy.Low,
                 unavailablePlaybackPolicy = UnavailablePlaybackPolicy.Skip,
+                smartReplacementUseOriginalMetadata = true,
+                smartReplacementUseOriginalLyrics = true,
             ),
         )
         val provider = FakeProviderRepository(emptyList())
@@ -1029,6 +1065,8 @@ class FuoPlayerControllerTest {
             assertEquals(AudioQualityPolicy.Highest, controller.wifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Low, controller.cellularAudioQualityPolicy)
             assertEquals(UnavailablePlaybackPolicy.Skip, controller.unavailablePlaybackPolicy)
+            assertEquals(true, controller.smartReplacementUseOriginalMetadata)
+            assertEquals(true, controller.smartReplacementUseOriginalLyrics)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Low, provider.lastCellularAudioQualityPolicy)
 
@@ -1045,6 +1083,8 @@ class FuoPlayerControllerTest {
             controller.onWifiAudioQualityPolicyChange(AudioQualityPolicy.High)
             controller.onCellularAudioQualityPolicyChange(AudioQualityPolicy.Standard)
             controller.onUnavailablePlaybackPolicyChange(UnavailablePlaybackPolicy.SmartReplace)
+            controller.onSmartReplacementUseOriginalMetadataChange(false)
+            controller.onSmartReplacementUseOriginalLyricsChange(false)
             advanceUntilIdle()
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
@@ -1066,6 +1106,8 @@ class FuoPlayerControllerTest {
             assertEquals(AudioQualityPolicy.High, store.saved.wifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Standard, store.saved.cellularAudioQualityPolicy)
             assertEquals(UnavailablePlaybackPolicy.SmartReplace, store.saved.unavailablePlaybackPolicy)
+            assertEquals(false, store.saved.smartReplacementUseOriginalMetadata)
+            assertEquals(false, store.saved.smartReplacementUseOriginalLyrics)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Standard, provider.lastCellularAudioQualityPolicy)
         } finally {
@@ -1492,7 +1534,7 @@ class FuoPlayerControllerTest {
         private val additionalFeatureTracks: Map<String, List<MusicTrack>> = emptyMap(),
         private val resolveFailures: Set<String> = emptySet(),
         private val resolveHandler: (
-            suspend (MusicTrack, UnavailablePlaybackPolicy, Set<String>, Double) -> PlaybackPayload
+            suspend (MusicTrack, UnavailablePlaybackPolicy, Set<String>, Double, Boolean, Boolean) -> PlaybackPayload
         )? = null,
         private val availableProviderInfos: List<ProviderInfo> = listOf(
             ProviderInfo(providerId = "netease", providerName = "网易云音乐"),
@@ -1519,6 +1561,8 @@ class FuoPlayerControllerTest {
         var lastCellularAudioQualityPolicy: AudioQualityPolicy? = null
         var lastSmartReplacementProviderIds: Set<String>? = null
         var lastSmartReplacementMinScore: Double? = null
+        var lastSmartReplacementUseOriginalMetadata: Boolean? = null
+        var lastSmartReplacementUseOriginalLyrics: Boolean? = null
         val loadedFeatureIds = mutableListOf<String>()
         val loadedMoreFeatureIds = mutableListOf<String>()
         val loadedMediaItemIds = mutableListOf<String>()
@@ -1542,10 +1586,14 @@ class FuoPlayerControllerTest {
             unavailablePolicy: UnavailablePlaybackPolicy,
             smartReplacementProviderIds: Set<String>,
             smartReplacementMinScore: Double,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
         ): PlaybackPayload {
             resolveCount += 1
             lastSmartReplacementProviderIds = smartReplacementProviderIds
             lastSmartReplacementMinScore = smartReplacementMinScore
+            lastSmartReplacementUseOriginalMetadata = smartReplacementUseOriginalMetadata
+            lastSmartReplacementUseOriginalLyrics = smartReplacementUseOriginalLyrics
             if (track.id in resolveFailures) {
                 throw RuntimeException("media not found: ${track.id}")
             }
@@ -1554,6 +1602,8 @@ class FuoPlayerControllerTest {
                 unavailablePolicy,
                 smartReplacementProviderIds,
                 smartReplacementMinScore,
+                smartReplacementUseOriginalMetadata,
+                smartReplacementUseOriginalLyrics,
             ) ?: PlaybackPayload(
                 url = "https://example.com/${track.id}.mp3",
                 title = track.title,

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -31,6 +31,7 @@ private class IosAppContainer {
     private val downloadRepository = IosDownloadRepository(providerRepository)
     private val playbackEngine = IosNativeAudioEngine(scope)
     private val settingsStore = IosAppSettingsStore()
+    private val playbackQueueStore = IosPlaybackQueueStore()
     private val resourceCacheRepository = IosResourceCacheRepository()
 
     val controller = FuoPlayerController(
@@ -39,6 +40,7 @@ private class IosAppContainer {
         downloadRepository = downloadRepository,
         playbackEngine = playbackEngine,
         settingsStore = settingsStore,
+        playbackQueueStore = playbackQueueStore,
         resourceCacheRepository = resourceCacheRepository,
         scope = scope,
     )

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -34,6 +34,8 @@ class IosAppSettingsStore : AppSettingsStore {
                 KEY_SMART_REPLACEMENT_MIN_SCORE,
                 DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
             ),
+            smartReplacementUseOriginalMetadata = boolValue(KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA, false),
+            smartReplacementUseOriginalLyrics = boolValue(KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS, false),
         )
     }
 
@@ -58,6 +60,8 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setObject(settings.cellularAudioQualityPolicy.name, KEY_CELLULAR_AUDIO_QUALITY_POLICY)
             defaults.setObject(settings.unavailablePlaybackPolicy.name, KEY_UNAVAILABLE_PLAYBACK_POLICY)
             defaults.setDouble(settings.smartReplacementMinScore, KEY_SMART_REPLACEMENT_MIN_SCORE)
+            defaults.setBool(settings.smartReplacementUseOriginalMetadata, KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA)
+            defaults.setBool(settings.smartReplacementUseOriginalLyrics, KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS)
             defaults.synchronize()
         }
     }
@@ -76,6 +80,11 @@ class IosAppSettingsStore : AppSettingsStore {
     private fun doubleValue(key: String, fallback: Double): Double {
         if (defaults.objectForKey(key) == null) return fallback
         return defaults.doubleForKey(key)
+    }
+
+    private fun boolValue(key: String, fallback: Boolean): Boolean {
+        if (defaults.objectForKey(key) == null) return fallback
+        return defaults.boolForKey(key)
     }
 
     private fun readStringSet(key: String): Set<String> = readStringList(key).toSet()
@@ -157,5 +166,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_CELLULAR_AUDIO_QUALITY_POLICY = "cellular_audio_quality_policy"
         private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"
         private const val KEY_SMART_REPLACEMENT_MIN_SCORE = "smart_replacement_min_score"
+        private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA = "smart_replacement_use_original_metadata"
+        private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS = "smart_replacement_use_original_lyrics"
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
@@ -32,6 +32,8 @@ class IosFuoCoreBridge : ProviderMusicRepository {
         unavailablePolicy: UnavailablePlaybackPolicy,
         smartReplacementProviderIds: Set<String>,
         smartReplacementMinScore: Double,
+        smartReplacementUseOriginalMetadata: Boolean,
+        smartReplacementUseOriginalLyrics: Boolean,
     ): PlaybackPayload = withContext(Dispatchers.Default) {
         pythonUnavailable()
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
@@ -1,0 +1,27 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSUserDefaults
+
+class IosPlaybackQueueStore : PlaybackQueueStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.Default) {
+        defaults.stringForKey(KEY_QUEUE_SNAPSHOT)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
+            ?: PlaybackQueueSnapshot()
+    }
+
+    override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+        withContext(Dispatchers.Default) {
+            defaults.setObject(PlaybackQueueCodec.encode(snapshot), KEY_QUEUE_SNAPSHOT)
+            defaults.synchronize()
+        }
+    }
+
+    private companion object {
+        private const val KEY_QUEUE_SNAPSHOT = "playback_queue_snapshot"
+    }
+}


### PR DESCRIPTION
## Summary
- Implement persistent playback queue snapshots for Android and iOS.
- Add up-next queue, shuffle with original queue restore, repeat toggle, and private FM shuffle override.
- Update player UI controls and track overflow menu actions for up next, downloads, artist, and album.
- Add smart replacement options to use original-track metadata and lyrics, both disabled by default.

## Validation
- ./gradlew :shared:allTests
- ./gradlew :androidApp:assembleDebug
- git diff --check
