### PR TITLE
[feat] Add Material 3 Expressive theme options

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -64,6 +64,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    lint {
+        disable.add("NullSafeMutableLiveData")
+    }
+
     signingConfigs {
         create("fuo") {
             if (hasFuoSigningConfig) {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -54,8 +54,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 false,
             ),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
-            materialStyle = enumValue(KEY_MATERIAL_STYLE, MaterialStyle.MaterialYou),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
+            themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
     }
 
@@ -89,8 +89,8 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 )
                 .putBoolean(KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS, settings.smartReplacementUseOriginalLyrics)
                 .putString(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
-                .putString(KEY_MATERIAL_STYLE, settings.materialStyle.name)
                 .putString(KEY_THEME_MODE, settings.themeMode.name)
+                .putString(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)
                 .apply()
         }
     }
@@ -225,7 +225,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA = "smart_replacement_use_original_metadata"
         private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS = "smart_replacement_use_original_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
-        private const val KEY_MATERIAL_STYLE = "material_style"
         private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
@@ -3,9 +3,11 @@ package org.feeluown.mobile
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.Gravity
@@ -47,13 +49,14 @@ class ProviderWebLoginActivity : Activity() {
         cookieManager().setAcceptCookie(true)
         val userAgent = loginUserAgent()
         val useMobileViewport = providerId == "bilibili"
+        val colors = webLoginColors()
 
         statusView = TextView(this).apply {
             text = "完成登录后会自动获取 Cookie"
             textSize = 13f
-            setTextColor(Color.parseColor("#5F6F66"))
+            setTextColor(colors.onSurfaceVariant)
             setPadding(dp(20), dp(10), dp(20), dp(10))
-            setBackgroundColor(Color.parseColor("#F3F7F4"))
+            setBackgroundColor(colors.surfaceVariant)
         }
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
@@ -78,42 +81,42 @@ class ProviderWebLoginActivity : Activity() {
             text = "$providerName 浏览器登录"
             textSize = 18f
             typeface = Typeface.DEFAULT_BOLD
-            setTextColor(Color.parseColor("#18211B"))
+            setTextColor(colors.onSurface)
             gravity = Gravity.CENTER_VERTICAL
             ellipsize = TextUtils.TruncateAt.END
             maxLines = 1
             setPadding(0, 0, dp(12), 0)
             layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
         }
-        val closeButton = toolbarButton(text = "关闭", filled = false) {
+        val closeButton = toolbarButton(text = "关闭", filled = false, colors = colors) {
             setResult(RESULT_CANCELED)
             finish()
         }
-        val doneButton = toolbarButton(text = "完成", filled = true) {
+        val doneButton = toolbarButton(text = "完成", filled = true, colors = colors) {
             finishWithCookies(webView.url, auto = false)
         }
         val toolbarDivider = View(this).apply {
-            setBackgroundColor(Color.parseColor("#E3E8E4"))
+            setBackgroundColor(colors.outline)
         }
         val toolbarContent = LinearLayout(this).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
             setPadding(dp(20), dp(8), dp(16), dp(8))
             minimumHeight = dp(56)
-            setBackgroundColor(Color.WHITE)
+            setBackgroundColor(colors.surface)
             addView(titleView)
             addView(closeButton)
             addView(doneButton)
         }
         val toolbar = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
+            setBackgroundColor(colors.surface)
             addView(toolbarContent, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
             addView(toolbarDivider, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1)))
         }
         val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(Color.WHITE)
