### PR TITLE
[feat] Add desktop app support

### DIFF
--- a/.github/workflows/desktop-appimage.yml
+++ b/.github/workflows/desktop-appimage.yml
@@ -1,0 +1,68 @@
+name: Desktop AppImage
+
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux-appimage:
+    name: Build Linux desktop app image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      FUO_BUILD_PYTHON: python
+      FUO_FEELUOWN_SOURCE: https://files.pythonhosted.org/packages/b2/41/c0f205f279e7bc5e1441d65679f693133dcac976b59ff14f3a1adf9e168d/feeluown-5.1.2.tar.gz
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            desktopApp/build.gradle.kts
+            androidApp/build.gradle.kts
+            gradle/libs.versions.toml
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build desktop app image
+        run: ./gradlew :desktopApp:packageAppImage
+
+      - name: Package desktop app image artifact
+        run: |
+          app_dir="desktopApp/build/compose/binaries/main/app/FuoEvolve"
+          if [ ! -x "${app_dir}/bin/FuoEvolve" ]; then
+            echo "::error::Desktop app image was not produced at ${app_dir}"
+            find desktopApp/build/compose/binaries/main -maxdepth 4 -type f -o -type d || true
+            exit 1
+          fi
+          mkdir -p build/artifacts
+          tar -czf "build/artifacts/fuo-evolve-desktop-linux-x64-appimage-${GITHUB_SHA}.tar.gz" \
+            -C desktopApp/build/compose/binaries/main/app \
+            FuoEvolve
+
+      - name: Upload desktop app image
+        uses: actions/upload-artifact@v7
+        with:
+          path: build/artifacts/fuo-evolve-desktop-linux-x64-appimage-${{ github.sha }}.tar.gz
+          archive: false
+          if-no-files-found: error

--- a/.github/workflows/desktop-appimage.yml
+++ b/.github/workflows/desktop-appimage.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build desktop app image
         run: ./gradlew :desktopApp:packageAppImage
 
-      - name: Package desktop app image artifact
+      - name: Check desktop app image artifact
         run: |
           app_dir="desktopApp/build/compose/binaries/main/app/FuoEvolve"
           if [ ! -x "${app_dir}/bin/FuoEvolve" ]; then
@@ -55,14 +55,11 @@ jobs:
             find desktopApp/build/compose/binaries/main -maxdepth 4 -type f -o -type d || true
             exit 1
           fi
-          mkdir -p build/artifacts
-          tar -czf "build/artifacts/fuo-evolve-desktop-linux-x64-appimage-${GITHUB_SHA}.tar.gz" \
-            -C desktopApp/build/compose/binaries/main/app \
-            FuoEvolve
 
       - name: Upload desktop app image
         uses: actions/upload-artifact@v7
         with:
-          path: build/artifacts/fuo-evolve-desktop-linux-x64-appimage-${{ github.sha }}.tar.gz
+          name: fuo-evolve-desktop-linux-x64-appimage-${{ github.sha }}
+          path: desktopApp/build/compose/binaries/main/app/FuoEvolve
           archive: false
           if-no-files-found: error

--- a/.github/workflows/desktop-appimage.yml
+++ b/.github/workflows/desktop-appimage.yml
@@ -56,10 +56,54 @@ jobs:
             exit 1
           fi
 
+      - name: Build AppImage file
+        run: |
+          set -euo pipefail
+
+          app_image_dir="desktopApp/build/compose/binaries/main/app/FuoEvolve"
+          app_dir="build/appimage/FuoEvolve.AppDir"
+          artifact_dir="build/artifacts"
+          artifact_path="${artifact_dir}/FuoEvolve-${GITHUB_SHA}.AppImage"
+          appimagetool="build/appimagetool-x86_64.AppImage"
+
+          rm -rf "${app_dir}"
+          mkdir -p "${app_dir}/usr/lib" "${artifact_dir}"
+          cp -a "${app_image_dir}" "${app_dir}/usr/lib/FuoEvolve"
+
+          cat > "${app_dir}/AppRun" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export APPDIR="${APPDIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+          exec "${APPDIR}/usr/lib/FuoEvolve/bin/FuoEvolve" "$@"
+          EOF
+          chmod +x "${app_dir}/AppRun"
+
+          cat > "${app_dir}/fuo-evolve.desktop" <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=FuoEvolve
+          Exec=FuoEvolve
+          Icon=fuo-evolve
+          Categories=AudioVideo;Audio;Player;
+          Terminal=false
+          EOF
+          cp androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png "${app_dir}/fuo-evolve.png"
+
+          curl -L \
+            --retry 3 \
+            --retry-delay 5 \
+            -o "${appimagetool}" \
+            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x "${appimagetool}"
+
+          APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 "${appimagetool}" "${app_dir}" "${artifact_path}"
+          test -f "${artifact_path}"
+          chmod +x "${artifact_path}"
+
       - name: Upload desktop app image
         uses: actions/upload-artifact@v7
         with:
           name: fuo-evolve-desktop-linux-x64-appimage-${{ github.sha }}
-          path: desktopApp/build/compose/binaries/main/app/FuoEvolve
+          path: build/artifacts/FuoEvolve-${{ github.sha }}.AppImage
           archive: false
           if-no-files-found: error

--- a/androidApp/src/main/python/fuo_mobile/bridge.py
+++ b/androidApp/src/main/python/fuo_mobile/bridge.py
@@ -735,6 +735,7 @@ class FuoMobileBridge:
         from fuo_ytmusic.consts import HEADER_FILE
         from fuo_ytmusic.headerfile import write_headerfile
 
+        os.makedirs(os.fspath(HEADER_FILE.parent), exist_ok=True)
         write_headerfile(auth, cookie_value, HEADER_FILE)
         user = provider.try_get_user_with_headerfile()
         if user is None:
@@ -756,6 +757,7 @@ class FuoMobileBridge:
         from fuo_ytmusic.consts import HEADER_FILE
         from fuo_ytmusic.headerfile import write_headerfile
 
