### PR TITLE
[feat] Cache local music library in database

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
@@ -3,10 +3,16 @@ package org.feeluown.mobile
 import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.provider.MediaStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -14,11 +20,38 @@ import java.io.File
 import java.util.Locale
 
 class AndroidLocalMusicRepository(
-    private val context: Context,
+    context: Context,
 ) : LocalMusicRepository {
-    private var cachedTracks: List<MusicTrack> = emptyList()
+    private val appContext = context.applicationContext
+    private val database = LocalMusicDatabase(appContext)
+    private val mutableMediaChangeEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     @Volatile
     private var scanSettings = LocalMusicScanSettings()
+
+    override val mediaChangeEvents: Flow<Unit> = mutableMediaChangeEvents
+
+    init {
+        val observer = object : android.database.ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                mutableMediaChangeEvents.tryEmit(Unit)
+            }
+
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                mutableMediaChangeEvents.tryEmit(Unit)
+            }
+        }
+        appContext.contentResolver.registerContentObserver(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            true,
+            observer,
+        )
+        appContext.contentResolver.registerContentObserver(
+            MediaStore.Files.getContentUri("external"),
+            true,
+            observer,
+        )
+    }
 
     override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
         withContext(Dispatchers.IO) {
@@ -26,70 +59,87 @@ class AndroidLocalMusicRepository(
         }
     }
 
