### PR TITLE
[fix] support Bilibili multi-part playback

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -394,6 +394,8 @@ class AndroidFuoCoreBridge(
             replacementCoverUrl = optString("replacement_cover_url").takeIf { smartReplacement && it.isNotBlank() },
             replacementStrategy = optString("standby_strategy").takeIf { smartReplacement && it.isNotBlank() },
             replacementScore = optDouble("standby_score").takeIf { smartReplacement && has("standby_score") },
+            parts = optJSONArray("parts").toPlaybackParts(),
+            currentPartIndex = optInt("current_part_index", -1),
         )
     }
 
@@ -439,6 +441,18 @@ class AndroidFuoCoreBridge(
             .mapNotNull { raw -> runCatching { ProviderLoginMode.valueOf(raw) }.getOrNull() }
             .toSet()
             .ifEmpty { setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie) }
+    }
+
+    private fun JSONArray?.toPlaybackParts(): List<PlaybackPart> {
+        if (this == null) return emptyList()
+        return List(length()) { index ->
+            val item = getJSONObject(index)
+            PlaybackPart(
+                id = item.optString("id"),
+                title = item.optString("title"),
+                durationMs = item.optLong("duration_ms").takeIf { it > 0 },
+            )
+        }.filter { it.id.isNotBlank() }
     }
 
     private fun JSONObject?.toStringMap(): Map<String, String> {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -47,6 +47,8 @@ class AndroidNativeAudioEngine(
             bufferedMs = 0,
             lyrics = track.lyrics,
             audioQuality = null,
+            playbackParts = emptyList(),
+            currentPartIndex = -1,
             errorMessage = null,
         )
         connectController()
@@ -61,6 +63,8 @@ class AndroidNativeAudioEngine(
             durationMs = payload.durationMs ?: 0,
             lyrics = payload.lyrics,
             audioQuality = payload.audioQuality,
+            playbackParts = payload.parts,
+            currentPartIndex = payload.currentPartIndex,
             errorMessage = null,
         )
         FuoPlaybackService.play(context, payload.toJson(track))

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -905,7 +905,13 @@ class FuoMobileBridge:
         provider = self._get_provider(provider_id)
         if not hasattr(provider, "song_get"):
             raise RuntimeError(f"provider does not support song_get: {provider_id}")
-        return provider.song_get(identifier)
+        song = provider.song_get(identifier)
+        if provider_id == "bilibili" and identifier.startswith("paged_"):
+            for child in getattr(song, "children", None) or []:
+                if getattr(child, "identifier", "") == identifier:
+                    self._tracks[track_id] = child
+                    return child
+        return song
 
     def _remember_song(self, song) -> Dict[str, Any]:
         track = song_to_dict(song, self.app.library)
@@ -1037,7 +1043,7 @@ class FuoMobileBridge:
         standby_use_origin_lyrics: bool,
     ) -> Dict[str, Any]:
         try:
