### PR TITLE
[feat] Add provider resource sharing

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,43 @@
+name: GitHub Pages
+
+"on":
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+      - .github/workflows/github-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -34,6 +34,17 @@
 
                 <data android:scheme="fuo" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="feeluown.github.io"
+                    android:pathPrefix="/FuoEvolve/r"
+                    android:scheme="https" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
 

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -20,10 +20,26 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="uiMode"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="fuo" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
         <activity

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -81,6 +81,22 @@ class AndroidFuoCoreBridge(
         }
     }
 
+    override suspend fun trackDetail(trackId: String): MusicTrack {
+        initialize()
+        return withContext(Dispatchers.IO) {
+            try {
+                Log.d(TAG, "trackDetail start trackId=$trackId")
+                val raw = requireNotNull(bridge).callAttr("track_detail", trackId).toString()
+                JSONObject(raw).getJSONObject("track").toTrack().also {
+                    Log.d(TAG, "trackDetail done trackId=$trackId title=${it.title}")
+                }
+            } catch (throwable: Throwable) {
+                Log.e(TAG, "trackDetail failed trackId=$trackId", throwable)
+                throw throwable
+            }
+        }
+    }
+
     override suspend fun resolve(
         track: MusicTrack,
         unavailablePolicy: UnavailablePlaybackPolicy,
@@ -311,6 +327,7 @@ class AndroidFuoCoreBridge(
             coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
             description = optString("description"),
             playCount = optLong("play_count").takeIf { it > 0 },
+            providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
         )
     }
 
@@ -332,6 +349,7 @@ class AndroidFuoCoreBridge(
             type = ProviderMediaItemType.valueOf(optString("type")),
             coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
             description = optString("description"),
+            providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
         )
     }
 
@@ -361,6 +379,7 @@ class AndroidFuoCoreBridge(
             providerName = optString("provider_name").ifBlank { source }.takeIf { it.isNotBlank() },
             artistItemId = optString("artist_item_id").takeIf { it.isNotBlank() },
             albumItemId = optString("album_item_id").takeIf { it.isNotBlank() },
+            providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
         )
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import android.Manifest
 import android.app.Activity.RESULT_OK
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -22,6 +23,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val fuoApplication = application as FuoEvolveApplication
+        val launchSharedText = sharedTextFromIntent(intent)
 
         setContent {
             var hasAudioPermission by remember { mutableStateOf(hasAudioPermission()) }
@@ -63,6 +65,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            LaunchedEffect(Unit) {
+                launchSharedText?.let(controller::openSharedResource)
+            }
+
             AppRoot(
                 controller = controller,
                 hasAudioPermission = hasAudioPermission,
@@ -81,7 +87,16 @@ class MainActivity : ComponentActivity() {
                     ProviderWebLoginActivity.clearWebLoginState()
                     controller.logoutProvider(provider.providerId)
                 },
+                onShareText = ::shareText,
             )
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        sharedTextFromIntent(intent)?.let {
+            (application as FuoEvolveApplication).controller.openSharedResource(it)
         }
     }
 
@@ -100,5 +115,20 @@ class MainActivity : ComponentActivity() {
             )
             else -> arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
+    }
+
+    private fun shareText(text: String) {
+        val sendIntent = Intent(Intent.ACTION_SEND)
+            .setType("text/plain")
+            .putExtra(Intent.EXTRA_TEXT, text)
+        startActivity(Intent.createChooser(sendIntent, "分享"))
+    }
+
+    private fun sharedTextFromIntent(intent: Intent?): String? {
+        return when (intent?.action) {
+            Intent.ACTION_VIEW -> intent.dataString
+            Intent.ACTION_SEND -> intent.getStringExtra(Intent.EXTRA_TEXT)
+            else -> null
+        }?.takeIf { it.isNotBlank() }
     }
 }

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -541,6 +541,13 @@ class FuoMobileBridge:
                 tracks.append(track)
         return json.dumps({"tracks": tracks}, ensure_ascii=False)
 
+    def track_detail(self, track_id: str) -> str:
+        song = self._tracks.get(track_id)
+        if song is None:
+            song = self._song_from_track_id(track_id)
+            self._tracks[track_id] = song
+        return json.dumps({"track": self._remember_song(song)}, ensure_ascii=False)
+
     def resolve(
         self,
         track_id: str,
@@ -1467,6 +1474,7 @@ def song_to_dict(song, library: Library) -> Dict[str, Any]:
         "cover_url": normalize_image_url(display(song, "pic_url")),
         "artist_item_id": first_artist_item_id(song),
         "album_item_id": album_item_id(song),
+        "provider_url": song_provider_url(song, library),
     }
 
 
@@ -1504,6 +1512,7 @@ def playlist_to_dict(playlist, library: Library) -> Dict[str, Any]:
         "cover_url": normalize_image_url(display(playlist, "cover")),
         "description": display(playlist, "description") or display(playlist, "creator_name"),
         "play_count": play_count(playlist),
+        "provider_url": provider_web_url(source, "playlist", identifier),
     }
 
 
@@ -1518,6 +1527,7 @@ def media_item_to_dict(item, item_type: str, library: Library) -> Dict[str, Any]
         "type": "Artist" if item_type == "artist" else "Album",
         "cover_url": normalize_image_url(display(item, "pic_url") or display(item, "cover") or display(item, "cover_url")),
         "description": display(item, "description") or display(item, "artists_name"),
+        "provider_url": provider_web_url(source, item_type, identifier),
     }
 
 
@@ -1555,6 +1565,44 @@ def normalize_image_url(url: Optional[str]) -> str:
     if value.startswith("http://qpic.y.qq.com/") or value.startswith("http://y.gtimg.cn/"):
         return "https://" + value[len("http://"):]
     return value
+
+
+def song_provider_url(song, library: Library) -> str:
+    try:
+        url = library.song_get_web_url(song)
+        if url:
+            return str(url)
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return provider_web_url(getattr(song, "source", ""), "song", getattr(song, "identifier", ""))
+
+
+def provider_web_url(source: str, resource_type: str, identifier: str) -> str:
+    if not source or not identifier:
+        return ""
+    if source == "netease":
+        path = {
+            "song": "song",
+            "playlist": "playlist",
+            "artist": "artist",
+            "album": "album",
+        }.get(resource_type)
+        return f"https://y.music.163.com/m/{path}?id={identifier}" if path else ""
+    if source == "qqmusic":
+        path = {
+            "song": "songDetail",
+            "artist": "singer",
+            "album": "albumDetail",
+        }.get(resource_type)
+        return f"https://y.qq.com/n/ryqq/{path}/{identifier}" if path else ""
+    if source == "ytmusic":
+        if resource_type == "song":
+            return f"https://music.youtube.com/watch?v={identifier}"
+        if resource_type == "playlist":
+            return f"https://music.youtube.com/playlist?list={identifier}"
+    if source == "bilibili" and resource_type == "song":
+        return f"https://www.bilibili.com/video/{identifier}"
+    return ""
 
 
 def display_artists(song) -> str:

