### PR TITLE
[feat] Page provider content loading

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -215,16 +215,20 @@ class AndroidFuoCoreBridge(
         }
     }
 
-    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection {
+    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+        loadFeaturePage(feature, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun loadFeaturePage(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection {
         initialize()
         return withContext(Dispatchers.IO) {
             try {
-                Log.d(TAG, "loadFeature start featureId=${feature.id}")
-                val raw = requireNotNull(bridge).callAttr("load_feature", feature.id).toString()
+                Log.d(TAG, "loadFeature start featureId=${feature.id} offset=$offset limit=$limit")
+                val raw = requireNotNull(bridge).callAttr("load_feature", feature.id, offset, limit).toString()
                 JSONObject(raw).toContentSection(feature).also {
                     Log.d(
                         TAG,
-                        "loadFeature done featureId=${feature.id} tracks=${it.tracks.size} playlists=${it.playlists.size} loginRequired=${it.isLoginRequired}",
+                        "loadFeature done featureId=${feature.id} tracks=${it.tracks.size} playlists=${it.playlists.size} " +
+                            "loginRequired=${it.isLoginRequired} hasMore=${it.hasMore}",
                     )
                 }
             } catch (throwable: Throwable) {
@@ -251,14 +255,17 @@ class AndroidFuoCoreBridge(
         }
     }
 
-    override suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail {
+    override suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail =
+        playlistDetailPage(playlist, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun playlistDetailPage(playlist: ProviderPlaylist, offset: Int, limit: Int): ProviderPlaylistDetail {
         initialize()
         return withContext(Dispatchers.IO) {
             try {
-                Log.d(TAG, "playlistDetail start playlistId=${playlist.id} title=${playlist.title}")
-                val raw = requireNotNull(bridge).callAttr("playlist_detail", playlist.id).toString()
+                Log.d(TAG, "playlistDetail start playlistId=${playlist.id} title=${playlist.title} offset=$offset limit=$limit")
+                val raw = requireNotNull(bridge).callAttr("playlist_detail", playlist.id, offset, limit).toString()
                 JSONObject(raw).toPlaylistDetail(playlist).also {
-                    Log.d(TAG, "playlistDetail done playlistId=${playlist.id} count=${it.tracks.size}")
+                    Log.d(TAG, "playlistDetail done playlistId=${playlist.id} count=${it.tracks.size} hasMore=${it.tracksHasMore}")
                 }
             } catch (throwable: Throwable) {
                 Log.e(TAG, "playlistDetail failed playlistId=${playlist.id}", throwable)
@@ -315,16 +322,31 @@ class AndroidFuoCoreBridge(
         }
     }
 
-    override suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail {
+    override suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
+        mediaItemDetailPage(item, tracksOffset = 0, albumsOffset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun mediaItemDetailPage(
+        item: ProviderMediaItem,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail {
         initialize()
         return withContext(Dispatchers.IO) {
             try {
-                Log.d(TAG, "mediaItemDetail start itemId=${item.id} title=${item.title}")
-                val raw = requireNotNull(bridge).callAttr("media_item_detail", item.id).toString()
+                Log.d(
+                    TAG,
+                    "mediaItemDetail start itemId=${item.id} title=${item.title} " +
+                        "tracksOffset=$tracksOffset albumsOffset=$albumsOffset limit=$limit",
+                )
+                val raw = requireNotNull(bridge)
+                    .callAttr("media_item_detail", item.id, tracksOffset, albumsOffset, limit)
+                    .toString()
                 JSONObject(raw).toMediaItemDetail(item).also {
                     Log.d(
                         TAG,
-                        "mediaItemDetail done itemId=${item.id} tracks=${it.tracks.size} albums=${it.albums.size}",
+                        "mediaItemDetail done itemId=${item.id} tracks=${it.tracks.size} albums=${it.albums.size} " +
+                            "tracksHasMore=${it.tracksHasMore} albumsHasMore=${it.albumsHasMore}",
                     )
                 }
             } catch (throwable: Throwable) {
@@ -440,6 +462,8 @@ class AndroidFuoCoreBridge(
             mediaItems = List(mediaItemsArray.length()) { index -> mediaItemsArray.getJSONObject(index).toMediaItem() },
             isLoginRequired = optBoolean("is_login_required"),
             errorMessage = optString("error_message").takeIf { it.isNotBlank() },
+            nextOffset = optInt("next_offset"),
+            hasMore = optBoolean("has_more"),
         )
     }
 
@@ -454,6 +478,7 @@ class AndroidFuoCoreBridge(
             description = optString("description"),
             playCount = optLong("play_count").takeIf { it > 0 },
             providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+            trackCount = optNullableInt("track_count"),
         )
     }
 
@@ -462,6 +487,8 @@ class AndroidFuoCoreBridge(
         return ProviderPlaylistDetail(
             playlist = optJSONObject("playlist")?.toPlaylist() ?: fallbackPlaylist,
             tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
+            tracksNextOffset = optInt("tracks_next_offset"),
+            tracksHasMore = optBoolean("tracks_has_more"),
         )
     }
 
@@ -476,6 +503,8 @@ class AndroidFuoCoreBridge(
             coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
             description = optString("description"),
             providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+            trackCount = optNullableInt("track_count"),
+            albumCount = optNullableInt("album_count"),
         )
     }
 
@@ -510,6 +539,10 @@ class AndroidFuoCoreBridge(
             item = optJSONObject("item")?.toMediaItem() ?: fallbackItem,
             tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
             albums = List(albumsArray.length()) { index -> albumsArray.getJSONObject(index).toMediaItem() },
+            tracksNextOffset = optInt("tracks_next_offset"),
+            tracksHasMore = optBoolean("tracks_has_more"),
+            albumsNextOffset = optInt("albums_next_offset"),
+            albumsHasMore = optBoolean("albums_has_more"),
         )
     }
 
@@ -649,6 +682,10 @@ class AndroidFuoCoreBridge(
             result[key] = optString(key)
         }
         return result
+    }
+
+    private fun JSONObject.optNullableInt(name: String): Int? {
+        return if (has(name) && !isNull(name)) optInt(name) else null
     }
 
     private companion object {

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -772,7 +772,7 @@ class FuoMobileBridge:
         self._delete_saved_login(provider_id)
         return json.dumps(provider_auth_state(provider, None), ensure_ascii=False)
 
-    def load_feature(self, feature_id: str) -> str:
+    def load_feature(self, feature_id: str, offset: int = 0, limit: int = 60) -> str:
         feature = self._feature_by_id(feature_id)
         provider = self._get_provider(feature["provider_id"])
         feature_payload = feature_to_dict(feature, provider)
@@ -785,11 +785,13 @@ class FuoMobileBridge:
                     "media_items": [],
                     "is_login_required": True,
                     "error_message": "",
+                    "next_offset": 0,
+                    "has_more": False,
                 },
                 ensure_ascii=False,
             )
         try:
-            tracks, playlists, media_items, title = self._load_feature_content(provider, feature)
+            tracks, playlists, media_items, title, page = self._load_feature_content(provider, feature, offset, limit)
             if title:
                 feature_payload["title"] = title
             payload = {
@@ -799,6 +801,8 @@ class FuoMobileBridge:
                 "media_items": media_items,
                 "is_login_required": False,
                 "error_message": "",
+                "next_offset": page["next_offset"],
+                "has_more": page["has_more"],
             }
         except Exception as exc:  # pylint: disable=broad-except
             payload = {
@@ -808,6 +812,8 @@ class FuoMobileBridge:
                 "media_items": [],
                 "is_login_required": False,
                 "error_message": str(exc) or exc.__class__.__name__,
+                "next_offset": offset,
+                "has_more": False,
             }
         return json.dumps(payload, ensure_ascii=False)
 
@@ -827,9 +833,9 @@ class FuoMobileBridge:
         bridge_log(f"playlist_tracks done playlist_id={playlist_id} count={len(tracks)}")
         return json.dumps({"tracks": tracks}, ensure_ascii=False)
 
-    def playlist_detail(self, playlist_id: str) -> str:
+    def playlist_detail(self, playlist_id: str, offset: int = 0, limit: int = 60) -> str:
         bridge_log(f"playlist_detail start playlist_id={playlist_id}")
-        payload = self._playlist_detail_payload(playlist_id)
+        payload = self._playlist_detail_payload(playlist_id, offset, limit)
         bridge_log(
             f"playlist_detail done playlist_id={playlist_id} count={len(payload['tracks'])}"
         )
@@ -919,9 +925,15 @@ class FuoMobileBridge:
         bridge_log(f"media_item_tracks done item_id={item_id} count={len(tracks)}")
         return json.dumps({"tracks": tracks}, ensure_ascii=False)
 
-    def media_item_detail(self, item_id: str) -> str:
+    def media_item_detail(
+        self,
+        item_id: str,
+        tracks_offset: int = 0,
+        albums_offset: int = 0,
+        limit: int = 60,
+    ) -> str:
         bridge_log(f"media_item_detail start item_id={item_id}")
-        payload = self._media_item_detail_payload(item_id)
+        payload = self._media_item_detail_payload(item_id, tracks_offset, albums_offset, limit)
         bridge_log(
             f"media_item_detail done item_id={item_id} "
             f"tracks={len(payload['tracks'])} albums={len(payload['albums'])}"
@@ -956,7 +968,7 @@ class FuoMobileBridge:
         bridge_log(f"playlist_tracks hydrated playlist_id={playlist_id}")
         return detail
 
-    def _playlist_detail_payload(self, playlist_id: str) -> Dict[str, Any]:
+    def _playlist_detail_payload(self, playlist_id: str, offset: int = 0, limit: int = 60) -> Dict[str, Any]:
         playlist = self._playlist_from_id(playlist_id)
         detail_playlist = self._playlist_detail_from_id(playlist_id)
         provider = self._get_provider(getattr(playlist, "source", ""))
@@ -965,37 +977,53 @@ class FuoMobileBridge:
             f"playlist_detail resolved playlist_id={playlist_id} source={getattr(track_playlist, 'source', '')}"
         )
         reader = provider.playlist_create_songs_rd(track_playlist)
-        songs = read_models(reader, limit=300)
+        page = read_model_page(reader, offset=offset, limit=limit)
+        songs = page["items"]
         tracks = [self._remember_song(song) for song in songs]
         return {
             "playlist": self._remember_playlist(detail_playlist),
             "tracks": tracks,
+            "tracks_next_offset": page["next_offset"],
+            "tracks_has_more": page["has_more"],
         }
 
-    def _media_item_detail_payload(self, item_id: str) -> Dict[str, Any]:
+    def _media_item_detail_payload(
+        self,
+        item_id: str,
+        tracks_offset: int = 0,
+        albums_offset: int = 0,
+        limit: int = 60,
+    ) -> Dict[str, Any]:
         item_type, provider_id, _ = self._parse_media_item_id(item_id)
         item = self._media_item_from_id(item_id)
         detail_item = self._media_item_detail_from_id(item_id)
         provider = self._get_provider(provider_id)
         albums = []
+        album_page = empty_page(albums_offset)
         if item_type == "artist":
             reader = provider.artist_create_songs_rd(item)
             album_reader = getattr(provider, "artist_create_albums_rd", None)
             if album_reader is not None:
+                album_page = read_model_page(album_reader(item), offset=albums_offset, limit=limit)
                 albums = [
                     self._remember_media_item(album, "album")
-                    for album in read_models(album_reader(item), limit=100)
+                    for album in album_page["items"]
                 ]
         elif item_type == "album":
             reader = provider.album_create_songs_rd(item)
         else:
             raise RuntimeError(f"unsupported media item type: {item_type}")
-        songs = read_models(reader, limit=300)
+        track_page = read_model_page(reader, offset=tracks_offset, limit=limit)
+        songs = track_page["items"]
         tracks = [self._remember_song(song) for song in songs]
         return {
             "item": self._remember_media_item(detail_item, item_type),
             "tracks": tracks,
             "albums": albums,
+            "tracks_next_offset": track_page["next_offset"],
+            "tracks_has_more": track_page["has_more"],
+            "albums_next_offset": album_page["next_offset"],
+            "albums_has_more": album_page["has_more"],
         }
 
     def _feature_by_id(self, feature_id: str) -> Dict[str, Any]:
@@ -1005,39 +1033,44 @@ class FuoMobileBridge:
                     return {**feature, "provider_id": provider_id}
         raise RuntimeError(f"feature not found: {feature_id}")
 
-    def _load_feature_content(self, provider, feature: Dict[str, Any]):
+    def _load_feature_content(self, provider, feature: Dict[str, Any], offset: int = 0, limit: int = 60):
         action = feature["action"]
         if action == "rec_list_daily_songs":
-            songs = read_models(provider.rec_list_daily_songs(), limit=50)
-            return [self._remember_song(song) for song in songs], [], [], ""
+            page = read_model_page(provider.rec_list_daily_songs(), offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], "", page
         if action == "rec_list_daily_playlists":
-            playlists = read_models(provider.rec_list_daily_playlists(), limit=30)
-            return [], [self._remember_playlist(playlist) for playlist in playlists], [], ""
+            page = read_model_page(provider.rec_list_daily_playlists(), offset=offset, limit=limit)
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
         if action == "current_user_list_radio_songs":
-            songs = provider.current_user_list_radio_songs(20)
-            return [self._remember_song(song) for song in songs], [], [], ""
+            songs = provider.current_user_list_radio_songs(max(1, min(int_limit(limit), 60)))
+            page = {
+                "items": songs,
+                "next_offset": offset + len(songs),
+                "has_more": bool(songs),
+            }
+            return [self._remember_song(song) for song in songs], [], [], "", page
         if action == "toplist_list":
-            playlists = read_models(provider.toplist_list(), limit=50)
-            return [], [self._remember_playlist(playlist) for playlist in playlists], [], ""
+            page = read_model_page(provider.toplist_list(), offset=offset, limit=limit)
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
         if action == "rec_a_collection_of_songs":
             collection = provider.rec_a_collection_of_songs()
-            songs = read_models(getattr(collection, "models", []) or [], limit=50)
-            return [self._remember_song(song) for song in songs], [], [], getattr(collection, "name", "")
+            page = read_model_page(getattr(collection, "models", []) or [], offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], getattr(collection, "name", ""), page
         if action == "current_user_fav_create_songs_rd":
-            songs = read_models(provider.current_user_fav_create_songs_rd(), limit=100)
-            return [self._remember_song(song) for song in songs], [], [], ""
+            page = read_model_page(provider.current_user_fav_create_songs_rd(), offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], "", page
         if action == "current_user_fav_create_playlists_rd":
-            playlists = read_models(provider.current_user_fav_create_playlists_rd(), limit=60)
-            return [], [self._remember_playlist(playlist) for playlist in playlists], [], ""
+            page = read_model_page(provider.current_user_fav_create_playlists_rd(), offset=offset, limit=limit)
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
         if action == "current_user_list_playlists":
-            playlists = read_models(provider.current_user_list_playlists(), limit=60)
-            return [], [self._remember_playlist(playlist) for playlist in playlists], [], ""
+            page = read_model_page(provider.current_user_list_playlists(), offset=offset, limit=limit)
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
         if action == "current_user_fav_create_artists_rd":
-            artists = read_models(provider.current_user_fav_create_artists_rd(), limit=60)
-            return [], [], [self._remember_media_item(artist, "artist") for artist in artists], ""
+            page = read_model_page(provider.current_user_fav_create_artists_rd(), offset=offset, limit=limit)
+            return [], [], [self._remember_media_item(artist, "artist") for artist in page["items"]], "", page
         if action == "current_user_fav_create_albums_rd":
-            albums = read_models(provider.current_user_fav_create_albums_rd(), limit=60)
-            return [], [], [self._remember_media_item(album, "album") for album in albums], ""
+            page = read_model_page(provider.current_user_fav_create_albums_rd(), offset=offset, limit=limit)
+            return [], [], [self._remember_media_item(album, "album") for album in page["items"]], "", page
         raise RuntimeError(f"unsupported feature action: {action}")
 
     def _playlist_from_id(self, playlist_id: str):
@@ -1770,6 +1803,66 @@ def read_models(value, limit: int = 50) -> List[Any]:
         return []
 
 
+def read_model_page(value, offset: int = 0, limit: int = 60) -> Dict[str, Any]:
+    safe_offset = max(0, int_offset(offset))
+    safe_limit = max(1, int_limit(limit))
+    read_limit = safe_limit + 1
+    if value is None:
+        return empty_page(safe_offset)
+    if isinstance(value, list):
+        items = value[safe_offset:safe_offset + read_limit]
+        return page_result(items, safe_offset, safe_limit)
+    if hasattr(value, "read_range"):
+        items = value.read_range(safe_offset, safe_offset + read_limit)
+        return page_result(items, safe_offset, safe_limit)
+    if hasattr(value, "readall"):
+        items = value.readall()[safe_offset:safe_offset + read_limit]
+        return page_result(items, safe_offset, safe_limit)
+    try:
+        items = []
+        for index, model in enumerate(value):
+            if index < safe_offset:
+                continue
+            items.append(model)
+            if len(items) >= read_limit:
+                break
+        return page_result(items, safe_offset, safe_limit)
+    except TypeError:
+        return empty_page(safe_offset)
+
+
+def page_result(items, offset: int, limit: int) -> Dict[str, Any]:
+    values = list(items or [])
+    page_items = values[:limit]
+    return {
+        "items": page_items,
+        "next_offset": offset + len(page_items),
+        "has_more": len(values) > limit,
+    }
+
+
+def empty_page(offset: int = 0) -> Dict[str, Any]:
+    return {
+        "items": [],
+        "next_offset": max(0, int_offset(offset)),
+        "has_more": False,
+    }
+
+
+def int_offset(value) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def int_limit(value) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 60
+
+
 def is_unsupported_search_type(exc: Exception) -> bool:
     return isinstance(exc, (KeyError, ValueError))
 
@@ -1857,6 +1950,7 @@ def playlist_to_dict(playlist, library: Library) -> Dict[str, Any]:
         "description": display(playlist, "description") or display(playlist, "creator_name"),
         "play_count": play_count(playlist),
         "provider_url": provider_web_url(source, "playlist", identifier),
+        "track_count": model_count(playlist, "count", "song_count", "songs_count", "track_count", "tracks_count"),
     }
 
 
@@ -1872,6 +1966,8 @@ def media_item_to_dict(item, item_type: str, library: Library) -> Dict[str, Any]
         "cover_url": normalize_image_url(display(item, "pic_url") or display(item, "cover") or display(item, "cover_url")),
         "description": display(item, "description") or display(item, "artists_name"),
         "provider_url": provider_web_url(source, item_type, identifier),
+        "track_count": model_count(item, "song_count", "songs_count", "track_count", "tracks_count"),
+        "album_count": model_count(item, "album_count", "albums_count"),
     }
 
 
@@ -2239,3 +2335,17 @@ def play_count(model) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def model_count(model, *fields: str) -> Optional[int]:
+    for field in fields:
+        value = getattr(model, field, None)
+        if value is None:
+            continue
+        try:
+            count = int(value)
+        except (TypeError, ValueError):
+            continue
+        if count >= 0:
+            return count
+    return None

--- a/androidApp/src/test/python/test_bridge_share.py
+++ b/androidApp/src/test/python/test_bridge_share.py
@@ -69,6 +69,19 @@ class BridgeShareTest(unittest.TestCase):
             media_item_to_dict(album, "album", library)["provider_url"],
         )
 
+    def test_playlist_and_media_items_include_known_detail_counts(self):
+        library = _Library()
+        playlist = SimpleNamespace(source="bilibili", identifier="123", name="Favorite", count=42)
+        artist = SimpleNamespace(source="netease", identifier="456", name="Artist", song_count=80, album_count=9)
+        album = SimpleNamespace(source="netease", identifier="789", name="Album", song_count=12)
+        unknown_playlist = SimpleNamespace(source="netease", identifier="321", name="Unknown")
+
+        self.assertEqual(42, playlist_to_dict(playlist, library)["track_count"])
+        self.assertEqual(80, media_item_to_dict(artist, "artist", library)["track_count"])
+        self.assertEqual(9, media_item_to_dict(artist, "artist", library)["album_count"])
+        self.assertEqual(12, media_item_to_dict(album, "album", library)["track_count"])
+        self.assertIsNone(playlist_to_dict(unknown_playlist, library)["track_count"])
+
     def test_provider_web_url_returns_empty_for_unsupported_resource(self):
         self.assertEqual("", provider_web_url("bilibili", "album", "123"))
         self.assertEqual("https://www.bilibili.com/video/BV1xx", provider_web_url("bilibili", "song", "BV1xx"))

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -113,6 +113,7 @@ val DEFAULT_WIFI_AUDIO_QUALITY_POLICY = AudioQualityPolicy.High
 val DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY = AudioQualityPolicy.Standard
 val DEFAULT_UNAVAILABLE_PLAYBACK_POLICY = UnavailablePlaybackPolicy.SmartReplace
 const val DEFAULT_SMART_REPLACEMENT_MIN_SCORE = 0.55
+const val PROVIDER_PAGE_SIZE = 60
 
 data class LocalMusicScanSettings(
     val excludedDirectoryIds: Set<String> = emptySet(),
@@ -514,6 +515,7 @@ data class ProviderPlaylist(
     val description: String = "",
     val playCount: Long? = null,
     val providerUrl: String? = null,
+    val trackCount: Int? = null,
 )
 
 enum class ProviderMediaItemType {
@@ -530,6 +532,8 @@ data class ProviderMediaItem(
     val coverUrl: String? = null,
     val description: String = "",
     val providerUrl: String? = null,
+    val trackCount: Int? = null,
+    val albumCount: Int? = null,
 )
 
 data class ProviderVideo(
@@ -567,17 +571,25 @@ data class ProviderContentSection(
     val mediaItems: List<ProviderMediaItem> = emptyList(),
     val isLoginRequired: Boolean = false,
     val errorMessage: String? = null,
+    val nextOffset: Int = 0,
+    val hasMore: Boolean = false,
 )
 
 data class ProviderPlaylistDetail(
     val playlist: ProviderPlaylist,
     val tracks: List<MusicTrack> = emptyList(),
+    val tracksNextOffset: Int = 0,
+    val tracksHasMore: Boolean = false,
 )
 
 data class ProviderMediaItemDetail(
     val item: ProviderMediaItem,
     val tracks: List<MusicTrack> = emptyList(),
     val albums: List<ProviderMediaItem> = emptyList(),
+    val tracksNextOffset: Int = 0,
+    val tracksHasMore: Boolean = false,
+    val albumsNextOffset: Int = 0,
+    val albumsHasMore: Boolean = false,
 )
 
 data class VideoPlaybackPayload(
@@ -618,9 +630,19 @@ interface ProviderMusicRepository {
     suspend fun providerCapabilities(): List<ProviderCapabilities> = emptyList()
     suspend fun features(): List<ProviderFeature>
     suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection
+    suspend fun loadFeaturePage(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int = PROVIDER_PAGE_SIZE,
+    ): ProviderContentSection = loadFeature(feature)
     suspend fun loadMoreFeatureTracks(feature: ProviderFeature): List<MusicTrack> = loadFeature(feature).tracks
     suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail =
         ProviderPlaylistDetail(playlist, playlistTracks(playlist))
+    suspend fun playlistDetailPage(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int = PROVIDER_PAGE_SIZE,
+    ): ProviderPlaylistDetail = playlistDetail(playlist)
     suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack>
     suspend fun playlistOperationTargets(track: MusicTrack): List<ProviderPlaylist> = emptyList()
     suspend fun addTrackToPlaylist(playlist: ProviderPlaylist, track: MusicTrack): ProviderMutationResult =
@@ -629,6 +651,12 @@ interface ProviderMusicRepository {
         ProviderMutationResult(false, "provider does not support playlist remove song")
     suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
         ProviderMediaItemDetail(item, mediaItemTracks(item))
+    suspend fun mediaItemDetailPage(
+        item: ProviderMediaItem,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int = PROVIDER_PAGE_SIZE,
+    ): ProviderMediaItemDetail = mediaItemDetail(item)
     suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack>
     suspend fun similarTracks(track: MusicTrack): List<MusicTrack> = emptyList()
     suspend fun hotComments(track: MusicTrack): List<ProviderComment> = emptyList()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -53,6 +53,7 @@ enum class LocalMusicViewMode {
 }
 
 private const val DYNAMIC_QUEUE_PREFETCH_REMAINING = 2
+private const val LIST_PREFETCH_REMAINING = 8
 private val DEFAULT_DEBUG_LOG_LEVEL_FILTERS = setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error)
 
 class FuoPlayerController(
@@ -100,11 +101,15 @@ class FuoPlayerController(
         private set
     var selectedPlaylistTracks by mutableStateOf<List<MusicTrack>>(emptyList())
         private set
+    var selectedPlaylistTracksHasMore by mutableStateOf(false)
+        private set
     var selectedPlaylistError by mutableStateOf<String?>(null)
         private set
     var selectedFeature by mutableStateOf<ProviderFeature?>(null)
         private set
     var selectedFeatureTracks by mutableStateOf<List<MusicTrack>>(emptyList())
+        private set
+    var selectedFeatureTracksHasMore by mutableStateOf(false)
         private set
     var selectedFeatureError by mutableStateOf<String?>(null)
         private set
@@ -112,7 +117,11 @@ class FuoPlayerController(
         private set
     var selectedMediaItemTracks by mutableStateOf<List<MusicTrack>>(emptyList())
         private set
+    var selectedMediaItemTracksHasMore by mutableStateOf(false)
+        private set
     var selectedMediaItemAlbums by mutableStateOf<List<ProviderMediaItem>>(emptyList())
+        private set
+    var selectedMediaItemAlbumsHasMore by mutableStateOf(false)
         private set
     var selectedMediaItemError by mutableStateOf<String?>(null)
         private set
@@ -265,6 +274,14 @@ class FuoPlayerController(
     private var isFmQueue: Boolean = false
     private var shuffleBeforeFm: Boolean? = null
     private var appendQueueFeatureTask: Deferred<Int>? = null
+    private var selectedFeatureTracksNextOffset = 0
+    private var selectedFeatureLoadMoreJob: Job? = null
+    private var selectedPlaylistTracksNextOffset = 0
+    private var selectedPlaylistLoadMoreJob: Job? = null
+    private var selectedMediaItemTracksNextOffset = 0
+    private var selectedMediaItemAlbumsNextOffset = 0
+    private var selectedMediaItemTracksLoadMoreJob: Job? = null
+    private var selectedMediaItemAlbumsLoadMoreJob: Job? = null
     private var lastEndedTrackId: String? = null
     private var autoAdvanceEligibleTrackId: String? = null
     private var lastRecoveredPlaybackErrorKey: String? = null
@@ -1169,7 +1186,7 @@ class FuoPlayerController(
                         } else if (feature.isDeferredHomeFeature()) {
                             ProviderContentSection(feature)
                         } else {
-                            runCatching { providerRepository.loadFeature(feature) }
+                            runCatching { providerRepository.loadFeaturePage(feature, offset = 0) }
                                 .getOrElse { ProviderContentSection(feature, errorMessage = it.message ?: "加载失败") }
                         }
                     }.sortedSectionsByOrder()
@@ -1236,7 +1253,7 @@ class FuoPlayerController(
                 if (feature.requiresLogin && !isProviderLoggedIn(feature.providerId)) {
                     ProviderContentSection(feature, isLoginRequired = true)
                 } else {
-                    runCatching { providerRepository.loadFeature(feature) }
+                    runCatching { providerRepository.loadFeaturePage(feature, offset = 0) }
                         .getOrElse { ProviderContentSection(feature, errorMessage = it.message ?: "加载失败") }
                 }
             }.sortedSectionsByOrder()
@@ -1275,11 +1292,14 @@ class FuoPlayerController(
     fun openFeature(feature: ProviderFeature) {
         selectedFeature = feature
         selectedFeatureTracks = emptyList()
+        selectedFeatureTracksNextOffset = 0
+        selectedFeatureTracksHasMore = false
+        selectedFeatureLoadMoreJob = null
         selectedFeatureError = null
         scope.launch {
             isLoading = true
             message = "正在加载：${feature.title}"
-            val deferred = scope.async { providerRepository.loadFeature(feature) }
+            val deferred = scope.async { providerRepository.loadFeaturePage(feature, offset = 0) }
             val result = withTimeoutOrNull(30_000) {
                 runCatching { deferred.await() }
             }
@@ -1291,6 +1311,8 @@ class FuoPlayerController(
                 result.onSuccess { section ->
                     if (selectedFeature == feature) {
                         selectedFeatureTracks = section.tracks
+                        selectedFeatureTracksNextOffset = section.nextOffset
+                        selectedFeatureTracksHasMore = section.hasMore
                         selectedFeatureError = when {
                             section.isLoginRequired -> "登录后显示 ${section.feature.providerName} 的个性化内容"
                             section.errorMessage != null -> section.errorMessage
@@ -1314,6 +1336,9 @@ class FuoPlayerController(
     fun closeFeature() {
         selectedFeature = null
         selectedFeatureTracks = emptyList()
+        selectedFeatureTracksNextOffset = 0
+        selectedFeatureTracksHasMore = false
+        selectedFeatureLoadMoreJob = null
         selectedFeatureError = null
     }
 
@@ -1562,11 +1587,14 @@ class FuoPlayerController(
         selectedPlaylist = playlist
         selectedPlaylistCategory = category
         selectedPlaylistTracks = emptyList()
+        selectedPlaylistTracksNextOffset = 0
+        selectedPlaylistTracksHasMore = false
+        selectedPlaylistLoadMoreJob = null
         selectedPlaylistError = null
         scope.launch {
             isLoading = true
             message = "正在加载：${playlist.title}"
-            val deferred = scope.async { providerRepository.playlistDetail(playlist) }
+            val deferred = scope.async { providerRepository.playlistDetailPage(playlist, offset = 0) }
             val result = withTimeoutOrNull(30_000) {
                 runCatching { deferred.await() }
             }
@@ -1579,6 +1607,8 @@ class FuoPlayerController(
                     if (selectedPlaylist?.id == playlist.id) {
                         selectedPlaylist = detail.playlist
                         selectedPlaylistTracks = detail.tracks
+                        selectedPlaylistTracksNextOffset = detail.tracksNextOffset
+                        selectedPlaylistTracksHasMore = detail.tracksHasMore
                         selectedPlaylistError = null
                         message = if (detail.tracks.isEmpty()) {
                             "歌单暂无歌曲"
@@ -1599,18 +1629,29 @@ class FuoPlayerController(
         selectedPlaylist = null
         selectedPlaylistCategory = null
         selectedPlaylistTracks = emptyList()
+        selectedPlaylistTracksNextOffset = 0
+        selectedPlaylistTracksHasMore = false
+        selectedPlaylistLoadMoreJob = null
         selectedPlaylistError = null
     }
 
     fun openMediaItem(item: ProviderMediaItem) {
         selectedMediaItem = item
         selectedMediaItemTracks = emptyList()
+        selectedMediaItemTracksNextOffset = 0
+        selectedMediaItemTracksHasMore = false
         selectedMediaItemAlbums = emptyList()
+        selectedMediaItemAlbumsNextOffset = 0
+        selectedMediaItemAlbumsHasMore = false
+        selectedMediaItemTracksLoadMoreJob = null
+        selectedMediaItemAlbumsLoadMoreJob = null
         selectedMediaItemError = null
         scope.launch {
             isLoading = true
             message = "正在加载：${item.title}"
-            val deferred = scope.async { providerRepository.mediaItemDetail(item) }
+            val deferred = scope.async {
+                providerRepository.mediaItemDetailPage(item, tracksOffset = 0, albumsOffset = 0)
+            }
             val result = withTimeoutOrNull(30_000) {
                 runCatching { deferred.await() }
             }
@@ -1623,7 +1664,11 @@ class FuoPlayerController(
                     if (selectedMediaItem?.id == item.id) {
                         selectedMediaItem = detail.item
                         selectedMediaItemTracks = detail.tracks
+                        selectedMediaItemTracksNextOffset = detail.tracksNextOffset
+                        selectedMediaItemTracksHasMore = detail.tracksHasMore
                         selectedMediaItemAlbums = detail.albums
+                        selectedMediaItemAlbumsNextOffset = detail.albumsNextOffset
+                        selectedMediaItemAlbumsHasMore = detail.albumsHasMore
                         selectedMediaItemError = null
                         val loadedParts = buildList {
                             if (detail.tracks.isNotEmpty()) add("${detail.tracks.size} 首")
@@ -1643,8 +1688,247 @@ class FuoPlayerController(
     fun closeMediaItem() {
         selectedMediaItem = null
         selectedMediaItemTracks = emptyList()
+        selectedMediaItemTracksNextOffset = 0
+        selectedMediaItemTracksHasMore = false
         selectedMediaItemAlbums = emptyList()
+        selectedMediaItemAlbumsNextOffset = 0
+        selectedMediaItemAlbumsHasMore = false
+        selectedMediaItemTracksLoadMoreJob = null
+        selectedMediaItemAlbumsLoadMoreJob = null
         selectedMediaItemError = null
+    }
+
+    fun prefetchSelectedFeatureIfNeeded(visibleIndex: Int) {
+        if (selectedFeatureTracks.size - visibleIndex <= LIST_PREFETCH_REMAINING) {
+            loadMoreSelectedFeatureTracks()
+        }
+    }
+
+    fun prefetchSelectedPlaylistIfNeeded(visibleIndex: Int) {
+        if (selectedPlaylistTracks.size - visibleIndex <= LIST_PREFETCH_REMAINING) {
+            loadMoreSelectedPlaylistTracks()
+        }
+    }
+
+    fun prefetchSelectedMediaItemTracksIfNeeded(visibleIndex: Int) {
+        if (selectedMediaItemTracks.size - visibleIndex <= LIST_PREFETCH_REMAINING) {
+            loadMoreSelectedMediaItemTracks()
+        }
+    }
+
+    fun prefetchSelectedMediaItemAlbumsIfNeeded(visibleIndex: Int) {
+        if (selectedMediaItemAlbums.size - visibleIndex <= LIST_PREFETCH_REMAINING) {
+            loadMoreSelectedMediaItemAlbums()
+        }
+    }
+
+    private fun loadMoreSelectedFeatureTracks() {
+        val feature = selectedFeature ?: return
+        if (feature.isDynamicQueueFeature() || !selectedFeatureTracksHasMore) return
+        if (selectedFeatureLoadMoreJob?.isActive == true) return
+        selectedFeatureLoadMoreJob = scope.launch {
+            appendSelectedFeatureTracksPage()
+        }
+    }
+
+    private suspend fun appendSelectedFeatureTracksPage(): Boolean {
+        val feature = selectedFeature ?: return false
+        if (feature.isDynamicQueueFeature() || !selectedFeatureTracksHasMore) return false
+        val offset = selectedFeatureTracksNextOffset
+        return runCatching {
+            withTimeout(30_000) {
+                providerRepository.loadFeaturePage(feature, offset)
+            }
+        }.fold(
+            onSuccess = { section ->
+                if (selectedFeature != feature) return false
+                val seenIds = selectedFeatureTracks.mapTo(mutableSetOf()) { it.id }
+                val newTracks = section.tracks.filter { seenIds.add(it.id) }
+                if (newTracks.isNotEmpty()) {
+                    selectedFeatureTracks = selectedFeatureTracks + newTracks
+                    updateHomeFeatureSection(
+                        section.copy(
+                            tracks = selectedFeatureTracks,
+                            nextOffset = section.nextOffset,
+                            hasMore = section.hasMore,
+                        ),
+                    )
+                }
+                selectedFeatureTracksNextOffset = section.nextOffset
+                selectedFeatureTracksHasMore = section.hasMore
+                section.nextOffset != offset || newTracks.isNotEmpty()
+            },
+            onFailure = {
+                selectedFeatureError = it.message ?: it::class.simpleName.orEmpty()
+                false
+            },
+        )
+    }
+
+    private fun loadMoreSelectedPlaylistTracks() {
+        if (selectedPlaylist == null || !selectedPlaylistTracksHasMore) return
+        if (selectedPlaylistLoadMoreJob?.isActive == true) return
+        selectedPlaylistLoadMoreJob = scope.launch {
+            appendSelectedPlaylistTracksPage()
+        }
+    }
+
+    private suspend fun appendSelectedPlaylistTracksPage(): Boolean {
+        val playlist = selectedPlaylist ?: return false
+        if (!selectedPlaylistTracksHasMore) return false
+        val offset = selectedPlaylistTracksNextOffset
+        return runCatching {
+            withTimeout(30_000) {
+                providerRepository.playlistDetailPage(playlist, offset)
+            }
+        }.fold(
+            onSuccess = { detail ->
+                if (selectedPlaylist?.id != playlist.id) return false
+                val seenIds = selectedPlaylistTracks.mapTo(mutableSetOf()) { it.id }
+                val newTracks = detail.tracks.filter { seenIds.add(it.id) }
+                selectedPlaylist = detail.playlist
+                if (newTracks.isNotEmpty()) {
+                    selectedPlaylistTracks = selectedPlaylistTracks + newTracks
+                }
+                selectedPlaylistTracksNextOffset = detail.tracksNextOffset
+                selectedPlaylistTracksHasMore = detail.tracksHasMore
+                selectedPlaylistError = null
+                detail.tracksNextOffset != offset || newTracks.isNotEmpty()
+            },
+            onFailure = {
+                selectedPlaylistError = it.message ?: it::class.simpleName.orEmpty()
+                false
+            },
+        )
+    }
+
+    private fun loadMoreSelectedMediaItemTracks() {
+        if (selectedMediaItem == null || !selectedMediaItemTracksHasMore) return
+        if (selectedMediaItemTracksLoadMoreJob?.isActive == true) return
+        selectedMediaItemTracksLoadMoreJob = scope.launch {
+            appendSelectedMediaItemTracksPage()
+        }
+    }
+
+    private suspend fun appendSelectedMediaItemTracksPage(): Boolean {
+        val item = selectedMediaItem ?: return false
+        if (!selectedMediaItemTracksHasMore) return false
+        val offset = selectedMediaItemTracksNextOffset
+        return runCatching {
+            withTimeout(30_000) {
+                providerRepository.mediaItemDetailPage(item, offset, selectedMediaItemAlbumsNextOffset)
+            }
+        }.fold(
+            onSuccess = { detail ->
+                if (selectedMediaItem?.id != item.id) return false
+                val seenIds = selectedMediaItemTracks.mapTo(mutableSetOf()) { it.id }
+                val newTracks = detail.tracks.filter { seenIds.add(it.id) }
+                selectedMediaItem = detail.item
+                if (newTracks.isNotEmpty()) {
+                    selectedMediaItemTracks = selectedMediaItemTracks + newTracks
+                }
+                selectedMediaItemTracksNextOffset = detail.tracksNextOffset
+                selectedMediaItemTracksHasMore = detail.tracksHasMore
+                selectedMediaItemError = null
+                detail.tracksNextOffset != offset || newTracks.isNotEmpty()
+            },
+            onFailure = {
+                selectedMediaItemError = it.message ?: it::class.simpleName.orEmpty()
+                false
+            },
+        )
+    }
+
+    private fun loadMoreSelectedMediaItemAlbums() {
+        if (selectedMediaItem == null || !selectedMediaItemAlbumsHasMore) return
+        if (selectedMediaItemAlbumsLoadMoreJob?.isActive == true) return
+        selectedMediaItemAlbumsLoadMoreJob = scope.launch {
+            appendSelectedMediaItemAlbumsPage()
+        }
+    }
+
+    private suspend fun appendSelectedMediaItemAlbumsPage(): Boolean {
+        val item = selectedMediaItem ?: return false
+        if (!selectedMediaItemAlbumsHasMore) return false
+        val offset = selectedMediaItemAlbumsNextOffset
+        return runCatching {
+            withTimeout(30_000) {
+                providerRepository.mediaItemDetailPage(item, selectedMediaItemTracksNextOffset, offset)
+            }
+        }.fold(
+            onSuccess = { detail ->
+                if (selectedMediaItem?.id != item.id) return false
+                val seenIds = selectedMediaItemAlbums.mapTo(mutableSetOf()) { it.id }
+                val newAlbums = detail.albums.filter { seenIds.add(it.id) }
+                selectedMediaItem = detail.item
+                if (newAlbums.isNotEmpty()) {
+                    selectedMediaItemAlbums = selectedMediaItemAlbums + newAlbums
+                }
+                selectedMediaItemAlbumsNextOffset = detail.albumsNextOffset
+                selectedMediaItemAlbumsHasMore = detail.albumsHasMore
+                selectedMediaItemError = null
+                detail.albumsNextOffset != offset || newAlbums.isNotEmpty()
+            },
+            onFailure = {
+                selectedMediaItemError = it.message ?: it::class.simpleName.orEmpty()
+                false
+            },
+        )
+    }
+
+    private suspend fun ensureAllSelectedFeatureTracks() {
+        selectedFeatureLoadMoreJob?.join()
+        while (selectedFeatureTracksHasMore) {
+            if (!appendSelectedFeatureTracksPage()) break
+        }
+    }
+
+    private suspend fun ensureAllSelectedPlaylistTracks() {
+        selectedPlaylistLoadMoreJob?.join()
+        while (selectedPlaylistTracksHasMore) {
+            if (!appendSelectedPlaylistTracksPage()) break
+        }
+    }
+
+    private suspend fun ensureAllSelectedMediaItemTracks() {
+        selectedMediaItemTracksLoadMoreJob?.join()
+        while (selectedMediaItemTracksHasMore) {
+            if (!appendSelectedMediaItemTracksPage()) break
+        }
+    }
+
+    private suspend fun loadCompleteFeatureSection(section: ProviderContentSection): ProviderContentSection {
+        var nextOffset = section.nextOffset
+        var hasMore = section.hasMore
+        var currentSection = section
+        var tracks = section.tracks
+        val seenIds = tracks.mapTo(mutableSetOf()) { it.id }
+        while (hasMore) {
+            val pageResult = runCatching {
+                withTimeout(30_000) {
+                    providerRepository.loadFeaturePage(section.feature, nextOffset)
+                }
+            }
+            if (pageResult.isFailure) {
+                setError(pageResult.exceptionOrNull() ?: RuntimeException("加载失败"))
+                break
+            }
+            val page = pageResult.getOrThrow()
+            val newTracks = page.tracks.filter { seenIds.add(it.id) }
+            if (newTracks.isNotEmpty()) {
+                tracks = tracks + newTracks
+            }
+            val progressed = page.nextOffset != nextOffset || newTracks.isNotEmpty()
+            nextOffset = page.nextOffset
+            hasMore = page.hasMore
+            currentSection = page
+            if (!progressed) break
+        }
+        return currentSection.copy(
+            tracks = tracks,
+            nextOffset = nextOffset,
+            hasMore = hasMore,
+        )
     }
 
     fun playFromLocal(index: Int) {
@@ -1681,8 +1965,17 @@ class FuoPlayerController(
         val feature = section?.feature ?: return
         if (section.tracks.isEmpty() && feature.isDynamicQueueFeature()) {
             loadFeatureAndPlayAll(feature)
+        } else if (feature.isDynamicQueueFeature()) {
+            playFirst(section.tracks, feature)
         } else {
-            playFirst(section.tracks, feature.takeIf { it.isDynamicQueueFeature() })
+            scope.launch {
+                isLoading = true
+                message = "正在加载完整列表：${feature.title}"
+                val completeSection = loadCompleteFeatureSection(section)
+                updateHomeFeatureSection(completeSection)
+                playFirst(completeSection.tracks)
+                isLoading = false
+            }
         }
     }
 
@@ -1692,7 +1985,14 @@ class FuoPlayerController(
     }
 
     fun playAllFromSelectedPlaylist() {
-        playFirst(selectedPlaylistTracks)
+        val playlist = selectedPlaylist ?: return
+        scope.launch {
+            isLoading = true
+            message = "正在加载完整歌单：${playlist.title}"
+            ensureAllSelectedPlaylistTracks()
+            playFirst(selectedPlaylistTracks)
+            isLoading = false
+        }
     }
 
     fun playFromSelectedFeature(index: Int) {
@@ -1701,7 +2001,18 @@ class FuoPlayerController(
     }
 
     fun playAllFromSelectedFeature() {
-        playFirst(selectedFeatureTracks, selectedFeature?.takeIf { it.isDynamicQueueFeature() })
+        val feature = selectedFeature ?: return
+        if (feature.isDynamicQueueFeature()) {
+            playFirst(selectedFeatureTracks, feature)
+            return
+        }
+        scope.launch {
+            isLoading = true
+            message = "正在加载完整列表：${feature.title}"
+            ensureAllSelectedFeatureTracks()
+            playFirst(selectedFeatureTracks)
+            isLoading = false
+        }
     }
 
     fun playFromSelectedMediaItem(index: Int) {
@@ -1710,7 +2021,14 @@ class FuoPlayerController(
     }
 
     fun playAllFromSelectedMediaItem() {
-        playFirst(selectedMediaItemTracks)
+        val item = selectedMediaItem ?: return
+        scope.launch {
+            isLoading = true
+            message = "正在加载完整列表：${item.title}"
+            ensureAllSelectedMediaItemTracks()
+            playFirst(selectedMediaItemTracks)
+            isLoading = false
+        }
     }
 
     fun playSelectedTrack() {
@@ -2056,10 +2374,22 @@ class FuoPlayerController(
         selectedPlaylistCategory = null
         selectedMediaItem = null
         selectedFeatureTracks = emptyList()
+        selectedFeatureTracksNextOffset = 0
+        selectedFeatureTracksHasMore = false
+        selectedFeatureLoadMoreJob = null
         selectedTrackError = null
         selectedPlaylistTracks = emptyList()
+        selectedPlaylistTracksNextOffset = 0
+        selectedPlaylistTracksHasMore = false
+        selectedPlaylistLoadMoreJob = null
         selectedMediaItemTracks = emptyList()
+        selectedMediaItemTracksNextOffset = 0
+        selectedMediaItemTracksHasMore = false
         selectedMediaItemAlbums = emptyList()
+        selectedMediaItemAlbumsNextOffset = 0
+        selectedMediaItemAlbumsHasMore = false
+        selectedMediaItemTracksLoadMoreJob = null
+        selectedMediaItemAlbumsLoadMoreJob = null
         closePlaylistTargetPicker()
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -184,6 +185,9 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
                     }
                 } else {
                     itemsIndexed(controller.selectedFeatureTracks, key = { _, item -> item.id }) { index, track ->
+                        LaunchedEffect(index, controller.selectedFeatureTracks.size) {
+                            controller.prefetchSelectedFeatureIfNeeded(index)
+                        }
                         TrackRow(
                             track = track,
                             downloadState = controller.downloadStates[track.id],
@@ -213,6 +217,7 @@ fun SelectedFeatureTrackList(controller: FuoPlayerController, modifier: Modifier
         showEmpty = !controller.isLoading && controller.selectedFeatureError == null,
         modifier = modifier,
         onClick = controller::playFromSelectedFeature,
+        onItemVisible = controller::prefetchSelectedFeatureIfNeeded,
     )
 }
 
@@ -559,7 +564,7 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
                         text = buildList {
                             add(displayPlaylist.providerName)
                             displayPlaylist.playCount?.let { add(formatPlayCount(it)) }
-                            add("${controller.selectedPlaylistTracks.size} 首")
+                            displayPlaylist.trackCount?.let { add("$it 首") }
                         }.joinToString(" · "),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -622,7 +627,7 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
                 subtitle = buildList {
                     add(displayPlaylist.providerName)
                     displayPlaylist.playCount?.let { add(formatPlayCount(it)) }
-                    add("${controller.selectedPlaylistTracks.size} 首")
+                    displayPlaylist.trackCount?.let { add("$it 首") }
                 }.joinToString(" · "),
                 description = displayPlaylist.description,
                 action = if (controller.selectedPlaylistTracks.isNotEmpty()) {
@@ -660,6 +665,9 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
                     }
                 } else {
                     itemsIndexed(controller.selectedPlaylistTracks, key = { _, item -> item.id }) { index, track ->
+                        LaunchedEffect(index, controller.selectedPlaylistTracks.size) {
+                            controller.prefetchSelectedPlaylistIfNeeded(index)
+                        }
                         TrackRow(
                             track = track,
                             downloadState = controller.downloadStates[track.id],
@@ -690,6 +698,7 @@ fun SelectedPlaylistTrackList(controller: FuoPlayerController, modifier: Modifie
         showEmpty = !controller.isLoading && controller.selectedPlaylistError == null,
         modifier = modifier,
         onClick = controller::playFromSelectedPlaylist,
+        onItemVisible = controller::prefetchSelectedPlaylistIfNeeded,
     )
 }
 
@@ -764,8 +773,8 @@ fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMedia
                         text = buildList {
                             add(displayItem.providerName)
                             add(if (isArtist) "歌手" else "专辑")
-                            add("${controller.selectedMediaItemTracks.size} 首")
-                            if (isArtist) add("${controller.selectedMediaItemAlbums.size} 张专辑")
+                            displayItem.trackCount?.let { add("$it 首") }
+                            if (isArtist) displayItem.albumCount?.let { add("$it 张专辑") }
                         }.joinToString(" · "),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -842,8 +851,8 @@ fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMedia
                 subtitle = buildList {
                     add(displayItem.providerName)
                     add(if (isArtist) "歌手" else "专辑")
-                    add("${controller.selectedMediaItemTracks.size} 首")
-                    if (isArtist) add("${controller.selectedMediaItemAlbums.size} 张专辑")
+                    displayItem.trackCount?.let { add("$it 首") }
+                    if (isArtist) displayItem.albumCount?.let { add("$it 张专辑") }
                 }.joinToString(" · "),
                 description = displayItem.description,
                 action = if (controller.selectedMediaItemTracks.isNotEmpty()) {
@@ -897,6 +906,7 @@ fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMedia
                             ProviderMediaItemGrid(
                                 items = controller.selectedMediaItemAlbums,
                                 onClick = controller::openMediaItem,
+                                onItemVisible = controller::prefetchSelectedMediaItemAlbumsIfNeeded,
                             )
                         }
                     }
@@ -907,6 +917,9 @@ fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMedia
                         }
                     } else {
                         itemsIndexed(controller.selectedMediaItemTracks, key = { _, track -> track.id }) { index, track ->
+                            LaunchedEffect(index, controller.selectedMediaItemTracks.size) {
+                                controller.prefetchSelectedMediaItemTracksIfNeeded(index)
+                            }
                             TrackRow(
                                 track = track,
                                 downloadState = controller.downloadStates[track.id],
@@ -946,6 +959,7 @@ fun SelectedMediaItemContent(
                     ProviderMediaItemGrid(
                         items = controller.selectedMediaItemAlbums,
                         onClick = controller::openMediaItem,
+                        onItemVisible = controller::prefetchSelectedMediaItemAlbumsIfNeeded,
                     )
                 }
             }
@@ -959,6 +973,7 @@ fun SelectedMediaItemContent(
         showEmpty = !controller.isLoading && controller.selectedMediaItemError == null,
         modifier = modifier,
         onClick = controller::playFromSelectedMediaItem,
+        onItemVisible = controller::prefetchSelectedMediaItemTracksIfNeeded,
     )
 }
 
@@ -970,6 +985,7 @@ fun TrackCollectionList(
     showEmpty: Boolean,
     modifier: Modifier,
     onClick: (Int) -> Unit,
+    onItemVisible: ((Int) -> Unit)? = null,
 ) {
     if (LocalAppLayoutInfo.current.useWideLayout) {
         val indexedTracks = remember(tracks) { tracks.mapIndexed { index, track -> index to track } }
@@ -985,6 +1001,11 @@ fun TrackCollectionList(
                 }
             } else {
                 items(indexedTracks, key = { it.second.id }) { (index, track) ->
+                    if (onItemVisible != null) {
+                        LaunchedEffect(index, tracks.size) {
+                            onItemVisible(index)
+                        }
+                    }
                     TrackRow(
                         track = track,
                         downloadState = controller.downloadStates[track.id],
@@ -1010,6 +1031,11 @@ fun TrackCollectionList(
             }
         } else {
             itemsIndexed(tracks, key = { _, item -> item.id }) { index, track ->
+                if (onItemVisible != null) {
+                    LaunchedEffect(index, tracks.size) {
+                        onItemVisible(index)
+                    }
+                }
                 TrackRow(
                     track = track,
                     downloadState = controller.downloadStates[track.id],

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -391,6 +392,7 @@ fun ProviderPlaylistCard(
 fun ProviderMediaItemGrid(
     items: List<ProviderMediaItem>,
     onClick: (ProviderMediaItem) -> Unit,
+    onItemVisible: ((Int) -> Unit)? = null,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
     val columns = layoutInfo.gridColumns
@@ -399,12 +401,18 @@ fun ProviderMediaItemGrid(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        items.chunked(columns).forEach { row ->
+        items.chunked(columns).forEachIndexed { rowIndex, row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
-                row.forEach { item ->
+                row.forEachIndexed { columnIndex, item ->
+                    val index = rowIndex * columns + columnIndex
+                    if (onItemVisible != null) {
+                        LaunchedEffect(index, items.size) {
+                            onItemVisible(index)
+                        }
+                    }
                     ProviderMediaItemCard(
                         item = item,
                         onClick = { onClick(item) },

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -819,6 +819,49 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun playAllFromSelectedPlaylistLoadsRemainingPagesBeforePlayback() = runTest {
+        val tracks = (1..(PROVIDER_PAGE_SIZE + 5)).map { index ->
+            providerTrack("provider:$index", "Track $index")
+        }
+        val provider = FakeProviderRepository(emptyList(), playlistTracks = tracks)
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.openPlaylist(
+                ProviderPlaylist(
+                    id = "playlist:netease:1",
+                    title = "榜单",
+                    providerId = "netease",
+                    providerName = "网易云音乐",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(PROVIDER_PAGE_SIZE, controller.selectedPlaylistTracks.size)
+            assertEquals(true, controller.selectedPlaylistTracksHasMore)
+
+            controller.playAllFromSelectedPlaylist()
+            advanceUntilIdle()
+
+            assertEquals(tracks.size, controller.selectedPlaylistTracks.size)
+            assertEquals(false, controller.selectedPlaylistTracksHasMore)
+            assertEquals(tracks.map { it.id }, controller.playbackState.queue.map { it.id })
+            assertEquals("provider:1", engine.lastTrack?.id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun providerPlaylistTargetsLoadOnlyWhenCapabilityAndLoginAllow() = runTest {
         val track = providerTrack("netease:1", "First")
         val target = ProviderPlaylist(
@@ -1232,6 +1275,56 @@ class FuoPlayerControllerTest {
 
             assertEquals("provider:1", engine.lastTrack?.id)
             assertEquals(radioTracks, controller.recommendSections.first { it.feature.id == radioFeature.id }.tracks)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun playAllFromSelectedPrivateFmDoesNotLoadAllPagesBeforePlayback() = runTest {
+        val radioFeature = ProviderFeature(
+            id = "netease_radio",
+            providerId = "netease",
+            providerName = "网易云音乐",
+            title = "私人 FM",
+            category = ProviderFeatureCategory.Recommend,
+            contentType = ProviderContentType.Songs,
+            requiresLogin = true,
+        )
+        val radioTracks = (1..(PROVIDER_PAGE_SIZE + 5)).map { index ->
+            providerTrack("provider:$index", "Track $index")
+        }
+        val provider = FakeProviderRepository(
+            tracks = emptyList(),
+            features = listOf(radioFeature),
+            featureSections = mapOf(radioFeature.id to ProviderContentSection(radioFeature, tracks = radioTracks)),
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.openFeature(radioFeature)
+            advanceUntilIdle()
+
+            assertEquals(PROVIDER_PAGE_SIZE, controller.selectedFeatureTracks.size)
+            assertEquals(true, controller.selectedFeatureTracksHasMore)
+            val loadedFeatureCalls = provider.loadedFeatureIds.size
+
+            controller.playAllFromSelectedFeature()
+            advanceUntilIdle()
+
+            assertEquals(PROVIDER_PAGE_SIZE, controller.selectedFeatureTracks.size)
+            assertEquals(loadedFeatureCalls, provider.loadedFeatureIds.size)
+            assertEquals(PROVIDER_PAGE_SIZE, controller.playbackState.queue.size)
+            assertEquals("provider:1", engine.lastTrack?.id)
         } finally {
             controllerScope.cancel()
         }
@@ -2815,9 +2908,50 @@ class FuoPlayerControllerTest {
             return featureSections[feature.id] ?: ProviderContentSection(feature)
         }
 
+        override suspend fun loadFeaturePage(
+            feature: ProviderFeature,
+            offset: Int,
+            limit: Int,
+        ): ProviderContentSection {
+            loadedFeatureIds += feature.id
+            val section = featureSections[feature.id] ?: return ProviderContentSection(feature)
+            val tracks = section.tracks.drop(offset).take(limit)
+            val playlists = section.playlists.drop(offset).take(limit)
+            val mediaItems = section.mediaItems.drop(offset).take(limit)
+            val sourceSize = when (feature.contentType) {
+                ProviderContentType.Songs -> section.tracks.size
+                ProviderContentType.Playlists -> section.playlists.size
+                ProviderContentType.Artists,
+                ProviderContentType.Albums -> section.mediaItems.size
+            }
+            val nextOffset = offset + maxOf(tracks.size, playlists.size, mediaItems.size)
+            return section.copy(
+                tracks = tracks,
+                playlists = playlists,
+                mediaItems = mediaItems,
+                nextOffset = nextOffset,
+                hasMore = nextOffset < sourceSize,
+            )
+        }
+
         override suspend fun loadMoreFeatureTracks(feature: ProviderFeature): List<MusicTrack> {
             loadedMoreFeatureIds += feature.id
             return additionalFeatureTracks[feature.id] ?: loadFeature(feature).tracks
+        }
+
+        override suspend fun playlistDetailPage(
+            playlist: ProviderPlaylist,
+            offset: Int,
+            limit: Int,
+        ): ProviderPlaylistDetail {
+            val tracks = playlistTracks.drop(offset).take(limit)
+            val nextOffset = offset + tracks.size
+            return ProviderPlaylistDetail(
+                playlist = playlist,
+                tracks = tracks,
+                tracksNextOffset = nextOffset,
+                tracksHasMore = nextOffset < playlistTracks.size,
+            )
         }
 
         override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = playlistTracks
@@ -2843,6 +2977,23 @@ class FuoPlayerControllerTest {
         override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> {
             loadedMediaItemIds += item.id
             return mediaItemTracks
+        }
+
+        override suspend fun mediaItemDetailPage(
+            item: ProviderMediaItem,
+            tracksOffset: Int,
+            albumsOffset: Int,
+            limit: Int,
+        ): ProviderMediaItemDetail {
+            loadedMediaItemIds += item.id
+            val tracks = mediaItemTracks.drop(tracksOffset).take(limit)
+            val tracksNextOffset = tracksOffset + tracks.size
+            return ProviderMediaItemDetail(
+                item = item,
+                tracks = tracks,
+                tracksNextOffset = tracksNextOffset,
+                tracksHasMore = tracksNextOffset < mediaItemTracks.size,
+            )
         }
 
         override suspend fun similarTracks(track: MusicTrack): List<MusicTrack> = similarTracks


### PR DESCRIPTION
## Summary
- add paged provider content contracts for feature, playlist, artist, and album lists
- update the Android/Python FeelUOwn bridge to read pages with hasMore/nextOffset metadata
- prefetch near the end of loaded lists and make Play All load complete non-FM lists before playback

## Validation
- ./gradlew :shared:allTests
- python3 -m pytest androidApp/src/test/python
- ./gradlew :androidApp:assembleDebug