+        os.makedirs(os.fspath(HEADER_FILE.parent), exist_ok=True)
         write_headerfile(auth, cookie_value, HEADER_FILE)
         user = provider.try_get_user_with_headerfile()
         if user is None:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,0 +1,150 @@
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Sync
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(compose.desktop.currentOs)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.swing)
+    implementation(libs.org.json)
+}
+
+compose.desktop {
+    application {
+        mainClass = "org.feeluown.mobile.desktop.MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.AppImage)
+            packageName = "FuoEvolve"
+            packageVersion = "0.1.0"
+            description = "FeelUOwn-based Compose Multiplatform music player"
+            vendor = "FeelUOwn"
+            appResourcesRootDir.set(layout.buildDirectory.dir("app-resources"))
+            linux {
+                packageName = "fuo-evolve"
+                appCategory = "Audio"
+                menuGroup = "Audio"
+                iconFile.set(layout.projectDirectory.file("../androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"))
+            }
+        }
+    }
+}
+
+val desktopPythonDir = layout.projectDirectory.dir("../.gradle/desktop-python")
+val desktopBridgeScript = layout.projectDirectory.file("src/main/python/desktop_bridge.py")
+val androidPythonDir = layout.projectDirectory.dir("../androidApp/src/main/python")
+val feelUOwnSource = providers.environmentVariable("FUO_FEELUOWN_SOURCE")
+    .orElse("https://files.pythonhosted.org/packages/b2/41/c0f205f279e7bc5e1441d65679f693133dcac976b59ff14f3a1adf9e168d/feeluown-5.1.2.tar.gz")
+
+tasks.register("prepareDesktopPython") {
+    val marker = desktopPythonDir.file("install.marker")
+    outputs.file(marker)
+    doLast {
+        fun runCommand(vararg args: String) {
+            val exitCode = ProcessBuilder(*args)
+                .inheritIO()
+                .start()
+                .waitFor()
+            check(exitCode == 0) { "Command failed (${args.joinToString(" ")}): exit=$exitCode" }
+        }
+
+        val venvDir = desktopPythonDir.asFile
+        val python = providers.environmentVariable("FUO_BUILD_PYTHON").orNull ?: "python3"
+        val pip = venvDir.resolve("bin/pip")
+        if (!pip.isFile) {
+            venvDir.deleteRecursively()
+            runCommand(python, "-m", "venv", venvDir.absolutePath)
+        }
+        runCommand(pip.absolutePath, "install", "--upgrade", "pip")
+        runCommand(
+            pip.absolutePath,
+            "install",
+            "--no-deps",
+            feelUOwnSource.get(),
+            "https://files.pythonhosted.org/packages/1c/70/cf356c9096d401ad63acbe686b51f1d50d491e9afb478e704c574ab17606/fuo_netease-1.0.8.tar.gz",
+            "fuo-qqmusic==1.0.16",
+            "feeluown-bilibili==0.5.5",
+            "fuo-ytmusic==0.4.18",
+            "attrs",
+            "beautifulsoup4",
+            "babel",
+            "cachetools",
+            "certifi",
+            "charset-normalizer",
+            "fluent-runtime==0.4.0",
+            "fluent.syntax",
+            "idna",
+            "janus",
+            "marshmallow==3.26.2",
+            "mutagen",
+            "packaging",
+            "pydantic==1.10.26",
+            "pycryptodome==3.21.0",
+            "pytz",
+            "qasync",
+            "requests",
+            "soupsieve",
+            "tomlkit",
+            "typing-extensions",
+            "urllib3",
+            "yt-dlp",
+            "ytmusicapi",
+        )
+        marker.asFile.writeText("ok\n")
+    }
+}
+
+val syncDesktopAppResources = tasks.register<Sync>("syncDesktopAppResources") {
+    dependsOn("prepareDesktopPython")
+    into(layout.buildDirectory.dir("app-resources/common"))
+    from(desktopBridgeScript) {
+        into("desktop-python/bridge")
+    }
+    from(androidPythonDir) {
+        into("desktop-python/android-python")
+        exclude("**/__pycache__/**")
+        exclude("**/*.pyc")
+        exclude("**/*.iml")
+    }
+    from(desktopPythonDir) {
+        into("desktop-python/venv")
+        exclude("**/__pycache__/**")
+        exclude("**/*.pyc")
+        exclude("bin/𝜋thon")
+    }
+}
+
+tasks.withType<JavaExec>().configureEach {
+    if (name == "run") {
+        dependsOn("prepareDesktopPython")
+        systemProperty("fuo.desktop.python", desktopPythonDir.file("bin/python").asFile.absolutePath)
+        systemProperty("fuo.desktop.bridgeScript", desktopBridgeScript.asFile.absolutePath)
+        systemProperty("fuo.desktop.androidPythonDir", androidPythonDir.asFile.absolutePath)
+    }
+}
+
+tasks.matching { task ->
+    task.name == "prepareAppResources" ||
+        task.name == "runDistributable" ||
+        task.name.startsWith("create") ||
+        task.name.startsWith("package")
+}.configureEach {
+    dependsOn(syncDesktopAppResources)
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopFuoCoreBridge.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopFuoCoreBridge.kt
@@ -1,0 +1,274 @@
+package org.feeluown.mobile.desktop
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.feeluown.mobile.AudioQualityPolicy
+import org.feeluown.mobile.DEFAULT_AUDIO_CACHE_LIMIT_MB
+import org.feeluown.mobile.DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY
+import org.feeluown.mobile.DEFAULT_ENABLED_PROVIDER_IDS
+import org.feeluown.mobile.DEFAULT_SMART_REPLACEMENT_MIN_SCORE
+import org.feeluown.mobile.DEFAULT_UNAVAILABLE_PLAYBACK_POLICY
+import org.feeluown.mobile.DEFAULT_WIFI_AUDIO_QUALITY_POLICY
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PROVIDER_PAGE_SIZE
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.ProviderAuthState
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderComment
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderInfo
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemDetail
+import org.feeluown.mobile.ProviderMutationResult
+import org.feeluown.mobile.ProviderMusicRepository
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderResourceState
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.UnavailablePlaybackPolicy
+import org.feeluown.mobile.VideoPlaybackPayload
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal class DesktopFuoCoreBridge(
+    private val client: DesktopPythonClient = DesktopPythonClient(),
+) : ProviderMusicRepository, AutoCloseable {
+    @Volatile
+    private var enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS
+    @Volatile
+    private var wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY
+    @Volatile
+    private var cellularAudioQualityPolicy: AudioQualityPolicy = DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY
+
+    override suspend fun initialize() {
+        client.initialize(enabledProvidersJson(enabledProviderIds))
+    }
+
+    override suspend fun availableProviders(): List<ProviderInfo> = AVAILABLE_PROVIDERS
+
+    override suspend fun updateEnabledProviders(providerIds: Set<String>) {
+        val nextProviderIds = providerIds
+            .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
+            .intersect(AVAILABLE_PROVIDERS.map { it.providerId }.toSet())
+            .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
+        enabledProviderIds = nextProviderIds
+        client.initialize(enabledProvidersJson(nextProviderIds))
+    }
+
+    override suspend fun providers(): List<ProviderInfo> = callArray("providers", "providers") { it.toProviderInfo() }
+
+    override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> =
+        callArray("search", "tracks", listOf(keyword, providerId.orEmpty())) { it.toTrack() }
+
+    override suspend fun searchAll(keyword: String, providerId: String?): ProviderSearchResults {
+        initialize()
+        return JSONObject(client.call("search_all", listOf(keyword, providerId.orEmpty()))).toSearchResults()
+    }
+
+    override suspend fun trackDetail(trackId: String): MusicTrack {
+        initialize()
+        return JSONObject(client.call("track_detail", listOf(trackId))).getJSONObject("track").toTrack()
+    }
+
+    override suspend fun resolve(
+        track: MusicTrack,
+        unavailablePolicy: UnavailablePlaybackPolicy,
+        smartReplacementProviderIds: Set<String>,
+        smartReplacementMinScore: Double,
+        smartReplacementUseOriginalMetadata: Boolean,
+        smartReplacementUseOriginalLyrics: Boolean,
+    ): PlaybackPayload {
+        initialize()
+        val policy = audioQualityPolicyForDesktop(wifiAudioQualityPolicy, cellularAudioQualityPolicy)
+        val raw = client.call(
+            "resolve",
+            listOf(
+                track.providerId ?: track.id,
+                policy.policy,
+                unavailablePolicy == UnavailablePlaybackPolicy.SmartReplace,
+                smartReplacementProviderIdsJson(smartReplacementProviderIds),
+                smartReplacementMinScore,
+                smartReplacementUseOriginalMetadata,
+                smartReplacementUseOriginalLyrics,
+            ),
+        )
+        return JSONObject(raw).toPayload(track)
+    }
+
+    override suspend fun authState(providerId: String): ProviderAuthState {
+        initialize()
+        return JSONObject(client.call("provider_auth_state", listOf(providerId))).toAuthState(providerId)
+    }
+
+    override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState {
+        initialize()
+        return JSONObject(client.call("provider_login_with_cookies", listOf(providerId, cookiesJson))).toAuthState(providerId)
+    }
+
+    override suspend fun loginWithHeaders(providerId: String, authorization: String, cookie: String): ProviderAuthState {
+        initialize()
+        return JSONObject(
+            client.call("provider_login_with_headers", listOf(providerId, authorization, cookie)),
+        ).toAuthState(providerId)
+    }
+
+    override suspend fun logout(providerId: String): ProviderAuthState {
+        initialize()
+        return JSONObject(client.call("provider_logout", listOf(providerId))).toAuthState(providerId)
+    }
+
+    override suspend fun updateAudioQualityPolicies(wifiPolicy: AudioQualityPolicy, cellularPolicy: AudioQualityPolicy) {
+        wifiAudioQualityPolicy = wifiPolicy
+        cellularAudioQualityPolicy = cellularPolicy
+    }
+
+    override suspend fun providerCapabilities(): List<ProviderCapabilities> =
+        callArray("provider_capabilities", "providers") { it.toCapabilities() }
+
+    override suspend fun features(): List<ProviderFeature> =
+        callArray("features", "features") { it.toFeature() }
+
+    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+        loadFeaturePage(feature, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun loadFeaturePage(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection {
+        initialize()
+        return JSONObject(client.call("load_feature", listOf(feature.id, offset, limit))).toContentSection(feature)
+    }
+
+    override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> =
+        callArray("playlist_tracks", "tracks", listOf(playlist.id)) { it.toTrack() }
+
+    override suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail =
+        playlistDetailPage(playlist, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun playlistDetailPage(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail {
+        initialize()
+        return JSONObject(client.call("playlist_detail", listOf(playlist.id, offset, limit))).toPlaylistDetail(playlist)
+    }
+
+    override suspend fun playlistOperationTargets(track: MusicTrack): List<ProviderPlaylist> =
+        callArray("playlist_operation_targets", "playlists", listOf(track.providerId ?: track.id)) { it.toPlaylist() }
+
+    override suspend fun addTrackToPlaylist(playlist: ProviderPlaylist, track: MusicTrack): ProviderMutationResult {
+        initialize()
+        return JSONObject(
+            client.call("playlist_add_song", listOf(playlist.id, track.providerId ?: track.id)),
+        ).toMutationResult()
+    }
+
+    override suspend fun removeTrackFromPlaylist(playlist: ProviderPlaylist, track: MusicTrack): ProviderMutationResult {
+        initialize()
+        return JSONObject(
+            client.call("playlist_remove_song", listOf(playlist.id, track.providerId ?: track.id)),
+        ).toMutationResult()
+    }
+
+    override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> =
+        callArray("media_item_tracks", "tracks", listOf(item.id)) { it.toTrack() }
+
+    override suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
+        mediaItemDetailPage(item, tracksOffset = 0, albumsOffset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun mediaItemDetailPage(
+        item: ProviderMediaItem,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail {
+        initialize()
+        return JSONObject(
+            client.call("media_item_detail", listOf(item.id, tracksOffset, albumsOffset, limit)),
+        ).toMediaItemDetail(item)
+    }
+
+    override suspend fun similarTracks(track: MusicTrack): List<MusicTrack> =
+        callArray("similar_tracks", "tracks", listOf(track.providerId ?: track.id)) { it.toTrack() }
+
+    override suspend fun hotComments(track: MusicTrack): List<ProviderComment> =
+        callArray("hot_comments", "comments", listOf(track.providerId ?: track.id)) { it.toProviderComment() }
+
+    override suspend fun trackVideo(track: MusicTrack): ProviderVideo? {
+        initialize()
+        return JSONObject(client.call("track_video", listOf(track.providerId ?: track.id))).optJSONObject("video")?.toProviderVideo()
+    }
+
+    override suspend fun videoPlaybackPayload(video: ProviderVideo): VideoPlaybackPayload {
+        initialize()
+        return JSONObject(client.call("video_payload", listOf(video.id, ""))).toVideoPlaybackPayload(video)
+    }
+
+    override suspend fun resourceState(resourceType: String, resourceId: String): ProviderResourceState =
+        ProviderResourceState(providerId = "", resourceId = resourceId)
+
+    override suspend fun setResourceFavorite(
+        resourceType: String,
+        resourceId: String,
+        favorite: Boolean,
+    ): ProviderMutationResult = ProviderMutationResult(false, "桌面端暂不支持收藏状态修改")
+
+    override fun close() {
+        client.close()
+    }
+
+    private suspend fun <T> callArray(
+        method: String,
+        key: String,
+        args: List<Any?> = emptyList(),
+        mapper: (JSONObject) -> T,
+    ): List<T> {
+        initialize()
+        val array = JSONObject(client.call(method, args)).optJSONArray(key) ?: JSONArray()
+        return List(array.length()) { index -> mapper(array.getJSONObject(index)) }
+    }
+
+    private companion object {
+        private val AVAILABLE_PROVIDERS = listOf(
+            ProviderInfo(
+                providerId = "netease",
+                providerName = "网易云音乐",
+                loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+                    loginUrl = "https://music.163.com",
+                    cookieKeyGroups = listOf(listOf("MUSIC_U")),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "qqmusic",
+                providerName = "QQ 音乐",
+                loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+                    loginUrl = "https://y.qq.com",
+                    cookieKeyGroups = listOf(
+                        listOf("qqmusic_key", "wxuin", "qm_keyst"),
+                        listOf("qqmusic_key", "uin", "qm_keyst"),
+                    ),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "bilibili",
+                providerName = "哔哩哔哩",
+                loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+                    loginUrl = "https://passport.bilibili.com/h5-app/passport/login?gourl=https%3A%2F%2Fm.bilibili.com%2F",
+                    cookieKeyGroups = listOf(listOf("SESSDATA", "bili_jct")),
+                ),
+            ),
+            ProviderInfo(
+                providerId = "ytmusic",
+                providerName = "YouTube Music",
+                loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+                    loginUrl = "https://music.youtube.com",
+                    cookieKeyGroups = listOf(listOf("__Secure-3PAPISID")),
+                ),
+                supportedLoginModes = setOf(
+                    org.feeluown.mobile.ProviderLoginMode.WebView,
+                    org.feeluown.mobile.ProviderLoginMode.Headers,
+                ),
+            ),
+        )
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopLocalMusicRepository.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopLocalMusicRepository.kt
@@ -1,0 +1,150 @@
+package org.feeluown.mobile.desktop
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.withContext
+import org.feeluown.mobile.LocalMusicDirectory
+import org.feeluown.mobile.LocalMusicRepository
+import org.feeluown.mobile.LocalMusicScanSettings
+import org.feeluown.mobile.LocalTrackMetadata
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.TrackSourceType
+import java.io.File
+
+internal class DesktopLocalMusicRepository(
+    private val musicDir: File = DesktopPaths.musicDir,
+) : LocalMusicRepository {
+    private val mutableMediaChangeEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private var scanSettings = LocalMusicScanSettings()
+    private var cachedTracks: List<MusicTrack> = emptyList()
+    private var initialized = false
+
+    override val mediaChangeEvents: Flow<Unit> = mutableMediaChangeEvents
+
+    override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
+        scanSettings = settings
+        cachedTracks = filter(cachedTracks)
+    }
+
+    override suspend fun isDatabaseReady(): Boolean = initialized
+
+    override suspend fun isDatabaseStale(): Boolean = !initialized
+
+    override suspend fun directories(): List<LocalMusicDirectory> = withContext(Dispatchers.IO) {
+        ensureScanned()
+        cachedTracks
+            .mapNotNull { track -> track.localUri?.let { File(java.net.URI(it)).parentFile } }
+            .groupBy { it.absolutePath }
+            .map { (_, files) ->
+                val directory = files.first()
+                LocalMusicDirectory(
+                    id = directory.absolutePath,
+                    name = directory.name.ifBlank { directory.absolutePath },
+                    trackCount = files.size,
+                )
+            }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    override suspend fun tracks(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        ensureScanned()
+        filter(cachedTracks)
+    }
+
+    override suspend fun refreshDatabase(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        cachedTracks = scanMusicDir()
+        initialized = true
+        mutableMediaChangeEvents.tryEmit(Unit)
+        filter(cachedTracks)
+    }
+
+    override suspend fun search(keyword: String): List<MusicTrack> {
+        val normalized = keyword.trim()
+        if (normalized.isEmpty()) return emptyList()
+        return tracks().filter {
+            it.title.contains(normalized, ignoreCase = true) ||
+                it.artists.contains(normalized, ignoreCase = true) ||
+                it.album.contains(normalized, ignoreCase = true)
+        }
+    }
+
+    override suspend fun updateMetadata(track: MusicTrack, metadata: LocalTrackMetadata) {
+        cachedTracks = cachedTracks.map {
+            if (it.id == track.id) {
+                it.copy(
+                    title = metadata.title.ifBlank { it.title },
+                    artists = metadata.artists,
+                    album = metadata.album,
+                )
+            } else {
+                it
+            }
+        }
+    }
+
+    override suspend fun saveLyrics(track: MusicTrack, lyrics: String) {
+        val localUri = track.localUri ?: return
+        withContext(Dispatchers.IO) {
+            val audio = File(java.net.URI(localUri))
+            val lyricFile = File(audio.parentFile, "${audio.nameWithoutExtension}.lrc")
+            lyricFile.writeText(lyrics)
+            cachedTracks = cachedTracks.map {
+                if (it.id == track.id) it.copy(lyrics = lyrics) else it
+            }
+        }
+    }
+
+    private fun ensureScanned() {
+        if (!initialized) {
+            cachedTracks = scanMusicDir()
+            initialized = true
+        }
+    }
+
+    private fun scanMusicDir(): List<MusicTrack> {
+        if (!musicDir.isDirectory) return emptyList()
+        return musicDir.walkTopDown()
+            .filter { it.isFile && it.extension.lowercase() in AUDIO_EXTENSIONS }
+            .map { file -> file.toTrack() }
+            .sortedBy { it.title.lowercase() }
+            .toList()
+    }
+
+    private fun File.toTrack(): MusicTrack {
+        val title = nameWithoutExtension.substringBefore(" - ").ifBlank { nameWithoutExtension }
+        val artists = nameWithoutExtension.substringAfter(" - ", missingDelimiterValue = "").ifBlank { "未知歌手" }
+        val cover = parentFile
+            ?.listFiles()
+            .orEmpty()
+            .firstOrNull { it.isFile && it.nameWithoutExtension.lowercase() in COVER_NAMES && it.extension.lowercase() in IMAGE_EXTENSIONS }
+            ?.toURI()
+            ?.toString()
+        val lyrics = File(parentFile, "$nameWithoutExtension.lrc").takeIf { it.isFile }?.readText()
+        return MusicTrack(
+            id = "local:${absolutePath}",
+            title = title,
+            artists = artists,
+            album = parentFile?.name.orEmpty().ifBlank { "本地音乐" },
+            source = "local",
+            sourceType = TrackSourceType.LocalMediaStore,
+            coverUrl = cover,
+            localUri = toURI().toString(),
+            lyrics = lyrics,
+        )
+    }
+
+    private fun filter(tracks: List<MusicTrack>): List<MusicTrack> {
+        val excluded = scanSettings.excludedDirectoryIds
+        return tracks.filter { track ->
+            val file = track.localUri?.let { runCatching { File(java.net.URI(it)) }.getOrNull() }
+            file?.parentFile?.absolutePath !in excluded
+        }
+    }
+
+    private companion object {
+        private val AUDIO_EXTENSIONS = setOf("mp3", "flac", "m4a", "aac", "ogg", "opus", "wav")
+        private val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "webp")
+        private val COVER_NAMES = setOf("cover", "folder", "front", "album")
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNativeAudioEngine.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNativeAudioEngine.kt
@@ -1,0 +1,194 @@
+package org.feeluown.mobile.desktop
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackEngine
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.PlaybackState
+import org.feeluown.mobile.PlayerStatus
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.net.URI
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+
+internal class DesktopNativeAudioEngine(
+    private val scope: CoroutineScope,
+    private val mpvExecutable: String = System.getenv("FUO_MPV") ?: "mpv",
+) : PlaybackEngine {
+    private val mutableState = MutableStateFlow(PlaybackState())
+    private var process: Process? = null
+    private var socketFile: File? = null
+    private var pollJob: Job? = null
+    private var currentPayload: PlaybackPayload? = null
+
+    override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
+
+    override fun prepareLoading(track: MusicTrack) {
+        mutableState.value = mutableState.value.copy(
+            status = PlayerStatus.Loading,
+            currentTrack = track,
+            positionMs = 0,
+            durationMs = track.durationMs ?: 0,
+            bufferedMs = 0,
+            lyrics = track.lyrics,
+            audioQuality = null,
+            errorMessage = null,
+        )
+    }
+
+    override fun play(track: MusicTrack, payload: PlaybackPayload) {
+        stopProcess()
+        currentPayload = payload
+        mutableState.value = PlaybackState(
+            status = PlayerStatus.Loading,
+            currentTrack = track,
+            durationMs = payload.durationMs ?: track.durationMs ?: 0,
+            lyrics = payload.lyrics,
+            audioQuality = payload.audioQuality,
+            playbackParts = payload.parts,
+            currentPartIndex = payload.currentPartIndex,
+        )
+
+        val target = playbackTarget(track, payload)
+        if (target.isBlank()) {
+            mutableState.value = mutableState.value.copy(
+                status = PlayerStatus.Error,
+                errorMessage = "播放地址为空",
+            )
+            return
+        }
+
+        val nextSocket = File.createTempFile("fuo-mpv-", ".sock").apply { delete() }
+        socketFile = nextSocket
+        val command = buildList {
+            add(mpvExecutable)
+            add("--no-terminal")
+            add("--force-window=no")
+            add("--input-ipc-server=${nextSocket.absolutePath}")
+            add("--really-quiet")
+            payload.headers.forEach { (key, value) ->
+                if (key.isNotBlank() && value.isNotBlank()) {
+                    add("--http-header-fields=$key: $value")
+                }
+            }
+            add(target)
+        }
+        runCatching {
+            process = ProcessBuilder(command).redirectErrorStream(true).start()
+        }.onFailure { throwable ->
+            mutableState.value = mutableState.value.copy(
+                status = PlayerStatus.Error,
+                errorMessage = "无法启动 mpv：${throwable.message ?: "请确认已安装 mpv"}",
+            )
+            return
+        }
+        pollJob = scope.launch {
+            waitForSocket(nextSocket)
+            mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
+            while (process?.isAlive == true) {
+                updateStateFromMpv()
+                delay(1_000)
+            }
+            if (mutableState.value.status != PlayerStatus.Idle && mutableState.value.status != PlayerStatus.Error) {
+                mutableState.value = mutableState.value.copy(status = PlayerStatus.Ended)
+            }
+        }
+    }
+
+    override fun pause() {
+        sendCommand("set_property", "pause", true)
+        mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
+    }
+
+    override fun resume() {
+        sendCommand("set_property", "pause", false)
+        mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
+    }
+
+    override fun stop() {
+        stopProcess()
+        mutableState.value = PlaybackState(status = PlayerStatus.Idle)
+    }
+
+    override fun seekTo(positionMs: Long) {
+        sendCommand("set_property", "time-pos", positionMs.coerceAtLeast(0) / 1000.0)
+        mutableState.value = mutableState.value.copy(positionMs = positionMs.coerceAtLeast(0))
+    }
+
+    private suspend fun waitForSocket(socket: File) {
+        repeat(30) {
+            if (socket.exists()) return
+            delay(100)
+        }
+    }
+
+    private fun updateStateFromMpv() {
+        val position = getPropertyDouble("time-pos")?.let { (it * 1000).toLong() }
+        val duration = getPropertyDouble("duration")?.let { (it * 1000).toLong() }
+        val paused = getPropertyBoolean("pause")
+        val nextStatus = when (paused) {
+            true -> PlayerStatus.Paused
+            false -> PlayerStatus.Playing
+            null -> mutableState.value.status
+        }
+        mutableState.value = mutableState.value.copy(
+            status = nextStatus,
+            positionMs = position ?: mutableState.value.positionMs,
+            durationMs = duration ?: mutableState.value.durationMs,
+            bufferedMs = duration ?: mutableState.value.bufferedMs,
+            lyrics = mutableState.value.lyrics ?: currentPayload?.lyrics,
+            audioQuality = mutableState.value.audioQuality ?: currentPayload?.audioQuality,
+        )
+    }
+
+    private fun getPropertyDouble(name: String): Double? {
+        val response = sendCommand("get_property", name) ?: return null
+        return response.optDouble("data").takeIf { !it.isNaN() && it >= 0.0 }
+    }
+
+    private fun getPropertyBoolean(name: String): Boolean? {
+        val response = sendCommand("get_property", name) ?: return null
+        return if (response.has("data")) response.optBoolean("data") else null
+    }
+
+    private fun sendCommand(vararg args: Any): JSONObject? {
+        val socket = socketFile?.takeIf { it.exists() } ?: return null
+        return runCatching {
+            SocketChannel.open(UnixDomainSocketAddress.of(socket.absolutePath)).use { channel ->
+                val writer = Channels.newWriter(channel, Charsets.UTF_8)
+                val reader = Channels.newReader(channel, Charsets.UTF_8).buffered()
+                writer.write(JSONObject().put("command", JSONArray(args.toList())).toString())
+                writer.write("\n")
+                writer.flush()
+                JSONObject(reader.readLine())
+            }
+        }.getOrNull()
+    }
+
+    private fun playbackTarget(track: MusicTrack, payload: PlaybackPayload): String {
+        if (payload.url.isNotBlank()) return payload.url
+        val localUri = track.localUri.orEmpty()
+        if (localUri.startsWith("file:")) return File(URI(localUri)).absolutePath
+        return localUri
+    }
+
+    private fun stopProcess() {
+        pollJob?.cancel()
+        pollJob = null
+        runCatching { sendCommand("quit") }
+        process?.destroy()
+        process = null
+        socketFile?.delete()
+        socketFile = null
+        currentPayload = null
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
@@ -17,8 +17,31 @@ internal object DesktopPaths {
         File(base, "fuo-evolve").ensureDirectory()
     }
 
+    val dataDir: File by lazy {
+        val base = System.getenv("XDG_DATA_HOME")?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File(System.getProperty("user.home"), ".local/share")
+        File(base, "fuo-evolve").ensureDirectory()
+    }
+
+    val stateDir: File by lazy {
+        val base = System.getenv("XDG_STATE_HOME")?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File(System.getProperty("user.home"), ".local/state")
+        File(base, "fuo-evolve").ensureDirectory()
+    }
+
     val musicDir: File by lazy {
         File(System.getProperty("user.home"), "Music").ensureDirectory()
+    }
+
+    val feelUOwnDirs: List<File> by lazy {
+        listOf(
+            File(configDir, "feeluown"),
+            File(dataDir, "feeluown"),
+            File(stateDir, "feeluown"),
+            File(cacheDir, "feeluown"),
+        ).onEach { it.ensureDirectory() }
     }
 
     fun File.ensureDirectory(): File {

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
@@ -17,31 +17,8 @@ internal object DesktopPaths {
         File(base, "fuo-evolve").ensureDirectory()
     }
 
-    val dataDir: File by lazy {
-        val base = System.getenv("XDG_DATA_HOME")?.takeIf { it.isNotBlank() }
-            ?.let(::File)
-            ?: File(System.getProperty("user.home"), ".local/share")
-        File(base, "fuo-evolve").ensureDirectory()
-    }
-
-    val stateDir: File by lazy {
-        val base = System.getenv("XDG_STATE_HOME")?.takeIf { it.isNotBlank() }
-            ?.let(::File)
-            ?: File(System.getProperty("user.home"), ".local/state")
-        File(base, "fuo-evolve").ensureDirectory()
-    }
-
     val musicDir: File by lazy {
         File(System.getProperty("user.home"), "Music").ensureDirectory()
-    }
-
-    val feelUOwnDirs: List<File> by lazy {
-        listOf(
-            File(configDir, "feeluown"),
-            File(dataDir, "feeluown"),
-            File(stateDir, "feeluown"),
-            File(cacheDir, "feeluown"),
-        ).onEach { it.ensureDirectory() }
     }
 
     fun File.ensureDirectory(): File {

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPaths.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile.desktop
+
+import java.io.File
+
+internal object DesktopPaths {
+    val configDir: File by lazy {
+        val base = System.getenv("XDG_CONFIG_HOME")?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File(System.getProperty("user.home"), ".config")
+        File(base, "fuo-evolve").ensureDirectory()
+    }
+
+    val cacheDir: File by lazy {
+        val base = System.getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: File(System.getProperty("user.home"), ".cache")
+        File(base, "fuo-evolve").ensureDirectory()
+    }
+
+    val musicDir: File by lazy {
+        File(System.getProperty("user.home"), "Music").ensureDirectory()
+    }
+
+    fun File.ensureDirectory(): File {
+        if (!exists()) mkdirs()
+        return this
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProviderJson.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProviderJson.kt
@@ -1,0 +1,370 @@
+package org.feeluown.mobile.desktop
+
+import org.feeluown.mobile.AudioQualityPolicy
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackPart
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.ProviderAuthState
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderComment
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderContentType
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureCategory
+import org.feeluown.mobile.ProviderHeaderInput
+import org.feeluown.mobile.ProviderInfo
+import org.feeluown.mobile.ProviderLoginConfig
+import org.feeluown.mobile.ProviderLoginMode
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemDetail
+import org.feeluown.mobile.ProviderMediaItemType
+import org.feeluown.mobile.ProviderMutationResult
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.VideoPlaybackPayload
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun enabledProvidersJson(providerIds: Set<String>): String {
+    val array = JSONArray()
+    providerIds.forEach { array.put(it) }
+    return JSONObject().put("enabled", array).toString()
+}
+
+internal fun smartReplacementProviderIdsJson(providerIds: Set<String>): String {
+    val array = JSONArray()
+    providerIds.forEach { array.put(it) }
+    return array.toString()
+}
+
+internal fun JSONObject.toProviderInfo(): ProviderInfo {
+    val providerId = optString("provider_id")
+    return ProviderInfo(
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        loginConfig = optJSONObject("login_config")?.toLoginConfig(),
+        supportedLoginModes = optJSONArray("login_modes").toLoginModes(),
+    )
+}
+
+internal fun JSONObject.toSearchResults(): ProviderSearchResults {
+    val tracksArray = optJSONArray("tracks") ?: JSONArray()
+    val playlistsArray = optJSONArray("playlists") ?: JSONArray()
+    val artistsArray = optJSONArray("artists") ?: JSONArray()
+    val albumsArray = optJSONArray("albums") ?: JSONArray()
+    val videosArray = optJSONArray("videos") ?: JSONArray()
+    return ProviderSearchResults(
+        tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
+        playlists = List(playlistsArray.length()) { index -> playlistsArray.getJSONObject(index).toPlaylist() },
+        artists = List(artistsArray.length()) { index -> artistsArray.getJSONObject(index).toMediaItem() },
+        albums = List(albumsArray.length()) { index -> albumsArray.getJSONObject(index).toMediaItem() },
+        videos = List(videosArray.length()) { index -> videosArray.getJSONObject(index).toProviderVideo() },
+        errorMessage = optString("error_message").takeIf { it.isNotBlank() },
+    )
+}
+
+internal fun JSONObject.toLoginConfig(): ProviderLoginConfig = ProviderLoginConfig(
+    loginUrl = optString("login_url"),
+    cookieKeyGroups = optJSONArray("cookie_key_groups").toStringGroups(),
+)
+
+internal fun JSONObject.toCapabilities(): ProviderCapabilities {
+    val providerId = optString("provider_id")
+    return ProviderCapabilities(
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        canAddSongToPlaylist = optBoolean("can_add_song_to_playlist"),
+        canRemoveSongFromPlaylist = optBoolean("can_remove_song_from_playlist"),
+        canFavoritePlaylist = optBoolean("can_favorite_playlist"),
+        canUnfavoritePlaylist = optBoolean("can_unfavorite_playlist"),
+        canFavoriteArtist = optBoolean("can_favorite_artist"),
+        canUnfavoriteArtist = optBoolean("can_unfavorite_artist"),
+        canFavoriteAlbum = optBoolean("can_favorite_album"),
+        canUnfavoriteAlbum = optBoolean("can_unfavorite_album"),
+    )
+}
+
+internal fun JSONObject.toFeature(): ProviderFeature {
+    val providerId = optString("provider_id")
+    return ProviderFeature(
+        id = getString("id"),
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        title = optString("title"),
+        category = ProviderFeatureCategory.valueOf(optString("category")),
+        contentType = ProviderContentType.valueOf(optString("content_type")),
+        requiresLogin = optBoolean("requires_login"),
+    )
+}
+
+internal fun JSONObject.toContentSection(fallbackFeature: ProviderFeature): ProviderContentSection {
+    val parsedFeature = optJSONObject("feature")?.toFeature() ?: fallbackFeature
+    val tracksArray = optJSONArray("tracks") ?: JSONArray()
+    val playlistsArray = optJSONArray("playlists") ?: JSONArray()
+    val mediaItemsArray = optJSONArray("media_items") ?: JSONArray()
+    return ProviderContentSection(
+        feature = parsedFeature,
+        tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
+        playlists = List(playlistsArray.length()) { index -> playlistsArray.getJSONObject(index).toPlaylist() },
+        mediaItems = List(mediaItemsArray.length()) { index -> mediaItemsArray.getJSONObject(index).toMediaItem() },
+        isLoginRequired = optBoolean("is_login_required"),
+        errorMessage = optString("error_message").takeIf { it.isNotBlank() },
+        nextOffset = optInt("next_offset"),
+        hasMore = optBoolean("has_more"),
+    )
+}
+
+internal fun JSONObject.toPlaylist(): ProviderPlaylist {
+    val providerId = optString("provider_id")
+    return ProviderPlaylist(
+        id = getString("id"),
+        title = optString("title"),
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
+        description = optString("description"),
+        playCount = optLong("play_count").takeIf { it > 0 },
+        providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+        trackCount = optNullableInt("track_count"),
+    )
+}
+
+internal fun JSONObject.toPlaylistDetail(fallbackPlaylist: ProviderPlaylist): ProviderPlaylistDetail {
+    val tracksArray = optJSONArray("tracks") ?: JSONArray()
+    return ProviderPlaylistDetail(
+        playlist = optJSONObject("playlist")?.toPlaylist() ?: fallbackPlaylist,
+        tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
+        tracksNextOffset = optInt("tracks_next_offset"),
+        tracksHasMore = optBoolean("tracks_has_more"),
+    )
+}
+
+internal fun JSONObject.toMediaItem(): ProviderMediaItem {
+    val providerId = optString("provider_id")
+    return ProviderMediaItem(
+        id = getString("id"),
+        title = optString("title"),
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        type = ProviderMediaItemType.valueOf(optString("type")),
+        coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
+        description = optString("description"),
+        providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+        trackCount = optNullableInt("track_count"),
+        albumCount = optNullableInt("album_count"),
+    )
+}
+
+internal fun JSONObject.toProviderVideo(): ProviderVideo {
+    val providerId = optString("provider_id")
+    return ProviderVideo(
+        id = getString("id"),
+        title = optString("title"),
+        artists = optString("artists"),
+        providerId = providerId,
+        providerName = optString("provider_name").ifBlank { providerId },
+        coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
+        durationMs = optLong("duration_ms").takeIf { it > 0 },
+        providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+    )
+}
+
+internal fun JSONObject.toProviderComment(): ProviderComment = ProviderComment(
+    id = optString("id"),
+    userName = optString("user_name"),
+    content = optString("content"),
+    likedCount = optLong("liked_count"),
+    timeSeconds = optLong("time"),
+)
+
+internal fun JSONObject.toMediaItemDetail(fallbackItem: ProviderMediaItem): ProviderMediaItemDetail {
+    val tracksArray = optJSONArray("tracks") ?: JSONArray()
+    val albumsArray = optJSONArray("albums") ?: JSONArray()
+    return ProviderMediaItemDetail(
+        item = optJSONObject("item")?.toMediaItem() ?: fallbackItem,
+        tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
+        albums = List(albumsArray.length()) { index -> albumsArray.getJSONObject(index).toMediaItem() },
+        tracksNextOffset = optInt("tracks_next_offset"),
+        tracksHasMore = optBoolean("tracks_has_more"),
+        albumsNextOffset = optInt("albums_next_offset"),
+        albumsHasMore = optBoolean("albums_has_more"),
+    )
+}
+
+internal fun JSONObject.toVideoPlaybackPayload(fallbackVideo: ProviderVideo): VideoPlaybackPayload = VideoPlaybackPayload(
+    video = optJSONObject("video")?.toProviderVideo() ?: fallbackVideo,
+    url = optString("url"),
+    videoUrl = optString("video_url"),
+    audioUrl = optString("audio_url"),
+    headers = optJSONObject("headers").toStringMap(),
+    quality = optString("quality").takeIf { it.isNotBlank() },
+)
+
+internal fun JSONObject.toTrack(): MusicTrack {
+    val id = getString("id")
+    val source = optString("source")
+    return MusicTrack(
+        id = id,
+        title = optString("title"),
+        artists = optString("artists"),
+        album = optString("album"),
+        source = source,
+        sourceType = TrackSourceType.Provider,
+        coverUrl = optString("cover_url").takeIf { it.isNotBlank() },
+        durationMs = optLong("duration_ms").takeIf { it > 0 },
+        providerId = id,
+        providerName = optString("provider_name").ifBlank { source }.takeIf { it.isNotBlank() },
+        artistItemId = optString("artist_item_id").takeIf { it.isNotBlank() },
+        albumItemId = optString("album_item_id").takeIf { it.isNotBlank() },
+        providerUrl = optString("provider_url").takeIf { it.isNotBlank() },
+    )
+}
+
+internal fun JSONObject.toPayload(track: MusicTrack): PlaybackPayload {
+    val smartReplacement = optBoolean("smart_replacement", false)
+    return PlaybackPayload(
+        url = getString("url"),
+        title = optString("title").ifBlank { track.title },
+        artists = optString("artists").ifBlank { track.artists },
+        album = optString("album").ifBlank { track.album },
+        source = optString("source").ifBlank { track.source },
+        headers = optJSONObject("headers").toStringMap(),
+        coverUrl = optString("cover_url").takeIf { it.isNotBlank() }
+            ?: optString("original_cover_url").takeIf { smartReplacement && it.isNotBlank() }
+            ?: track.coverUrl,
+        durationMs = optLong("duration_ms").takeIf { it > 0 } ?: track.durationMs,
+        lyrics = optString("lyrics").takeIf { it.isNotBlank() },
+        audioQuality = optString("audio_quality").takeIf { it.isNotBlank() },
+        providerName = optString("replacement_provider_name")
+            .takeIf { smartReplacement && it.isNotBlank() }
+            ?: optString("provider_name").takeIf { it.isNotBlank() }
+            ?: track.providerName,
+        isSmartReplacement = smartReplacement,
+        originalTitle = optString("original_title").takeIf { smartReplacement && it.isNotBlank() },
+        originalProviderName = optString("original_provider_name").takeIf { smartReplacement && it.isNotBlank() },
+        originalCoverUrl = optString("original_cover_url").takeIf { smartReplacement && it.isNotBlank() },
+        replacementTitle = optString("replacement_title").takeIf { smartReplacement && it.isNotBlank() },
+        replacementArtists = optString("replacement_artists").takeIf { smartReplacement && it.isNotBlank() },
+        replacementSource = optString("replacement_source").takeIf { smartReplacement && it.isNotBlank() },
+        replacementProviderName = optString("replacement_provider_name").takeIf { smartReplacement && it.isNotBlank() },
+        replacementCoverUrl = optString("replacement_cover_url").takeIf { smartReplacement && it.isNotBlank() },
+        replacementStrategy = optString("standby_strategy").takeIf { smartReplacement && it.isNotBlank() },
+        replacementScore = optDouble("standby_score").takeIf { smartReplacement && has("standby_score") },
+        parts = optJSONArray("parts").toPlaybackParts(),
+        currentPartIndex = optInt("current_part_index", -1),
+    )
+}
+
+internal fun JSONObject.toAuthState(providerId: String): ProviderAuthState = ProviderAuthState(
+    providerId = optString("provider_id").ifBlank { providerId },
+    providerName = optString("provider_name").ifBlank { providerId },
+    isLoggedIn = optBoolean("is_logged_in"),
+    userName = optString("user_name").takeIf { it.isNotBlank() },
+)
+
+internal fun JSONObject.toMutationResult(): ProviderMutationResult = ProviderMutationResult(
+    success = optBoolean("success"),
+    message = optString("message"),
+)
+
+internal fun providerCookieInputsJson(inputs: Map<String, String>): String {
+    val json = JSONObject()
+    inputs.forEach { (key, value) ->
+        if (key.isNotBlank() && value.isNotBlank()) json.put(key, value)
+    }
+    return json.toString()
+}
+
+internal fun providerHeaderInputsJson(inputs: Map<String, ProviderHeaderInput>): String {
+    val json = JSONObject()
+    inputs.forEach { (providerId, input) ->
+        if (providerId.isNotBlank() && (input.authorization.isNotBlank() || input.cookie.isNotBlank())) {
+            json.put(
+                providerId,
+                JSONObject()
+                    .put("authorization", input.authorization)
+                    .put("cookie", input.cookie),
+            )
+        }
+    }
+    return json.toString()
+}
+
+internal fun JSONObject.readProviderCookieInputs(): Map<String, String> {
+    val result = linkedMapOf<String, String>()
+    val keys = keys()
+    while (keys.hasNext()) {
+        val key = keys.next()
+        val value = optString(key)
+        if (key.isNotBlank() && value.isNotBlank()) result[key] = value
+    }
+    return result
+}
+
+internal fun JSONObject.readProviderHeaderInputs(): Map<String, ProviderHeaderInput> {
+    val result = linkedMapOf<String, ProviderHeaderInput>()
+    val keys = keys()
+    while (keys.hasNext()) {
+        val providerId = keys.next()
+        val value = optJSONObject(providerId) ?: continue
+        val input = ProviderHeaderInput(
+            authorization = value.optString("authorization"),
+            cookie = value.optString("cookie"),
+        )
+        if (providerId.isNotBlank() && (input.authorization.isNotBlank() || input.cookie.isNotBlank())) {
+            result[providerId] = input
+        }
+    }
+    return result
+}
+
+internal fun audioQualityPolicyForDesktop(
+    wifiPolicy: AudioQualityPolicy,
+    cellularPolicy: AudioQualityPolicy,
+): AudioQualityPolicy = wifiPolicy
+
+private fun JSONArray?.toStringGroups(): List<List<String>> {
+    if (this == null) return emptyList()
+    return List(length()) { index ->
+        val group = getJSONArray(index)
+        List(group.length()) { keyIndex -> group.getString(keyIndex) }
+    }
+}
+
+private fun JSONArray?.toLoginModes(): Set<ProviderLoginMode> {
+    if (this == null) return setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie)
+    return List(length()) { index -> optString(index) }
+        .mapNotNull { raw -> runCatching { ProviderLoginMode.valueOf(raw) }.getOrNull() }
+        .toSet()
+        .ifEmpty { setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie) }
+}
+
+private fun JSONArray?.toPlaybackParts(): List<PlaybackPart> {
+    if (this == null) return emptyList()
+    return List(length()) { index ->
+        val item = getJSONObject(index)
+        PlaybackPart(
+            id = item.optString("id"),
+            title = item.optString("title"),
+            durationMs = item.optLong("duration_ms").takeIf { it > 0 },
+        )
+    }.filter { it.id.isNotBlank() }
+}
+
+private fun JSONObject?.toStringMap(): Map<String, String> {
+    if (this == null) return emptyMap()
+    val keys = keys()
+    val result = linkedMapOf<String, String>()
+    while (keys.hasNext()) {
+        val key = keys.next()
+        result[key] = optString(key)
+    }
+    return result
+}
+
+private fun JSONObject.optNullableInt(name: String): Int? {
+    return if (has(name) && !isNull(name)) optInt(name) else null
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
@@ -1,0 +1,211 @@
+package org.feeluown.mobile.desktop
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.util.concurrent.atomic.AtomicLong
+
+internal class DesktopPythonClient(
+    private val pythonExecutable: String = desktopPythonExecutable(),
+    private val bridgeScript: File = desktopResourceFile(
+        propertyName = "fuo.desktop.bridgeScript",
+        envName = "FUO_DESKTOP_BRIDGE_SCRIPT",
+        packagedRelativePath = "desktop-python/bridge/desktop_bridge.py",
+        sourceRelativePath = "desktopApp/src/main/python/desktop_bridge.py",
+    ),
+    private val androidPythonDir: File = desktopResourceFile(
+        propertyName = "fuo.desktop.androidPythonDir",
+        envName = "FUO_DESKTOP_ANDROID_PYTHON_DIR",
+        packagedRelativePath = "desktop-python/android-python",
+        sourceRelativePath = "androidApp/src/main/python",
+    ),
+) : AutoCloseable {
+    private val serial = AtomicLong()
+    private val stderr = StringBuilder()
+    private var process: Process? = null
+    private var input: BufferedWriter? = null
+    private var output: BufferedReader? = null
+    private var enabledProvidersJson: String = ""
+
+    suspend fun initialize(enabledProvidersJson: String) {
+        withContext(Dispatchers.IO) {
+            synchronized(this@DesktopPythonClient) {
+                if (process != null && this@DesktopPythonClient.enabledProvidersJson == enabledProvidersJson) return@synchronized
+                closeLocked()
+                startLocked()
+                sendLocked("create_bridge", listOf(enabledProvidersJson))
+                this@DesktopPythonClient.enabledProvidersJson = enabledProvidersJson
+            }
+        }
+    }
+
+    suspend fun call(method: String, args: List<Any?> = emptyList()): String = withContext(Dispatchers.IO) {
+        synchronized(this@DesktopPythonClient) {
+            if (process == null) {
+                startLocked()
+            }
+            sendLocked(method, args)
+        }
+    }
+
+    override fun close() {
+        synchronized(this) {
+            closeLocked()
+        }
+    }
+
+    private fun startLocked() {
+        if (!bridgeScript.isFile) {
+            error("找不到桌面 Python bridge：${bridgeScript.absolutePath}")
+        }
+        val builder = ProcessBuilder(pythonExecutable, bridgeScript.absolutePath)
+            .directory(File(".").absoluteFile)
+        builder.environment()["FUO_ANDROID_PYTHON_DIR"] = androidPythonDir.absolutePath
+        builder.environment()["PYTHONPATH"] = pythonPathEntries(androidPythonDir)
+            .joinToString(File.pathSeparator)
+        val nextProcess = builder.start()
+        process = nextProcess
+        input = BufferedWriter(OutputStreamWriter(nextProcess.outputStream, Charsets.UTF_8))
+        output = BufferedReader(InputStreamReader(nextProcess.inputStream, Charsets.UTF_8))
+        Thread {
+            nextProcess.errorStream.bufferedReader(Charsets.UTF_8).useLines { lines ->
+                lines.forEach { appendStderr(it) }
+            }
+        }.apply {
+            isDaemon = true
+            name = "fuo-desktop-python-stderr"
+            start()
+        }
+    }
+
+    private fun sendLocked(method: String, args: List<Any?>): String {
+        val requestId = serial.incrementAndGet()
+        val request = JSONObject()
+            .put("id", requestId)
+            .put("method", method)
+            .put("args", JSONArray(args))
+        val writer = requireNotNull(input) { "Python bridge stdin is not ready" }
+        val reader = requireNotNull(output) { "Python bridge stdout is not ready" }
+        writer.write(request.toString())
+        writer.newLine()
+        writer.flush()
+
+        while (true) {
+            val line = reader.readLine() ?: error("Python bridge 已退出：${stderrSnapshot()}")
+            val response = runCatching { JSONObject(line) }.getOrNull()
+            if (response == null) {
+                appendStderr(line)
+                continue
+            }
+            if (response.optLong("id") != requestId) {
+                appendStderr(line)
+                continue
+            }
+            if (!response.optBoolean("ok")) {
+                val message = response.optString("error").ifBlank { stderrSnapshot() }
+                error(message.ifBlank { "Python bridge 调用失败：$method" })
+            }
+            return response.optString("result")
+        }
+    }
+
+    private fun closeLocked() {
+        input?.close()
+        output?.close()
+        process?.destroy()
+        input = null
+        output = null
+        process = null
+        enabledProvidersJson = ""
+    }
+
+    private fun appendStderr(line: String) {
+        synchronized(stderr) {
+            if (stderr.length > MAX_STDERR_CHARS) {
+                stderr.delete(0, stderr.length - MAX_STDERR_CHARS)
+            }
+            stderr.appendLine(line)
+        }
+    }
+
+    private fun stderrSnapshot(): String = synchronized(stderr) {
+        stderr.toString().trim()
+    }
+
+    private companion object {
+        private const val MAX_STDERR_CHARS = 16_384
+    }
+}
+
+private fun desktopPythonExecutable(): String {
+    System.getProperty("fuo.desktop.python")?.takeIf { it.isNotBlank() }?.let { return it }
+    System.getenv("FUO_DESKTOP_PYTHON")?.takeIf { it.isNotBlank() }?.let { return it }
+    packagedResourceRoots()
+        .map { File(it, "desktop-python/venv/bin/python") }
+        .firstOrNull { it.isFile && it.canExecute() }
+        ?.let { return it.absolutePath }
+    return "python3"
+}
+
+private fun desktopResourceFile(
+    propertyName: String,
+    envName: String,
+    packagedRelativePath: String,
+    sourceRelativePath: String,
+): File {
+    System.getProperty(propertyName)?.takeIf { it.isNotBlank() }?.let { return File(it) }
+    System.getenv(envName)?.takeIf { it.isNotBlank() }?.let { return File(it) }
+    File(sourceRelativePath).takeIf { it.exists() }?.let { return it }
+    packagedResourceRoots()
+        .map { File(it, packagedRelativePath) }
+        .firstOrNull { it.exists() }
+        ?.let { return it }
+    return File(sourceRelativePath)
+}
+
+private fun packagedResourceRoots(): List<File> {
+    return buildList {
+        System.getProperty("compose.application.resources.dir")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { add(File(it)) }
+        System.getenv("APPDIR")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { appDir ->
+                add(File(appDir, "usr/lib/FuoEvolve/resources"))
+                add(File(appDir, "usr/lib/fuo-evolve/resources"))
+                add(File(appDir, "resources"))
+            }
+        val javaHome = File(System.getProperty("java.home").orEmpty())
+        listOf(
+            javaHome.parentFile,
+            javaHome.parentFile?.parentFile,
+            File(System.getProperty("user.dir")),
+        ).filterNotNull().forEach { base ->
+            add(File(base, "resources"))
+            add(File(base, "app/resources"))
+            add(File(base, "lib/app/resources"))
+        }
+    }.distinctBy { it.absolutePath }
+}
+
+private fun pythonPathEntries(androidPythonDir: File): List<String> {
+    return buildList {
+        add(androidPythonDir.absolutePath)
+        val resourceRoot = androidPythonDir.parentFile?.parentFile
+        val venvLib = resourceRoot?.let { File(it, "venv/lib") }
+        venvLib
+            ?.walkTopDown()
+            ?.maxDepth(2)
+            ?.firstOrNull { it.isDirectory && it.name == "site-packages" }
+            ?.let { add(it.absolutePath) }
+        System.getenv("PYTHONPATH")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { add(it) }
+    }.distinct()
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
@@ -64,11 +64,17 @@ internal class DesktopPythonClient(
         if (!bridgeScript.isFile) {
             error("找不到桌面 Python bridge：${bridgeScript.absolutePath}")
         }
+        DesktopPaths.feelUOwnDirs
         val builder = ProcessBuilder(pythonExecutable, bridgeScript.absolutePath)
-            .directory(File(".").absoluteFile)
-        builder.environment()["FUO_ANDROID_PYTHON_DIR"] = androidPythonDir.absolutePath
-        builder.environment()["PYTHONPATH"] = pythonPathEntries(androidPythonDir)
-            .joinToString(File.pathSeparator)
+            .directory(DesktopPaths.configDir)
+        builder.environment().apply {
+            this["FUO_ANDROID_PYTHON_DIR"] = androidPythonDir.absolutePath
+            this["PYTHONPATH"] = pythonPathEntries(androidPythonDir).joinToString(File.pathSeparator)
+            this["XDG_CONFIG_HOME"] = DesktopPaths.configDir.absolutePath
+            this["XDG_DATA_HOME"] = DesktopPaths.dataDir.absolutePath
+            this["XDG_STATE_HOME"] = DesktopPaths.stateDir.absolutePath
+            this["XDG_CACHE_HOME"] = DesktopPaths.cacheDir.absolutePath
+        }
         val nextProcess = builder.start()
         process = nextProcess
         input = BufferedWriter(OutputStreamWriter(nextProcess.outputStream, Charsets.UTF_8))

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopPythonClient.kt
@@ -64,16 +64,12 @@ internal class DesktopPythonClient(
         if (!bridgeScript.isFile) {
             error("找不到桌面 Python bridge：${bridgeScript.absolutePath}")
         }
-        DesktopPaths.feelUOwnDirs
         val builder = ProcessBuilder(pythonExecutable, bridgeScript.absolutePath)
             .directory(DesktopPaths.configDir)
         builder.environment().apply {
             this["FUO_ANDROID_PYTHON_DIR"] = androidPythonDir.absolutePath
             this["PYTHONPATH"] = pythonPathEntries(androidPythonDir).joinToString(File.pathSeparator)
-            this["XDG_CONFIG_HOME"] = DesktopPaths.configDir.absolutePath
-            this["XDG_DATA_HOME"] = DesktopPaths.dataDir.absolutePath
-            this["XDG_STATE_HOME"] = DesktopPaths.stateDir.absolutePath
-            this["XDG_CACHE_HOME"] = DesktopPaths.cacheDir.absolutePath
+            this["FEELUOWN_USER_HOME"] = System.getProperty("user.home")
         }
         val nextProcess = builder.start()
         process = nextProcess

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopStores.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopStores.kt
@@ -1,0 +1,301 @@
+package org.feeluown.mobile.desktop
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import org.feeluown.mobile.AppSettings
+import org.feeluown.mobile.AppSettingsStore
+import org.feeluown.mobile.AudioQualityPolicy
+import org.feeluown.mobile.CacheLimit
+import org.feeluown.mobile.CacheUsage
+import org.feeluown.mobile.DEFAULT_AUDIO_CACHE_LIMIT_MB
+import org.feeluown.mobile.DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY
+import org.feeluown.mobile.DEFAULT_ENABLED_PROVIDER_IDS
+import org.feeluown.mobile.DEFAULT_IMAGE_CACHE_LIMIT_MB
+import org.feeluown.mobile.DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS
+import org.feeluown.mobile.DEFAULT_PROVIDER_ORDER_IDS
+import org.feeluown.mobile.DEFAULT_SMART_REPLACEMENT_MIN_SCORE
+import org.feeluown.mobile.DEFAULT_UNAVAILABLE_PLAYBACK_POLICY
+import org.feeluown.mobile.DEFAULT_WIFI_AUDIO_QUALITY_POLICY
+import org.feeluown.mobile.DownloadRepository
+import org.feeluown.mobile.DownloadState
+import org.feeluown.mobile.HomeSection
+import org.feeluown.mobile.LocalMusicViewMode
+import org.feeluown.mobile.LyricFontSize
+import org.feeluown.mobile.MineSection
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackQueueCodec
+import org.feeluown.mobile.PlaybackQueueSnapshot
+import org.feeluown.mobile.PlaybackQueueStore
+import org.feeluown.mobile.PlaylistFilter
+import org.feeluown.mobile.ProviderHeaderInput
+import org.feeluown.mobile.ProviderLoginMode
+import org.feeluown.mobile.ProviderMusicRepository
+import org.feeluown.mobile.ResourceCacheRepository
+import org.feeluown.mobile.SearchScope
+import org.feeluown.mobile.ThemeColorScheme
+import org.feeluown.mobile.ThemeMode
+import org.feeluown.mobile.UnavailablePlaybackPolicy
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.net.URL
+import java.util.Properties
+
+internal class DesktopAppSettingsStore(
+    private val file: File = File(DesktopPaths.configDir, "settings.properties"),
+) : AppSettingsStore {
+    override suspend fun load(): AppSettings = withContext(Dispatchers.IO) {
+        val props = Properties().apply {
+            if (file.isFile) file.inputStream().use(::load)
+        }
+        AppSettings(
+            homeSection = enumValue(props, KEY_HOME_SECTION, HomeSection.Recommend),
+            mineSection = enumValue(props, KEY_MINE_SECTION, MineSection.Playlists),
+            playlistFilter = enumValue(props, KEY_PLAYLIST_FILTER, PlaylistFilter.All),
+            localMusicViewMode = enumValue(props, KEY_LOCAL_MUSIC_VIEW_MODE, LocalMusicViewMode.All),
+            excludedLocalMusicDirectoryIds = props.stringSet(KEY_EXCLUDED_LOCAL_MUSIC_DIRECTORY_IDS),
+            localMusicMinDurationSeconds = props.getProperty(KEY_LOCAL_MUSIC_MIN_DURATION_SECONDS)
+                ?.toIntOrNull()
+                ?: DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS,
+            searchScope = enumValue(props, KEY_SEARCH_SCOPE, SearchScope.All),
+            selectedSearchProviderId = props.getProperty(KEY_SELECTED_SEARCH_PROVIDER_ID)?.takeIf { it.isNotBlank() },
+            selectedSettingsProviderId = props.getProperty(KEY_SELECTED_SETTINGS_PROVIDER_ID)?.takeIf { it.isNotBlank() },
+            providerLoginMode = enumValue(props, KEY_PROVIDER_LOGIN_MODE, ProviderLoginMode.WebView),
+            providerCookieInputs = props.getProperty(KEY_PROVIDER_COOKIE_INPUTS)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it).readProviderCookieInputs() }.getOrNull() }
+                ?: emptyMap(),
+            providerHeaderInputs = props.getProperty(KEY_PROVIDER_HEADER_INPUTS)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { runCatching { JSONObject(it).readProviderHeaderInputs() }.getOrNull() }
+                ?: emptyMap(),
+            enabledProviderIds = props.stringSet(KEY_ENABLED_PROVIDER_IDS).ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS },
+            providerOrderIds = props.stringList(KEY_PROVIDER_ORDER_IDS).ifEmpty { DEFAULT_PROVIDER_ORDER_IDS },
+            audioCacheLimitMb = props.getProperty(KEY_AUDIO_CACHE_LIMIT_MB)?.toIntOrNull() ?: DEFAULT_AUDIO_CACHE_LIMIT_MB,
+            imageCacheLimitMb = props.getProperty(KEY_IMAGE_CACHE_LIMIT_MB)?.toIntOrNull() ?: DEFAULT_IMAGE_CACHE_LIMIT_MB,
+            wifiAudioQualityPolicy = enumValue(props, KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
+            cellularAudioQualityPolicy = enumValue(
+                props,
+                KEY_CELLULAR_AUDIO_QUALITY_POLICY,
+                DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY,
+            ),
+            unavailablePlaybackPolicy = enumValue(
+                props,
+                KEY_UNAVAILABLE_PLAYBACK_POLICY,
+                DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
+            ),
+            smartReplacementProviderIds = props.stringSet(KEY_SMART_REPLACEMENT_PROVIDER_IDS),
+            smartReplacementMinScore = props.getProperty(KEY_SMART_REPLACEMENT_MIN_SCORE)
+                ?.toDoubleOrNull()
+                ?: DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
+            smartReplacementUseReplacementMetadata = props.getProperty(
+                KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA,
+            ).toBoolean(),
+            smartReplacementUseReplacementLyrics = props.getProperty(
+                KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS,
+            ).toBoolean(),
+            lyricFontSize = enumValue(props, KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
+            themeMode = enumValue(props, KEY_THEME_MODE, ThemeMode.System),
+            themeColorScheme = enumValue(props, KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
+        )
+    }
+
+    override suspend fun save(settings: AppSettings) {
+        withContext(Dispatchers.IO) {
+            val props = Properties().apply {
+                setProperty(KEY_HOME_SECTION, settings.homeSection.name)
+                setProperty(KEY_MINE_SECTION, settings.mineSection.name)
+                setProperty(KEY_PLAYLIST_FILTER, settings.playlistFilter.name)
+                setProperty(KEY_LOCAL_MUSIC_VIEW_MODE, settings.localMusicViewMode.name)
+                setProperty(KEY_EXCLUDED_LOCAL_MUSIC_DIRECTORY_IDS, stringListJson(settings.excludedLocalMusicDirectoryIds.toList()))
+                setProperty(KEY_LOCAL_MUSIC_MIN_DURATION_SECONDS, settings.localMusicMinDurationSeconds.toString())
+                setProperty(KEY_SEARCH_SCOPE, settings.searchScope.name)
+                settings.selectedSearchProviderId?.let { setProperty(KEY_SELECTED_SEARCH_PROVIDER_ID, it) }
+                settings.selectedSettingsProviderId?.let { setProperty(KEY_SELECTED_SETTINGS_PROVIDER_ID, it) }
+                setProperty(KEY_PROVIDER_LOGIN_MODE, settings.providerLoginMode.name)
+                setProperty(KEY_PROVIDER_COOKIE_INPUTS, providerCookieInputsJson(settings.providerCookieInputs))
+                setProperty(KEY_PROVIDER_HEADER_INPUTS, providerHeaderInputsJson(settings.providerHeaderInputs))
+                setProperty(KEY_ENABLED_PROVIDER_IDS, stringListJson(settings.enabledProviderIds.toList()))
+                setProperty(KEY_PROVIDER_ORDER_IDS, stringListJson(settings.providerOrderIds))
+                setProperty(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb.toString())
+                setProperty(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb.toString())
+                setProperty(KEY_WIFI_AUDIO_QUALITY_POLICY, settings.wifiAudioQualityPolicy.name)
+                setProperty(KEY_CELLULAR_AUDIO_QUALITY_POLICY, settings.cellularAudioQualityPolicy.name)
+                setProperty(KEY_UNAVAILABLE_PLAYBACK_POLICY, settings.unavailablePlaybackPolicy.name)
+                setProperty(KEY_SMART_REPLACEMENT_PROVIDER_IDS, stringListJson(settings.smartReplacementProviderIds.toList()))
+                setProperty(KEY_SMART_REPLACEMENT_MIN_SCORE, settings.smartReplacementMinScore.toString())
+                setProperty(
+                    KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA,
+                    settings.smartReplacementUseReplacementMetadata.toString(),
+                )
+                setProperty(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, settings.smartReplacementUseReplacementLyrics.toString())
+                setProperty(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
+                setProperty(KEY_THEME_MODE, settings.themeMode.name)
+                setProperty(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)
+            }
+            file.parentFile?.mkdirs()
+            file.outputStream().use { props.store(it, "FuoEvolve desktop settings") }
+        }
+    }
+
+    private inline fun <reified T : Enum<T>> enumValue(props: Properties, key: String, fallback: T): T {
+        val raw = props.getProperty(key) ?: return fallback
+        return runCatching { enumValueOf<T>(raw) }.getOrDefault(fallback)
+    }
+
+    private fun Properties.stringSet(key: String): Set<String> = stringList(key).toSet()
+
+    private fun Properties.stringList(key: String): List<String> {
+        val raw = getProperty(key).orEmpty()
+        if (raw.isBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            List(array.length()) { index -> array.optString(index) }
+                .filter { it.isNotBlank() }
+                .distinct()
+        }.getOrDefault(emptyList())
+    }
+
+    private fun stringListJson(values: List<String>): String {
+        val array = JSONArray()
+        values.filter { it.isNotBlank() }.distinct().forEach { array.put(it) }
+        return array.toString()
+    }
+
+    private companion object {
+        private const val KEY_HOME_SECTION = "home_section"
+        private const val KEY_MINE_SECTION = "mine_section"
+        private const val KEY_PLAYLIST_FILTER = "playlist_filter"
+        private const val KEY_LOCAL_MUSIC_VIEW_MODE = "local_music_view_mode"
+        private const val KEY_EXCLUDED_LOCAL_MUSIC_DIRECTORY_IDS = "excluded_local_music_directory_ids"
+        private const val KEY_LOCAL_MUSIC_MIN_DURATION_SECONDS = "local_music_min_duration_seconds"
+        private const val KEY_SEARCH_SCOPE = "search_scope"
+        private const val KEY_SELECTED_SEARCH_PROVIDER_ID = "selected_search_provider_id"
+        private const val KEY_SELECTED_SETTINGS_PROVIDER_ID = "selected_settings_provider_id"
+        private const val KEY_PROVIDER_LOGIN_MODE = "provider_login_mode"
+        private const val KEY_PROVIDER_COOKIE_INPUTS = "provider_cookie_inputs"
+        private const val KEY_PROVIDER_HEADER_INPUTS = "provider_header_inputs"
+        private const val KEY_ENABLED_PROVIDER_IDS = "enabled_provider_ids"
+        private const val KEY_PROVIDER_ORDER_IDS = "provider_order_ids"
+        private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
+        private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
+        private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"
+        private const val KEY_CELLULAR_AUDIO_QUALITY_POLICY = "cellular_audio_quality_policy"
+        private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"
+        private const val KEY_SMART_REPLACEMENT_PROVIDER_IDS = "smart_replacement_provider_ids"
+        private const val KEY_SMART_REPLACEMENT_MIN_SCORE = "smart_replacement_min_score"
+        private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA = "smart_replacement_use_replacement_metadata"
+        private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"
+        private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
+        private const val KEY_THEME_MODE = "theme_mode"
+        private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
+    }
+}
+
+internal class DesktopPlaybackQueueStore(
+    private val file: File = File(DesktopPaths.configDir, "playback-queue.txt"),
+) : PlaybackQueueStore {
+    override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
+        file.takeIf { it.isFile }
+            ?.let { runCatching { PlaybackQueueCodec.decode(it.readText()) }.getOrNull() }
+            ?: PlaybackQueueSnapshot()
+    }
+
+    override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+        withContext(Dispatchers.IO) {
+            file.parentFile?.mkdirs()
+            file.writeText(PlaybackQueueCodec.encode(snapshot))
+        }
+    }
+}
+
+internal class DesktopResourceCacheRepository(
+    private val cacheDir: File = DesktopPaths.cacheDir,
+) : ResourceCacheRepository {
+    private val mutableUsage = MutableStateFlow(CacheUsage())
+    override val usage: StateFlow<CacheUsage> = mutableUsage.asStateFlow()
+
+    override suspend fun refreshUsage() {
+        mutableUsage.value = withContext(Dispatchers.IO) { CacheUsage(audioBytes = directorySize(cacheDir)) }
+    }
+
+    override suspend fun clearAll() {
+        withContext(Dispatchers.IO) {
+            cacheDir.deleteRecursively()
+            cacheDir.mkdirs()
+            mutableUsage.value = CacheUsage()
+        }
+    }
+
+    override suspend fun updateLimit(limit: CacheLimit) {
+        refreshUsage()
+    }
+
+    private fun directorySize(file: File): Long {
+        if (!file.exists()) return 0L
+        return if (file.isFile) file.length() else file.listFiles().orEmpty().sumOf(::directorySize)
+    }
+}
+
+internal class DesktopDownloadRepository(
+    private val providerRepository: ProviderMusicRepository,
+    private val downloadDir: File = File(DesktopPaths.musicDir, "FuoEvolve").apply { mkdirs() },
+) : DownloadRepository {
+    private val records = linkedMapOf<String, String>()
+    private val mutableStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
+
+    override val states: StateFlow<Map<String, DownloadState>> = mutableStates.asStateFlow()
+
+    override suspend fun load() {
+        mutableStates.value = records.mapValues { DownloadState.Downloaded(it.value) }
+    }
+
+    override suspend fun download(track: MusicTrack) {
+        withContext(Dispatchers.IO) {
+            mutableStates.update { it + (track.id to DownloadState.Downloading(0f)) }
+            val payload = providerRepository.resolve(track)
+            val extension = payload.url.substringBefore('?').substringAfterLast('.', "mp3").take(5).ifBlank { "mp3" }
+            val target = File(downloadDir, "${sanitize(payload.title)} - ${sanitize(payload.artists)}.$extension")
+            val connection = URL(payload.url).openConnection()
+            payload.headers.forEach { (key, value) -> connection.setRequestProperty(key, value) }
+            val total = connection.contentLengthLong.takeIf { it > 0 }
+            var written = 0L
+            connection.getInputStream().use { input ->
+                target.outputStream().use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        written += read
+                        if (total != null) {
+                            mutableStates.update { current ->
+                                current + (track.id to DownloadState.Downloading((written.toFloat() / total).coerceIn(0f, 1f)))
+                            }
+                        }
+                    }
+                }
+            }
+            val uri = target.toURI().toString()
+            records[track.id] = uri
+            mutableStates.update { it + (track.id to DownloadState.Downloaded(uri)) }
+        }
+    }
+
+    override suspend fun deleteDownloaded(track: MusicTrack) {
+        withContext(Dispatchers.IO) {
+            records.remove(track.id)?.let { uri ->
+                runCatching { File(java.net.URI(uri)).delete() }
+            }
+            mutableStates.update { it - track.id }
+        }
+    }
+
+    private fun sanitize(value: String): String = value.ifBlank { "unknown" }
+        .replace(Regex("""[\\/:*?"<>|]+"""), "_")
+        .take(120)
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -1,0 +1,108 @@
+package org.feeluown.mobile.desktop
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.feeluown.mobile.AppRoot
+import org.feeluown.mobile.FuoPlayerController
+import org.feeluown.mobile.NoOpDebugLogRepository
+import org.feeluown.mobile.ProviderInfo
+import org.feeluown.mobile.ProviderLoginMode
+import java.awt.Desktop
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.net.URI
+
+fun main() = application {
+    val container = remember { DesktopAppContainer() }
+    DisposableEffect(Unit) {
+        onDispose { container.close() }
+    }
+    Window(
+        onCloseRequest = {
+            container.close()
+            exitApplication()
+        },
+        title = "FuoEvolve",
+    ) {
+        DesktopApp(container)
+    }
+}
+
+@Composable
+private fun DesktopApp(container: DesktopAppContainer) {
+    AppRoot(
+        controller = container.controller,
+        hasAudioPermission = true,
+        appVersionInfo = "桌面开发版",
+        onRequestAudioPermission = container::requestAudioPermission,
+        onOpenProviderWebLogin = container::openProviderWebLogin,
+        onLogoutProvider = container::logoutProvider,
+        onShareText = ::copyShareText,
+    )
+}
+
+private class DesktopAppContainer : AutoCloseable {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val providerRepository = DesktopFuoCoreBridge()
+    private val localRepository = DesktopLocalMusicRepository()
+    private val downloadRepository = DesktopDownloadRepository(providerRepository)
+    private val playbackEngine = DesktopNativeAudioEngine(scope)
+    private val settingsStore = DesktopAppSettingsStore()
+    private val playbackQueueStore = DesktopPlaybackQueueStore()
+    private val resourceCacheRepository = DesktopResourceCacheRepository()
+
+    val controller = FuoPlayerController(
+        providerRepository = providerRepository,
+        localRepository = localRepository,
+        downloadRepository = downloadRepository,
+        playbackEngine = playbackEngine,
+        settingsStore = settingsStore,
+        playbackQueueStore = playbackQueueStore,
+        resourceCacheRepository = resourceCacheRepository,
+        debugLogRepository = NoOpDebugLogRepository,
+        scope = scope,
+    )
+
+    fun requestAudioPermission() {
+        controller.onLocalMusicPermissionChange(true)
+        controller.refreshLocalMusic()
+    }
+
+    fun openProviderWebLogin(provider: ProviderInfo) {
+        val url = provider.loginConfig?.loginUrl.orEmpty()
+        if (url.isNotBlank()) {
+            runCatching {
+                if (Desktop.isDesktopSupported()) {
+                    Desktop.getDesktop().browse(URI(url))
+                }
+            }
+        }
+        controller.openSettings(provider.providerId)
+        controller.onProviderLoginModeChange(ProviderLoginMode.Cookie)
+    }
+
+    fun logoutProvider(provider: ProviderInfo) {
+        controller.logoutProvider(provider.providerId)
+    }
+
+    override fun close() {
+        providerRepository.close()
+        playbackEngine.stop()
+        scope.cancel()
+    }
+}
+
+private fun copyShareText(text: String) {
+    runCatching {
+        Toolkit.getDefaultToolkit()
+            .systemClipboard
+            .setContents(StringSelection(text), null)
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -78,10 +78,8 @@ private class DesktopAppContainer : AutoCloseable {
     fun openProviderWebLogin(provider: ProviderInfo) {
         val url = provider.loginConfig?.loginUrl.orEmpty()
         if (url.isNotBlank()) {
-            runCatching {
-                if (Desktop.isDesktopSupported()) {
-                    Desktop.getDesktop().browse(URI(url))
-                }
+            if (!openExternalBrowser(url)) {
+                copyShareText(url)
             }
         }
         controller.openSettings(provider.providerId)
@@ -104,5 +102,26 @@ private fun copyShareText(text: String) {
         Toolkit.getDefaultToolkit()
             .systemClipboard
             .setContents(StringSelection(text), null)
+    }
+}
+
+private fun openExternalBrowser(url: String): Boolean {
+    val openedByDesktop = runCatching {
+        if (!Desktop.isDesktopSupported()) return@runCatching false
+        val desktop = Desktop.getDesktop()
+        if (!desktop.isSupported(Desktop.Action.BROWSE)) return@runCatching false
+        desktop.browse(URI(url))
+        true
+    }.getOrDefault(false)
+    if (openedByDesktop) return true
+
+    return listOf(
+        listOf("xdg-open", url),
+        listOf("gio", "open", url),
+    ).any { command ->
+        runCatching {
+            ProcessBuilder(command).start()
+            true
+        }.getOrDefault(false)
     }
 }

--- a/desktopApp/src/main/python/desktop_bridge.py
+++ b/desktopApp/src/main/python/desktop_bridge.py
@@ -1,7 +1,19 @@
 import json
 import os
+from pathlib import Path
+import shutil
 import sys
 import traceback
+
+
+LOGIN_STATE_RELATIVE_PATHS = (
+    "nem_users_info.json",
+    "qqmusic_user_info.json",
+    "ytmusic_header.json",
+    "ytmusic_header.cookies.txt",
+    "fuo_bilibili/bilibili_api.cookie",
+    "fuo_bilibili/bilibili_api_cookie.json",
+)
 
 
 def _write_response(request_id, ok, result=None, error=None):
@@ -14,12 +26,47 @@ def _write_response(request_id, ok, result=None, error=None):
     print(json.dumps(payload, ensure_ascii=False), flush=True)
 
 
+def _prepare_feeluown_storage():
+    try:
+        from feeluown import consts
+    except Exception:
+        return
+
+    for name in ("HOME_DIR", "DATA_DIR", "STATE_DIR", "CACHE_DIR"):
+        path = getattr(consts, name, None)
+        if path:
+            Path(path).mkdir(parents=True, exist_ok=True)
+
+    data_dir = Path(consts.DATA_DIR)
+    home = Path(os.path.expanduser("~"))
+    candidate_dirs = [
+        home / ".local" / "share" / "fuo-evolve" / "feeluown",
+        home / ".config" / "fuo-evolve" / "feeluown",
+        home / ".FeelUOwn",
+    ]
+    xdg_data_home = os.environ.get("XDG_DATA_HOME")
+    if xdg_data_home:
+        candidate_dirs.append(Path(xdg_data_home) / "fuo-evolve" / "feeluown")
+
+    for source_dir in candidate_dirs:
+        if source_dir.resolve() == data_dir.resolve() or not source_dir.exists():
+            continue
+        for relative_path in LOGIN_STATE_RELATIVE_PATHS:
+            source = source_dir / relative_path
+            target = data_dir / relative_path
+            if source.is_file() and not target.exists():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+
+
 def main():
     android_python_dir = os.environ.get("FUO_ANDROID_PYTHON_DIR")
     if android_python_dir:
         sys.path.insert(0, android_python_dir)
 
     from fuo_mobile.bridge import create_bridge
+
+    _prepare_feeluown_storage()
 
     bridge = None
     for line in sys.stdin:

--- a/desktopApp/src/main/python/desktop_bridge.py
+++ b/desktopApp/src/main/python/desktop_bridge.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+import traceback
+
+
+def _write_response(request_id, ok, result=None, error=None):
+    payload = {
+        "id": request_id,
+        "ok": ok,
+        "result": result,
+        "error": error,
+    }
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+
+
+def main():
+    android_python_dir = os.environ.get("FUO_ANDROID_PYTHON_DIR")
+    if android_python_dir:
+        sys.path.insert(0, android_python_dir)
+
+    from fuo_mobile.bridge import create_bridge
+
+    bridge = None
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request_id = None
+        try:
+            request = json.loads(line)
+            request_id = request.get("id")
+            method = request.get("method")
+            args = request.get("args") or []
+            if method == "create_bridge":
+                bridge = create_bridge(args[0] if args else "")
+                _write_response(request_id, True, "")
+                continue
+            if bridge is None:
+                raise RuntimeError("bridge is not initialized")
+            result = getattr(bridge, method)(*args)
+            _write_response(request_id, True, result)
+        except Exception as exc:
+            traceback.print_exc(file=sys.stderr)
+            _write_response(request_id, False, error=str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/desktopApp/src/test/python/test_desktop_bridge.py
+++ b/desktopApp/src/test/python/test_desktop_bridge.py
@@ -51,6 +51,74 @@ class DesktopBridgeTest(unittest.TestCase):
                 process.stdout.close()
                 process.stderr.close()
 
+    def test_migrates_previous_appimage_login_state(self):
+        root = Path(__file__).resolve().parents[3]
+        bridge_script = root / "src" / "main" / "python" / "desktop_bridge.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            home_dir = temp_path / "home"
+            target_data_dir = temp_path / "target-data"
+            old_data_dir = home_dir / ".local" / "share" / "fuo-evolve" / "feeluown"
+            old_data_dir.mkdir(parents=True)
+            (old_data_dir / "qqmusic_user_info.json").write_text('{"cookies": {"uin": "1"}}', encoding="utf-8")
+
+            module_dir = temp_path / "fuo_mobile"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("", encoding="utf-8")
+            (module_dir / "bridge.py").write_text(
+                textwrap.dedent(
+                    f"""
+                    from pathlib import Path
+
+                    class FakeBridge:
+                        def providers(self):
+                            migrated = Path({str(target_data_dir / "qqmusic_user_info.json")!r}).is_file()
+                            return '{{"providers":[{{"provider_id":"fake","provider_name":"Fake","migrated":' + str(migrated).lower() + '}}]}}'
+
+                    def create_bridge(providers_json):
+                        return FakeBridge()
+                    """
+                ),
+                encoding="utf-8",
+            )
+            feeluown_dir = temp_path / "feeluown"
+            feeluown_dir.mkdir()
+            (feeluown_dir / "__init__.py").write_text("", encoding="utf-8")
+            (feeluown_dir / "consts.py").write_text(
+                textwrap.dedent(
+                    f"""
+                    HOME_DIR = {str(temp_path / "home-dir")!r}
+                    DATA_DIR = {str(target_data_dir)!r}
+                    STATE_DIR = {str(temp_path / "state-dir")!r}
+                    CACHE_DIR = {str(temp_path / "cache-dir")!r}
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            process = subprocess.Popen(
+                [sys.executable, str(bridge_script)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "HOME": str(home_dir), "FUO_ANDROID_PYTHON_DIR": temp_dir},
+            )
+            try:
+                self._send(process, 1, "create_bridge", ['{"enabled":["fake"]}'])
+                self.assertEqual(self._read(process)["ok"], True)
+                self._send(process, 2, "providers", [])
+                response = self._read(process)
+                self.assertEqual(response["ok"], True)
+                provider = json.loads(response["result"])["providers"][0]
+                self.assertEqual(provider["migrated"], True)
+            finally:
+                process.terminate()
+                process.wait(timeout=5)
+                process.stdin.close()
+                process.stdout.close()
+                process.stderr.close()
+
     def _send(self, process, request_id, method, args):
         process.stdin.write(json.dumps({"id": request_id, "method": method, "args": args}) + "\n")
         process.stdin.flush()

--- a/desktopApp/src/test/python/test_desktop_bridge.py
+++ b/desktopApp/src/test/python/test_desktop_bridge.py
@@ -1,0 +1,66 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class DesktopBridgeTest(unittest.TestCase):
+    def test_rpc_create_and_call(self):
+        root = Path(__file__).resolve().parents[3]
+        bridge_script = root / "src" / "main" / "python" / "desktop_bridge.py"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_dir = Path(temp_dir) / "fuo_mobile"
+            module_dir.mkdir()
+            (module_dir / "__init__.py").write_text("", encoding="utf-8")
+            (module_dir / "bridge.py").write_text(
+                textwrap.dedent(
+                    """
+                    class FakeBridge:
+                        def providers(self):
+                            return '{"providers":[{"provider_id":"fake","provider_name":"Fake"}]}'
+
+                    def create_bridge(providers_json):
+                        return FakeBridge()
+                    """
+                ),
+                encoding="utf-8",
+            )
+            process = subprocess.Popen(
+                [sys.executable, str(bridge_script)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "FUO_ANDROID_PYTHON_DIR": temp_dir},
+            )
+            try:
+                self._send(process, 1, "create_bridge", ['{"enabled":["fake"]}'])
+                self.assertEqual(self._read(process)["ok"], True)
+                self._send(process, 2, "providers", [])
+                response = self._read(process)
+                self.assertEqual(response["ok"], True)
+                self.assertEqual(json.loads(response["result"])["providers"][0]["provider_id"], "fake")
+            finally:
+                process.terminate()
+                process.wait(timeout=5)
+                process.stdin.close()
+                process.stdout.close()
+                process.stderr.close()
+
+    def _send(self, process, request_id, method, args):
+        process.stdin.write(json.dumps({"id": request_id, "method": method, "args": args}) + "\n")
+        process.stdin.flush()
+
+    def _read(self, process):
+        line = process.stdout.readline()
+        if not line:
+            self.fail(process.stderr.read())
+        return json.loads(line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ media3 = "1.5.1"
 activityCompose = "1.10.1"
 coreKtx = "1.15.0"
 coroutines = "1.10.1"
+json = "20240303"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -18,8 +19,10 @@ androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "medi
 jellyfin-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-decoder", version = "1.5.0+1" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0-alpha04" }
+org-json = { module = "org.json:json", version.ref = "json" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -28,4 +31,5 @@ chaquopy = { id = "com.chaquo.python", version.ref = "chaquopy" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,3 +18,4 @@ rootProject.name = "FuoEvolve"
 
 include(":shared")
 include(":androidApp")
+include(":desktopApp")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -12,6 +12,12 @@ kotlin {
         }
     }
 
+    jvm("desktop") {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
     listOf(
         iosX64(),
         iosArm64(),

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformCoverArt.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformCoverArt.desktop.kt
@@ -1,0 +1,88 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import java.io.File
+import java.net.URI
+import java.net.URL
+
+private const val MAX_COVER_BYTES = 8 * 1024 * 1024
+
+@Composable
+actual fun PlatformCoverArt(
+    title: String,
+    imageUrl: String?,
+    modifier: Modifier,
+) {
+    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
+
+    LaunchedEffect(imageUrl) {
+        image = imageUrl?.takeIf { it.isNotBlank() }?.let {
+            runCatching { loadCover(it) }.getOrNull()
+        }
+    }
+
+    val bitmap = image
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = title,
+            modifier = modifier,
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        CoverFallback(title = title, modifier = modifier)
+    }
+}
+
+private suspend fun loadCover(imageUrl: String): ImageBitmap? = withContext(Dispatchers.IO) {
+    val bytes = when {
+        imageUrl.startsWith("file:") -> URI(imageUrl).path?.let { File(it).readBytesIfSmall() }
+        imageUrl.startsWith("http://") || imageUrl.startsWith("https://") -> URL(imageUrl).openConnection().run {
+            connectTimeout = 15_000
+            readTimeout = 20_000
+            getInputStream().use { it.readBytes().takeIf { bytes -> bytes.size <= MAX_COVER_BYTES } }
+        }
+        else -> File(imageUrl).readBytesIfSmall()
+    } ?: return@withContext null
+
+    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+}
+
+private fun File.readBytesIfSmall(): ByteArray? {
+    if (!isFile || length() <= 0L || length() > MAX_COVER_BYTES) return null
+    return readBytes()
+}
+
+@Composable
+private fun CoverFallback(title: String, modifier: Modifier) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.primaryContainer,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = title.firstOrNull()?.uppercase() ?: "F",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformTheme.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformTheme.desktop.kt
@@ -1,0 +1,7 @@
+package org.feeluown.mobile
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme? = null

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun PlatformVideoPlayer(
+    payload: VideoPlaybackPayload?,
+    modifier: Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = "桌面端视频播放尚未接入",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Compose Desktop `desktopApp` module and shared desktop target.
- Wire desktop provider support through an external Python JSON-RPC bridge that reuses `fuo_mobile.bridge`.
- Add desktop playback, local music, settings, queue, cache, download, cover art, video placeholder, and AppImage packaging support.

## Notes

- Desktop packaging is configured with `packageAppImage`, producing a jpackage app image directory under `desktopApp/build/compose/binaries/main/app/FuoEvolve`.
- Runtime still expects system `python3` and `mpv`; packaged resources include the Python bridge and provider dependencies for `PYTHONPATH`.

## Validation

- `./gradlew :desktopApp:compileKotlin`
- `python -m unittest discover -s desktopApp/src/test/python`
- `python -m unittest discover -s androidApp/src/test/python`
- `./gradlew :shared:allTests`
- `./gradlew :desktopApp:prepareDesktopPython`
- desktop bridge smoke test with packaged resources and `netease` provider initialization
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :desktopApp:packageAppImage`
- `git diff --check`