-    override suspend fun directories(): List<LocalMusicDirectory> = withContext(Dispatchers.IO) {
-        val counts = linkedMapOf<String, Pair<String, Int>>()
-        queryAudioRows { row ->
-            val directory = directoryInfo(row.relativePath)
-            val current = counts[directory.id]
-            counts[directory.id] = directory.name to ((current?.second ?: 0) + 1)
-        }
-        counts.map { (id, value) ->
-            LocalMusicDirectory(
-                id = id,
-                name = value.first,
-                trackCount = value.second,
-            )
-        }.sortedBy { it.name }
+    override suspend fun isDatabaseReady(): Boolean = withContext(Dispatchers.IO) {
+        database.readableDatabase.getMeta(KEY_INITIALIZED) == "1"
     }
 
-    override suspend fun scan(): List<MusicTrack> = withContext(Dispatchers.IO) {
-        val tracks = mutableListOf<MusicTrack>()
-        val settings = scanSettings
-        val excludedDirectoryIds = settings.excludedDirectoryIds.normalizedDirectoryIds()
-        val metadataOverrides = metadataOverrides()
-        val lyrics = queryLyrics()
-        val appLyrics = queryAppLyrics()
-        queryAudioRows { row ->
-            val directory = directoryInfo(row.relativePath)
-            if (directory.id in excludedDirectoryIds) return@queryAudioRows
-            val durationMs = row.durationMs.takeIf { it > 0 }
-            if (settings.minDurationSeconds > 0 &&
-                (durationMs == null || durationMs < settings.minDurationSeconds * 1000L)
-            ) {
-                return@queryAudioRows
+    override suspend fun isDatabaseStale(): Boolean = withContext(Dispatchers.IO) {
+        val stored = database.readableDatabase.getMeta(KEY_MEDIA_FINGERPRINT)
+        stored == null || stored != queryMediaFingerprint()
+    }
+
+    override suspend fun directories(): List<LocalMusicDirectory> = withContext(Dispatchers.IO) {
+        val db = database.readableDatabase
+        val result = mutableListOf<LocalMusicDirectory>()
+        db.rawQuery(
+            """
+            SELECT directory_id, directory_name, COUNT(*)
+            FROM tracks
+            GROUP BY directory_id, directory_name
+            ORDER BY directory_name
+            """.trimIndent(),
+            null,
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                result += LocalMusicDirectory(
+                    id = cursor.getString(0).orEmpty(),
+                    name = cursor.getString(1).orEmpty(),
+                    trackCount = cursor.getInt(2),
+                )
             }
+        }
+        result
+    }
+
+    override suspend fun tracks(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        database.readableDatabase.readTracks(scanSettings)
+    }
+
+    override suspend fun refreshDatabase(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        val rows = queryAudioRows()
+        val metadataOverrides = metadataOverrides()
+        val folderLyrics = queryLyrics()
+        val appLyrics = queryAppLyrics()
+        val records = rows.map { row ->
+            val directory = directoryInfo(row.relativePath)
             val sourceType = if (row.relativePath.contains(FEELUOWN_FOLDER)) {
                 TrackSourceType.Downloaded
             } else {
                 TrackSourceType.LocalMediaStore
             }
             val override = metadataOverrides[row.uri.toString()]
-            tracks += MusicTrack(
-                id = if (sourceType == TrackSourceType.Downloaded) {
-                    "downloaded:${row.uri}"
-                } else {
-                    "local:${row.uri}"
-                },
-                title = override?.title ?: row.title,
-                artists = override?.artists ?: row.artist,
-                album = override?.album ?: row.album,
-                source = "local",
-                sourceType = sourceType,
-                coverUrl = localCoverUri(row.uri, row.albumId),
-                durationMs = durationMs,
-                localUri = row.uri.toString(),
-                lyrics = row.lyrics(lyrics, appLyrics),
+            LocalTrackRecord(
+                track = MusicTrack(
+                    id = if (sourceType == TrackSourceType.Downloaded) {
+                        "downloaded:${row.uri}"
+                    } else {
+                        "local:${row.uri}"
+                    },
+                    title = override?.title ?: row.title,
+                    artists = override?.artists ?: row.artist,
+                    album = override?.album ?: row.album,
+                    source = "local",
+                    sourceType = sourceType,
+                    coverUrl = localCoverUri(row.uri, row.albumId),
+                    durationMs = row.durationMs.takeIf { it > 0 },
+                    localUri = row.uri.toString(),
+                    lyrics = row.lyrics(folderLyrics, appLyrics),
+                ),
+                directory = directory,
+                displayName = row.displayName,
+                mediaId = row.mediaId,
+                dateAdded = row.dateAdded,
+                dateModified = row.dateModified,
             )
         }
-        cachedTracks = tracks
-        tracks
+        database.writableDatabase.replaceTracks(records, mediaFingerprint(rows))
+        database.readableDatabase.readTracks(scanSettings)
     }
 
     override suspend fun search(keyword: String): List<MusicTrack> {
-        val tracks = cachedTracks.ifEmpty { scan() }
         val normalized = keyword.trim()
         if (normalized.isEmpty()) return emptyList()
-        return tracks.filter {
+        return tracks().filter {
             it.title.contains(normalized, ignoreCase = true) ||
                 it.artists.contains(normalized, ignoreCase = true) ||
                 it.album.contains(normalized, ignoreCase = true)
@@ -108,17 +158,7 @@ class AndroidLocalMusicRepository(
             overrides[key] = nextMetadata
             saveMetadataOverrides(overrides)
             updateMediaStoreMetadata(key, nextMetadata)
-            cachedTracks = cachedTracks.map {
-                if (it.localUri == key) {
-                    it.copy(
-                        title = nextMetadata.title,
-                        artists = nextMetadata.artists,
-                        album = nextMetadata.album,
-                    )
-                } else {
-                    it
-                }
-            }
+            database.writableDatabase.updateTrackMetadata(key, nextMetadata)
         }
     }
 
@@ -126,17 +166,16 @@ class AndroidLocalMusicRepository(
         withContext(Dispatchers.IO) {
             val text = lyrics.takeIf { it.isNotBlank() } ?: return@withContext
             val fileName = lyricFileNameForTrack(track)
-            val target = File(File(context.filesDir, LYRICS_FOLDER), fileName)
+            val target = File(File(appContext.filesDir, LYRICS_FOLDER), fileName)
             val directory = requireNotNull(target.parentFile)
             if (!directory.exists()) directory.mkdirs()
             target.writeText(text, Charsets.UTF_8)
-            cachedTracks = cachedTracks.map {
-                if (it.id == track.id) it.copy(lyrics = text) else it
-            }
+            track.localUri?.let { database.writableDatabase.updateTrackLyrics(it, text) }
         }
     }
 
-    private fun queryAudioRows(onRow: (AudioRow) -> Unit) {
+    private fun queryAudioRows(): List<AudioRow> {
+        val rows = mutableListOf<AudioRow>()
         val collection = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
         val projection = mutableListOf(
             MediaStore.Audio.Media._ID,
@@ -146,6 +185,8 @@ class AndroidLocalMusicRepository(
             MediaStore.Audio.Media.ALBUM_ID,
             MediaStore.Audio.Media.DURATION,
             MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.DATE_ADDED,
+            MediaStore.Audio.Media.DATE_MODIFIED,
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 add(MediaStore.Audio.Media.RELATIVE_PATH)
@@ -157,7 +198,7 @@ class AndroidLocalMusicRepository(
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
         val sortOrder = "${MediaStore.Audio.Media.DATE_ADDED} DESC"
         try {
-            context.contentResolver.query(collection, projection, selection, null, sortOrder)
+            appContext.contentResolver.query(collection, projection, selection, null, sortOrder)
         } catch (_: SecurityException) {
             null
         }?.use { cursor ->
@@ -168,6 +209,8 @@ class AndroidLocalMusicRepository(
             val albumIdColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
             val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
             val displayNameColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            val dateModifiedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED)
             val relativePathColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
             } else {
@@ -181,31 +224,34 @@ class AndroidLocalMusicRepository(
             }
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idColumn)
-                val uri = ContentUris.withAppendedId(collection, id)
-                onRow(
-                    AudioRow(
-                        uri = uri,
-                        title = cursor.getString(titleColumn).orEmpty(),
-                        artist = cursor.getString(artistColumn).orEmpty(),
-                        album = cursor.getString(albumColumn).orEmpty(),
-                        albumId = cursor.getLong(albumIdColumn),
-                        durationMs = cursor.getLong(durationColumn),
-                        displayName = cursor.getString(displayNameColumn).orEmpty(),
-                        relativePath = if (relativePathColumn >= 0) {
-                            cursor.getString(relativePathColumn).orEmpty()
-                        } else {
-                            ""
-                        },
-                        filePath = if (dataColumn >= 0) {
-                            cursor.getString(dataColumn).orEmpty()
-                        } else {
-                            ""
-                        },
-                    )
+                rows += AudioRow(
+                    uri = ContentUris.withAppendedId(collection, id),
+                    title = cursor.getString(titleColumn).orEmpty(),
+                    artist = cursor.getString(artistColumn).orEmpty(),
+                    album = cursor.getString(albumColumn).orEmpty(),
+                    albumId = cursor.getLong(albumIdColumn),
+                    durationMs = cursor.getLong(durationColumn),
+                    displayName = cursor.getString(displayNameColumn).orEmpty(),
+                    relativePath = if (relativePathColumn >= 0) {
+                        cursor.getString(relativePathColumn).orEmpty()
+                    } else {
+                        ""
+                    },
+                    filePath = if (dataColumn >= 0) {
+                        cursor.getString(dataColumn).orEmpty()
+                    } else {
+                        ""
+                    },
+                    mediaId = id,
+                    dateAdded = cursor.getLong(dateAddedColumn),
+                    dateModified = cursor.getLong(dateModifiedColumn),
                 )
             }
         }
+        return rows
     }
+
+    private fun queryMediaFingerprint(): String = mediaFingerprint(queryAudioRows())
 
     private fun queryLyrics(): Map<String, String> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return emptyMap()
@@ -218,7 +264,7 @@ class AndroidLocalMusicRepository(
         val selection = "${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ?"
         val result = linkedMapOf<String, String>()
         try {
-            context.contentResolver.query(collection, projection, selection, arrayOf("%.lrc"), null)
+            appContext.contentResolver.query(collection, projection, selection, arrayOf("%.lrc"), null)
         } catch (_: SecurityException) {
             null
         }?.use { cursor ->
@@ -239,7 +285,7 @@ class AndroidLocalMusicRepository(
     }
 
     private fun queryAppLyrics(): Map<String, String> {
-        val directory = File(context.filesDir, LYRICS_FOLDER)
+        val directory = File(appContext.filesDir, LYRICS_FOLDER)
         if (!directory.isDirectory) return emptyMap()
         val result = linkedMapOf<String, String>()
         directory.listFiles { file ->
@@ -254,7 +300,7 @@ class AndroidLocalMusicRepository(
 
     private fun readText(uri: Uri): String? {
         return runCatching {
-            context.contentResolver.openInputStream(uri)?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }
+            appContext.contentResolver.openInputStream(uri)?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }
         }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 
@@ -293,7 +339,7 @@ class AndroidLocalMusicRepository(
         metadataOverrideFile().writeText(array.toString())
     }
 
-    private fun metadataOverrideFile(): File = File(context.filesDir, METADATA_OVERRIDE_FILE)
+    private fun metadataOverrideFile(): File = File(appContext.filesDir, METADATA_OVERRIDE_FILE)
 
     private fun updateMediaStoreMetadata(uriString: String, metadata: LocalTrackMetadata) {
         val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return
@@ -304,7 +350,7 @@ class AndroidLocalMusicRepository(
                 put(MediaStore.Audio.Media.ARTIST, metadata.artists)
                 put(MediaStore.Audio.Media.ALBUM, metadata.album)
             }
-            context.contentResolver.update(uri, values, null, null)
+            appContext.contentResolver.update(uri, values, null, null)
         }
     }
 
@@ -323,7 +369,7 @@ class AndroidLocalMusicRepository(
         }
         if (uri?.scheme == "content") {
             runCatching {
-                context.contentResolver.query(
+                appContext.contentResolver.query(
                     uri,
                     arrayOf(MediaStore.MediaColumns.DISPLAY_NAME),
                     null,
@@ -355,8 +401,61 @@ class AndroidLocalMusicRepository(
         private const val LYRICS_FOLDER = "lyrics"
         private const val METADATA_OVERRIDE_FILE = "local_music_metadata.json"
         private const val OTHER_DIRECTORY_ID = "__other__"
+        private const val KEY_INITIALIZED = "initialized"
+        private const val KEY_MEDIA_FINGERPRINT = "media_fingerprint"
+        private const val KEY_LAST_REFRESH_AT = "last_refresh_at"
     }
 }
+
+private class LocalMusicDatabase(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE tracks (
+                id TEXT PRIMARY KEY NOT NULL,
+                local_uri TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL,
+                artists TEXT NOT NULL,
+                album TEXT NOT NULL,
+                source TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                cover_url TEXT,
+                duration_ms INTEGER,
+                lyrics TEXT,
+                directory_id TEXT NOT NULL,
+                directory_name TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                media_id INTEGER NOT NULL,
+                date_added INTEGER NOT NULL,
+                date_modified INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX tracks_directory_idx ON tracks(directory_id)")
+        db.execSQL("CREATE INDEX tracks_title_idx ON tracks(title)")
+        db.execSQL("CREATE TABLE meta (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL)")
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        db.execSQL("DROP TABLE IF EXISTS tracks")
+        db.execSQL("DROP TABLE IF EXISTS meta")
+        onCreate(db)
+    }
+
+    private companion object {
+        private const val DATABASE_NAME = "local_music.db"
+        private const val DATABASE_VERSION = 1
+    }
+}
+
+private data class LocalTrackRecord(
+    val track: MusicTrack,
+    val directory: LocalMusicDirectory,
+    val displayName: String,
+    val mediaId: Long,
+    val dateAdded: Long,
+    val dateModified: Long,
+)
 
 private data class AudioRow(
     val uri: Uri,
@@ -368,7 +467,124 @@ private data class AudioRow(
     val displayName: String,
     val relativePath: String,
     val filePath: String,
+    val mediaId: Long,
+    val dateAdded: Long,
+    val dateModified: Long,
 )
+
+private fun SQLiteDatabase.replaceTracks(records: List<LocalTrackRecord>, fingerprint: String) {
+    beginTransaction()
+    try {
+        delete("tracks", null, null)
+        records.forEach { record ->
+            replace("tracks", null, record.toContentValues())
+        }
+        putMeta("initialized", "1")
+        putMeta("media_fingerprint", fingerprint)
+        putMeta("last_refresh_at", System.currentTimeMillis().toString())
+        setTransactionSuccessful()
+    } finally {
+        endTransaction()
+    }
+}
+
+private fun SQLiteDatabase.readTracks(settings: LocalMusicScanSettings): List<MusicTrack> {
+    val result = mutableListOf<MusicTrack>()
+    val excludedDirectoryIds = settings.excludedDirectoryIds.normalizedDirectoryIds()
+    rawQuery(
+        """
+        SELECT id, title, artists, album, source, source_type, cover_url, duration_ms, local_uri, lyrics, directory_id
+        FROM tracks
+        ORDER BY date_added DESC, title COLLATE NOCASE ASC
+        """.trimIndent(),
+        null,
+    ).use { cursor ->
+        while (cursor.moveToNext()) {
+            val directoryId = cursor.getString(10).orEmpty()
+            if (directoryId in excludedDirectoryIds) continue
+            val durationMs = cursor.getLong(7).takeIf { it > 0 }
+            if (settings.minDurationSeconds > 0 &&
+                (durationMs == null || durationMs < settings.minDurationSeconds * 1000L)
+            ) {
+                continue
+            }
+            result += MusicTrack(
+                id = cursor.getString(0).orEmpty(),
+                title = cursor.getString(1).orEmpty(),
+                artists = cursor.getString(2).orEmpty(),
+                album = cursor.getString(3).orEmpty(),
+                source = cursor.getString(4).orEmpty(),
+                sourceType = runCatching { TrackSourceType.valueOf(cursor.getString(5).orEmpty()) }
+                    .getOrDefault(TrackSourceType.LocalMediaStore),
+                coverUrl = cursor.getString(6)?.takeIf { it.isNotBlank() },
+                durationMs = durationMs,
+                localUri = cursor.getString(8).orEmpty(),
+                lyrics = cursor.getString(9)?.takeIf { it.isNotBlank() },
+            )
+        }
+    }
+    return result
+}
+
+private fun SQLiteDatabase.updateTrackMetadata(localUri: String, metadata: LocalTrackMetadata) {
+    update(
+        "tracks",
+        ContentValues().apply {
+            put("title", metadata.title)
+            put("artists", metadata.artists)
+            put("album", metadata.album)
+        },
+        "local_uri = ?",
+        arrayOf(localUri),
+    )
+}
+
+private fun SQLiteDatabase.updateTrackLyrics(localUri: String, lyrics: String) {
+    update(
+        "tracks",
+        ContentValues().apply { put("lyrics", lyrics) },
+        "local_uri = ?",
+        arrayOf(localUri),
+    )
+}
+
+private fun SQLiteDatabase.getMeta(key: String): String? {
+    query("meta", arrayOf("value"), "key = ?", arrayOf(key), null, null, null).use { cursor ->
+        return if (cursor.moveToFirst()) cursor.getString(0) else null
+    }
+}
+
+private fun SQLiteDatabase.putMeta(key: String, value: String) {
+    replace(
+        "meta",
+        null,
+        ContentValues().apply {
+            put("key", key)
+            put("value", value)
+        },
+    )
+}
+
+private fun LocalTrackRecord.toContentValues(): ContentValues {
+    return ContentValues().apply {
+        put("id", track.id)
+        put("local_uri", track.localUri.orEmpty())
+        put("title", track.title)
+        put("artists", track.artists)
+        put("album", track.album)
+        put("source", track.source)
+        put("source_type", track.sourceType.name)
+        put("cover_url", track.coverUrl)
+        put("duration_ms", track.durationMs ?: 0)
+        put("lyrics", track.lyrics)
+        put("directory_id", directory.id)
+        put("directory_name", directory.name)
+        put("display_name", displayName)
+        put("media_id", mediaId)
+        put("date_added", dateAdded)
+        put("date_modified", dateModified)
+    }
+}
 
 private fun AudioRow.lyrics(folderLyrics: Map<String, String>, appLyrics: Map<String, String>): String? {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
@@ -385,6 +601,20 @@ private fun AudioRow.lyrics(folderLyrics: Map<String, String>, appLyrics: Map<St
     if (folderLyric != null) return folderLyric
     val baseName = lyricBaseName(displayName)?.lowercase(Locale.ROOT) ?: return null
     return appLyrics[baseName]
+}
+
+private fun mediaFingerprint(rows: List<AudioRow>): String {
+    var maxDateAdded = 0L
+    var maxDateModified = 0L
+    var hash = 1125899906842597L
+    rows.forEach { row ->
+        if (row.dateAdded > maxDateAdded) maxDateAdded = row.dateAdded
+        if (row.dateModified > maxDateModified) maxDateModified = row.dateModified
+        hash = hash * 31 + row.mediaId
+        hash = hash * 31 + row.dateModified
+        hash = hash * 31 + row.durationMs
+    }
+    return "${rows.size}:$maxDateAdded:$maxDateModified:$hash"
 }
 
 private fun lyricKey(relativePath: String, fileName: String): String? {
@@ -423,10 +653,10 @@ private fun albumArtUri(albumId: Long): String? {
 }
 
 private fun localCoverUri(audioUri: Uri, albumId: Long): String {
-    return Uri.parse("fuo-cover://local")
-        .buildUpon()
-        .appendQueryParameter("audio", audioUri.toString())
+    return Uri.Builder()
+        .scheme("fuo-local-cover")
         .appendQueryParameter("albumArt", albumArtUri(albumId).orEmpty())
+        .appendQueryParameter("audio", audioUri.toString())
         .build()
         .toString()
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -59,12 +59,6 @@ class MainActivity : ComponentActivity() {
                 controller.navigateBack()
             }
 
-            LaunchedEffect(hasAudioPermission) {
-                if (hasAudioPermission) {
-                    controller.refreshLocalMusic()
-                }
-            }
-
             LaunchedEffect(Unit) {
                 launchSharedText?.let(controller::openSharedResource)
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -296,17 +296,24 @@ private fun HomeScreen(
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            if (!hasAudioPermission) {
-                PermissionPanel(onRequestAudioPermission)
-            }
             LoadingIndicator(controller.isLoading)
-            HomeSectionPager(controller, Modifier.weight(1f))
+            HomeSectionPager(
+                controller = controller,
+                hasAudioPermission = hasAudioPermission,
+                onRequestAudioPermission = onRequestAudioPermission,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }
 
 @Composable
-private fun HomeSectionPager(controller: FuoPlayerController, modifier: Modifier) {
+private fun HomeSectionPager(
+    controller: FuoPlayerController,
+    hasAudioPermission: Boolean,
+    onRequestAudioPermission: () -> Unit,
+    modifier: Modifier,
+) {
     val sections = listOf(
         HomeSection.Recommend to "推荐",
         HomeSection.Music to "探索",
@@ -371,6 +378,8 @@ private fun HomeSectionPager(controller: FuoPlayerController, modifier: Modifier
                 )
                 HomeSection.Mine -> MineHomeSection(
                     controller = controller,
+                    hasAudioPermission = hasAudioPermission,
+                    onRequestAudioPermission = onRequestAudioPermission,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -1070,7 +1079,12 @@ private fun EmptyProviderContentHint(title: String) {
 }
 
 @Composable
-private fun MineHomeSection(controller: FuoPlayerController, modifier: Modifier) {
+private fun MineHomeSection(
+    controller: FuoPlayerController,
+    hasAudioPermission: Boolean,
+    onRequestAudioPermission: () -> Unit,
+    modifier: Modifier,
+) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -1086,6 +1100,7 @@ private fun MineHomeSection(controller: FuoPlayerController, modifier: Modifier)
                 fontWeight = FontWeight.SemiBold,
             )
             IconButton(
+                enabled = controller.mineSection != MineSection.LocalMusic || hasAudioPermission,
                 onClick = {
                     when (controller.mineSection) {
                         MineSection.Playlists -> controller.refreshMinePlaylistContent()
@@ -1118,6 +1133,8 @@ private fun MineHomeSection(controller: FuoPlayerController, modifier: Modifier)
             )
             MineSection.LocalMusic -> LocalMusicSection(
                 controller = controller,
+                hasAudioPermission = hasAudioPermission,
+                onRequestAudioPermission = onRequestAudioPermission,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -1317,7 +1334,18 @@ private fun MineMediaItemsSection(
 }
 
 @Composable
-private fun LocalMusicSection(controller: FuoPlayerController, modifier: Modifier) {
+private fun LocalMusicSection(
+    controller: FuoPlayerController,
+    hasAudioPermission: Boolean,
+    onRequestAudioPermission: () -> Unit,
+    modifier: Modifier,
+) {
+    LaunchedEffect(hasAudioPermission) {
+        controller.onLocalMusicPermissionChange(hasAudioPermission)
+        if (hasAudioPermission) {
+            controller.ensureLocalMusic()
+        }
+    }
     val displayTracks = remember(controller.localTracks, controller.localMusicViewMode) {
         when (controller.localMusicViewMode) {
             LocalMusicViewMode.All -> controller.localTracks.sortedWith(
@@ -1359,6 +1387,10 @@ private fun LocalMusicSection(controller: FuoPlayerController, modifier: Modifie
                     Icon(Icons.Filled.Refresh, contentDescription = "刷新本地音乐")
                 }
             }
+        }
+        if (!hasAudioPermission) {
+            PermissionPanel(onRequestAudioPermission)
+            return@Column
         }
         LocalMusicViewModeTabs(controller)
         LazyColumn(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -1,7 +1,9 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 
 enum class TrackSourceType {
     Provider,
@@ -534,9 +536,15 @@ interface ProviderMusicRepository {
 }
 
 interface LocalMusicRepository {
+    val mediaChangeEvents: Flow<Unit>
+        get() = emptyFlow()
+
     suspend fun updateScanSettings(settings: LocalMusicScanSettings)
+    suspend fun isDatabaseReady(): Boolean = false
+    suspend fun isDatabaseStale(): Boolean = true
     suspend fun directories(): List<LocalMusicDirectory>
-    suspend fun scan(): List<MusicTrack>
+    suspend fun tracks(): List<MusicTrack>
+    suspend fun refreshDatabase(): List<MusicTrack>
     suspend fun search(keyword: String): List<MusicTrack>
     suspend fun updateMetadata(track: MusicTrack, metadata: LocalTrackMetadata) = Unit
     suspend fun saveLyrics(track: MusicTrack, lyrics: String) = Unit

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -227,6 +229,8 @@ class FuoPlayerController(
     private var autoAdvanceEligibleTrackId: String? = null
     private var playRequestSerial: Long = 0
     private var localMusicRefreshSerial: Long = 0
+    private var hasLocalMusicPermission: Boolean = false
+    private var pendingLocalMusicMediaRefresh: Job? = null
     private var playbackParts: List<PlaybackPart> = emptyList()
     private var currentPartIndex: Int = -1
 
@@ -296,6 +300,18 @@ class FuoPlayerController(
                 )
             }
         }
+        scope.launch {
+            localRepository.mediaChangeEvents.collect {
+                pendingLocalMusicMediaRefresh?.cancel()
+                pendingLocalMusicMediaRefresh = launch {
+                    delay(750)
+                    if (hasLocalMusicPermission && localRepository.isDatabaseReady()) {
+                        val showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic
+                        refreshLocalMusic(forceRefresh = true, showLoading = showLoading)
+                    }
+                }
+            }
+        }
     }
 
     fun authStateFor(provider: ProviderInfo): ProviderAuthState {
@@ -328,23 +344,92 @@ class FuoPlayerController(
         }
     }
 
+    fun onLocalMusicPermissionChange(hasPermission: Boolean) {
+        val wasGranted = hasLocalMusicPermission
+        hasLocalMusicPermission = hasPermission
+        if (hasPermission && !wasGranted && homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic) {
+            ensureLocalMusic()
+        }
+    }
+
+    fun ensureLocalMusic() {
+        if (!hasLocalMusicPermission) return
+        refreshLocalMusic(forceRefresh = false, showLoading = true)
+    }
+
     fun refreshLocalMusic() {
+        if (!hasLocalMusicPermission) {
+            message = "允许访问音频后可加载本地音乐"
+            return
+        }
+        refreshLocalMusic(forceRefresh = true, showLoading = true)
+    }
+
+    private fun refreshLocalMusic(forceRefresh: Boolean, showLoading: Boolean) {
+        val refreshSerial = ++localMusicRefreshSerial
+        scope.launch {
+            if (showLoading) {
+                isLoading = true
+                message = if (forceRefresh) "正在刷新本地音乐库" else "正在加载本地音乐"
+            }
+            val result = runCatching {
+                updateLocalMusicScanSettings()
+                val databaseReady = localRepository.isDatabaseReady()
+                val databaseStale = databaseReady && localRepository.isDatabaseStale()
+                val shouldRefresh = forceRefresh || !databaseReady || databaseStale
+                if (showLoading) {
+                    message = when {
+                        !databaseReady -> "正在建立本地音乐库"
+                        shouldRefresh -> "正在更新本地音乐库"
+                        else -> "正在加载本地音乐"
+                    }
+                }
+                val tracks = if (shouldRefresh) {
+                    localRepository.refreshDatabase()
+                } else {
+                    localRepository.tracks()
+                }
+                localMusicDirectories = localRepository.directories()
+                tracks
+            }
+            if (refreshSerial == localMusicRefreshSerial) {
+                result
+                    .onSuccess {
+                        localTracks = it
+                        if (showLoading) {
+                            message = if (it.isEmpty()) "未发现本地音乐" else "本地音乐 ${it.size} 首"
+                        }
+                    }
+                    .onFailure {
+                        if (showLoading) {
+                            setError(it)
+                        }
+                    }
+            }
+            if (showLoading) isLoading = false
+        }
+    }
+
+    private fun reloadLocalMusic() {
+        if (!hasLocalMusicPermission) return
         val refreshSerial = ++localMusicRefreshSerial
         scope.launch {
             isLoading = true
-            message = "正在扫描本地音乐"
+            message = "正在更新本地音乐筛选"
             val result = runCatching {
                 updateLocalMusicScanSettings()
+                val tracks = localRepository.tracks()
                 localMusicDirectories = localRepository.directories()
-                localRepository.scan()
+                tracks
             }
-            if (refreshSerial != localMusicRefreshSerial) return@launch
-            result
-                .onSuccess {
-                    localTracks = it
-                    message = if (it.isEmpty()) "未发现本地音乐" else "本地音乐 ${it.size} 首"
-                }
-                .onFailure { setError(it) }
+            if (refreshSerial == localMusicRefreshSerial) {
+                result
+                    .onSuccess {
+                        localTracks = it
+                        message = if (it.isEmpty()) "未发现本地音乐" else "本地音乐 ${it.size} 首"
+                    }
+                    .onFailure { setError(it) }
+            }
             isLoading = false
         }
     }
@@ -752,7 +837,7 @@ class FuoPlayerController(
             MineSection.Playlists -> if (minePlaylistSections.isEmpty()) refreshMinePlaylistContent()
             MineSection.Artists,
             MineSection.Albums -> if (mineSections.isEmpty()) refreshMineContent()
-            MineSection.LocalMusic -> if (localTracks.isEmpty()) refreshLocalMusic()
+            MineSection.LocalMusic -> ensureLocalMusic()
         }
     }
 
@@ -773,13 +858,13 @@ class FuoPlayerController(
             excludedLocalMusicDirectoryIds + directoryId
         }
         persistSettings()
-        refreshLocalMusic()
+        reloadLocalMusic()
     }
 
     fun onLocalMusicMinDurationChange(value: Int) {
         localMusicMinDurationSeconds = value
         persistSettings()
-        refreshLocalMusic()
+        reloadLocalMusic()
     }
 
     fun openLocalMetadataEditor(track: MusicTrack) {
@@ -815,7 +900,7 @@ class FuoPlayerController(
             runCatching {
                 localRepository.updateMetadata(track, metadata)
                 updateLocalMusicScanSettings()
-                localRepository.scan()
+                localRepository.refreshDatabase()
             }.onSuccess {
                 localTracks = it
                 updateLocalTrackCopies(track.id, it.firstOrNull { item -> item.id == track.id } ?: track.copy(
@@ -893,11 +978,11 @@ class FuoPlayerController(
                     message = "未获取到歌词"
                     localMetadataSearchMessage = "未获取到歌词"
                 } else {
-                    runCatching {
-                        localRepository.saveLyrics(track, lyrics)
-                        updateLocalMusicScanSettings()
-                        localRepository.scan()
-                    }.onSuccess {
+                        runCatching {
+                            localRepository.saveLyrics(track, lyrics)
+                            updateLocalMusicScanSettings()
+                            localRepository.refreshDatabase()
+                        }.onSuccess {
                         localTracks = it
                         val updatedTrack = it.firstOrNull { item -> item.id == track.id } ?: track.copy(lyrics = lyrics)
                         updateLocalTrackCopies(track.id, updatedTrack)
@@ -1066,7 +1151,7 @@ class FuoPlayerController(
             }
             MineSection.Artists,
             MineSection.Albums -> if (mineSections.isEmpty()) refreshMineContent()
-            MineSection.LocalMusic -> if (localTracks.isEmpty()) refreshLocalMusic()
+            MineSection.LocalMusic -> ensureLocalMusic()
         }
     }
 
@@ -1075,7 +1160,7 @@ class FuoPlayerController(
             MineSection.Playlists -> refreshMinePlaylistContent()
             MineSection.Artists,
             MineSection.Albums -> refreshMineContent()
-            MineSection.LocalMusic -> refreshLocalMusic()
+            MineSection.LocalMusic -> ensureLocalMusic()
         }
     }
 
@@ -1536,7 +1621,9 @@ class FuoPlayerController(
         scope.launch {
             runCatching { downloadRepository.download(track) }
                 .onSuccess {
-                    refreshLocalMusic()
+                    if (hasLocalMusicPermission) {
+                        refreshLocalMusic(forceRefresh = true, showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic)
+                    }
                     message = "已下载：${track.title}"
                 }
                 .onFailure { setError(it) }
@@ -1547,7 +1634,9 @@ class FuoPlayerController(
         scope.launch {
             runCatching { downloadRepository.deleteDownloaded(track) }
                 .onSuccess {
-                    refreshLocalMusic()
+                    if (hasLocalMusicPermission) {
+                        refreshLocalMusic(forceRefresh = true, showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic)
+                    }
                     message = "已删除下载：${track.title}"
                 }
                 .onFailure { setError(it) }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1,11 +1,13 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -1305,6 +1307,8 @@ class FuoPlayerControllerTest {
             )
 
             advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            advanceUntilIdle()
 
             assertEquals(HomeSection.Mine, controller.homeSection)
             assertEquals(MineSection.LocalMusic, controller.mineSection)
@@ -1387,7 +1391,7 @@ class FuoPlayerControllerTest {
     }
 
     @Test
-    fun staleLocalMusicRefreshDoesNotOverrideLatestDirectoryFilter() = runTest {
+    fun staleLocalMusicRefreshDoesNotOverrideLatestRefresh() = runTest {
         val staleScan = CompletableDeferred<List<MusicTrack>>()
         val filteredScan = CompletableDeferred<List<MusicTrack>>()
         val local = DeferredScanLocalMusicRepository(
@@ -1405,22 +1409,169 @@ class FuoPlayerControllerTest {
             )
 
             advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
             controller.refreshLocalMusic()
             advanceUntilIdle()
-            controller.onLocalMusicDirectoryEnabledChange("Blocked/", enabled = false)
+            controller.refreshLocalMusic()
             advanceUntilIdle()
 
             filteredScan.complete(listOf(localTrack("local:content://music/allowed", "Allowed")))
             advanceUntilIdle()
 
-            assertEquals(setOf("Blocked/"), controller.excludedLocalMusicDirectoryIds)
             assertEquals(listOf("Allowed"), controller.localTracks.map { it.title })
 
             staleScan.complete(listOf(localTrack("local:content://music/blocked", "Blocked")))
             advanceUntilIdle()
 
             assertEquals(listOf("Allowed"), controller.localTracks.map { it.title })
-            assertEquals(LocalMusicScanSettings(setOf("Blocked/"), 0), local.lastSettings)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun localMusicTabWithoutPermissionDoesNotReadOrRefreshDatabase() = runTest {
+        val local = FakeLocalMusicRepository(databaseReady = false)
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onHomeSectionChange(HomeSection.Mine)
+            controller.onMineSectionChange(MineSection.LocalMusic)
+            advanceUntilIdle()
+
+            assertEquals(0, local.refreshDatabaseCount)
+            assertEquals(0, local.tracksReadCount)
+            assertEquals(emptyList(), controller.localTracks)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun firstLocalMusicEntryWithPermissionRefreshesDatabaseOnce() = runTest {
+        val local = FakeLocalMusicRepository(
+            tracks = listOf(localTrack("local:content://music/1", "Local")),
+            databaseReady = false,
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            controller.onHomeSectionChange(HomeSection.Mine)
+            controller.onMineSectionChange(MineSection.LocalMusic)
+            advanceUntilIdle()
+            controller.ensureLocalMusic()
+            advanceUntilIdle()
+
+            assertEquals(1, local.refreshDatabaseCount)
+            assertEquals(listOf("Local"), controller.localTracks.map { it.title })
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun readyLocalMusicDatabaseReadsTracksWithoutRefresh() = runTest {
+        val local = FakeLocalMusicRepository(
+            tracks = listOf(localTrack("local:content://music/1", "Cached")),
+            databaseReady = true,
+            databaseStale = false,
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            controller.onMineSectionChange(MineSection.LocalMusic)
+            advanceUntilIdle()
+
+            assertEquals(0, local.refreshDatabaseCount)
+            assertEquals(1, local.tracksReadCount)
+            assertEquals(listOf("Cached"), controller.localTracks.map { it.title })
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun localMusicFilterChangesOnlyReadDatabase() = runTest {
+        val local = FakeLocalMusicRepository(
+            tracks = listOf(localTrack("local:content://music/1", "Cached")),
+            databaseReady = true,
+            databaseStale = false,
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            controller.onMineSectionChange(MineSection.LocalMusic)
+            advanceUntilIdle()
+            controller.onLocalMusicMinDurationChange(60)
+            advanceUntilIdle()
+
+            assertEquals(0, local.refreshDatabaseCount)
+            assertEquals(LocalMusicScanSettings(emptySet(), 60), local.lastSettings)
+            assertEquals(2, local.tracksReadCount)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun mediaChangeRefreshesInitializedLocalMusicDatabase() = runTest {
+        val local = FakeLocalMusicRepository(
+            tracks = listOf(localTrack("local:content://music/1", "Cached")),
+            databaseReady = true,
+            databaseStale = false,
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            local.emitMediaChange()
+            advanceTimeBy(750)
+            advanceUntilIdle()
+
+            assertEquals(1, local.refreshDatabaseCount)
         } finally {
             controllerScope.cancel()
         }
@@ -2211,19 +2362,43 @@ class FuoPlayerControllerTest {
     private class FakeLocalMusicRepository(
         private val directories: List<LocalMusicDirectory> = emptyList(),
         tracks: List<MusicTrack> = emptyList(),
+        var databaseReady: Boolean = true,
+        var databaseStale: Boolean = false,
     ) : LocalMusicRepository {
+        private val mutableMediaChangeEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        override val mediaChangeEvents = mutableMediaChangeEvents
         var lastSettings = LocalMusicScanSettings()
         var lastMetadata: LocalTrackMetadata? = null
         var lastSavedLyrics: String? = null
+        var tracksReadCount = 0
+        var refreshDatabaseCount = 0
         private var tracks = tracks
+
+        fun emitMediaChange() {
+            mutableMediaChangeEvents.tryEmit(Unit)
+        }
 
         override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
             lastSettings = settings
         }
 
+        override suspend fun isDatabaseReady(): Boolean = databaseReady
+
+        override suspend fun isDatabaseStale(): Boolean = databaseStale
+
         override suspend fun directories(): List<LocalMusicDirectory> = directories
 
-        override suspend fun scan(): List<MusicTrack> = tracks
+        override suspend fun tracks(): List<MusicTrack> {
+            tracksReadCount += 1
+            return tracks
+        }
+
+        override suspend fun refreshDatabase(): List<MusicTrack> {
+            refreshDatabaseCount += 1
+            databaseReady = true
+            databaseStale = false
+            return tracks
+        }
 
         override suspend fun search(keyword: String): List<MusicTrack> = tracks.filter {
             it.title.contains(keyword, ignoreCase = true) ||
@@ -2260,14 +2435,22 @@ class FuoPlayerControllerTest {
     ) : LocalMusicRepository {
         private val pendingScans = ArrayDeque(scans)
         var lastSettings = LocalMusicScanSettings()
+        var databaseReady: Boolean = true
+        var databaseStale: Boolean = false
 
         override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
             lastSettings = settings
         }
 
+        override suspend fun isDatabaseReady(): Boolean = databaseReady
+
+        override suspend fun isDatabaseStale(): Boolean = databaseStale
+
         override suspend fun directories(): List<LocalMusicDirectory> = directories
 
-        override suspend fun scan(): List<MusicTrack> {
+        override suspend fun tracks(): List<MusicTrack> = emptyList()
+
+        override suspend fun refreshDatabase(): List<MusicTrack> {
             return pendingScans.removeFirst().await()
         }
 

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -50,6 +50,7 @@ private class IosAppContainer {
 
     fun requestAudioPermission() {
         localRepository.requestPermission {
+            controller.onLocalMusicPermissionChange(true)
             controller.refreshLocalMusic()
         }
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
@@ -13,9 +13,15 @@ class IosLocalMusicRepository : LocalMusicRepository {
         scanSettings = settings
     }
 
+    override suspend fun isDatabaseReady(): Boolean = true
+
+    override suspend fun isDatabaseStale(): Boolean = false
+
     override suspend fun directories(): List<LocalMusicDirectory> = emptyList()
 
-    override suspend fun scan(): List<MusicTrack> = emptyList()
+    override suspend fun tracks(): List<MusicTrack> = emptyList()
+
+    override suspend fun refreshDatabase(): List<MusicTrack> = emptyList()
 
     override suspend fun search(keyword: String): List<MusicTrack> = emptyList()
 }


### PR DESCRIPTION
## Summary
- cache Android local music scan results in a SQLite-backed local library database
- move audio permission prompt into the local music tab and stop startup scans
- refresh the local library from manual refresh, app file changes, and debounced MediaStore change events

## Validation
- ./gradlew :shared:allTests
- ./gradlew :androidApp:assembleDebug