-            media, quality = self._select_media(song, audio_select_policy)
+            playback_song, media, quality, parts, current_part_index = self._select_media(song, audio_select_policy)
         except MediaNotFound as exc:
             bridge_log(
                 "media not found "
@@ -1055,7 +1061,7 @@ class FuoMobileBridge:
                 if standby_payload is not None:
                     return standby_payload
             raise RuntimeError(f"media not found: {song}") from exc
-        payload = self._payload_from_media(song, media, quality)
+        payload = self._payload_from_media(playback_song, media, quality, parts, current_part_index)
         return payload
 
     def _prepare_standby_payload(
@@ -1132,13 +1138,16 @@ class FuoMobileBridge:
                 f"replacement={song_log_label(standby)}"
             )
             try:
-                media, quality = self._select_media(standby, audio_select_policy)
+                playback_standby, media, quality, parts, current_part_index = self._select_media(
+                    standby,
+                    audio_select_policy,
+                )
             except MediaNotFound:
                 bridge_log(
                     f"standby candidate media not found score={score:.2f} replacement={song_log_label(standby)}"
                 )
                 continue
-            payload = self._payload_from_media(standby, media, quality)
+            payload = self._payload_from_media(playback_standby, media, quality, parts, current_part_index)
             return self._mark_standby_payload(
                 payload,
                 song,
@@ -1188,7 +1197,10 @@ class FuoMobileBridge:
             return None
         for score, standby in sorted(candidates, key=lambda item: item[0], reverse=True)[:8]:
             try:
-                media, quality = self._select_media(standby, audio_select_policy)
+                playback_standby, media, quality, parts, current_part_index = self._select_media(
+                    standby,
+                    audio_select_policy,
+                )
             except MediaNotFound:
                 bridge_log(
                     f"search standby candidate media not found score={score:.2f} replacement={song_log_label(standby)}"
@@ -1199,7 +1211,7 @@ class FuoMobileBridge:
                 f"search standby selected score={score:.2f} "
                 f"origin={song_log_label(song)} replacement={song_log_label(standby)}"
             )
-            payload = self._payload_from_media(standby, media, quality)
+            payload = self._payload_from_media(playback_standby, media, quality, parts, current_part_index)
             return self._mark_standby_payload(
                 payload,
                 song,
@@ -1215,17 +1227,70 @@ class FuoMobileBridge:
     def _select_media(self, song, audio_select_policy: str):
         provider = self.app.library.get(getattr(song, "source", ""))
         if provider is not None and isinstance(provider, SupportsSongMultiQuality):
+            playback_song = song
+            parts = []
             try:
-                media, quality = provider.song_select_media(song, audio_select_policy)
-            except MediaNotFound:
-                refreshed_song = self._refresh_song_for_media_retry(song, provider)
-                if refreshed_song is None:
-                    raise
-                media, quality = provider.song_select_media(refreshed_song, audio_select_policy)
-                song = refreshed_song
-            self._tracks[f"{getattr(song, 'source', '')}:{getattr(song, 'identifier', '')}"] = song
-            return media, getattr(quality, "value", str(quality)).upper()
-        return self.app.library.song_prepare_media(song, audio_select_policy), ""
+                media, quality = provider.song_select_media(playback_song, audio_select_policy)
+            except MediaNotFound as exc:
+                parts = self._bilibili_parts_for_song(playback_song, provider)
+                child_song = self._bilibili_first_child_for_media_retry(playback_song, provider, exc, parts)
+                if child_song is not None:
+                    playback_song = child_song
+                    media, quality = provider.song_select_media(playback_song, audio_select_policy)
+                else:
+                    refreshed_song = self._refresh_song_for_media_retry(playback_song, provider)
+                    if refreshed_song is None:
+                        raise
+                    playback_song = refreshed_song
+                    media, quality = provider.song_select_media(playback_song, audio_select_policy)
+            if str(getattr(playback_song, "identifier", "")).startswith("paged_"):
+                parts = parts or self._bilibili_parts_for_song(playback_song, provider)
+            self._tracks[
+                f"{getattr(playback_song, 'source', '')}:{getattr(playback_song, 'identifier', '')}"
+            ] = playback_song
+            return (
+                playback_song,
+                media,
+                getattr(quality, "value", str(quality)).upper(),
+                parts,
+                playback_part_index(playback_song, parts),
+            )
+        return song, self.app.library.song_prepare_media(song, audio_select_policy), "", [], -1
+
+    def _bilibili_first_child_for_media_retry(self, song, provider, exc: MediaNotFound, parts: List[Any]):
+        if (
+            getattr(exc, "reason", None) is not MediaNotFound.Reason.check_children
+            or getattr(song, "source", "") != "bilibili"
+            or str(getattr(song, "identifier", "")).startswith("paged_")
+        ):
+            return None
+        children = parts or self._bilibili_parts_for_song(song, provider)
+        if not children:
+            return None
+        child_song = children[0]
+        bridge_log(
+            f"bilibili media retry first child parent={song_log_label(song)} "
+            f"child={song_log_label(child_song)}"
+        )
+        return child_song
+
+    def _bilibili_parts_for_song(self, song, provider) -> List[Any]:
+        if getattr(song, "source", "") != "bilibili":
+            return []
+        detail_song = song
+        parts = getattr(detail_song, "children", None) or []
+        if not parts and hasattr(provider, "song_get"):
+            try:
+                detail_song = provider.song_get(getattr(song, "identifier", ""))
+            except Exception as detail_exc:  # pylint: disable=broad-except
+                bridge_log(f"bilibili parts lookup failed track={song_log_label(song)} error={detail_exc}")
+                return []
+            parts = getattr(detail_song, "children", None) or []
+        if len(parts) <= 1:
+            return []
+        for part in parts:
+            self._tracks[f"{getattr(part, 'source', '')}:{getattr(part, 'identifier', '')}"] = part
+        return list(parts)
 
     def _refresh_song_for_media_retry(self, song, provider):
         source = getattr(song, "source", "")
@@ -1246,12 +1311,23 @@ class FuoMobileBridge:
         bridge_log(f"netease media retry track={song_log_label(retry_song)}")
         return retry_song
 
-    def _payload_from_media(self, song, media: Media, quality: str) -> Dict[str, Any]:
+    def _payload_from_media(
+        self,
+        song,
+        media: Media,
+        quality: str,
+        parts: Optional[List[Any]] = None,
+        current_part_index: int = -1,
+    ) -> Dict[str, Any]:
         payload = media_to_payload(media, song_to_metadata(song, self.app.library))
+        parts = parts or []
         if getattr(song, "source", "") == "bilibili":
             headers = payload.setdefault("headers", {})
             headers.setdefault("Referer", "https://www.bilibili.com/")
             headers.setdefault("User-Agent", BILIBILI_MEDIA_USER_AGENT)
+            if parts:
+                payload["parts"] = [playback_part_to_dict(part) for part in parts]
+                payload["current_part_index"] = current_part_index
         if quality:
             payload["audio_quality"] = quality
         cover = self._get_cover(song)
@@ -1468,6 +1544,28 @@ def song_to_dict(song, library: Library) -> Dict[str, Any]:
         "artist_item_id": first_artist_item_id(song),
         "album_item_id": album_item_id(song),
     }
+
+
+def playback_part_to_dict(song) -> Dict[str, Any]:
+    source = getattr(song, "source", "")
+    identifier = getattr(song, "identifier", "")
+    return {
+        "id": f"{source}:{identifier}",
+        "title": display(song, "title"),
+        "duration_ms": duration_ms(song),
+    }
+
+
+def playback_part_index(song, parts: List[Any]) -> int:
+    if not parts:
+        return -1
+    identifier = getattr(song, "identifier", "")
+    for index, part in enumerate(parts):
+        if getattr(part, "identifier", "") == identifier:
+            return index
+    if getattr(song, "source", "") == "bilibili" and not str(identifier).startswith("paged_"):
+        return 0
+    return -1
 
 
 def song_to_metadata(song, library: Library) -> Dict[str, Any]:

--- a/androidApp/src/test/python/test_bridge_bilibili_pages.py
+++ b/androidApp/src/test/python/test_bridge_bilibili_pages.py
@@ -1,0 +1,89 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SRC_ROOT / "main" / "python"))
+
+from feeluown.excs import MediaNotFound  # noqa: E402
+from feeluown.media import Media, Quality  # noqa: E402
+from fuo_mobile.bridge import FuoMobileBridge  # noqa: E402
+
+
+def song(identifier, title, children=None):
+    return SimpleNamespace(
+        source="bilibili",
+        identifier=identifier,
+        title=title,
+        artists=[],
+        children=children or [],
+    )
+
+
+class _Library:
+    def __init__(self, provider):
+        self.provider = provider
+
+    def get(self, provider_id):
+        if provider_id == "bilibili":
+            return self.provider
+        return None
+
+
+class _BilibiliProvider:
+    def __init__(self):
+        self.children = [
+            song("paged_BV1xx__1", "P1"),
+            song("paged_BV1xx__2", "P2"),
+        ]
+        self.calls = []
+
+    def song_list_quality(self, song):
+        return [Quality.Audio.hq]
+
+    def song_get_media(self, song, quality):
+        return None
+
+    def song_select_media(self, song, policy=None):
+        self.calls.append(song.identifier)
+        if song.identifier == "BV1xx":
+            raise MediaNotFound(reason=MediaNotFound.Reason.check_children)
+        return Media("https://example.test/audio.m4s"), Quality.Audio.hq
+
+    def song_get(self, identifier):
+        return song("BV1xx", "parent", self.children)
+
+
+class BilibiliPagesTest(unittest.TestCase):
+    def test_select_media_uses_first_child_when_parent_has_multiple_pages(self):
+        provider = _BilibiliProvider()
+        bridge = FuoMobileBridge.__new__(FuoMobileBridge)
+        bridge.app = SimpleNamespace(library=_Library(provider))
+        bridge._tracks = {}
+
+        playback_song, media, quality, parts, current_part_index = bridge._select_media(song("BV1xx", "parent"), "")
+
+        self.assertEqual("paged_BV1xx__1", playback_song.identifier)
+        self.assertEqual("https://example.test/audio.m4s", media.url)
+        self.assertEqual("HQ", quality)
+        self.assertEqual(["paged_BV1xx__1", "paged_BV1xx__2"], [part.identifier for part in parts])
+        self.assertEqual(0, current_part_index)
+        self.assertEqual(["BV1xx", "paged_BV1xx__1"], provider.calls)
+        self.assertIs(bridge._tracks["bilibili:paged_BV1xx__1"], playback_song)
+        self.assertIs(bridge._tracks["bilibili:paged_BV1xx__2"], parts[1])
+
+    def test_song_from_track_id_returns_requested_page_child(self):
+        provider = _BilibiliProvider()
+        bridge = FuoMobileBridge.__new__(FuoMobileBridge)
+        bridge.app = SimpleNamespace(library=_Library(provider))
+        bridge._tracks = {}
+
+        result = bridge._song_from_track_id("bilibili:paged_BV1xx__2")
+
+        self.assertEqual("paged_BV1xx__2", result.identifier)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -3298,7 +3298,7 @@ private fun FullPlayer(controller: FuoPlayerController) {
                     }
                 }
                 Spacer(Modifier.weight(1f))