+            setBackgroundColor(colors.background)
             addView(toolbar, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
             addView(statusView, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
             addView(webView, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
@@ -132,7 +135,12 @@ class ProviderWebLoginActivity : Activity() {
         return if (providerId == "bilibili") MOBILE_USER_AGENT else DESKTOP_USER_AGENT
     }
 
-    private fun toolbarButton(text: String, filled: Boolean, onClick: () -> Unit): TextView {
+    private fun toolbarButton(
+        text: String,
+        filled: Boolean,
+        colors: WebLoginColors,
+        onClick: () -> Unit,
+    ): TextView {
         return TextView(this).apply {
             this.text = text
             textSize = 14f
@@ -143,10 +151,10 @@ class ProviderWebLoginActivity : Activity() {
             minWidth = dp(64)
             minHeight = dp(40)
             setPadding(dp(14), 0, dp(14), 0)
-            setTextColor(if (filled) Color.WHITE else Color.parseColor("#516157"))
+            setTextColor(if (filled) colors.onPrimary else colors.onSurfaceVariant)
             background = roundedBackground(
-                color = if (filled) Color.parseColor("#1DB954") else Color.TRANSPARENT,
-                strokeColor = if (filled) Color.TRANSPARENT else Color.parseColor("#D6DED8"),
+                color = if (filled) colors.primary else Color.TRANSPARENT,
+                strokeColor = if (filled) Color.TRANSPARENT else colors.outline,
             )
             layoutParams = LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
@@ -156,6 +164,82 @@ class ProviderWebLoginActivity : Activity() {
             }
             setOnClickListener { onClick() }
         }
+    }
+
+    private fun webLoginColors(): WebLoginColors {
+        val preferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val themeMode = enumValue(
+            preferences.getString(KEY_THEME_MODE, null),
+            ThemeMode.System,
+        )
+        val scheme = enumValue(
+            preferences.getString(KEY_THEME_COLOR_SCHEME, null),
+            ThemeColorScheme.Dynamic,
+        )
+        val darkTheme = resolvedDarkTheme(themeMode)
+        if (scheme == ThemeColorScheme.Dynamic && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return dynamicWebLoginColors(darkTheme)
+        }
+        val primary = presetPrimaryColor(
+            if (scheme == ThemeColorScheme.Dynamic) ThemeColorScheme.ExpressiveDefault else scheme,
+            darkTheme,
+        )
+        return WebLoginColors(
+            background = if (darkTheme) Color.parseColor("#111411") else Color.WHITE,
+            surface = if (darkTheme) Color.parseColor("#191C19") else Color.WHITE,
+            surfaceVariant = if (darkTheme) Color.parseColor("#424940") else Color.parseColor("#EDF2EC"),
+            outline = if (darkTheme) Color.parseColor("#8C9389") else Color.parseColor("#D6DED5"),
+            primary = primary,
+            onPrimary = if (darkTheme) Color.parseColor("#1C1B1F") else Color.WHITE,
+            onSurface = if (darkTheme) Color.parseColor("#E3E3DE") else Color.parseColor("#1B1D1A"),
+            onSurfaceVariant = if (darkTheme) Color.parseColor("#C3C8BF") else Color.parseColor("#555F55"),
+        )
+    }
+
+    private fun dynamicWebLoginColors(darkTheme: Boolean): WebLoginColors {
+        val primary = if (darkTheme) {
+            getColor(android.R.color.system_accent1_200)
+        } else {
+            getColor(android.R.color.system_accent1_600)
+        }
+        return WebLoginColors(
+            background = if (darkTheme) Color.parseColor("#111411") else Color.WHITE,
+            surface = if (darkTheme) Color.parseColor("#191C19") else Color.WHITE,
+            surfaceVariant = if (darkTheme) Color.parseColor("#424940") else Color.parseColor("#EDF2EC"),
+            outline = if (darkTheme) Color.parseColor("#8C9389") else Color.parseColor("#D6DED5"),
+            primary = primary,
+            onPrimary = if (darkTheme) Color.parseColor("#1C1B1F") else Color.WHITE,
+            onSurface = if (darkTheme) Color.parseColor("#E3E3DE") else Color.parseColor("#1B1D1A"),
+            onSurfaceVariant = if (darkTheme) Color.parseColor("#C3C8BF") else Color.parseColor("#555F55"),
+        )
+    }
+
+    private fun presetPrimaryColor(scheme: ThemeColorScheme, darkTheme: Boolean): Int {
+        val raw = when (scheme) {
+            ThemeColorScheme.Dynamic,
+            ThemeColorScheme.ExpressiveDefault -> if (darkTheme) "#D0BCFF" else "#6750A4"
+            ThemeColorScheme.FuoGreen -> if (darkTheme) "#93DDAA" else "#246B43"
+            ThemeColorScheme.OceanBlue -> if (darkTheme) "#A7C8FF" else "#0066B3"
+            ThemeColorScheme.Violet -> if (darkTheme) "#D7B8FF" else "#7650B4"
+            ThemeColorScheme.Rose -> if (darkTheme) "#FFB1C8" else "#B13F66"
+            ThemeColorScheme.Amber -> if (darkTheme) "#FFCF73" else "#8A5A00"
+        }
+        return Color.parseColor(raw)
+    }
+
+    private fun resolvedDarkTheme(themeMode: ThemeMode): Boolean {
+        return when (themeMode) {
+            ThemeMode.System -> {
+                val uiMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                uiMode == Configuration.UI_MODE_NIGHT_YES
+            }
+            ThemeMode.Light -> false
+            ThemeMode.Dark -> true
+        }
+    }
+
+    private inline fun <reified T : Enum<T>> enumValue(raw: String?, fallback: T): T {
+        return runCatching { enumValueOf<T>(raw.orEmpty()) }.getOrDefault(fallback)
     }
 
     private fun roundedBackground(color: Int, strokeColor: Int): GradientDrawable {
@@ -298,6 +382,9 @@ class ProviderWebLoginActivity : Activity() {
         private const val EXTRA_PROVIDER_NAME = "provider_name"
         private const val EXTRA_LOGIN_URL = "login_url"
         private const val EXTRA_COOKIE_KEY_GROUPS = "cookie_key_groups"
+        private const val PREFS_NAME = "fuo_settings"
+        private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
         private const val DESKTOP_USER_AGENT =
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
@@ -328,4 +415,15 @@ class ProviderWebLoginActivity : Activity() {
             WebStorage.getInstance().deleteAllData()
         }
     }
+
+    private data class WebLoginColors(
+        val background: Int,
+        val surface: Int,
+        val surfaceVariant: Int,
+        val outline: Int,
+        val primary: Int,
+        val onPrimary: Int,
+        val onSurface: Int,
+        val onSurfaceVariant: Int,
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.7.3"
 chaquopy = "17.0.0"
-compose = "1.7.3"
+compose = "1.9.3"
 kotlin = "2.1.20"
 media3 = "1.5.1"
 activityCompose = "1.10.1"
@@ -18,6 +18,7 @@ jellyfin-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-d
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0-alpha04" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -54,4 +54,8 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    lint {
+        disable.add("NullSafeMutableLiveData")
+    }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.animation)
-            implementation(compose.material3)
+            implementation(libs.compose.material3.expressive)
             implementation(compose.materialIconsExtended)
             implementation(libs.kotlinx.coroutines.core)
         }

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformTheme.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformTheme.android.kt
@@ -1,0 +1,15 @@
+package org.feeluown.mobile
+
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+    val context = LocalContext.current
+    return if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -81,6 +82,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -94,8 +96,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -107,7 +107,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
@@ -131,8 +130,8 @@ fun AppRoot(
     onLogoutProvider: (ProviderInfo) -> Unit,
 ) {
     FuoEvolveTheme(
-        materialStyle = controller.materialStyle,
         themeMode = controller.themeMode,
+        themeColorScheme = controller.themeColorScheme,
     ) {
         val destination = appDestination(controller)
         val currentFeature = controller.selectedFeature
@@ -201,48 +200,6 @@ fun AppRoot(
     }
 }
 
-@Composable
-private fun FuoEvolveTheme(
-    materialStyle: MaterialStyle,
-    themeMode: ThemeMode,
-    content: @Composable () -> Unit,
-) {
-    val systemDark = isSystemInDarkTheme()
-    MaterialTheme(
-        colorScheme = materialColorScheme(materialStyle, resolvedDarkTheme(themeMode, systemDark)),
-        content = content,
-    )
-}
-
-internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boolean {
-    return when (themeMode) {
-        ThemeMode.System -> systemDark
-        ThemeMode.Light -> false
-        ThemeMode.Dark -> true
-    }
-}
-
-private fun materialColorScheme(materialStyle: MaterialStyle, darkTheme: Boolean) =
-    when (materialStyle) {
-        MaterialStyle.MaterialYou -> if (darkTheme) darkColorScheme() else lightColorScheme()
-        MaterialStyle.Expressive -> expressiveColorScheme(darkTheme)
-    }
-
-private fun expressiveColorScheme(darkTheme: Boolean) =
-    if (darkTheme) {
-        darkColorScheme(
-            onPrimaryContainer = Color(234, 221, 255),
-            onSecondaryContainer = Color(232, 222, 248),
-            onTertiaryContainer = Color(232, 222, 248),
-        )
-    } else {
-        lightColorScheme(
-            onPrimaryContainer = Color(79, 55, 139),
-            onSecondaryContainer = Color(74, 68, 88),
-            onTertiaryContainer = Color(74, 68, 88),
-        )
-    }
-
 private enum class AppDestination {
     Home,
     Feature,
@@ -293,7 +250,7 @@ private fun HomeScreen(
                         Icon(Icons.Filled.Search, contentDescription = "搜索")
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                 ),
             )
@@ -394,6 +351,7 @@ private fun HomeSectionPager(controller: FuoPlayerController, modifier: Modifier
 }
 
 @Composable
+@Suppress("DEPRECATION")
 private fun HomeSectionTabs(
     sections: List<Pair<HomeSection, String>>,
     selectedIndex: Int,
@@ -2028,6 +1986,7 @@ private fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
 
 @Composable
 private fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
+    val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surfaceVariant,
@@ -2062,25 +2021,6 @@ private fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                 }
             }
             Text(
-                text = "Material 风格",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                MaterialStyle.entries.forEachIndexed { index, style ->
-                    SegmentedButton(
-                        selected = controller.materialStyle == style,
-                        onClick = { controller.onMaterialStyleChange(style) },
-                        shape = SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = MaterialStyle.entries.size,
-                        ),
-                    ) {
-                        Text(style.label)
-                    }
-                }
-            }
-            Text(
                 text = "外观模式",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -2099,7 +2039,78 @@ private fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
+            Text(
+                text = "配色方案",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ThemeColorScheme.entries.chunked(2).forEach { rowSchemes ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        rowSchemes.forEach { scheme ->
+                            ThemeColorSchemeOption(
+                                modifier = Modifier.weight(1f),
+                                scheme = scheme,
+                                selected = controller.themeColorScheme == scheme,
+                                darkTheme = darkTheme,
+                                onClick = { controller.onThemeColorSchemeChange(scheme) },
+                            )
+                        }
+                        if (rowSchemes.size == 1) {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
         }
+    }
+}
+
+@Composable
+private fun ThemeColorSchemeOption(
+    modifier: Modifier,
+    scheme: ThemeColorScheme,
+    selected: Boolean,
+    darkTheme: Boolean,
+    onClick: () -> Unit,
+) {
+    val shape = MaterialTheme.shapes.medium
+    Row(
+        modifier = modifier
+            .clip(shape)
+            .background(
+                if (selected) {
+                    MaterialTheme.colorScheme.primaryContainer
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(18.dp)
+                .clip(CircleShape)
+                .background(themePreviewColor(scheme, darkTheme)),
+        )
+        Text(
+            modifier = Modifier.weight(1f),
+            text = scheme.label,
+            style = MaterialTheme.typography.labelMedium,
+            color = if (selected) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -2705,7 +2716,7 @@ private fun ProviderMediaItemScreen(controller: FuoPlayerController, item: Provi
             }
             if (isArtist) {
                 val tabs = listOf("歌曲", "专辑")
-                TabRow(selectedTabIndex = selectedTabIndex) {
+                PrimaryTabRow(selectedTabIndex = selectedTabIndex) {
                     tabs.forEachIndexed { index, title ->
                         Tab(
                             selected = selectedTabIndex == index,
@@ -3149,7 +3160,7 @@ private fun FullPlayer(controller: FuoPlayerController) {
                         Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = "播放队列")
                     }
                 }
-                TabRow(selectedTabIndex = pagerState.currentPage.coerceIn(0, PlayerVisualTab.entries.lastIndex)) {
+                PrimaryTabRow(selectedTabIndex = pagerState.currentPage.coerceIn(0, PlayerVisualTab.entries.lastIndex)) {
                     PlayerVisualTab.entries.forEach { tab ->
                         Tab(
                             selected = pagerState.currentPage == tab.ordinal,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -40,19 +40,24 @@ enum class LyricFontSize(
     Large("大"),
 }
 
-enum class MaterialStyle(
-    val label: String,
-) {
-    MaterialYou("Material You"),
-    Expressive("Expressive"),
-}
-
 enum class ThemeMode(
     val label: String,
 ) {
     System("跟随系统"),
     Light("亮色"),
     Dark("暗色"),
+}
+
+enum class ThemeColorScheme(
+    val label: String,
+) {
+    Dynamic("动态颜色"),
+    ExpressiveDefault("Expressive 默认"),
+    FuoGreen("青绿"),
+    OceanBlue("海蓝"),
+    Violet("紫罗兰"),
+    Rose("蔷薇"),
+    Amber("琥珀"),
 }
 
 data class AppSettings(
@@ -80,8 +85,8 @@ data class AppSettings(
     val smartReplacementUseOriginalMetadata: Boolean = false,
     val smartReplacementUseOriginalLyrics: Boolean = false,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
-    val materialStyle: MaterialStyle = MaterialStyle.MaterialYou,
     val themeMode: ThemeMode = ThemeMode.System,
+    val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
 )
 
 data class ProviderHeaderInput(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -171,9 +171,9 @@ class FuoPlayerController(
         private set
     var lyricFontSize by mutableStateOf(LyricFontSize.Small)
         private set
-    var materialStyle by mutableStateOf(MaterialStyle.MaterialYou)
-        private set
     var themeMode by mutableStateOf(ThemeMode.System)
+        private set
+    var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
         private set
     var debugLogLines by mutableStateOf<List<String>>(emptyList())
         private set
@@ -688,13 +688,13 @@ class FuoPlayerController(
         persistSettings()
     }
 
-    fun onMaterialStyleChange(value: MaterialStyle) {
-        materialStyle = value
+    fun onThemeModeChange(value: ThemeMode) {
+        themeMode = value
         persistSettings()
     }
 
-    fun onThemeModeChange(value: ThemeMode) {
-        themeMode = value
+    fun onThemeColorSchemeChange(value: ThemeColorScheme) {
+        themeColorScheme = value
         persistSettings()
     }
 
@@ -2018,8 +2018,8 @@ class FuoPlayerController(
         smartReplacementUseOriginalMetadata = settings.smartReplacementUseOriginalMetadata
         smartReplacementUseOriginalLyrics = settings.smartReplacementUseOriginalLyrics
         lyricFontSize = settings.lyricFontSize
-        materialStyle = settings.materialStyle
         themeMode = settings.themeMode
+        themeColorScheme = settings.themeColorScheme
     }
 
     private fun persistSettings() {
@@ -2048,8 +2048,8 @@ class FuoPlayerController(
             smartReplacementUseOriginalMetadata = smartReplacementUseOriginalMetadata,
             smartReplacementUseOriginalLyrics = smartReplacementUseOriginalLyrics,
             lyricFontSize = lyricFontSize,
-            materialStyle = materialStyle,
             themeMode = themeMode,
+            themeColorScheme = themeColorScheme,
         )
         scope.launch {
             settingsStore.save(settings)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -1,0 +1,237 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.expressiveLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun FuoEvolveTheme(
+    themeMode: ThemeMode,
+    themeColorScheme: ThemeColorScheme,
+    content: @Composable () -> Unit,
+) {
+    val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
+    MaterialExpressiveTheme(
+        colorScheme = fuoColorScheme(themeColorScheme, darkTheme),
+        content = content,
+    )
+}
+
+internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boolean {
+    return when (themeMode) {
+        ThemeMode.System -> systemDark
+        ThemeMode.Light -> false
+        ThemeMode.Dark -> true
+    }
+}
+
+@Composable
+private fun fuoColorScheme(themeColorScheme: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
+    if (themeColorScheme == ThemeColorScheme.Dynamic) {
+        platformDynamicColorScheme(darkTheme)?.let { return it }
+    }
+    return presetColorScheme(
+        preset = if (themeColorScheme == ThemeColorScheme.Dynamic) {
+            ThemeColorScheme.ExpressiveDefault
+        } else {
+            themeColorScheme
+        },
+        darkTheme = darkTheme,
+    )
+}
+
+@Composable
+internal expect fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme?
+
+internal fun themePreviewColor(themeColorScheme: ThemeColorScheme, darkTheme: Boolean): Color {
+    if (themeColorScheme == ThemeColorScheme.Dynamic) {
+        return if (darkTheme) Color(0xFFB8C8FF) else Color(0xFF3F5FDC)
+    }
+    return when (themeColorScheme) {
+        ThemeColorScheme.Dynamic -> Color.Unspecified
+        ThemeColorScheme.ExpressiveDefault -> if (darkTheme) Color(0xFFD0BCFF) else Color(0xFF6750A4)
+        ThemeColorScheme.FuoGreen -> if (darkTheme) Color(0xFF93DDAA) else Color(0xFF246B43)
+        ThemeColorScheme.OceanBlue -> if (darkTheme) Color(0xFFA7C8FF) else Color(0xFF0066B3)
+        ThemeColorScheme.Violet -> if (darkTheme) Color(0xFFD7B8FF) else Color(0xFF7650B4)
+        ThemeColorScheme.Rose -> if (darkTheme) Color(0xFFFFB1C8) else Color(0xFFB13F66)
+        ThemeColorScheme.Amber -> if (darkTheme) Color(0xFFFFCF73) else Color(0xFF8A5A00)
+    }
+}
+
+private fun presetColorScheme(preset: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
+    return when (preset) {
+        ThemeColorScheme.Dynamic,
+        ThemeColorScheme.ExpressiveDefault -> expressiveDefaultColorScheme(darkTheme)
+        ThemeColorScheme.FuoGreen -> if (darkTheme) {
+            darkColorScheme(
+                primary = Color(0xFF93DDAA),
+                onPrimary = Color(0xFF00391F),
+                primaryContainer = Color(0xFF0A5430),
+                onPrimaryContainer = Color(0xFFB0FAC5),
+                secondary = Color(0xFFAFCDB7),
+                onSecondary = Color(0xFF1B3524),
+                secondaryContainer = Color(0xFF314C39),
+                onSecondaryContainer = Color(0xFFCAE9D2),
+                tertiary = Color(0xFFA4D1DC),
+                onTertiary = Color(0xFF05363F),
+                tertiaryContainer = Color(0xFF224D57),
+                onTertiaryContainer = Color(0xFFC0EDF8),
+            )
+        } else {
+            lightColorScheme(
+                primary = Color(0xFF246B43),
+                onPrimary = Color.White,
+                primaryContainer = Color(0xFFA9F5C1),
+                onPrimaryContainer = Color(0xFF00210F),
+                secondary = Color(0xFF4D6353),
+                onSecondary = Color.White,
+                secondaryContainer = Color(0xFFD0E8D6),
+                onSecondaryContainer = Color(0xFF0A1F13),
+                tertiary = Color(0xFF3D6670),
+                onTertiary = Color.White,
+                tertiaryContainer = Color(0xFFC0ECF7),
+                onTertiaryContainer = Color(0xFF001F27),
+            )
+        }
+        ThemeColorScheme.OceanBlue -> if (darkTheme) {
+            darkColorScheme(
+                primary = Color(0xFFA7C8FF),
+                onPrimary = Color(0xFF00315F),
+                primaryContainer = Color(0xFF004786),
+                onPrimaryContainer = Color(0xFFD5E3FF),
+                secondary = Color(0xFFBBC7DB),
+                onSecondary = Color(0xFF253140),
+                secondaryContainer = Color(0xFF3B4858),
+                onSecondaryContainer = Color(0xFFD7E3F7),
+                tertiary = Color(0xFFD8BDE8),
+                onTertiary = Color(0xFF3B2948),
+                tertiaryContainer = Color(0xFF523F5F),
+                onTertiaryContainer = Color(0xFFF5D9FF),
+            )
+        } else {
+            lightColorScheme(
+                primary = Color(0xFF0066B3),
+                onPrimary = Color.White,
+                primaryContainer = Color(0xFFD5E3FF),
+                onPrimaryContainer = Color(0xFF001C39),
+                secondary = Color(0xFF53606F),
+                onSecondary = Color.White,
+                secondaryContainer = Color(0xFFD7E3F7),
+                onSecondaryContainer = Color(0xFF101C2B),
+                tertiary = Color(0xFF6A5778),
+                onTertiary = Color.White,
+                tertiaryContainer = Color(0xFFF2DAFF),
+                onTertiaryContainer = Color(0xFF241432),
+            )
+        }
+        ThemeColorScheme.Violet -> if (darkTheme) {
+            darkColorScheme(
+                primary = Color(0xFFD7B8FF),
+                onPrimary = Color(0xFF40206F),
+                primaryContainer = Color(0xFF583688),
+                onPrimaryContainer = Color(0xFFEEDBFF),
+                secondary = Color(0xFFCDC1D7),
+                onSecondary = Color(0xFF342D3E),
+                secondaryContainer = Color(0xFF4B4355),
+                onSecondaryContainer = Color(0xFFE9DDF3),
+                tertiary = Color(0xFFF0B8C8),
+                onTertiary = Color(0xFF4A2533),
+                tertiaryContainer = Color(0xFF643B49),
+                onTertiaryContainer = Color(0xFFFFD9E3),
+            )
+        } else {
+            lightColorScheme(
+                primary = Color(0xFF7650B4),
+                onPrimary = Color.White,
+                primaryContainer = Color(0xFFEEDBFF),
+                onPrimaryContainer = Color(0xFF2A0055),
+                secondary = Color(0xFF625A6B),
+                onSecondary = Color.White,
+                secondaryContainer = Color(0xFFE9DDF3),
+                onSecondaryContainer = Color(0xFF1E1726),
+                tertiary = Color(0xFF7E5260),
+                onTertiary = Color.White,
+                tertiaryContainer = Color(0xFFFFD9E3),
+                onTertiaryContainer = Color(0xFF31101D),
+            )
+        }
+        ThemeColorScheme.Rose -> if (darkTheme) {
+            darkColorScheme(
+                primary = Color(0xFFFFB1C8),
+                onPrimary = Color(0xFF651B3B),
+                primaryContainer = Color(0xFF8B2A52),
+                onPrimaryContainer = Color(0xFFFFD9E4),
+                secondary = Color(0xFFE3BDC7),
+                onSecondary = Color(0xFF422932),
+                secondaryContainer = Color(0xFF5A3F49),
+                onSecondaryContainer = Color(0xFFFFD9E4),
+                tertiary = Color(0xFFF4C09B),
+                onTertiary = Color(0xFF4A280D),
+                tertiaryContainer = Color(0xFF653E21),
+                onTertiaryContainer = Color(0xFFFFDCC5),
+            )
+        } else {
+            lightColorScheme(
+                primary = Color(0xFFB13F66),
+                onPrimary = Color.White,
+                primaryContainer = Color(0xFFFFD9E4),
+                onPrimaryContainer = Color(0xFF3F001F),
+                secondary = Color(0xFF735762),
+                onSecondary = Color.White,
+                secondaryContainer = Color(0xFFFFD9E4),
+                onSecondaryContainer = Color(0xFF2A151F),
+                tertiary = Color(0xFF805433),
+                onTertiary = Color.White,
+                tertiaryContainer = Color(0xFFFFDCC5),
+                onTertiaryContainer = Color(0xFF2E1500),
+            )
+        }
+        ThemeColorScheme.Amber -> if (darkTheme) {
+            darkColorScheme(
+                primary = Color(0xFFFFCF73),
+                onPrimary = Color(0xFF482900),
+                primaryContainer = Color(0xFF664000),
+                onPrimaryContainer = Color(0xFFFFDFA6),
+                secondary = Color(0xFFD9C3A4),
+                onSecondary = Color(0xFF3C2E1B),
+                secondaryContainer = Color(0xFF554430),
+                onSecondaryContainer = Color(0xFFF6DEBF),
+                tertiary = Color(0xFFBBD0A4),
+                onTertiary = Color(0xFF273619),
+                tertiaryContainer = Color(0xFF3D4D2E),
+                onTertiaryContainer = Color(0xFFD7ECC0),
+            )
+        } else {
+            lightColorScheme(
+                primary = Color(0xFF8A5A00),
+                onPrimary = Color.White,
+                primaryContainer = Color(0xFFFFDFA6),
+                onPrimaryContainer = Color(0xFF2B1700),
+                secondary = Color(0xFF6D5C43),
+                onSecondary = Color.White,
+                secondaryContainer = Color(0xFFF6DEBF),
+                onSecondaryContainer = Color(0xFF251A08),
+                tertiary = Color(0xFF54643D),
+                onTertiary = Color.White,
+                tertiaryContainer = Color(0xFFD7ECC0),
+                onTertiaryContainer = Color(0xFF121F04),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+private fun expressiveDefaultColorScheme(darkTheme: Boolean): ColorScheme {
+    return if (darkTheme) {
+        darkColorScheme()
+    } else {
+        expressiveLightColorScheme()
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1103,8 +1103,8 @@ class FuoPlayerControllerTest {
                 smartReplacementUseOriginalMetadata = true,
                 smartReplacementUseOriginalLyrics = true,
                 lyricFontSize = LyricFontSize.Large,
-                materialStyle = MaterialStyle.Expressive,
                 themeMode = ThemeMode.Dark,
+                themeColorScheme = ThemeColorScheme.OceanBlue,
             ),
         )
         val provider = FakeProviderRepository(emptyList())
@@ -1150,8 +1150,8 @@ class FuoPlayerControllerTest {
             assertEquals(true, controller.smartReplacementUseOriginalMetadata)
             assertEquals(true, controller.smartReplacementUseOriginalLyrics)
             assertEquals(LyricFontSize.Large, controller.lyricFontSize)
-            assertEquals(MaterialStyle.Expressive, controller.materialStyle)
             assertEquals(ThemeMode.Dark, controller.themeMode)
+            assertEquals(ThemeColorScheme.OceanBlue, controller.themeColorScheme)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Low, provider.lastCellularAudioQualityPolicy)
 
@@ -1171,8 +1171,8 @@ class FuoPlayerControllerTest {
             controller.onSmartReplacementUseOriginalMetadataChange(false)
             controller.onSmartReplacementUseOriginalLyricsChange(false)
             controller.onLyricFontSizeChange(LyricFontSize.Medium)
-            controller.onMaterialStyleChange(MaterialStyle.MaterialYou)
             controller.onThemeModeChange(ThemeMode.Light)
+            controller.onThemeColorSchemeChange(ThemeColorScheme.FuoGreen)
             advanceUntilIdle()
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
@@ -1197,8 +1197,8 @@ class FuoPlayerControllerTest {
             assertEquals(false, store.saved.smartReplacementUseOriginalMetadata)
             assertEquals(false, store.saved.smartReplacementUseOriginalLyrics)
             assertEquals(LyricFontSize.Medium, store.saved.lyricFontSize)
-            assertEquals(MaterialStyle.MaterialYou, store.saved.materialStyle)
             assertEquals(ThemeMode.Light, store.saved.themeMode)
+            assertEquals(ThemeColorScheme.FuoGreen, store.saved.themeColorScheme)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Standard, provider.lastCellularAudioQualityPolicy)
         } finally {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -37,8 +37,8 @@ class IosAppSettingsStore : AppSettingsStore {
             smartReplacementUseOriginalMetadata = boolValue(KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA, false),
             smartReplacementUseOriginalLyrics = boolValue(KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS, false),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
-            materialStyle = enumValue(KEY_MATERIAL_STYLE, MaterialStyle.MaterialYou),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
+            themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
     }
 
@@ -66,8 +66,8 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setBool(settings.smartReplacementUseOriginalMetadata, KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA)
             defaults.setBool(settings.smartReplacementUseOriginalLyrics, KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS)
             defaults.setObject(settings.lyricFontSize.name, KEY_LYRIC_FONT_SIZE)
-            defaults.setObject(settings.materialStyle.name, KEY_MATERIAL_STYLE)
             defaults.setObject(settings.themeMode.name, KEY_THEME_MODE)
+            defaults.setObject(settings.themeColorScheme.name, KEY_THEME_COLOR_SCHEME)
             defaults.synchronize()
         }
     }
@@ -175,7 +175,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_METADATA = "smart_replacement_use_original_metadata"
         private const val KEY_SMART_REPLACEMENT_USE_ORIGINAL_LYRICS = "smart_replacement_use_original_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
-        private const val KEY_MATERIAL_STYLE = "material_style"
         private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformTheme.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformTheme.ios.kt
@@ -1,0 +1,7 @@
+package org.feeluown.mobile
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme? = null


### PR DESCRIPTION
## Summary

- Force the shared Compose UI through Material 3 Expressive theming.
- Remove the old selectable Material style option and replace it with dynamic color plus preset color schemes.
- Persist the new theme color scheme across Android and iOS settings stores.
- Sync the Android WebView login toolbar with the selected theme mode and color scheme.

## Validation

- `git diff --check`
- `./gradlew :shared:compileDebugKotlinAndroid`
- `./gradlew :shared:allTests :androidApp:assembleDebug`

## Notes

- Android 12+ uses system dynamic color when selected.
- Unsupported platforms fall back to the default Expressive preset.