--- a/androidApp/src/test/python/test_bridge_share.py
+++ b/androidApp/src/test/python/test_bridge_share.py
@@ -1,0 +1,90 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SRC_ROOT / "main" / "python"))
+
+from fuo_mobile.bridge import (  # noqa: E402
+    FuoMobileBridge,
+    media_item_to_dict,
+    playlist_to_dict,
+    provider_web_url,
+    song_to_dict,
+)
+
+
+class _Library:
+    def get(self, source):
+        return SimpleNamespace(identifier=source, name=source)
+
+    def song_get_web_url(self, song):
+        return f"https://provider.example/songs/{song.identifier}"
+
+
+class _Provider:
+    def __init__(self, song):
+        self.song = song
+
+    def song_get(self, identifier):
+        if identifier != self.song.identifier:
+            raise RuntimeError("not found")
+        return self.song
+
+
+def song(source="netease", identifier="1811961337"):
+    return SimpleNamespace(
+        source=source,
+        identifier=identifier,
+        title="Igallta",
+        artists=[SimpleNamespace(name="Se-U-Ra", identifier="artist1", source=source)],
+        album=SimpleNamespace(name="Igallta", identifier="album1", source=source),
+    )
+
+
+class BridgeShareTest(unittest.TestCase):
+    def test_song_to_dict_uses_core_web_url(self):
+        data = song_to_dict(song(), _Library())
+
+        self.assertEqual("https://provider.example/songs/1811961337", data["provider_url"])
+
+    def test_playlist_and_media_items_include_provider_url(self):
+        library = _Library()
+        playlist = SimpleNamespace(source="netease", identifier="123", name="Daily")
+        artist = SimpleNamespace(source="netease", identifier="456", name="Artist")
+        album = SimpleNamespace(source="netease", identifier="789", name="Album")
+
+        self.assertEqual(
+            "https://y.music.163.com/m/playlist?id=123",
+            playlist_to_dict(playlist, library)["provider_url"],
+        )
+        self.assertEqual(
+            "https://y.music.163.com/m/artist?id=456",
+            media_item_to_dict(artist, "artist", library)["provider_url"],
+        )
+        self.assertEqual(
+            "https://y.music.163.com/m/album?id=789",
+            media_item_to_dict(album, "album", library)["provider_url"],
+        )
+
+    def test_provider_web_url_returns_empty_for_unsupported_resource(self):
+        self.assertEqual("", provider_web_url("bilibili", "album", "123"))
+        self.assertEqual("https://www.bilibili.com/video/BV1xx", provider_web_url("bilibili", "song", "BV1xx"))
+
+    def test_track_detail_returns_track_payload(self):
+        bridge = FuoMobileBridge.__new__(FuoMobileBridge)
+        shared_song = song("qqmusic", "abc")
+        bridge._tracks = {}
+        bridge._get_provider = lambda provider_id: _Provider(shared_song)
+        bridge.app = SimpleNamespace(library=_Library())
+
+        payload = bridge.track_detail("qqmusic:abc")
+
+        self.assertIn('"id": "qqmusic:abc"', payload)
+        self.assertIn('"provider_url": "https://provider.example/songs/abc"', payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/.well-known/assetlinks.json
+++ b/docs/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.feeluown.mobile",
+      "sha256_cert_fingerprints": [
+        "8D:8B:E4:5A:04:CF:32:42:C1:3B:43:36:1C:9F:FA:1C:A8:FB:2F:39:D1:A4:3C:E3:5B:EA:DF:A8:DB:FE:FB:74"
+      ]
+    }
+  }
+]

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/FuoEvolve/">
+  <title>FuoEvolve</title>
+</head>
+<body>
+  <script>
+    sessionStorage.setItem("fuoevolve:path", location.pathname);
+    location.replace("/FuoEvolve/");
+  </script>
+</body>
+</html>