-                PlayerTitleBlock(currentTrack, state.audioQuality)
+                PlayerTitleBlock(currentTrack, state.audioQuality, currentPlaybackPartLabel(state))
                 Text(
                     text = currentTrack?.let(::artistAlbumLabel).orEmpty(),
                     style = MaterialTheme.typography.bodyLarge,
@@ -3344,10 +3344,10 @@ private enum class PlayerVisualTab(val title: String) {
 }
 
 @Composable
-private fun PlayerTitleBlock(track: MusicTrack?, audioQuality: String?) {
+private fun PlayerTitleBlock(track: MusicTrack?, audioQuality: String?, partLabel: String?) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         Text(
             text = track?.title ?: "未播放",
@@ -3355,6 +3355,15 @@ private fun PlayerTitleBlock(track: MusicTrack?, audioQuality: String?) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        partLabel?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
         PlayerInfoTags(track, audioQuality)
     }
 }
@@ -3742,6 +3751,8 @@ private fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier:
 @Composable
 private fun QueueList(controller: FuoPlayerController, modifier: Modifier) {
     val queue = controller.playbackState.queue
+    val playbackParts = controller.playbackState.playbackParts
+    val currentPartIndex = controller.playbackState.currentPartIndex
     val currentCount = if (controller.playbackState.queueIndex == 0 && queue.isNotEmpty()) 1 else 0
     val upNextCount = controller.displayUpNextCount
     LazyColumn(
@@ -3818,9 +3829,86 @@ private fun QueueList(controller: FuoPlayerController, modifier: Modifier) {
                     Icon(Icons.Filled.RemoveCircleOutline, contentDescription = "从队列移除")
                 }
             }
+            if (isCurrent && playbackParts.isNotEmpty()) {
+                PlaybackPartList(
+                    parts = playbackParts,
+                    currentPartIndex = currentPartIndex,
+                    onPartClick = controller::playPlaybackPart,
+                )
+            }
             HorizontalDivider()
         }
     }
+}
+
+@Composable
+private fun PlaybackPartList(
+    parts: List<PlaybackPart>,
+    currentPartIndex: Int,
+    onPartClick: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 56.dp, bottom = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = "分 P 列表",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        parts.forEachIndexed { index, part ->
+            val selected = index == currentPartIndex
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onPartClick(index) },
+                color = if (selected) {
+                    MaterialTheme.colorScheme.primaryContainer
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+                contentColor = if (selected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                shape = RoundedCornerShape(6.dp),
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "P${index + 1}",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                    )
+                    Text(
+                        text = part.title.ifBlank { "未命名分段" },
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    part.durationMs?.takeIf { it > 0 }?.let {
+                        Text(
+                            text = formatMs(it),
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun currentPlaybackPartLabel(state: PlaybackState): String? {
+    val part = state.playbackParts.getOrNull(state.currentPartIndex) ?: return null
+    return "第 ${state.currentPartIndex + 1}P · ${part.title.ifBlank { "未命名分段" }}"
 }
 
 private fun sourceLabel(track: MusicTrack, downloadState: DownloadState?): String {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -150,6 +150,12 @@ data class MusicTrack(
     val albumItemId: String? = null,
 )
 
+data class PlaybackPart(
+    val id: String,
+    val title: String,
+    val durationMs: Long? = null,
+)
+
 data class PlaybackPayload(
     val url: String,
     val title: String,
@@ -173,6 +179,8 @@ data class PlaybackPayload(
     val replacementCoverUrl: String? = null,
     val replacementStrategy: String? = null,
     val replacementScore: Double? = null,
+    val parts: List<PlaybackPart> = emptyList(),
+    val currentPartIndex: Int = -1,
 )
 
 enum class PlayerStatus {
@@ -200,6 +208,8 @@ data class PlaybackState(
     val playMode: PlayMode = PlayMode.ListLoop,
     val lyrics: String? = null,
     val audioQuality: String? = null,
+    val playbackParts: List<PlaybackPart> = emptyList(),
+    val currentPartIndex: Int = -1,
     val errorMessage: String? = null,
 )
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -222,6 +222,8 @@ class FuoPlayerController(
     private var autoAdvanceEligibleTrackId: String? = null
     private var playRequestSerial: Long = 0
     private var localMusicRefreshSerial: Long = 0
+    private var playbackParts: List<PlaybackPart> = emptyList()
+    private var currentPartIndex: Int = -1
 
     init {
         scope.launch {
@@ -284,6 +286,8 @@ class FuoPlayerController(
                     queue = displayQueue(),
                     queueIndex = displayQueueIndex(),
                     currentTrack = currentQueueTrack() ?: engineState.currentTrack,
+                    playbackParts = playbackParts,
+                    currentPartIndex = currentPartIndex,
                 )
             }
         }
@@ -1298,6 +1302,11 @@ class FuoPlayerController(
         }
     }
 
+    fun playPlaybackPart(index: Int) {
+        if (index !in playbackParts.indices) return
+        currentQueueTrack()?.let { startPlayback(it, requestedPartIndex = index) }
+    }
+
     fun toggle() {
         when (playbackState.status) {
             PlayerStatus.Playing -> playbackEngine.pause()
@@ -1312,6 +1321,7 @@ class FuoPlayerController(
     }
 
     fun next() {
+        if (playPlaybackPartOffset(1)) return
         if (currentIsUpNext) {
             currentUpNextTrack = null
             currentIsUpNext = false
@@ -1344,6 +1354,7 @@ class FuoPlayerController(
     }
 
     fun previous() {
+        if (playPlaybackPartOffset(-1)) return
         if (currentIsUpNext) {
             currentUpNextTrack = null
             currentIsUpNext = false
@@ -1594,9 +1605,15 @@ class FuoPlayerController(
     private fun startPlayback(
         track: MusicTrack,
         skippedUnavailableCount: Int = 0,
+        requestedPartIndex: Int? = null,
     ) {
         val requestSerial = ++playRequestSerial
         val playbackTrack = track.preferDownloaded()
+        val isPlaybackPartRequest = requestedPartIndex != null && playbackParts.isNotEmpty()
+        if (!isPlaybackPartRequest) {
+            playbackParts = emptyList()
+            currentPartIndex = -1
+        }
         updateCurrentTrack(playbackTrack)
         playbackState = playbackState.copy(
             status = PlayerStatus.Loading,
@@ -1604,6 +1621,8 @@ class FuoPlayerController(
             queue = displayQueue(),
             queueIndex = displayQueueIndex(),
             positionMs = 0,
+            playbackParts = playbackParts,
+            currentPartIndex = if (isPlaybackPartRequest) requestedPartIndex ?: -1 else -1,
             errorMessage = null,
         )
         persistPlaybackQueue()
@@ -1612,9 +1631,13 @@ class FuoPlayerController(
             isLoading = true
             message = "正在播放：${track.title}"
             runCatching {
-                val payload = playbackTrack.toPayload()
+                val partTrack = requestedPartIndex
+                    ?.let { index -> playbackParts.getOrNull(index) }
+                    ?.toTrack(playbackTrack)
+                val resolveTrack = partTrack ?: playbackTrack
+                val payload = resolveTrack.toPayload()
                     ?: providerRepository.resolve(
-                        playbackTrack,
+                        resolveTrack,
                         unavailablePlaybackPolicy,
                         selectedSmartReplacementProviderIds(),
                         smartReplacementMinScore,
@@ -1622,13 +1645,23 @@ class FuoPlayerController(
                         smartReplacementUseOriginalLyrics,
                     )
                 if (requestSerial != playRequestSerial) return@playRequest
+                val nextParts = payload.parts
+                val nextPartIndex = when {
+                    nextParts.isEmpty() -> -1
+                    payload.currentPartIndex in nextParts.indices -> payload.currentPartIndex
+                    requestedPartIndex != null && requestedPartIndex in nextParts.indices -> requestedPartIndex
+                    else -> -1
+                }
+                playbackParts = nextParts
+                currentPartIndex = nextPartIndex
+                val isMultipartPlayback = playbackParts.isNotEmpty()
                 val playableTrack = playbackTrack.copy(
-                    title = payload.title.ifBlank { playbackTrack.title },
+                    title = if (isMultipartPlayback) playbackTrack.title else payload.title.ifBlank { playbackTrack.title },
                     artists = payload.artists.ifBlank { playbackTrack.artists },
                     album = payload.album.ifBlank { playbackTrack.album },
                     source = payload.source.ifBlank { playbackTrack.source },
                     coverUrl = payload.coverUrl ?: playbackTrack.coverUrl,
-                    durationMs = payload.durationMs ?: playbackTrack.durationMs,
+                    durationMs = if (isMultipartPlayback) playbackTrack.durationMs else payload.durationMs ?: playbackTrack.durationMs,
                     providerName = payload.providerName ?: playbackTrack.providerName,
                     isSmartReplacement = payload.isSmartReplacement,
                     originalTitle = payload.originalTitle,
@@ -1652,9 +1685,16 @@ class FuoPlayerController(
                     queueIndex = displayQueueIndex(),
                     lyrics = payload.lyrics,
                     audioQuality = payload.audioQuality,
+                    playbackParts = playbackParts,
+                    currentPartIndex = currentPartIndex,
                 )
                 persistPlaybackQueue()
-                message = "${playableTrack.title} - ${playableTrack.artists}"
+                val partLabel = currentPlaybackPartLabel()
+                message = if (partLabel != null) {
+                    "${playableTrack.title} · $partLabel"
+                } else {
+                    "${playableTrack.title} - ${playableTrack.artists}"
+                }
                 prefetchFeatureQueueIfNeeded()
             }.onFailure {
                 if (requestSerial != playRequestSerial) return@playRequest
@@ -1863,6 +1903,28 @@ class FuoPlayerController(
         )
     }
 
+    private fun PlaybackPart.toTrack(parent: MusicTrack): MusicTrack {
+        return parent.copy(
+            id = id,
+            title = title.ifBlank { parent.title },
+            durationMs = durationMs ?: parent.durationMs,
+            providerId = id,
+        )
+    }
+
+    private fun playPlaybackPartOffset(offset: Int): Boolean {
+        if (playbackParts.isEmpty() || currentPartIndex < 0) return false
+        val nextPartIndex = currentPartIndex + offset
+        if (nextPartIndex !in playbackParts.indices) return false
+        currentQueueTrack()?.let { startPlayback(it, requestedPartIndex = nextPartIndex) } ?: return false
+        return true
+    }
+
+    private fun currentPlaybackPartLabel(): String? {
+        val part = playbackParts.getOrNull(currentPartIndex) ?: return null
+        return "第 ${currentPartIndex + 1}P · ${part.title.ifBlank { "未命名分段" }}"
+    }
+
     private fun currentQueueTrack(): MusicTrack? {
         return if (currentIsUpNext) currentUpNextTrack else mainQueue.getOrNull(mainQueueIndex)
     }
@@ -1917,6 +1979,8 @@ class FuoPlayerController(
             queue = displayQueue(),
             queueIndex = displayQueueIndex(),
             currentTrack = currentQueueTrack() ?: playbackState.currentTrack,
+            playbackParts = playbackParts,
+            currentPartIndex = currentPartIndex,
         )
     }
 
@@ -1931,10 +1995,14 @@ class FuoPlayerController(
         shuffleBeforeFm = snapshot.shuffleBeforeFm
         currentUpNextTrack = null
         currentIsUpNext = false
+        playbackParts = emptyList()
+        currentPartIndex = -1
         playbackState = playbackState.copy(
             currentTrack = mainQueue.getOrNull(mainQueueIndex),
             queue = displayQueue(),
             queueIndex = displayQueueIndex(),
+            playbackParts = playbackParts,
+            currentPartIndex = currentPartIndex,
         )
     }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -224,6 +224,66 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun multiPartTrackPlaysPartsInOrderBeforeMainQueueNextWhenShuffleIsEnabled() = runTest {
+        val parent = providerTrack("bilibili:BV1xx", "Multi Part").copy(
+            source = "bilibili",
+            providerName = "哔哩哔哩",
+        )
+        val other = providerTrack("provider:2", "Second")
+        val parts = listOf(
+            PlaybackPart("bilibili:paged_BV1xx__1", "P1", 60_000),
+            PlaybackPart("bilibili:paged_BV1xx__2", "P2", 70_000),
+        )
+        val provider = FakeProviderRepository(
+            tracks = listOf(parent, other),
+            resolveHandler = { track, _, _, _, _, _ ->
+                val partIndex = parts.indexOfFirst { it.id == track.id }.takeIf { it >= 0 } ?: 0
+                PlaybackPayload(
+                    url = "https://example.com/${parts[partIndex].id}.m4s",
+                    title = parts[partIndex].title,
+                    artists = parent.artists,
+                    album = parent.album,
+                    source = parent.source,
+                    providerName = parent.providerName,
+                    durationMs = parts[partIndex].durationMs,
+                    parts = parts,
+                    currentPartIndex = partIndex,
+                )
+            },
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.toggleShuffle()
+            controller.playLocalTrack(parent, listOf(parent, other))
+            advanceUntilIdle()
+
+            assertEquals("bilibili:BV1xx", engine.lastTrack?.id)
+            assertEquals(0, controller.playbackState.currentPartIndex)
+            assertEquals(parts, controller.playbackState.playbackParts)
+
+            engine.emitEnded(engine.lastTrack ?: parent)
+            advanceUntilIdle()
+
+            assertEquals("bilibili:BV1xx", engine.lastTrack?.id)
+            assertEquals("https://example.com/bilibili:paged_BV1xx__2.m4s", engine.lastPayload?.url)
+            assertEquals(1, controller.playbackState.currentPartIndex)
+            assertEquals("bilibili:BV1xx", controller.playbackState.queue.first().id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun staleEndedWhileNextTrackIsLoadingDoesNotSkipAgain() = runTest {
         val tracks = listOf(
             providerTrack("provider:1", "First"),


### PR DESCRIPTION
## Summary

- Support Bilibili multi-part videos as an internal ordered playback sequence.
- Keep the main playback queue item as the parent video while resolving and playing each `paged_` part in order.
- Show the part list inside the queue sheet and highlight the currently playing part.
- Show the current part number and title below the full-player title.

## Root Cause

`feeluown-bilibili` raises `MediaNotFound.Reason.check_children` for multi-page videos because the parent video has no single playable media. The mobile bridge previously selected only the first child, so playback could not continue through the remaining parts.

## Validation

- `PYTHONPATH=androidApp/build/python/pip/debug/common:androidApp/src/main/python python3 -m unittest androidApp/src/test/python/test_bridge_bilibili_pages.py androidApp/src/test/python/test_bridge_bilibili_standby.py androidApp/src/test/python/test_bridge_ytmusic_login.py`
- `./gradlew :shared:allTests`
- `./gradlew :androidApp:assembleDebug`
- `git diff --check`