--- a/docs/app-links.md
+++ b/docs/app-links.md
@@ -1,0 +1,17 @@
+# FuoEvolve App Links
+
+FuoEvolve shares provider resources as GitHub Pages HTTPS links:
+
+```text
+https://feeluown.github.io/FuoEvolve/r/{provider}/{songs|playlists|artists|albums}/{id}
+```
+
+Android App Links verification requires the Digital Asset Links file at the host root:
+
+```text
+https://feeluown.github.io/.well-known/assetlinks.json
+```
+
+The copy in `docs/.well-known/assetlinks.json` is provided for GitHub Pages content and as the source file to publish in the `feeluown.github.io` organization/user Pages repository. A project Pages URL such as `https://feeluown.github.io/FuoEvolve/.well-known/assetlinks.json` is not enough for Android verification of the `feeluown.github.io` host.
+
+The app also keeps `fuo://{provider}/{namespace}/{id}` support as a manual fallback.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FuoEvolve</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: Canvas;
+      color: CanvasText;
+    }
+    main {
+      width: min(560px, calc(100vw - 32px));
+      padding: 32px 0;
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: 28px;
+      line-height: 1.2;
+    }
+    p {
+      margin: 0 0 20px;
+      line-height: 1.6;
+      color: color-mix(in srgb, CanvasText 72%, Canvas 28%);
+    }
+    a, button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      padding: 0 18px;
+      border-radius: 8px;
+      border: 1px solid color-mix(in srgb, CanvasText 18%, Canvas 82%);
+      background: CanvasText;
+      color: Canvas;
+      font: inherit;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    .secondary {
+      margin-left: 8px;
+      background: Canvas;
+      color: CanvasText;
+    }
+    code {
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>FuoEvolve</h1>
+    <p id="summary">正在读取分享链接。</p>
+    <button id="openButton" type="button">打开 FuoEvolve</button>
+    <a class="secondary" href="https://github.com/feeluown/FuoEvolve">查看项目</a>
+    <p><code id="fuoUri"></code></p>
+  </main>
+  <script>
+    const namespaceLabels = {
+      songs: "歌曲",
+      playlists: "歌单",
+      artists: "歌手",
+      albums: "专辑",
+    };
+
+    function parseResource() {
+      const path = sessionStorage.getItem("fuoevolve:path") || location.pathname;
+      sessionStorage.removeItem("fuoevolve:path");
+      const match = path.match(/\/FuoEvolve\/r\/([A-Za-z0-9_]+)\/(songs|playlists|artists|albums)\/([A-Za-z0-9_-]+)/);
+      if (!match) return null;
+      return {
+        provider: match[1],
+        namespace: match[2],
+        identifier: match[3],
+      };
+    }
+
+    const resource = parseResource();
+    const summary = document.getElementById("summary");
+    const openButton = document.getElementById("openButton");
+    const fuoUri = document.getElementById("fuoUri");
+
+    if (resource) {
+      const uri = `fuo://${resource.provider}/${resource.namespace}/${resource.identifier}`;
+      summary.textContent = `来自 ${resource.provider} 的${namespaceLabels[resource.namespace] || "资源"}分享。`;
+      fuoUri.textContent = uri;
+      openButton.addEventListener("click", () => {
+        location.href = uri;
+      });
+    } else {
+      summary.textContent = "这个链接没有包含可打开的 FuoEvolve 资源。";
+      openButton.disabled = true;
+      fuoUri.textContent = "";
+    }
+  </script>
+</body>
+</html>

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -67,6 +67,7 @@ import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
@@ -100,6 +101,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -107,13 +109,16 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -124,6 +129,8 @@ import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
+private val LocalShareHandler = staticCompositionLocalOf<(SharePayload) -> Unit> { {} }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppRoot(
@@ -132,6 +139,7 @@ fun AppRoot(
     onRequestAudioPermission: () -> Unit,
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
     onLogoutProvider: (ProviderInfo) -> Unit,
+    onShareText: (String) -> Unit = {},
     appVersionInfo: String? = null,
 ) {
     FuoEvolveTheme(
@@ -140,15 +148,24 @@ fun AppRoot(
     ) {
         val destination = appDestination(controller)
         val currentFeature = controller.selectedFeature
+        val currentTrack = controller.selectedTrack
         val currentPlaylist = controller.selectedPlaylist
         val currentMediaItem = controller.selectedMediaItem
+        var sharePayload by remember { mutableStateOf<SharePayload?>(null) }
+        val clipboardManager = LocalClipboardManager.current
         var lastFeature by remember { mutableStateOf<ProviderFeature?>(null) }
+        var lastTrack by remember { mutableStateOf<MusicTrack?>(null) }
         var lastPlaylist by remember { mutableStateOf<ProviderPlaylist?>(null) }
         var lastMediaItem by remember { mutableStateOf<ProviderMediaItem?>(null) }
 
         LaunchedEffect(currentFeature) {
             if (currentFeature != null) {
                 lastFeature = currentFeature
+            }
+        }
+        LaunchedEffect(currentTrack) {
+            if (currentTrack != null) {
+                lastTrack = currentTrack
             }
         }
         LaunchedEffect(currentPlaylist) {
@@ -162,6 +179,7 @@ fun AppRoot(
             }
         }
 
+        CompositionLocalProvider(LocalShareHandler provides { sharePayload = it }) {
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedContent(
                 targetState = destination,
@@ -191,6 +209,7 @@ fun AppRoot(
                     )
                     AppDestination.Search -> SearchScreen(controller)
                     AppDestination.Feature -> ProviderFeatureScreen(controller, currentFeature ?: lastFeature)
+                    AppDestination.Track -> ProviderTrackScreen(controller, currentTrack ?: lastTrack)
                     AppDestination.Playlist -> ProviderPlaylistScreen(controller, currentPlaylist ?: lastPlaylist)
                     AppDestination.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
                 }
@@ -206,6 +225,21 @@ fun AppRoot(
             controller.localMetadataEditorTrack?.let { track ->
                 LocalMetadataDialog(controller = controller, track = track)
             }
+            sharePayload?.let { payload ->
+                ShareResourceDialog(
+                    payload = payload,
+                    onDismiss = { sharePayload = null },
+                    onShare = { text ->
+                        sharePayload = null
+                        onShareText(text)
+                    },
+                    onCopy = { text ->
+                        clipboardManager.setText(AnnotatedString(text))
+                        sharePayload = null
+                    },
+                )
+            }
+        }
         }
     }
 }
@@ -213,6 +247,7 @@ fun AppRoot(
 private enum class AppDestination {
     Home,
     Feature,
+    Track,
     Playlist,
     Search,
     Settings,
@@ -224,6 +259,7 @@ private fun appDestination(controller: FuoPlayerController): AppDestination {
     return when {
         controller.isDebugLogOpen -> AppDestination.DebugLogs
         controller.isSettingsOpen -> AppDestination.Settings
+        controller.selectedTrack != null -> AppDestination.Track
         controller.selectedMediaItem != null -> AppDestination.MediaItem
         controller.selectedPlaylist != null -> AppDestination.Playlist
         controller.selectedFeature != null -> AppDestination.Feature
@@ -892,6 +928,93 @@ private fun PlayAllButton(onClick: () -> Unit, enabled: Boolean = true) {
 }
 
 @Composable
+private fun ShareTextButton(payload: SharePayload?) {
+    val onShare = LocalShareHandler.current
+    TextButton(
+        onClick = { if (payload != null) onShare(payload) },
+        enabled = payload != null,
+    ) {
+        Icon(
+            Icons.Filled.Share,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.size(4.dp))
+        Text("分享")
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ShareResourceDialog(
+    payload: SharePayload,
+    onDismiss: () -> Unit,
+    onShare: (String) -> Unit,
+    onCopy: (String) -> Unit,
+) {
+    var mode by remember(payload) { mutableStateOf(ShareMode.FullText) }
+    val modes = listOf(
+        ShareMode.FullText to "完整文本",
+        ShareMode.FuoLink to "Fuo 链接",
+        ShareMode.ProviderLink to "原站链接",
+    )
+    val content = payload.content(mode)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("分享${payload.resource.type.displayName}") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    modes.forEachIndexed { index, (itemMode, label) ->
+                        SegmentedButton(
+                            selected = mode == itemMode,
+                            onClick = { mode = itemMode },
+                            enabled = itemMode != ShareMode.ProviderLink || payload.providerUrl != null,
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
+                        ) {
+                            Text(label)
+                        }
+                    }
+                }
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(8.dp),
+                ) {
+                    Text(
+                        modifier = Modifier.padding(12.dp),
+                        text = content ?: "当前 provider 不支持原站链接",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { content?.let(onShare) },
+                enabled = content != null,
+            ) {
+                Text("分享")
+            }
+        },
+        dismissButton = {
+            Row {
+                TextButton(
+                    onClick = { content?.let(onCopy) },
+                    enabled = content != null,
+                ) {
+                    Text("复制")
+                }
+                TextButton(onClick = onDismiss) {
+                    Text("取消")
+                }
+            }
+        },
+    )
+}
+
+@Composable
 private fun ProviderDetailHeader(
     track: MusicTrack,
     title: String,
@@ -971,6 +1094,7 @@ private fun ProviderPlaylist.toDisplayTrack(): MusicTrack {
         sourceType = TrackSourceType.Provider,
         coverUrl = coverUrl,
         providerName = providerName,
+        providerUrl = providerUrl,
     )
 }
 
@@ -984,6 +1108,7 @@ private fun ProviderMediaItem.toDisplayTrack(): MusicTrack {
         sourceType = TrackSourceType.Provider,
         coverUrl = coverUrl,
         providerName = providerName,
+        providerUrl = providerUrl,
     )
 }
 
@@ -2668,8 +2793,85 @@ private fun ProviderFeatureScreen(controller: FuoPlayerController, feature: Prov
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+private fun ProviderTrackScreen(controller: FuoPlayerController, track: MusicTrack?) {
+    val displayTrack = controller.selectedTrack ?: track ?: return
+    val sharePayload = displayTrack.toSharePayload()
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = displayTrack.title.ifBlank { "歌曲" },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = controller::closeTrack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    val onShare = LocalShareHandler.current
+                    IconButton(
+                        onClick = { if (sharePayload != null) onShare(sharePayload) },
+                        enabled = sharePayload != null,
+                    ) {
+                        Icon(Icons.Filled.Share, contentDescription = "分享")
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            if (controller.playbackState.currentTrack != null) {
+                MiniPlayer(controller)
+            }
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            LoadingIndicator(controller.isLoading)
+            ProviderDetailHeader(
+                track = displayTrack,
+                title = displayTrack.title.ifBlank { "未知歌曲" },
+                subtitle = buildList {
+                    if (displayTrack.artists.isNotBlank()) add(displayTrack.artists)
+                    if (displayTrack.album.isNotBlank()) add("《${displayTrack.album}》")
+                    add(displayTrack.providerName ?: displayTrack.source)
+                }.joinToString(" · "),
+                description = "",
+                action = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        TextButton(onClick = controller::playSelectedTrack) {
+                            Icon(
+                                Icons.Filled.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.size(4.dp))
+                            Text("播放")
+                        }
+                        ShareTextButton(sharePayload)
+                    }
+                },
+            )
+            if (controller.selectedTrackError != null) {
+                ProviderContentMessage(controller.selectedTrackError.orEmpty())
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 private fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPlaylist?) {
     val displayPlaylist = controller.selectedPlaylist ?: playlist ?: return
+    val sharePayload = displayPlaylist.toSharePayload()
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -2683,6 +2885,15 @@ private fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: Pr
                 navigationIcon = {
                     IconButton(onClick = controller::closePlaylist) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    val onShare = LocalShareHandler.current
+                    IconButton(
+                        onClick = { if (sharePayload != null) onShare(sharePayload) },
+                        enabled = sharePayload != null,
+                    ) {
+                        Icon(Icons.Filled.Share, contentDescription = "分享")
                     }
                 },
             )
@@ -2712,10 +2923,15 @@ private fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: Pr
                 description = displayPlaylist.description,
                 action = if (controller.selectedPlaylistTracks.isNotEmpty()) {
                     {
-                        PlayAllButton(onClick = controller::playAllFromSelectedPlaylist)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            PlayAllButton(onClick = controller::playAllFromSelectedPlaylist)
+                            ShareTextButton(sharePayload)
+                        }
                     }
                 } else {
-                    null
+                    {
+                        ShareTextButton(sharePayload)
+                    }
                 },
             )
             if (controller.selectedPlaylistError != null) {
@@ -2763,6 +2979,7 @@ private fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: Pr
 private fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMediaItem?) {
     val displayItem = controller.selectedMediaItem ?: item ?: return
     val isArtist = displayItem.type == ProviderMediaItemType.Artist
+    val sharePayload = displayItem.toSharePayload()
     var selectedTabIndex by remember(displayItem.id) { mutableStateOf(0) }
     Scaffold(
         topBar = {
@@ -2779,6 +2996,15 @@ private fun ProviderMediaItemScreen(controller: FuoPlayerController, item: Provi
                 navigationIcon = {
                     IconButton(onClick = controller::closeMediaItem) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    val onShare = LocalShareHandler.current
+                    IconButton(
+                        onClick = { if (sharePayload != null) onShare(sharePayload) },
+                        enabled = sharePayload != null,
+                    ) {
+                        Icon(Icons.Filled.Share, contentDescription = "分享")
                     }
                 },
             )
@@ -2809,10 +3035,15 @@ private fun ProviderMediaItemScreen(controller: FuoPlayerController, item: Provi
                 description = displayItem.description,
                 action = if (controller.selectedMediaItemTracks.isNotEmpty()) {
                     {
-                        PlayAllButton(onClick = controller::playAllFromSelectedMediaItem)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            PlayAllButton(onClick = controller::playAllFromSelectedMediaItem)
+                            ShareTextButton(sharePayload)
+                        }
                     }
                 } else {
-                    null
+                    {
+                        ShareTextButton(sharePayload)
+                    }
                 },
             )
             if (controller.selectedMediaItemError != null) {
@@ -3024,6 +3255,8 @@ private fun TrackRow(
     onOpenAlbum: () -> Unit,
     onEditLocalMetadata: (() -> Unit)? = null,
 ) {
+    val onShare = LocalShareHandler.current
+    val sharePayload = track.toSharePayload()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -3064,6 +3297,7 @@ private fun TrackRow(
             onOpenArtist = onOpenArtist,
             onOpenAlbum = onOpenAlbum,
             onEditLocalMetadata = onEditLocalMetadata,
+            onShare = sharePayload?.let { payload -> { onShare(payload) } },
         )
     }
 }
@@ -3092,6 +3326,7 @@ private fun TrackAction(
     onOpenArtist: () -> Unit,
     onOpenAlbum: () -> Unit,
     onEditLocalMetadata: (() -> Unit)?,
+    onShare: (() -> Unit)?,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box {
@@ -3169,6 +3404,16 @@ private fun TrackAction(
                     onOpenAlbum()
                 },
             )
+            if (onShare != null) {
+                DropdownMenuItem(
+                    text = { Text("分享") },
+                    leadingIcon = { Icon(Icons.Filled.Share, contentDescription = null) },
+                    onClick = {
+                        expanded = false
+                        onShare()
+                    },
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -955,7 +955,7 @@ private fun ShareResourceDialog(
     var mode by remember(payload) { mutableStateOf(ShareMode.FullText) }
     val modes = listOf(
         ShareMode.FullText to "完整文本",
-        ShareMode.FuoLink to "Fuo 链接",
+        ShareMode.FuoLink to "FuoEvolve 链接",
         ShareMode.ProviderLink to "原站链接",
     )
     val content = payload.content(mode)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -114,11 +114,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -151,8 +149,6 @@ fun AppRoot(
         val currentTrack = controller.selectedTrack
         val currentPlaylist = controller.selectedPlaylist
         val currentMediaItem = controller.selectedMediaItem
-        var sharePayload by remember { mutableStateOf<SharePayload?>(null) }
-        val clipboardManager = LocalClipboardManager.current
         var lastFeature by remember { mutableStateOf<ProviderFeature?>(null) }
         var lastTrack by remember { mutableStateOf<MusicTrack?>(null) }
         var lastPlaylist by remember { mutableStateOf<ProviderPlaylist?>(null) }
@@ -179,7 +175,7 @@ fun AppRoot(
             }
         }
 
-        CompositionLocalProvider(LocalShareHandler provides { sharePayload = it }) {
+        CompositionLocalProvider(LocalShareHandler provides { onShareText(it.text) }) {
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedContent(
                 targetState = destination,
@@ -224,20 +220,6 @@ fun AppRoot(
             }
             controller.localMetadataEditorTrack?.let { track ->
                 LocalMetadataDialog(controller = controller, track = track)
-            }
-            sharePayload?.let { payload ->
-                ShareResourceDialog(
-                    payload = payload,
-                    onDismiss = { sharePayload = null },
-                    onShare = { text ->
-                        sharePayload = null
-                        onShareText(text)
-                    },
-                    onCopy = { text ->
-                        clipboardManager.setText(AnnotatedString(text))
-                        sharePayload = null
-                    },
-                )
             }
         }
         }
@@ -942,76 +924,6 @@ private fun ShareTextButton(payload: SharePayload?) {
         Spacer(Modifier.size(4.dp))
         Text("分享")
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ShareResourceDialog(
-    payload: SharePayload,
-    onDismiss: () -> Unit,
-    onShare: (String) -> Unit,
-    onCopy: (String) -> Unit,
-) {
-    var mode by remember(payload) { mutableStateOf(ShareMode.FullText) }
-    val modes = listOf(
-        ShareMode.FullText to "完整文本",
-        ShareMode.FuoLink to "FuoEvolve 链接",
-        ShareMode.ProviderLink to "原站链接",
-    )
-    val content = payload.content(mode)
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("分享${payload.resource.type.displayName}") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    modes.forEachIndexed { index, (itemMode, label) ->
-                        SegmentedButton(
-                            selected = mode == itemMode,
-                            onClick = { mode = itemMode },
-                            enabled = itemMode != ShareMode.ProviderLink || payload.providerUrl != null,
-                            shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
-                        ) {
-                            Text(label)
-                        }
-                    }
-                }
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                    shape = RoundedCornerShape(8.dp),
-                ) {
-                    Text(
-                        modifier = Modifier.padding(12.dp),
-                        text = content ?: "当前 provider 不支持原站链接",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { content?.let(onShare) },
-                enabled = content != null,
-            ) {
-                Text("分享")
-            }
-        },
-        dismissButton = {
-            Row {
-                TextButton(
-                    onClick = { content?.let(onCopy) },
-                    enabled = content != null,
-                ) {
-                    Text("复制")
-                }
-                TextButton(onClick = onDismiss) {
-                    Text("取消")
-                }
-            }
-        },
-    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -148,6 +148,7 @@ data class MusicTrack(
     val isUnavailable: Boolean = false,
     val artistItemId: String? = null,
     val albumItemId: String? = null,
+    val providerUrl: String? = null,
 )
 
 data class PlaybackPayload(
@@ -448,6 +449,7 @@ data class ProviderPlaylist(
     val coverUrl: String? = null,
     val description: String = "",
     val playCount: Long? = null,
+    val providerUrl: String? = null,
 )
 
 enum class ProviderMediaItemType {
@@ -463,6 +465,7 @@ data class ProviderMediaItem(
     val type: ProviderMediaItemType,
     val coverUrl: String? = null,
     val description: String = "",
+    val providerUrl: String? = null,
 )
 
 data class ProviderContentSection(
@@ -491,6 +494,9 @@ interface ProviderMusicRepository {
     suspend fun updateEnabledProviders(providerIds: Set<String>) = Unit
     suspend fun providers(): List<ProviderInfo>
     suspend fun search(keyword: String, providerId: String? = null): List<MusicTrack>
+    suspend fun trackDetail(trackId: String): MusicTrack {
+        throw UnsupportedOperationException("provider does not support track detail: $trackId")
+    }
     suspend fun resolve(
         track: MusicTrack,
         unavailablePolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -101,6 +101,10 @@ class FuoPlayerController(
         private set
     var selectedMediaItemError by mutableStateOf<String?>(null)
         private set
+    var selectedTrack by mutableStateOf<MusicTrack?>(null)
+        private set
+    var selectedTrackError by mutableStateOf<String?>(null)
+        private set
     var localTracks by mutableStateOf<List<MusicTrack>>(emptyList())
         private set
     var query by mutableStateOf("")
@@ -203,6 +207,7 @@ class FuoPlayerController(
             isSettingsOpen ||
             isSearchOpen ||
             selectedFeature != null ||
+            selectedTrack != null ||
             selectedMediaItem != null ||
             selectedPlaylist != null
 
@@ -368,6 +373,10 @@ class FuoPlayerController(
             }
             isSettingsOpen -> {
                 closeSettings()
+                true
+            }
+            selectedTrack != null -> {
+                closeTrack()
                 true
             }
             selectedMediaItem != null -> {
@@ -1120,6 +1129,83 @@ class FuoPlayerController(
         selectedFeatureError = null
     }
 
+    fun openTrackDetail(track: MusicTrack) {
+        if (track.sourceType != TrackSourceType.Provider) return
+        selectedTrack = track
+        selectedTrackError = null
+    }
+
+    fun openSharedResource(text: String) {
+        val resource = parseSharedResource(text)
+        if (resource == null) {
+            message = "无法识别分享链接"
+            return
+        }
+        scope.launch {
+            if (availableProviders.isEmpty()) {
+                runCatching { refreshProviderCatalog() }
+                    .onFailure {
+                        setError(it)
+                        return@launch
+                    }
+            }
+            val knownProviderIds = availableProviders.map { it.providerId }.toSet()
+            if (knownProviderIds.isNotEmpty() && resource.providerId !in knownProviderIds) {
+                message = "未找到 provider：${resource.providerId}"
+                return@launch
+            }
+            if (resource.providerId !in enabledProviderIds && resource.providerId in knownProviderIds) {
+                enabledProviderIds = enabledProviderIds + resource.providerId
+                persistSettings()
+                runCatching {
+                    providerRepository.updateEnabledProviders(enabledProviderIds)
+                    refreshProviderCatalog()
+                }.onFailure {
+                    setError(it)
+                    return@launch
+                }
+            }
+            when (resource.type) {
+                ShareResourceType.Song -> openSharedTrack(resource)
+                ShareResourceType.Playlist -> openPlaylist(resource.toProviderPlaylist())
+                ShareResourceType.Artist,
+                ShareResourceType.Album -> openMediaItem(resource.toProviderMediaItem())
+            }
+        }
+    }
+
+    private suspend fun openSharedTrack(resource: ShareResourceRef) {
+        val placeholder = MusicTrack(
+            id = resource.toProviderTrackId(),
+            title = resource.title,
+            artists = resource.artists,
+            album = resource.album,
+            source = resource.providerId,
+            sourceType = TrackSourceType.Provider,
+            providerName = resource.providerName,
+        )
+        selectedTrack = placeholder
+        selectedTrackError = null
+        isLoading = true
+        message = "正在加载：${resource.providerId}"
+        runCatching { providerRepository.trackDetail(resource.toProviderTrackId()) }
+            .onSuccess {
+                selectedTrack = it
+                selectedTrackError = null
+                message = it.title.ifBlank { "歌曲已加载" }
+            }
+            .onFailure {
+                selectedTrackError = it.message ?: "资源加载失败"
+                message = "资源加载失败"
+            }
+        isLoading = false
+    }
+
+    fun closeTrack() {
+        selectedTrack = null
+        selectedTrackError = null
+    }
+
     fun openPlaylist(playlist: ProviderPlaylist) {
         selectedPlaylist = playlist
         selectedPlaylistTracks = emptyList()
@@ -1271,6 +1357,11 @@ class FuoPlayerController(
 
     fun playAllFromSelectedMediaItem() {
         playFirst(selectedMediaItemTracks)
+    }
+
+    fun playSelectedTrack() {
+        val track = selectedTrack ?: return
+        play(track, listOf(track), 0)
     }
 
     fun playQueueIndex(index: Int) {
@@ -1544,9 +1635,11 @@ class FuoPlayerController(
         minePlaylistSections = emptyList()
         mineFavoritePlaylistSections = emptyList()
         selectedFeature = null
+        selectedTrack = null
         selectedPlaylist = null
         selectedMediaItem = null
         selectedFeatureTracks = emptyList()
+        selectedTrackError = null
         selectedPlaylistTracks = emptyList()
         selectedMediaItemTracks = emptyList()
         selectedMediaItemAlbums = emptyList()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
@@ -29,13 +29,14 @@ data class ShareResourceRef(
 
 data class SharePayload(
     val resource: ShareResourceRef,
+    val appLinkUrl: String,
     val fuoUri: String,
     val providerUrl: String?,
     val text: String,
 ) {
     fun content(mode: ShareMode): String? = when (mode) {
         ShareMode.FullText -> text
-        ShareMode.FuoLink -> fuoUri
+        ShareMode.FuoLink -> appLinkUrl
         ShareMode.ProviderLink -> providerUrl
     }
 }
@@ -89,6 +90,7 @@ fun ProviderMediaItem.toSharePayload(): SharePayload? {
 
 fun ShareResourceRef.toSharePayload(): SharePayload {
     val fuoUri = "fuo://$providerId/${type.namespace}/$identifier"
+    val appLinkUrl = "$FUO_EVOLVE_PAGES_BASE_URL/$providerId/${type.namespace}/$identifier"
     val titleLine = when (type) {
         ShareResourceType.Song -> buildString {
             append("《")
@@ -104,12 +106,14 @@ fun ShareResourceRef.toSharePayload(): SharePayload {
     val text = buildList {
         add(titleLine)
         add("来源：$providerName")
+        add("点击 $appLinkUrl 用 FuoEvolve 打开")
         providerUrl?.takeIf { it.isNotBlank() }?.let { add("点击 $it 一起听") }
         add("或复制到 FuoEvolve：")
         add(fuoUri)
     }.joinToString("\n")
     return SharePayload(
         resource = this,
+        appLinkUrl = appLinkUrl,
         fuoUri = fuoUri,
         providerUrl = providerUrl?.takeIf { it.isNotBlank() },
         text = text,
@@ -117,7 +121,9 @@ fun ShareResourceRef.toSharePayload(): SharePayload {
 }
 
 fun parseSharedResource(text: String): ShareResourceRef? {
-    val match = FUO_URI_REGEX.find(text) ?: return null
+    val appLinkMatch = FUO_EVOLVE_PAGES_REGEX.find(text)
+    val fuoMatch = FUO_URI_REGEX.find(text)
+    val match = appLinkMatch ?: fuoMatch ?: return null
     val providerId = match.groupValues[1]
     val namespace = match.groupValues[2].ifBlank { ShareResourceType.Song.namespace }
     val identifier = match.groupValues[3]
@@ -165,7 +171,11 @@ fun ShareResourceRef.toProviderMediaItem(): ProviderMediaItem {
     )
 }
 
+const val FUO_EVOLVE_PAGES_BASE_URL = "https://feeluown.github.io/FuoEvolve/r"
+
 private val FUO_URI_REGEX = Regex("""fuo://([A-Za-z0-9_]+)/(?:(songs|playlists|artists|albums)/)?([A-Za-z0-9_-]+)""")
+private val FUO_EVOLVE_PAGES_REGEX =
+    Regex("""https://feeluown\.github\.io/FuoEvolve/r/([A-Za-z0-9_]+)/(songs|playlists|artists|albums)/([A-Za-z0-9_-]+)""")
 
 private fun providerIdentifier(id: String, providerId: String, prefix: String? = null): String? {
     if (id.isBlank() || providerId.isBlank()) return null

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
@@ -91,23 +91,31 @@ fun ProviderMediaItem.toSharePayload(): SharePayload? {
 fun ShareResourceRef.toSharePayload(): SharePayload {
     val fuoUri = "fuo://$providerId/${type.namespace}/$identifier"
     val appLinkUrl = "$FUO_EVOLVE_PAGES_BASE_URL/$providerId/${type.namespace}/$identifier"
+    val introLine = when (type) {
+        ShareResourceType.Song -> "分享一首歌："
+        ShareResourceType.Playlist -> "分享一个歌单："
+        ShareResourceType.Artist -> "分享一位歌手："
+        ShareResourceType.Album -> "分享一张专辑："
+    }
     val titleLine = when (type) {
         ShareResourceType.Song -> buildString {
             append("《")
             append(title)
             append("》")
             if (artists.isNotBlank()) append(" - ").append(artists)
-            if (album.isNotBlank()) append("，来自专辑《").append(album).append("》")
+            if (album.isNotBlank()) append("（专辑：").append(album).append("）")
         }
-        ShareResourceType.Playlist -> "分享歌单《$title》"
-        ShareResourceType.Artist -> "分享歌手 $title"
-        ShareResourceType.Album -> "分享专辑《$title》"
+        ShareResourceType.Playlist -> "《$title》"
+        ShareResourceType.Artist -> title
+        ShareResourceType.Album -> "《$title》"
     }
+    val openVerb = if (type == ShareResourceType.Song) "打开收听" else "打开查看"
+    val providerVerb = if (type == ShareResourceType.Song) "收听" else "查看"
     val text = buildList {
+        add(introLine)
         add(titleLine)
-        add("来源：$providerName")
-        add("点击 $appLinkUrl 用 FuoEvolve 打开")
-        providerUrl?.takeIf { it.isNotBlank() }?.let { add("点击 $it 一起听") }
+        add("$openVerb：$appLinkUrl")
+        providerUrl?.takeIf { it.isNotBlank() }?.let { add("也可以在$providerName$providerVerb：$it") }
     }.joinToString("\n")
     return SharePayload(
         resource = this,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
@@ -108,8 +108,6 @@ fun ShareResourceRef.toSharePayload(): SharePayload {
         add("来源：$providerName")
         add("点击 $appLinkUrl 用 FuoEvolve 打开")
         providerUrl?.takeIf { it.isNotBlank() }?.let { add("点击 $it 一起听") }
-        add("或复制到 FuoEvolve：")
-        add(fuoUri)
     }.joinToString("\n")
     return SharePayload(
         resource = this,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
@@ -1,0 +1,179 @@
+package org.feeluown.mobile
+
+enum class ShareResourceType(
+    val namespace: String,
+    val displayName: String,
+) {
+    Song("songs", "歌曲"),
+    Playlist("playlists", "歌单"),
+    Artist("artists", "歌手"),
+    Album("albums", "专辑"),
+}
+
+enum class ShareMode {
+    FullText,
+    FuoLink,
+    ProviderLink,
+}
+
+data class ShareResourceRef(
+    val type: ShareResourceType,
+    val providerId: String,
+    val providerName: String,
+    val identifier: String,
+    val title: String,
+    val artists: String = "",
+    val album: String = "",
+    val providerUrl: String? = null,
+)
+
+data class SharePayload(
+    val resource: ShareResourceRef,
+    val fuoUri: String,
+    val providerUrl: String?,
+    val text: String,
+) {
+    fun content(mode: ShareMode): String? = when (mode) {
+        ShareMode.FullText -> text
+        ShareMode.FuoLink -> fuoUri
+        ShareMode.ProviderLink -> providerUrl
+    }
+}
+
+fun MusicTrack.toSharePayload(): SharePayload? {
+    if (sourceType != TrackSourceType.Provider || source.isBlank()) return null
+    val identifier = providerIdentifier(id, source) ?: return null
+    return ShareResourceRef(
+        type = ShareResourceType.Song,
+        providerId = source,
+        providerName = providerName.orEmpty().ifBlank { source },
+        identifier = identifier,
+        title = title.ifBlank { "未知歌曲" },
+        artists = artists,
+        album = album,
+        providerUrl = providerUrl,
+    ).toSharePayload()
+}
+
+fun ProviderPlaylist.toSharePayload(): SharePayload? {
+    val identifier = providerIdentifier(id, providerId, "playlist") ?: return null
+    return ShareResourceRef(
+        type = ShareResourceType.Playlist,
+        providerId = providerId,
+        providerName = providerName.ifBlank { providerId },
+        identifier = identifier,
+        title = title.ifBlank { "未命名歌单" },
+        providerUrl = providerUrl,
+    ).toSharePayload()
+}
+
+fun ProviderMediaItem.toSharePayload(): SharePayload? {
+    val resourceType = when (type) {
+        ProviderMediaItemType.Artist -> ShareResourceType.Artist
+        ProviderMediaItemType.Album -> ShareResourceType.Album
+    }
+    val prefix = when (type) {
+        ProviderMediaItemType.Artist -> "artist"
+        ProviderMediaItemType.Album -> "album"
+    }
+    val identifier = providerIdentifier(id, providerId, prefix) ?: return null
+    return ShareResourceRef(
+        type = resourceType,
+        providerId = providerId,
+        providerName = providerName.ifBlank { providerId },
+        identifier = identifier,
+        title = title.ifBlank { resourceType.displayName },
+        providerUrl = providerUrl,
+    ).toSharePayload()
+}
+
+fun ShareResourceRef.toSharePayload(): SharePayload {
+    val fuoUri = "fuo://$providerId/${type.namespace}/$identifier"
+    val titleLine = when (type) {
+        ShareResourceType.Song -> buildString {
+            append("《")
+            append(title)
+            append("》")
+            if (artists.isNotBlank()) append(" - ").append(artists)
+            if (album.isNotBlank()) append("，来自专辑《").append(album).append("》")
+        }
+        ShareResourceType.Playlist -> "分享歌单《$title》"
+        ShareResourceType.Artist -> "分享歌手 $title"
+        ShareResourceType.Album -> "分享专辑《$title》"
+    }
+    val text = buildList {
+        add(titleLine)
+        add("来源：$providerName")
+        providerUrl?.takeIf { it.isNotBlank() }?.let { add("点击 $it 一起听") }
+        add("或复制到 FuoEvolve：")
+        add(fuoUri)
+    }.joinToString("\n")
+    return SharePayload(
+        resource = this,
+        fuoUri = fuoUri,
+        providerUrl = providerUrl?.takeIf { it.isNotBlank() },
+        text = text,
+    )
+}
+
+fun parseSharedResource(text: String): ShareResourceRef? {
+    val match = FUO_URI_REGEX.find(text) ?: return null
+    val providerId = match.groupValues[1]
+    val namespace = match.groupValues[2].ifBlank { ShareResourceType.Song.namespace }
+    val identifier = match.groupValues[3]
+    val type = when (namespace) {
+        ShareResourceType.Song.namespace -> ShareResourceType.Song
+        ShareResourceType.Playlist.namespace -> ShareResourceType.Playlist
+        ShareResourceType.Artist.namespace -> ShareResourceType.Artist
+        ShareResourceType.Album.namespace -> ShareResourceType.Album
+        else -> return null
+    }
+    return ShareResourceRef(
+        type = type,
+        providerId = providerId,
+        providerName = providerId,
+        identifier = identifier,
+        title = "",
+    )
+}
+
+fun ShareResourceRef.toProviderTrackId(): String = "$providerId:$identifier"
+
+fun ShareResourceRef.toProviderPlaylist(): ProviderPlaylist = ProviderPlaylist(
+    id = "playlist:$providerId:$identifier",
+    title = title,
+    providerId = providerId,
+    providerName = providerName,
+)
+
+fun ShareResourceRef.toProviderMediaItem(): ProviderMediaItem {
+    val itemType = when (type) {
+        ShareResourceType.Artist -> ProviderMediaItemType.Artist
+        ShareResourceType.Album -> ProviderMediaItemType.Album
+        else -> error("unsupported media item type: $type")
+    }
+    val prefix = when (itemType) {
+        ProviderMediaItemType.Artist -> "artist"
+        ProviderMediaItemType.Album -> "album"
+    }
+    return ProviderMediaItem(
+        id = "$prefix:$providerId:$identifier",
+        title = title,
+        providerId = providerId,
+        providerName = providerName,
+        type = itemType,
+    )
+}
+
+private val FUO_URI_REGEX = Regex("""fuo://([A-Za-z0-9_]+)/(?:(songs|playlists|artists|albums)/)?([A-Za-z0-9_-]+)""")
+
+private fun providerIdentifier(id: String, providerId: String, prefix: String? = null): String? {
+    if (id.isBlank() || providerId.isBlank()) return null
+    val parts = id.split(":", limit = 3)
+    return when {
+        prefix == null && parts.size == 2 && parts[0] == providerId -> parts[1]
+        prefix != null && parts.size == 3 && parts[0] == prefix && parts[1] == providerId -> parts[2]
+        !id.contains(":") -> id
+        else -> null
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -36,9 +36,7 @@ class FuoPlayerControllerTest {
             "《Igallta》 - Se-U-Ra，来自专辑《Igallta》\n" +
                 "来源：网易云音乐\n" +
                 "点击 https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337 用 FuoEvolve 打开\n" +
-                "点击 https://y.music.163.com/m/song?id=1811961337 一起听\n" +
-                "或复制到 FuoEvolve：\n" +
-                "fuo://netease/songs/1811961337",
+                "点击 https://y.music.163.com/m/song?id=1811961337 一起听",
             payload?.content(ShareMode.FullText),
         )
     }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -33,10 +33,10 @@ class FuoPlayerControllerTest {
             payload?.content(ShareMode.FuoLink),
         )
         assertEquals(
-            "《Igallta》 - Se-U-Ra，来自专辑《Igallta》\n" +
-                "来源：网易云音乐\n" +
-                "点击 https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337 用 FuoEvolve 打开\n" +
-                "点击 https://y.music.163.com/m/song?id=1811961337 一起听",
+            "分享一首歌：\n" +
+                "《Igallta》 - Se-U-Ra（专辑：Igallta）\n" +
+                "打开收听：https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337\n" +
+                "也可以在网易云音乐收听：https://y.music.163.com/m/song?id=1811961337",
             payload?.content(ShareMode.FullText),
         )
     }
@@ -53,6 +53,12 @@ class FuoPlayerControllerTest {
         assertEquals("fuo://netease/playlists/123", payload?.fuoUri)
         assertEquals("https://feeluown.github.io/FuoEvolve/r/netease/playlists/123", payload?.content(ShareMode.FuoLink))
         assertNull(payload?.content(ShareMode.ProviderLink))
+        assertEquals(
+            "分享一个歌单：\n" +
+                "《每日推荐》\n" +
+                "打开查看：https://feeluown.github.io/FuoEvolve/r/netease/playlists/123",
+            payload?.content(ShareMode.FullText),
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -11,9 +11,115 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FuoPlayerControllerTest {
+    @Test
+    fun providerTrackSharePayloadUsesFuoUriAndProviderUrl() {
+        val track = providerTrack("netease:1811961337", "Igallta").copy(
+            artists = "Se-U-Ra",
+            album = "Igallta",
+            providerUrl = "https://y.music.163.com/m/song?id=1811961337",
+        )
+
+        val payload = track.toSharePayload()
+
+        assertEquals("fuo://netease/songs/1811961337", payload?.fuoUri)
+        assertEquals("https://y.music.163.com/m/song?id=1811961337", payload?.content(ShareMode.ProviderLink))
+        assertEquals("fuo://netease/songs/1811961337", payload?.content(ShareMode.FuoLink))
+        assertEquals(
+            "《Igallta》 - Se-U-Ra，来自专辑《Igallta》\n" +
+                "来源：网易云音乐\n" +
+                "点击 https://y.music.163.com/m/song?id=1811961337 一起听\n" +
+                "或复制到 FuoEvolve：\n" +
+                "fuo://netease/songs/1811961337",
+            payload?.content(ShareMode.FullText),
+        )
+    }
+
+    @Test
+    fun sharePayloadWithoutProviderUrlDisablesProviderLinkOnly() {
+        val payload = ProviderPlaylist(
+            id = "playlist:netease:123",
+            title = "每日推荐",
+            providerId = "netease",
+            providerName = "网易云音乐",
+        ).toSharePayload()
+
+        assertEquals("fuo://netease/playlists/123", payload?.fuoUri)
+        assertNull(payload?.content(ShareMode.ProviderLink))
+    }
+
+    @Test
+    fun parseSharedResourceSupportsCanonicalAndShortSongUris() {
+        val canonical = parseSharedResource("复制到 FuoEvolve：fuo://netease/albums/456")
+        val shortSong = parseSharedResource("fuo://netease/1811961337")
+
+        assertEquals(ShareResourceType.Album, canonical?.type)
+        assertEquals("netease", canonical?.providerId)
+        assertEquals("456", canonical?.identifier)
+        assertEquals(ShareResourceType.Song, shortSong?.type)
+        assertEquals("1811961337", shortSong?.identifier)
+    }
+
+    @Test
+    fun openSharedSongEnablesProviderAndLoadsTrack() = runTest {
+        val providerTrack = providerTrack("qqmusic:abc", "Shared Song").copy(
+            source = "qqmusic",
+            providerName = "QQ 音乐",
+        )
+        val provider = FakeProviderRepository(listOf(providerTrack))
+        val settings = FakeSettingsStore(AppSettings(enabledProviderIds = setOf("netease")))
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = settings,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.openSharedResource("fuo://qqmusic/songs/abc")
+            advanceUntilIdle()
+
+            assertEquals("qqmusic:abc", provider.lastTrackDetailId)
+            assertEquals("Shared Song", controller.selectedTrack?.title)
+            assertEquals(setOf("netease", "qqmusic"), provider.lastEnabledProviderIds)
+            assertEquals(setOf("netease", "qqmusic"), settings.saved.enabledProviderIds)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun invalidSharedResourceDoesNotNavigate() = runTest {
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.openSharedResource("hello")
+            advanceUntilIdle()
+
+            assertNull(controller.selectedTrack)
+            assertNull(controller.selectedPlaylist)
+            assertNull(controller.selectedMediaItem)
+            assertEquals("无法识别分享链接", controller.message)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
     @Test
     fun downloadedProviderTrackUsesLocalPayload() = runTest {
         val provider = FakeProviderRepository(listOf(providerTrack("provider:1", "First")))
@@ -1920,6 +2026,7 @@ class FuoPlayerControllerTest {
         var lastSmartReplacementMinScore: Double? = null
         var lastSmartReplacementUseOriginalMetadata: Boolean? = null
         var lastSmartReplacementUseOriginalLyrics: Boolean? = null
+        var lastTrackDetailId: String? = null
         val loadedFeatureIds = mutableListOf<String>()
         val loadedMoreFeatureIds = mutableListOf<String>()
         val loadedMediaItemIds = mutableListOf<String>()
@@ -1937,6 +2044,11 @@ class FuoPlayerControllerTest {
             availableProviderInfos.filter { it.providerId in enabledProviderIds }
 
         override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> = tracks
+
+        override suspend fun trackDetail(trackId: String): MusicTrack {
+            lastTrackDetailId = trackId
+            return tracks.firstOrNull { it.id == trackId } ?: throw RuntimeException("track not found: $trackId")
+        }
 
         override suspend fun resolve(
             track: MusicTrack,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -26,11 +26,16 @@ class FuoPlayerControllerTest {
         val payload = track.toSharePayload()
 
         assertEquals("fuo://netease/songs/1811961337", payload?.fuoUri)
+        assertEquals("https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337", payload?.appLinkUrl)
         assertEquals("https://y.music.163.com/m/song?id=1811961337", payload?.content(ShareMode.ProviderLink))
-        assertEquals("fuo://netease/songs/1811961337", payload?.content(ShareMode.FuoLink))
+        assertEquals(
+            "https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337",
+            payload?.content(ShareMode.FuoLink),
+        )
         assertEquals(
             "《Igallta》 - Se-U-Ra，来自专辑《Igallta》\n" +
                 "来源：网易云音乐\n" +
+                "点击 https://feeluown.github.io/FuoEvolve/r/netease/songs/1811961337 用 FuoEvolve 打开\n" +
                 "点击 https://y.music.163.com/m/song?id=1811961337 一起听\n" +
                 "或复制到 FuoEvolve：\n" +
                 "fuo://netease/songs/1811961337",
@@ -48,19 +53,24 @@ class FuoPlayerControllerTest {
         ).toSharePayload()
 
         assertEquals("fuo://netease/playlists/123", payload?.fuoUri)
+        assertEquals("https://feeluown.github.io/FuoEvolve/r/netease/playlists/123", payload?.content(ShareMode.FuoLink))
         assertNull(payload?.content(ShareMode.ProviderLink))
     }
 
     @Test
-    fun parseSharedResourceSupportsCanonicalAndShortSongUris() {
+    fun parseSharedResourceSupportsCanonicalShortSongAndAppLinkUris() {
         val canonical = parseSharedResource("复制到 FuoEvolve：fuo://netease/albums/456")
         val shortSong = parseSharedResource("fuo://netease/1811961337")
+        val appLink = parseSharedResource("https://feeluown.github.io/FuoEvolve/r/qqmusic/songs/abc")
 
         assertEquals(ShareResourceType.Album, canonical?.type)
         assertEquals("netease", canonical?.providerId)
         assertEquals("456", canonical?.identifier)
         assertEquals(ShareResourceType.Song, shortSong?.type)
         assertEquals("1811961337", shortSong?.identifier)
+        assertEquals(ShareResourceType.Song, appLink?.type)
+        assertEquals("qqmusic", appLink?.providerId)
+        assertEquals("abc", appLink?.identifier)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add shared resource sharing models for songs, playlists, artists, and albums.
- Add Android fuo:// deep link handling and text share receive support.
- Share all resources directly through the system share sheet with full text; no in-app share mode dialog is shown.
- Full share text uses GitHub Pages HTTPS App Links and provider URLs, without including a raw fuo:// fallback.
- Register the GitHub Pages URL in Android as an App Link and keep fuo:// parsing as a compatibility fallback.
- Add provider URL generation in the Python bridge and Android share sheet UI.
- Add GitHub Pages deployment files plus Digital Asset Links documentation.

## App Links note
- Android verifies App Links against https://feeluown.github.io/.well-known/assetlinks.json for the feeluown.github.io host.
- The organization Pages repository feeluown/feeluown.github.io has been created and now publishes the matching assetlinks.json at the host root.

## Validation
- python -m unittest discover -s androidApp/src/test/python
- ./gradlew :shared:allTests
- ./gradlew :androidApp:assembleDebug
- git diff --check
- curl -iL https://feeluown.github.io/.well-known/assetlinks.json

Closes #8
