### PR TITLE
feat: complete iOS music runtime integration

### DIFF
--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -10,8 +10,9 @@ jobs:
   build-debug-app:
     name: Build debug iOS app
     runs-on: macos-15
-    continue-on-error: true
     timeout-minutes: 45
+    env:
+      PYTHON_APPLE_SUPPORT_TAG: 3.12-b8
 
     steps:
       - name: Checkout
@@ -23,8 +24,24 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: iosApp/python/requirements-ios.txt
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache iOS Python distribution
+        uses: actions/cache@v4
+        with:
+          path: build/ios-python
+          key: ${{ runner.os }}-${{ runner.arch }}-python-apple-support-${{ env.PYTHON_APPLE_SUPPORT_TAG }}
+
+      - name: Prepare iOS Python runtime
+        run: bash scripts/prepare-ios-python.sh
 
       - name: Build debug simulator app
         run: |

--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Prepare iOS Python runtime
         run: bash scripts/prepare-ios-python.sh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build debug simulator app
         run: |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ media3 = "1.5.1"
 activityCompose = "1.10.1"
 coreKtx = "1.15.0"
 coroutines = "1.10.1"
+serializationJson = "1.8.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -19,6 +20,7 @@ jellyfin-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-d
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
 compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0-alpha04" }
 
 [plugins]

--- a/iosApp/FuoEvolve.xcodeproj/project.pbxproj
+++ b/iosApp/FuoEvolve.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
             buildConfigurationList = A10000000000000000000090 /* Build configuration list for PBXNativeTarget "FuoEvolve" */;
             buildPhases = (
                 A10000000000000000000060 /* Embed Shared Framework */,
+                A10000000000000000000061 /* Embed Python Runtime */,
                 A10000000000000000000050 /* Sources */,
                 A10000000000000000000020 /* Frameworks */,
             );
@@ -136,6 +137,25 @@
             runOnlyForDeploymentPostprocessing = 0;
             shellPath = /bin/sh;
             shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+        };
+        A10000000000000000000061 /* Embed Python Runtime */ = {
+            isa = PBXShellScriptBuildPhase;
+            alwaysOutOfDate = 1;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            inputFileListPaths = (
+            );
+            inputPaths = (
+            );
+            name = "Embed Python Runtime";
+            outputFileListPaths = (
+            );
+            outputPaths = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+            shellPath = /bin/sh;
+            shellScript = "set -eu\nRUNTIME_ROOT=\"$SRCROOT/FuoEvolve/PythonResources\"\nif [ ! -d \"$RUNTIME_ROOT/python/Python.xcframework\" ]; then\n  echo \"error: iOS Python runtime is missing; run scripts/prepare-ios-python.sh\"\n  exit 1\nfi\nif [ \"$PLATFORM_NAME\" = \"iphonesimulator\" ]; then\n  PYTHON_SLICE=ios-arm64_x86_64-simulator\nelse\n  PYTHON_SLICE=ios-arm64\nfi\nif [ \"$CURRENT_ARCH\" = \"x86_64\" ]; then\n  PYTHON_ARCH=lib-x86_64\nelse\n  PYTHON_ARCH=lib-arm64\nfi\nAPP_ROOT=\"$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH\"\nmkdir -p \"$APP_ROOT/Frameworks\" \"$APP_ROOT/python/lib/python3.12/lib-dynload\" \"$APP_ROOT/python-app\"\nrsync -a --delete \"$RUNTIME_ROOT/python/Python.xcframework/$PYTHON_SLICE/Python.framework\" \"$APP_ROOT/Frameworks/\"\nrsync -a --delete \"$RUNTIME_ROOT/python/Python.xcframework/lib/\" \"$APP_ROOT/python/lib/\"\nrsync -a --delete \"$RUNTIME_ROOT/python/Python.xcframework/$PYTHON_SLICE/$PYTHON_ARCH/python3.12/lib-dynload/\" \"$APP_ROOT/python/lib/python3.12/lib-dynload/\"\nrsync -a --delete \"$RUNTIME_ROOT/app/\" \"$APP_ROOT/python-app/\"\nif [ \"$CODE_SIGNING_ALLOWED\" = \"YES\" ]; then\n  find \"$APP_ROOT/python/lib/python3.12/lib-dynload\" -type f -name '*.so' -print0 | while IFS= read -r -d '' extension; do\n    codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --timestamp=none \"$extension\"\n  done\n  codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --timestamp=none \"$APP_ROOT/Frameworks/Python.framework\"\nfi\n";
         };
 /* End PBXShellScriptBuildPhase section */
 
@@ -281,6 +301,8 @@
                     "$(inherited)",
                     "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
                 );
+                "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/FuoEvolve/PythonResources/python/Python.xcframework/ios-arm64";
+                "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/FuoEvolve/PythonResources/python/Python.xcframework/ios-arm64_x86_64-simulator";
                 INFOPLIST_FILE = FuoEvolve/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",
@@ -290,6 +312,8 @@
                     "$(inherited)",
                     "-framework",
                     Shared,
+                    "-framework",
+                    Python,
                 );
                 PRODUCT_BUNDLE_IDENTIFIER = org.feeluown.mobile;
                 PRODUCT_NAME = "$(TARGET_NAME)";
@@ -310,6 +334,8 @@
                     "$(inherited)",
                     "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
                 );
+                "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/FuoEvolve/PythonResources/python/Python.xcframework/ios-arm64";
+                "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/FuoEvolve/PythonResources/python/Python.xcframework/ios-arm64_x86_64-simulator";
                 INFOPLIST_FILE = FuoEvolve/Info.plist;
                 LD_RUNPATH_SEARCH_PATHS = (
                     "$(inherited)",
@@ -319,6 +345,8 @@
                     "$(inherited)",
                     "-framework",
                     Shared,
+                    "-framework",
+                    Python,
                 );
                 PRODUCT_BUNDLE_IDENTIFIER = org.feeluown.mobile;
                 PRODUCT_NAME = "$(TARGET_NAME)";

--- a/iosApp/FuoEvolve/FuoEvolveApp.swift
+++ b/iosApp/FuoEvolve/FuoEvolveApp.swift
@@ -13,7 +13,17 @@ struct FuoEvolveApp: App {
 
 private struct SharedComposeRoot: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        IosAppHostKt.MainViewController()
+        let viewController = IosAppHostKt.MainViewController(
+            pythonRuntime: PythonCoreBridge.shared,
+            audioOutput: IOSNativeAudioEngine.shared,
+            videoOutput: IOSNativeVideoOutput.shared,
+            mediaLibraryOutput: IOSMediaLibraryOutput.shared,
+            downloadOutput: IOSDownloadOutput.shared,
+            webLoginOutput: IOSWebLoginOutput.shared,
+            shareOutput: IOSShareOutput.shared
+        )
+        IOSWebLoginOutput.shared.hostViewController = viewController
+        return viewController
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {

--- a/iosApp/FuoEvolve/FuoEvolveApp.swift
+++ b/iosApp/FuoEvolve/FuoEvolveApp.swift
@@ -20,7 +20,8 @@ private struct SharedComposeRoot: UIViewControllerRepresentable {
             mediaLibraryOutput: IOSMediaLibraryOutput.shared,
             downloadOutput: IOSDownloadOutput.shared,
             webLoginOutput: IOSWebLoginOutput.shared,
-            shareOutput: IOSShareOutput.shared
+            shareOutput: IOSShareOutput.shared,
+            networkStatusOutput: IOSNetworkStatusOutput.shared
         )
         IOSWebLoginOutput.shared.hostViewController = viewController
         return viewController

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import AVKit
 import MediaPlayer
+import Network
 import Shared
 import WebKit
 
@@ -455,6 +456,32 @@ final class IOSShareOutput: NSObject, IosShareOutput {
     }
 }
 
+final class IOSNetworkStatusOutput: NSObject, IosNetworkStatusOutput {
+    static let shared = IOSNetworkStatusOutput()
+
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "org.feeluown.mobile.network-status")
+    private let lock = NSLock()
+    private var cellularConnection = false
+
+    override init() {
+        super.init()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            self.lock.lock()
+            self.cellularConnection = path.usesInterfaceType(.cellular)
+            self.lock.unlock()
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    func isCellularConnection() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cellularConnection
+    }
+}
+
 private final class FuoWebLoginViewController: UIViewController, WKNavigationDelegate {
     private let webView = WKWebView(frame: .zero)
     private let requiredCookieGroups: [[String]]
@@ -503,7 +530,10 @@ private final class FuoWebLoginViewController: UIViewController, WKNavigationDel
 
     @objc private func done() {
         webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            let values = Dictionary(uniqueKeysWithValues: cookies.map { ($0.name, $0.value) })
+            var values: [String: String] = [:]
+            for cookie in cookies where !cookie.value.isEmpty || values[cookie.name] == nil {
+                values[cookie.name] = cookie.value
+            }
             let valid = self.requiredCookieGroups.isEmpty || self.requiredCookieGroups.contains { group in
                 group.allSatisfy { !(values[$0] ?? "").isEmpty }
             }

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -1,17 +1,44 @@
 import AVFoundation
+import AVKit
 import MediaPlayer
+import Shared
+import WebKit
 
-final class IOSNativeAudioEngine: NativeAudioEngine {
+final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
+    static let shared = IOSNativeAudioEngine()
     private let player = AVPlayer()
     private var currentPayload: PlaybackPayload?
+    private var didReachEnd = false
+    private var playbackError: String?
+    private var endObserver: NSObjectProtocol?
 
-    init() {
+    override init() {
+        super.init()
         configureAudioSession()
         configureRemoteCommands()
+        endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self, notification.object as? AVPlayerItem === self.player.currentItem else { return }
+            self.didReachEnd = true
+        }
+    }
+
+    deinit {
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+        }
     }
 
     func play(_ payload: PlaybackPayload) {
-        guard let url = URL(string: payload.url) else { return }
+        guard let url = preferredMediaURL(payload.url) else {
+            playbackError = "音频地址无效"
+            return
+        }
+        didReachEnd = false
+        playbackError = nil
         currentPayload = payload
         var assetOptions: [String: Any] = [:]
         if !payload.headers.isEmpty {
@@ -23,12 +50,82 @@ final class IOSNativeAudioEngine: NativeAudioEngine {
         player.play()
     }
 
+    func play(url: String, headers: [String: String], title: String, artists: String, album: String) {
+        play(PlaybackPayload(url: url, title: title, artists: artists, album: album, source: "", headers: headers, coverUrl: nil))
+    }
+
     func pause() {
         player.pause()
     }
 
     func resume() {
         player.play()
+    }
+
+    func stop() {
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        didReachEnd = false
+        playbackError = nil
+    }
+
+    func seekTo(positionMs: Int64) {
+        didReachEnd = false
+        player.seek(to: CMTime(value: positionMs, timescale: 1000))
+    }
+
+    func playbackStatus() -> String {
+        if playbackError != nil || player.currentItem?.status == .failed {
+            return "Error"
+        }
+        if didReachEnd {
+            return "Ended"
+        }
+        guard player.currentItem != nil else {
+            return "Idle"
+        }
+        switch player.timeControlStatus {
+        case .waitingToPlayAtSpecifiedRate:
+            return "Loading"
+        case .playing:
+            return "Playing"
+        case .paused:
+            return "Paused"
+        @unknown default:
+            return "Paused"
+        }
+    }
+
+    func positionMs() -> Int64 {
+        milliseconds(player.currentTime())
+    }
+
+    func durationMs() -> Int64 {
+        guard let duration = player.currentItem?.duration else { return 0 }
+        return milliseconds(duration)
+    }
+
+    func bufferedMs() -> Int64 {
+        guard let range = player.currentItem?.loadedTimeRanges.last?.timeRangeValue else { return 0 }
+        return milliseconds(CMTimeAdd(range.start, range.duration))
+    }
+
+    func errorMessage() -> String? {
+        playbackError ?? player.currentItem?.error?.localizedDescription
+    }
+
+    private func milliseconds(_ time: CMTime) -> Int64 {
+        let seconds = CMTimeGetSeconds(time)
+        guard seconds.isFinite, seconds > 0 else { return 0 }
+        return Int64(seconds * 1000)
+    }
+
+    private func preferredMediaURL(_ rawURL: String) -> URL? {
+        guard !rawURL.isEmpty, var components = URLComponents(string: rawURL) else { return nil }
+        if components.scheme == "http", components.host?.hasSuffix(".qqmusic.qq.com") == true {
+            components.scheme = "https"
+        }
+        return components.url
     }
 
     private func configureAudioSession() {
@@ -58,5 +155,367 @@ final class IOSNativeAudioEngine: NativeAudioEngine {
             MPMediaItemPropertyArtist: payload.artists,
             MPMediaItemPropertyAlbumTitle: payload.album,
         ]
+    }
+}
+
+final class IOSNativeVideoOutput: NSObject, IosVideoOutput {
+    static let shared = IOSNativeVideoOutput()
+
+    func makePlayer(
+        url: String,
+        videoUrl: String,
+        audioUrl: String,
+        headers: [String: String]
+    ) -> UIViewController {
+        let controller = FuoVideoViewController()
+        configure(controller, url: url, videoUrl: videoUrl, audioUrl: audioUrl, headers: headers)
+        return controller
+    }
+
+    func updatePlayer(
+        viewController: UIViewController,
+        url: String,
+        videoUrl: String,
+        audioUrl: String,
+        headers: [String: String]
+    ) {
+        guard let controller = viewController as? FuoVideoViewController else { return }
+        configure(controller, url: url, videoUrl: videoUrl, audioUrl: audioUrl, headers: headers)
+    }
+
+    func releasePlayer(viewController: UIViewController) {
+        guard let controller = viewController as? AVPlayerViewController else { return }
+        controller.player?.pause()
+        controller.player = nil
+    }
+
+    private func configure(
+        _ controller: FuoVideoViewController,
+        url: String,
+        videoUrl: String,
+        audioUrl: String,
+        headers: [String: String]
+    ) {
+        let signature = [url, videoUrl, audioUrl, headers.description].joined(separator: "|")
+        guard controller.payloadSignature != signature else { return }
+        controller.payloadSignature = signature
+        controller.player?.pause()
+        controller.player = makePlayer(url: url, videoUrl: videoUrl, audioUrl: audioUrl, headers: headers)
+        controller.player?.play()
+    }
+
+    private func makePlayer(
+        url: String,
+        videoUrl: String,
+        audioUrl: String,
+        headers: [String: String]
+    ) -> AVPlayer? {
+        if let mediaURL = URL(string: url), !url.isEmpty {
+            return AVPlayer(playerItem: AVPlayerItem(asset: asset(url: mediaURL, headers: headers)))
+        }
+        guard
+            let videoMediaURL = URL(string: videoUrl),
+            let audioMediaURL = URL(string: audioUrl),
+            !videoUrl.isEmpty,
+            !audioUrl.isEmpty
+        else {
+            return nil
+        }
+        let videoAsset = asset(url: videoMediaURL, headers: headers)
+        let audioAsset = asset(url: audioMediaURL, headers: headers)
+        guard
+            let videoTrack = videoAsset.tracks(withMediaType: .video).first,
+            let audioTrack = audioAsset.tracks(withMediaType: .audio).first
+        else {
+            return nil
+        }
+        let composition = AVMutableComposition()
+        guard
+            let compositionVideo = composition.addMutableTrack(
+                withMediaType: .video,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            ),
+            let compositionAudio = composition.addMutableTrack(
+                withMediaType: .audio,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            )
+        else {
+            return nil
+        }
+        do {
+            try compositionVideo.insertTimeRange(
+                CMTimeRange(start: .zero, duration: videoAsset.duration),
+                of: videoTrack,
+                at: .zero
+            )
+            try compositionAudio.insertTimeRange(
+                CMTimeRange(start: .zero, duration: audioAsset.duration),
+                of: audioTrack,
+                at: .zero
+            )
+            compositionVideo.preferredTransform = videoTrack.preferredTransform
+            return AVPlayer(playerItem: AVPlayerItem(asset: composition))
+        } catch {
+            return nil
+        }
+    }
+
+    private func asset(url: URL, headers: [String: String]) -> AVURLAsset {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if components?.scheme == "http", components?.host?.hasSuffix(".qqmusic.qq.com") == true {
+            components?.scheme = "https"
+        }
+        let resolvedURL = components?.url ?? url
+        let options: [String: Any]? = headers.isEmpty ? nil : ["AVURLAssetHTTPHeaderFieldsKey": headers]
+        return AVURLAsset(url: resolvedURL, options: options)
+    }
+}
+
+private final class FuoVideoViewController: AVPlayerViewController {
+    var payloadSignature = ""
+}
+
+final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
+    static let shared = IOSMediaLibraryOutput()
+
+    func hasPermission() -> Bool {
+        MPMediaLibrary.authorizationStatus() == .authorized
+    }
+
+    func requestPermission(completionHandler: @escaping @Sendable (KotlinBoolean) -> Void) {
+        if hasPermission() {
+            completionHandler(KotlinBoolean(bool: true))
+            return
+        }
+        MPMediaLibrary.requestAuthorization { status in
+            DispatchQueue.main.async {
+                completionHandler(KotlinBoolean(bool: status == .authorized))
+            }
+        }
+    }
+
+    func tracksJson() -> String {
+        let tracks: [[String: Any]] = (MPMediaQuery.songs().items ?? []).compactMap { item in
+            guard let assetURL = item.assetURL else { return nil }
+            return [
+                "id": String(item.persistentID),
+                "title": item.title ?? "",
+                "artists": item.artist ?? "",
+                "album": item.albumTitle ?? "",
+                "duration_ms": Int64(item.playbackDuration * 1000),
+                "local_uri": assetURL.absoluteString,
+            ]
+        }
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: ["tracks": tracks]),
+            let json = String(data: data, encoding: .utf8)
+        else {
+            return #"{"tracks":[]}"#
+        }
+        return json
+    }
+}
+
+final class IOSDownloadOutput: NSObject, IosDownloadOutput {
+    static let shared = IOSDownloadOutput()
+
+    func download(
+        url: String,
+        headers: [String: String],
+        fileName: String,
+        lyrics: String?,
+        completionHandler: @escaping (String?, String?) -> Void
+    ) {
+        guard let sourceURL = URL(string: url) else {
+            completionHandler(nil, "下载地址无效")
+            return
+        }
+        var request = URLRequest(url: sourceURL)
+        headers.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
+        URLSession.shared.downloadTask(with: request) { temporaryURL, _, error in
+            if let error {
+                DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
+                return
+            }
+            guard let temporaryURL else {
+                DispatchQueue.main.async { completionHandler(nil, "下载文件为空") }
+                return
+            }
+            do {
+                let directory = try self.downloadDirectory()
+                let target = directory.appendingPathComponent(fileName)
+                if FileManager.default.fileExists(atPath: target.path) {
+                    try FileManager.default.removeItem(at: target)
+                }
+                try FileManager.default.moveItem(at: temporaryURL, to: target)
+                if let lyrics, !lyrics.isEmpty {
+                    let lyricsURL = target.deletingPathExtension().appendingPathExtension("lrc")
+                    try? lyrics.write(to: lyricsURL, atomically: true, encoding: .utf8)
+                }
+                DispatchQueue.main.async { completionHandler(target.absoluteString, nil) }
+            } catch {
+                DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
+            }
+        }.resume()
+    }
+
+    func delete(uri: String) -> Bool {
+        guard let url = URL(string: uri) else { return false }
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+            let lyricsURL = url.deletingPathExtension().appendingPathExtension("lrc")
+            if FileManager.default.fileExists(atPath: lyricsURL.path) {
+                try? FileManager.default.removeItem(at: lyricsURL)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func downloadDirectory() throws -> URL {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let directory = documents.appendingPathComponent("FeelUOwn", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}
+
+final class IOSWebLoginOutput: NSObject, IosWebLoginOutput {
+    static let shared = IOSWebLoginOutput()
+    weak var hostViewController: UIViewController?
+
+    func open(
+        providerId: String,
+        providerName: String,
+        loginUrl: String,
+        cookieKeyGroupsJson: String,
+        completionHandler: @escaping (String?) -> Void
+    ) {
+        DispatchQueue.main.async {
+            guard let url = URL(string: loginUrl), let presenter = Self.topViewController() else {
+                completionHandler(nil)
+                return
+            }
+            let groups = (try? JSONSerialization.jsonObject(with: Data(cookieKeyGroupsJson.utf8)))
+                as? [[String]] ?? []
+            let login = FuoWebLoginViewController(
+                providerName: providerName,
+                url: url,
+                requiredCookieGroups: groups,
+                completion: completionHandler
+            )
+            presenter.present(UINavigationController(rootViewController: login), animated: true)
+        }
+    }
+
+    func clear() {
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+            cookies.forEach { WKWebsiteDataStore.default().httpCookieStore.delete($0) }
+        }
+    }
+
+    fileprivate static func topViewController() -> UIViewController? {
+        let sceneController = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)?
+            .rootViewController
+        var controller = shared.hostViewController ?? sceneController
+        while true {
+            if let presented = controller?.presentedViewController {
+                controller = presented
+            } else if let navigation = controller as? UINavigationController {
+                controller = navigation.visibleViewController
+            } else if let tabs = controller as? UITabBarController {
+                controller = tabs.selectedViewController
+            } else {
+                return controller
+            }
+        }
+    }
+}
+
+final class IOSShareOutput: NSObject, IosShareOutput {
+    static let shared = IOSShareOutput()
+
+    func share(text: String) {
+        guard let presenter = IOSWebLoginOutput.topViewController() else { return }
+        let activity = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        activity.popoverPresentationController?.sourceView = presenter.view
+        activity.popoverPresentationController?.sourceRect = CGRect(
+            x: presenter.view.bounds.midX,
+            y: presenter.view.bounds.midY,
+            width: 1,
+            height: 1
+        )
+        presenter.present(activity, animated: true)
+    }
+}
+
+private final class FuoWebLoginViewController: UIViewController, WKNavigationDelegate {
+    private let webView = WKWebView(frame: .zero)
+    private let requiredCookieGroups: [[String]]
+    private let completion: (String?) -> Void
+
+    init(
+        providerName: String,
+        url: URL,
+        requiredCookieGroups: [[String]],
+        completion: @escaping (String?) -> Void
+    ) {
+        self.requiredCookieGroups = requiredCookieGroups
+        self.completion = completion
+        super.init(nibName: nil, bundle: nil)
+        title = providerName
+        webView.navigationDelegate = self
+        webView.load(URLRequest(url: url))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = webView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(cancel)
+        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(done)
+        )
+    }
+
+    @objc private func cancel() {
+        dismiss(animated: true) { self.completion(nil) }
+    }
+
+    @objc private func done() {
+        webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+            let values = Dictionary(uniqueKeysWithValues: cookies.map { ($0.name, $0.value) })
+            let valid = self.requiredCookieGroups.isEmpty || self.requiredCookieGroups.contains { group in
+                group.allSatisfy { !(values[$0] ?? "").isEmpty }
+            }
+            guard valid,
+                  let data = try? JSONSerialization.data(withJSONObject: values),
+                  let json = String(data: data, encoding: .utf8)
+            else {
+                return
+            }
+            DispatchQueue.main.async {
+                self.dismiss(animated: true) { self.completion(json) }
+            }
+        }
     }
 }

--- a/iosApp/FuoEvolve/Info.plist
+++ b/iosApp/FuoEvolve/Info.plist
@@ -18,12 +18,19 @@
     <string>0.1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppleMusicUsageDescription</key>
     <string>用于扫描并播放本地音乐库。</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>用于访问音源服务和播放媒体资源。</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UISupportedInterfaceOrientations</key>

--- a/iosApp/FuoEvolve/PythonCoreBridge.swift
+++ b/iosApp/FuoEvolve/PythonCoreBridge.swift
@@ -1,33 +1,163 @@
 import Foundation
+import Python
+import Shared
 
-final class PythonCoreBridge: FuoCoreBridge {
-    func initialize() async throws {
-        // The shared Compose app now owns provider calls through IosFuoCoreBridge.
-        // This legacy SwiftUI bridge is kept for local experiments until the
-        // Python.xcframework cinterop is wired into shared/src/iosMain.
+final class PythonCoreBridge: NSObject, IosPythonRuntime {
+    static let shared = PythonCoreBridge()
+
+    private let queue = DispatchQueue(label: "org.feeluown.mobile.python")
+    private var bridge: UnsafeMutablePointer<PyObject>?
+    private var configuredProviders = ""
+
+    func createBridge(enabledProvidersJson: String) -> String {
+        queue.sync {
+            do {
+                try startPythonIfNeeded()
+                return try withGIL {
+                    if bridge != nil, configuredProviders == enabledProvidersJson {
+                        return ""
+                    }
+                    let module = try importModule("fuo_mobile.bridge")
+                    let factory = try attribute("create_bridge", of: module)
+                    bridge = try invoke(factory, arguments: [enabledProvidersJson])
+                    configuredProviders = enabledProvidersJson
+                    return ""
+                }
+            } catch {
+                return errorResult(error)
+            }
+        }
     }
 
-    func search(keyword: String) async throws -> [FuoTrack] {
-        throw BridgeError.pythonRuntimeNotLinked
+    func call(method: String, arguments: [String]) -> String {
+        queue.sync {
+            do {
+                return try withGIL {
+                    guard let bridge else {
+                        throw PythonBridgeError.message("Python bridge 尚未初始化")
+                    }
+                    let function = try attribute(method, of: bridge)
+                    let result = try invoke(function, arguments: arguments)
+                    guard let utf8 = PyUnicode_AsUTF8(result) else {
+                        throw currentPythonError(fallback: "Python 返回值不是字符串")
+                    }
+                    return String(cString: utf8)
+                }
+            } catch {
+                return errorResult(error)
+            }
+        }
     }
 
-    func play(trackId: String) async throws -> PlaybackPayload {
-        throw BridgeError.pythonRuntimeNotLinked
+    private func startPythonIfNeeded() throws {
+        if Py_IsInitialized() != 0 {
+            return
+        }
+        guard let resources = Bundle.main.resourceURL else {
+            throw PythonBridgeError.message("找不到 App 资源目录")
+        }
+        let pythonHome = resources.appendingPathComponent("python", isDirectory: true)
+        let appPath = resources.appendingPathComponent("python-app", isDirectory: true)
+        guard let userHome = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw PythonBridgeError.message("找不到 App Documents 目录")
+        }
+        let fuoData = userHome
+            .appendingPathComponent(".FeelUOwn", isDirectory: true)
+            .appendingPathComponent("data", isDirectory: true)
+        try FileManager.default.createDirectory(at: fuoData, withIntermediateDirectories: true)
+        setenv("PYTHONHOME", pythonHome.path, 1)
+        setenv("PYTHONPATH", appPath.path, 1)
+        setenv("PYTHONDONTWRITEBYTECODE", "1", 1)
+        setenv("FEELUOWN_USER_HOME", userHome.path, 1)
+        setenv("HOME", userHome.path, 1)
+        Py_Initialize()
+        guard Py_IsInitialized() != 0 else {
+            throw PythonBridgeError.message("CPython 初始化失败")
+        }
+        PyEval_SaveThread()
     }
 
-    func next() async throws -> PlaybackPayload? {
-        throw BridgeError.pythonRuntimeNotLinked
+    private func withGIL<T>(_ body: () throws -> T) rethrows -> T {
+        let state = PyGILState_Ensure()
+        defer { PyGILState_Release(state) }
+        return try body()
     }
 
-    func previous() async throws -> PlaybackPayload? {
-        throw BridgeError.pythonRuntimeNotLinked
+    private func importModule(_ name: String) throws -> UnsafeMutablePointer<PyObject> {
+        guard let module = PyImport_ImportModule(name) else {
+            throw currentPythonError(fallback: "无法导入 \(name)")
+        }
+        return module
+    }
+
+    private func attribute(
+        _ name: String,
+        of object: UnsafeMutablePointer<PyObject>
+    ) throws -> UnsafeMutablePointer<PyObject> {
+        guard let value = PyObject_GetAttrString(object, name) else {
+            throw currentPythonError(fallback: "找不到 Python 方法 \(name)")
+        }
+        return value
+    }
+
+    private func invoke(
+        _ callable: UnsafeMutablePointer<PyObject>,
+        arguments: [String]
+    ) throws -> UnsafeMutablePointer<PyObject> {
+        guard let tuple = PyTuple_New(arguments.count) else {
+            throw currentPythonError(fallback: "无法创建 Python 参数")
+        }
+        for (index, argument) in arguments.enumerated() {
+            let value: UnsafeMutablePointer<PyObject>?
+            if argument.hasPrefix("__FUO_INT__:"),
+               let integer = Int64(argument.dropFirst("__FUO_INT__:".count)) {
+                value = PyLong_FromLongLong(integer)
+            } else if argument.hasPrefix("__FUO_BOOL__:") {
+                let boolean = argument.dropFirst("__FUO_BOOL__:".count) == "true"
+                value = PyBool_FromLong(boolean ? 1 : 0)
+            } else if argument.hasPrefix("__FUO_DOUBLE__:"),
+                      let double = Double(argument.dropFirst("__FUO_DOUBLE__:".count)) {
+                value = PyFloat_FromDouble(double)
+            } else {
+                value = PyUnicode_FromString(argument)
+            }
+            guard let value else {
+                throw currentPythonError(fallback: "无法编码 Python 参数")
+            }
+            PyTuple_SetItem(tuple, index, value)
+        }
+        guard let result = PyObject_CallObject(callable, tuple) else {
+            throw currentPythonError(fallback: "Python 调用失败")
+        }
+        return result
+    }
+
+    private func currentPythonError(fallback: String) -> PythonBridgeError {
+        guard PyErr_Occurred() != nil else {
+            return .message(fallback)
+        }
+        var type: UnsafeMutablePointer<PyObject>?
+        var value: UnsafeMutablePointer<PyObject>?
+        var traceback: UnsafeMutablePointer<PyObject>?
+        PyErr_Fetch(&type, &value, &traceback)
+        PyErr_NormalizeException(&type, &value, &traceback)
+        if let value, let description = PyObject_Str(value), let utf8 = PyUnicode_AsUTF8(description) {
+            return .message(String(cString: utf8))
+        }
+        return .message(fallback)
+    }
+
+    private func errorResult(_ error: Error) -> String {
+        "__FUO_PYTHON_ERROR__:\(error.localizedDescription)"
     }
 }
 
-enum BridgeError: LocalizedError {
-    case pythonRuntimeNotLinked
+private enum PythonBridgeError: LocalizedError {
+    case message(String)
 
     var errorDescription: String? {
-        "Python Apple Support is not linked yet"
+        switch self {
+        case let .message(message): message
+        }
     }
 }

--- a/iosApp/python/requirements-ios.txt
+++ b/iosApp/python/requirements-ios.txt
@@ -17,7 +17,7 @@ marshmallow==3.26.2
 mutagen
 packaging
 pydantic==1.10.26
-pycryptodome==3.21.0
+pyaes==1.6.1
 pytz
 qasync
 requests

--- a/scripts/prepare-ios-python.sh
+++ b/scripts/prepare-ios-python.sh
@@ -13,12 +13,20 @@ mkdir -p "$RESOURCE_DIR" "$BUILD_DIR"
 
 ASSET_URL="$("$HOST_PYTHON" - "$PYTHON_TAG" <<'PY'
 import json
+import os
 import sys
 import urllib.request
 
 tag = sys.argv[1]
 url = f"https://api.github.com/repos/beeware/Python-Apple-support/releases/tags/{tag}"
-with urllib.request.urlopen(url, timeout=30) as response:
+headers = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "FuoEvolve-iOS-Python-preparer",
+}
+if token := os.environ.get("GITHUB_TOKEN"):
+    headers["Authorization"] = f"Bearer {token}"
+request = urllib.request.Request(url, headers=headers)
+with urllib.request.urlopen(request, timeout=30) as response:
     release = json.load(response)
 for asset in release.get("assets", []):
     name = asset.get("name", "")

--- a/scripts/prepare-ios-python.sh
+++ b/scripts/prepare-ios-python.sh
@@ -37,14 +37,67 @@ fi
 
 rm -rf "$RESOURCE_DIR/python" "$RESOURCE_DIR/app"
 mkdir -p "$RESOURCE_DIR/python" "$RESOURCE_DIR/app"
-tar -xzf "$ARCHIVE" -C "$RESOURCE_DIR/python" --strip-components=1
+tar -xzf "$ARCHIVE" -C "$RESOURCE_DIR/python"
+
+for framework in "$RESOURCE_DIR/python/Python.xcframework"/*/Python.framework; do
+    mkdir -p "$framework/Modules"
+    cp "$framework/Headers/module.modulemap" "$framework/Modules/module.modulemap"
+    sed -i '' 's/^module Python/framework module Python/' "$framework/Modules/module.modulemap"
+done
 
 rsync -a "$ROOT_DIR/androidApp/src/main/python/fuo_mobile" "$RESOURCE_DIR/app/"
 
-"$HOST_PYTHON" -m pip install \
+PYPYDANTIC_NO_EXTENSIONS=1 "$HOST_PYTHON" -m pip install \
     --upgrade \
+    --no-deps \
+    --no-binary pydantic,charset-normalizer \
     --target "$RESOURCE_DIR/app" \
     -r "$REQUIREMENTS"
+
+mkdir -p "$RESOURCE_DIR/app/Crypto/Cipher"
+cat > "$RESOURCE_DIR/app/Crypto/__init__.py" <<'PY'
+PY
+cat > "$RESOURCE_DIR/app/Crypto/Cipher/__init__.py" <<'PY'
+from .AES import AES
+PY
+cat > "$RESOURCE_DIR/app/Crypto/Cipher/AES.py" <<'PY'
+import pyaes
+
+MODE_ECB = 1
+MODE_CBC = 2
+
+
+class _Cipher:
+    def __init__(self, key, mode, iv=None):
+        if mode == MODE_CBC:
+            self._aes = pyaes.AESModeOfOperationCBC(key, iv=iv)
+        elif mode == MODE_ECB:
+            self._aes = pyaes.AESModeOfOperationECB(key)
+        else:
+            raise ValueError(f"unsupported AES mode: {mode}")
+
+    def encrypt(self, data):
+        if len(data) % 16:
+            raise ValueError("data length must be a multiple of 16")
+        return b"".join(
+            self._aes.encrypt(data[offset:offset + 16])
+            for offset in range(0, len(data), 16)
+        )
+
+
+class AES:
+    MODE_ECB = MODE_ECB
+    MODE_CBC = MODE_CBC
+
+    @staticmethod
+    def new(key, mode, iv=None):
+        return _Cipher(key, mode, iv)
+PY
+
+if find "$RESOURCE_DIR/app" -type f \( -name '*.so' -o -name '*.dylib' \) | grep -q .; then
+    echo "native extension modules are not supported in the iOS app package" >&2
+    exit 1
+fi
 
 find "$RESOURCE_DIR/app" -type d -name "__pycache__" -prune -exec rm -rf {} +
 find "$RESOURCE_DIR/app" -type f -name "*.pyc" -delete

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(libs.compose.material3.expressive)
             implementation(compose.materialIconsExtended)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -307,6 +307,10 @@ class FuoPlayerController(
             updateResourceCacheLimit()
             updateAudioQualityPolicies()
             resourceCacheRepository.refreshUsage()
+            runCatching { providerRepository.availableProviders() }
+                .onSuccess { loadedProviders ->
+                    availableProviders = loadedProviders.sortedProvidersByOrder()
+                }
             runCatching {
                 providerRepository.updateEnabledProviders(enabledProviderIds)
                 providerRepository.initialize()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -391,6 +391,21 @@ fun ProviderLoginPanel(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            val authFeedback = controller.message.takeIf { message ->
+                message.contains(provider.providerName) ||
+                    message.contains("音源运行时尚未接入")
+            }
+            authFeedback?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (authState.isLoggedIn) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                )
+            }
             if (authState.isLoggedIn) {
                 Button(
                     enabled = !controller.isLoading,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -61,7 +61,7 @@ class FuoPlayerControllerTest {
         assertEquals(
             "分享一个歌单：\n" +
                 "《每日推荐》\n" +
-                "打开查看：https://feeluown.github.io/FuoEvolve/r/netease/playlists/123?d=5q-P5pel5o6I2Q",
+                "打开查看：https://feeluown.github.io/FuoEvolve/r/netease/playlists/123?d=5q-P5pel5o6o6I2Q",
             payload?.content(ShareMode.FullText),
         )
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -16,8 +16,18 @@ fun MainViewController(
     downloadOutput: IosDownloadOutput,
     webLoginOutput: IosWebLoginOutput,
     shareOutput: IosShareOutput,
+    networkStatusOutput: IosNetworkStatusOutput,
 ): UIViewController = ComposeUIViewController {
-    IosApp(pythonRuntime, audioOutput, videoOutput, mediaLibraryOutput, downloadOutput, webLoginOutput, shareOutput)
+    IosApp(
+        pythonRuntime,
+        audioOutput,
+        videoOutput,
+        mediaLibraryOutput,
+        downloadOutput,
+        webLoginOutput,
+        shareOutput,
+        networkStatusOutput,
+    )
 }
 
 @Composable
@@ -29,10 +39,18 @@ private fun IosApp(
     downloadOutput: IosDownloadOutput,
     webLoginOutput: IosWebLoginOutput,
     shareOutput: IosShareOutput,
+    networkStatusOutput: IosNetworkStatusOutput,
 ) {
     IosVideoOutputHolder.output = videoOutput
     val container = remember {
-        IosAppContainer(pythonRuntime, audioOutput, mediaLibraryOutput, downloadOutput, webLoginOutput)
+        IosAppContainer(
+            pythonRuntime,
+            audioOutput,
+            mediaLibraryOutput,
+            downloadOutput,
+            webLoginOutput,
+            networkStatusOutput,
+        )
     }
     AppRoot(
         controller = container.controller,
@@ -50,9 +68,10 @@ private class IosAppContainer(
     mediaLibraryOutput: IosMediaLibraryOutput,
     downloadOutput: IosDownloadOutput,
     private val webLoginOutput: IosWebLoginOutput,
+    networkStatusOutput: IosNetworkStatusOutput,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val providerRepository = IosFuoCoreBridge(pythonRuntime)
+    private val providerRepository = IosFuoCoreBridge(pythonRuntime, networkStatusOutput)
     private val localRepository = IosLocalMusicRepository(mediaLibraryOutput)
     private val downloadRepository = IosDownloadRepository(providerRepository, downloadOutput)
     private val playbackEngine = IosNativeAudioEngine(scope, audioOutput)

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -8,28 +8,54 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import platform.UIKit.UIViewController
 
-fun MainViewController(): UIViewController = ComposeUIViewController {
-    IosApp()
+fun MainViewController(
+    pythonRuntime: IosPythonRuntime,
+    audioOutput: IosAudioOutput,
+    videoOutput: IosVideoOutput,
+    mediaLibraryOutput: IosMediaLibraryOutput,
+    downloadOutput: IosDownloadOutput,
+    webLoginOutput: IosWebLoginOutput,
+    shareOutput: IosShareOutput,
+): UIViewController = ComposeUIViewController {
+    IosApp(pythonRuntime, audioOutput, videoOutput, mediaLibraryOutput, downloadOutput, webLoginOutput, shareOutput)
 }
 
 @Composable
-private fun IosApp() {
-    val container = remember { IosAppContainer() }
+private fun IosApp(
+    pythonRuntime: IosPythonRuntime,
+    audioOutput: IosAudioOutput,
+    videoOutput: IosVideoOutput,
+    mediaLibraryOutput: IosMediaLibraryOutput,
+    downloadOutput: IosDownloadOutput,
+    webLoginOutput: IosWebLoginOutput,
+    shareOutput: IosShareOutput,
+) {
+    IosVideoOutputHolder.output = videoOutput
+    val container = remember {
+        IosAppContainer(pythonRuntime, audioOutput, mediaLibraryOutput, downloadOutput, webLoginOutput)
+    }
     AppRoot(
         controller = container.controller,
         hasAudioPermission = container.hasAudioPermission,
         onRequestAudioPermission = container::requestAudioPermission,
         onOpenProviderWebLogin = container::openProviderWebLogin,
         onLogoutProvider = container::logoutProvider,
+        onShareText = shareOutput::share,
     )
 }
 
-private class IosAppContainer {
+private class IosAppContainer(
+    pythonRuntime: IosPythonRuntime,
+    audioOutput: IosAudioOutput,
+    mediaLibraryOutput: IosMediaLibraryOutput,
+    downloadOutput: IosDownloadOutput,
+    private val webLoginOutput: IosWebLoginOutput,
+) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private val providerRepository = IosFuoCoreBridge()
-    private val localRepository = IosLocalMusicRepository()
-    private val downloadRepository = IosDownloadRepository(providerRepository)
-    private val playbackEngine = IosNativeAudioEngine(scope)
+    private val providerRepository = IosFuoCoreBridge(pythonRuntime)
+    private val localRepository = IosLocalMusicRepository(mediaLibraryOutput)
+    private val downloadRepository = IosDownloadRepository(providerRepository, downloadOutput)
+    private val playbackEngine = IosNativeAudioEngine(scope, audioOutput)
     private val settingsStore = IosAppSettingsStore()
     private val playbackQueueStore = IosPlaybackQueueStore()
     private val resourceCacheRepository = IosResourceCacheRepository()
@@ -56,12 +82,24 @@ private class IosAppContainer {
     }
 
     fun openProviderWebLogin(provider: ProviderInfo) {
-        // Web cookie extraction is owned by the Swift host in the Xcode target.
-        // Until that host callback is wired, users can still paste Cookie/Header values in settings.
-        controller.onProviderLoginModeChange(ProviderLoginMode.Cookie)
+        val loginConfig = provider.loginConfig ?: return
+        val groupsJson = loginConfig.cookieKeyGroups.joinToString(prefix = "[", postfix = "]") { group ->
+            group.joinToString(prefix = "[\"", postfix = "\"]", separator = "\",\"")
+        }
+        webLoginOutput.open(
+            provider.providerId,
+            provider.providerName,
+            loginConfig.loginUrl,
+            groupsJson,
+        ) { cookiesJson ->
+            if (!cookiesJson.isNullOrBlank()) {
+                controller.loginProviderWithCookies(provider.providerId, cookiesJson)
+            }
+        }
     }
 
     fun logoutProvider(provider: ProviderInfo) {
+        webLoginOutput.clear()
         controller.logoutProvider(provider.providerId)
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAudioOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAudioOutput.kt
@@ -1,0 +1,14 @@
+package org.feeluown.mobile
+
+interface IosAudioOutput {
+    fun play(url: String, headers: Map<String, String>, title: String, artists: String, album: String)
+    fun pause()
+    fun resume()
+    fun stop()
+    fun seekTo(positionMs: Long)
+    fun playbackStatus(): String
+    fun positionMs(): Long
+    fun durationMs(): Long
+    fun bufferedMs(): Long
+    fun errorMessage(): String?
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadOutput.kt
@@ -1,0 +1,12 @@
+package org.feeluown.mobile
+
+interface IosDownloadOutput {
+    fun download(
+        url: String,
+        headers: Map<String, String>,
+        fileName: String,
+        lyrics: String?,
+        completionHandler: (String?, String?) -> Unit,
+    )
+    fun delete(uri: String): Boolean
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
@@ -3,28 +3,96 @@ package org.feeluown.mobile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSUserDefaults
+import kotlin.coroutines.resume
 
 class IosDownloadRepository(
     private val providerRepository: ProviderMusicRepository,
+    private val output: IosDownloadOutput,
 ) : DownloadRepository {
     private val mutableStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
+    private val defaults = NSUserDefaults.standardUserDefaults
 
     override val states: StateFlow<Map<String, DownloadState>> = mutableStates.asStateFlow()
 
-    override suspend fun load() = Unit
+    override suspend fun load() {
+        mutableStates.value = readRecords().mapValues { DownloadState.Downloaded(it.value) }
+    }
 
     override suspend fun download(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
-        runCatching { providerRepository.resolve(track) }
-            .onFailure {
-                mutableStates.value = mutableStates.value + (track.id to DownloadState.Failed("iOS 下载暂未接入"))
+        mutableStates.value = mutableStates.value + (track.id to DownloadState.Queued)
+        val payload = runCatching { providerRepository.resolve(track) }.getOrElse { throwable ->
+            mutableStates.value = mutableStates.value +
+                (track.id to DownloadState.Failed(throwable.message ?: "下载解析失败"))
+            throw throwable
+        }
+        mutableStates.value = mutableStates.value + (track.id to DownloadState.Downloading(0f))
+        val result = suspendCancellableCoroutine<Result<String>> { continuation ->
+            output.download(
+                url = payload.url,
+                headers = payload.headers,
+                fileName = downloadFileName(track, payload),
+                lyrics = payload.lyrics,
+            ) { uri, error ->
+                if (!continuation.isActive) return@download
+                if (uri != null) continuation.resume(Result.success(uri))
+                else continuation.resume(Result.failure(IllegalStateException(error ?: "下载失败")))
             }
-            .onSuccess {
-                mutableStates.value = mutableStates.value + (track.id to DownloadState.Failed("iOS 下载暂未接入"))
-            }
+        }
+        result.onSuccess { uri ->
+            val records = readRecords() + (track.id to uri)
+            writeRecords(records)
+            mutableStates.value = mutableStates.value + (track.id to DownloadState.Downloaded(uri))
+        }.onFailure { throwable ->
+            mutableStates.value = mutableStates.value +
+                (track.id to DownloadState.Failed(throwable.message ?: "下载失败"))
+            throw throwable
+        }
     }
 
     override suspend fun deleteDownloaded(track: MusicTrack) {
-        mutableStates.value = mutableStates.value - track.id
+        val key = track.providerId ?: track.id
+        val records = readRecords().toMutableMap()
+        val uri = records.remove(key) ?: track.localUri
+        if (uri != null) output.delete(uri)
+        writeRecords(records)
+        mutableStates.value = mutableStates.value - key
+    }
+
+    private fun downloadFileName(track: MusicTrack, payload: PlaybackPayload): String {
+        val extension = payload.url.substringBefore('?').substringAfterLast('.', "mp3")
+            .takeIf { it.length in 2..5 && it.all(Char::isLetterOrDigit) }
+            ?: "mp3"
+        val raw = "${payload.title.ifBlank { track.title }} - ${payload.artists.ifBlank { track.artists }}"
+        val safe = raw.map { character ->
+            if (character in "\\/:*?\"<>|") '_' else character
+        }.joinToString("").take(120).ifBlank { "FeelUOwn" }
+        return "$safe.$extension"
+    }
+
+    private fun readRecords(): Map<String, String> {
+        return defaults.stringForKey(KEY_DOWNLOAD_RECORDS)
+            ?.lineSequence()
+            ?.mapNotNull { line ->
+                val values = line.split(RECORD_SEPARATOR, limit = 2)
+                if (values.size == 2) values[0] to values[1] else null
+            }
+            ?.toMap()
+            .orEmpty()
+    }
+
+    private fun writeRecords(records: Map<String, String>) {
+        defaults.setObject(
+            records.entries.joinToString("\n") { "${it.key}$RECORD_SEPARATOR${it.value}" },
+            KEY_DOWNLOAD_RECORDS,
+        )
+        defaults.synchronize()
+    }
+
+    private companion object {
+        private const val KEY_DOWNLOAD_RECORDS = "ios_download_records"
+        private const val RECORD_SEPARATOR = "\u001f"
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.longOrNull
 
 class IosFuoCoreBridge(
     private val pythonRuntime: IosPythonRuntime,
+    private val networkStatusOutput: IosNetworkStatusOutput,
 ) : ProviderMusicRepository {
     private var enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS
     private var wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY
@@ -590,7 +591,11 @@ class IosFuoCoreBridge(
     }
 
     private fun currentAudioQualityPolicy(): AudioQualityPolicy {
-        return wifiAudioQualityPolicy
+        return if (networkStatusOutput.isCellularConnection()) {
+            cellularAudioQualityPolicy
+        } else {
+            wifiAudioQualityPolicy
+        }
     }
 
     private fun String.toAuthState(providerId: String): ProviderAuthState {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosFuoCoreBridge.kt
@@ -2,13 +2,28 @@ package org.feeluown.mobile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
-class IosFuoCoreBridge : ProviderMusicRepository {
+class IosFuoCoreBridge(
+    private val pythonRuntime: IosPythonRuntime,
+) : ProviderMusicRepository {
     private var enabledProviderIds: Set<String> = DEFAULT_ENABLED_PROVIDER_IDS
     private var wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY
     private var cellularAudioQualityPolicy: AudioQualityPolicy = DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY
 
-    override suspend fun initialize() = Unit
+    override suspend fun initialize() {
+        updateEnabledProviders(enabledProviderIds)
+    }
 
     override suspend fun availableProviders(): List<ProviderInfo> = AVAILABLE_PROVIDERS
 
@@ -17,14 +32,49 @@ class IosFuoCoreBridge : ProviderMusicRepository {
             .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
             .intersect(AVAILABLE_PROVIDERS.map { it.providerId }.toSet())
             .ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
+        val providersJson = enabledProviderIds.joinToString(prefix = "{\"enabled\":[", postfix = "]}") { "\"$it\"" }
+        pythonRuntime.checked(pythonRuntime.createBridge(providersJson))
     }
 
     override suspend fun providers(): List<ProviderInfo> {
-        return AVAILABLE_PROVIDERS.filter { it.providerId in enabledProviderIds }
+        initialize()
+        return withContext(Dispatchers.Default) {
+            pythonRuntime.checked(pythonRuntime.call("providers", emptyList()))
+                .rootObject()
+                .array("providers")
+                .map { it.jsonObject.toProviderInfo() }
+        }
     }
 
     override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("search", listOf(keyword, providerId.orEmpty())),
+        ).rootObject().array("tracks").map { it.jsonObject.toTrack() }
+    }
+
+    override suspend fun searchAll(keyword: String, providerId: String?): ProviderSearchResults = withContext(Dispatchers.Default) {
+        initialize()
+        val root = pythonRuntime.checked(
+            pythonRuntime.call("search_all", listOf(keyword, providerId.orEmpty())),
+        ).rootObject()
+        ProviderSearchResults(
+            tracks = root.array("tracks").map { it.jsonObject.toTrack() },
+            playlists = root.array("playlists").map { it.jsonObject.toPlaylist() },
+            artists = root.array("artists").map { it.jsonObject.toMediaItem() },
+            albums = root.array("albums").map { it.jsonObject.toMediaItem() },
+            videos = root.array("videos").map { it.jsonObject.toProviderVideo() },
+            errorMessage = root.string("error_message").takeIf { it.isNotBlank() },
+        )
+    }
+
+    override suspend fun trackDetail(trackId: String): MusicTrack = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(pythonRuntime.call("track_detail", listOf(trackId)))
+            .rootObject()
+            .objectValue("track")
+            ?.toTrack()
+            ?: throw IllegalStateException("音源未返回歌曲详情")
     }
 
     override suspend fun resolve(
@@ -35,20 +85,45 @@ class IosFuoCoreBridge : ProviderMusicRepository {
         smartReplacementUseOriginalMetadata: Boolean,
         smartReplacementUseOriginalLyrics: Boolean,
     ): PlaybackPayload = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        val trackId = track.providerId ?: track.id
+        val policy = currentAudioQualityPolicy().policy
+        pythonRuntime.checked(
+            pythonRuntime.call(
+                "resolve",
+                listOf(
+                    trackId,
+                    policy,
+                    "__FUO_BOOL__:${unavailablePolicy == UnavailablePlaybackPolicy.SmartReplace}",
+                    smartReplacementProviderIds.joinToString(prefix = "[\"", postfix = "\"]", separator = "\",\"")
+                        .takeIf { smartReplacementProviderIds.isNotEmpty() } ?: "[]",
+                    "__FUO_DOUBLE__:$smartReplacementMinScore",
+                    "__FUO_BOOL__:$smartReplacementUseOriginalMetadata",
+                    "__FUO_BOOL__:$smartReplacementUseOriginalLyrics",
+                ),
+            ),
+        ).rootObject().toPayload(track)
     }
 
     override suspend fun authState(providerId: String): ProviderAuthState {
-        val providerName = providerName(providerId)
-        return ProviderAuthState(
-            providerId = providerId,
-            providerName = providerName,
-            isLoggedIn = false,
-        )
+        initialize()
+        return pythonRuntime.checked(
+            pythonRuntime.call("provider_auth_state", listOf(providerId)),
+        ).toAuthState(providerId)
+    }
+
+    override suspend fun refreshAuthState(providerId: String): ProviderAuthState {
+        initialize()
+        return pythonRuntime.checked(
+            pythonRuntime.call("provider_auth_state_with_user", listOf(providerId)),
+        ).toAuthState(providerId)
     }
 
     override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("provider_login_with_cookies", listOf(providerId, cookiesJson)),
+        ).toAuthState(providerId)
     }
 
     override suspend fun loginWithHeaders(
@@ -56,35 +131,170 @@ class IosFuoCoreBridge : ProviderMusicRepository {
         authorization: String,
         cookie: String,
     ): ProviderAuthState = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("provider_login_with_headers", listOf(providerId, authorization, cookie)),
+        ).toAuthState(providerId)
     }
 
-    override suspend fun logout(providerId: String): ProviderAuthState = authState(providerId)
+    override suspend fun logout(providerId: String): ProviderAuthState {
+        initialize()
+        return pythonRuntime.checked(
+            pythonRuntime.call("provider_logout", listOf(providerId)),
+        ).toAuthState(providerId)
+    }
 
     override suspend fun updateAudioQualityPolicies(wifiPolicy: AudioQualityPolicy, cellularPolicy: AudioQualityPolicy) {
         wifiAudioQualityPolicy = wifiPolicy
         cellularAudioQualityPolicy = cellularPolicy
     }
 
+    override suspend fun providerCapabilities(): List<ProviderCapabilities> = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(pythonRuntime.call("provider_capabilities", emptyList()))
+            .rootObject()
+            .array("providers")
+            .map { it.jsonObject.toCapabilities() }
+    }
+
     override suspend fun features(): List<ProviderFeature> {
-        return enabledProviderIds.flatMap { providerId ->
-            providerFeatures(providerId)
+        initialize()
+        return withContext(Dispatchers.Default) {
+            pythonRuntime.checked(pythonRuntime.call("features", emptyList()))
+                .rootObject()
+                .array("features")
+                .map { it.jsonObject.toFeature() }
         }
     }
 
-    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection {
-        return ProviderContentSection(
-            feature = feature,
-            errorMessage = "iOS Python 音源运行时尚未接入",
-        )
+    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+        loadFeaturePage(feature, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun loadFeaturePage(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        initialize()
+        return withContext(Dispatchers.Default) {
+            pythonRuntime.checked(
+                pythonRuntime.call(
+                    "load_feature",
+                    listOf(feature.id, "__FUO_INT__:$offset", "__FUO_INT__:$limit"),
+                ),
+            ).rootObject().toContentSection(feature)
+        }
     }
 
     override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        pythonRuntime.checked(pythonRuntime.call("playlist_tracks", listOf(playlist.id)))
+            .rootObject()
+            .array("tracks")
+            .map { it.jsonObject.toTrack() }
+    }
+
+    override suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail =
+        playlistDetailPage(playlist, offset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun playlistDetailPage(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call(
+                "playlist_detail",
+                listOf(playlist.id, "__FUO_INT__:$offset", "__FUO_INT__:$limit"),
+            ),
+        ).rootObject().toPlaylistDetail(playlist)
+    }
+
+    override suspend fun playlistOperationTargets(track: MusicTrack): List<ProviderPlaylist> = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("playlist_operation_targets", listOf(track.providerId ?: track.id)),
+        ).rootObject().array("playlists").map { it.jsonObject.toPlaylist() }
+    }
+
+    override suspend fun addTrackToPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("playlist_add_song", listOf(playlist.id, track.providerId ?: track.id)),
+        ).rootObject().toMutationResult()
+    }
+
+    override suspend fun removeTrackFromPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("playlist_remove_song", listOf(playlist.id, track.providerId ?: track.id)),
+        ).rootObject().toMutationResult()
     }
 
     override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> = withContext(Dispatchers.Default) {
-        pythonUnavailable()
+        initialize()
+        pythonRuntime.checked(pythonRuntime.call("media_item_tracks", listOf(item.id)))
+            .rootObject()
+            .array("tracks")
+            .map { it.jsonObject.toTrack() }
+    }
+
+    override suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
+        mediaItemDetailPage(item, tracksOffset = 0, albumsOffset = 0, limit = PROVIDER_PAGE_SIZE)
+
+    override suspend fun mediaItemDetailPage(
+        item: ProviderMediaItem,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call(
+                "media_item_detail",
+                listOf(
+                    item.id,
+                    "__FUO_INT__:$tracksOffset",
+                    "__FUO_INT__:$albumsOffset",
+                    "__FUO_INT__:$limit",
+                ),
+            ),
+        ).rootObject().toMediaItemDetail(item)
+    }
+
+    override suspend fun similarTracks(track: MusicTrack): List<MusicTrack> = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("similar_tracks", listOf(track.providerId ?: track.id)),
+        ).rootObject().array("tracks").map { it.jsonObject.toTrack() }
+    }
+
+    override suspend fun hotComments(track: MusicTrack): List<ProviderComment> = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("hot_comments", listOf(track.providerId ?: track.id)),
+        ).rootObject().array("comments").map { it.jsonObject.toProviderComment() }
+    }
+
+    override suspend fun trackVideo(track: MusicTrack): ProviderVideo? = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("track_video", listOf(track.providerId ?: track.id)),
+        ).rootObject().objectValue("video")?.toProviderVideo()
+    }
+
+    override suspend fun videoPlaybackPayload(video: ProviderVideo): VideoPlaybackPayload = withContext(Dispatchers.Default) {
+        initialize()
+        pythonRuntime.checked(
+            pythonRuntime.call("video_payload", listOf(video.id, "")),
+        ).rootObject().toVideoPlaybackPayload(video)
     }
 
     private fun providerName(providerId: String): String {
@@ -142,6 +352,265 @@ class IosFuoCoreBridge : ProviderMusicRepository {
 
     private fun pythonUnavailable(): Nothing {
         throw IllegalStateException("iOS Python 音源运行时尚未接入")
+    }
+
+    private fun String.rootObject(): JsonObject = Json.parseToJsonElement(this).jsonObject
+
+    private fun JsonObject.array(key: String): JsonArray = this[key]?.jsonArray ?: JsonArray(emptyList())
+
+    private fun JsonObject.objectValue(key: String): JsonObject? = this[key] as? JsonObject
+
+    private fun JsonObject.string(key: String): String = this[key]?.jsonPrimitive?.contentOrNull.orEmpty()
+
+    private fun JsonObject.boolean(key: String): Boolean = this[key]?.jsonPrimitive?.booleanOrNull ?: false
+
+    private fun JsonObject.int(key: String): Int = this[key]?.jsonPrimitive?.intOrNull ?: 0
+
+    private fun JsonObject.longOrNull(key: String): Long? = this[key]?.jsonPrimitive?.longOrNull
+
+    private fun JsonObject.toProviderInfo(): ProviderInfo {
+        val providerId = string("provider_id")
+        val loginConfig = objectValue("login_config")?.let { config ->
+            ProviderLoginConfig(
+                loginUrl = config.string("login_url"),
+                cookieKeyGroups = config.array("cookie_key_groups").map { group ->
+                    group.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
+                },
+            )
+        }
+        val loginModes = array("login_modes")
+            .mapNotNull { element ->
+                element.jsonPrimitive.contentOrNull?.let { raw ->
+                    runCatching { ProviderLoginMode.valueOf(raw) }.getOrNull()
+                }
+            }
+            .toSet()
+            .ifEmpty { setOf(ProviderLoginMode.WebView, ProviderLoginMode.Cookie) }
+        return ProviderInfo(
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            loginConfig = loginConfig,
+            supportedLoginModes = loginModes,
+        )
+    }
+
+    private fun JsonObject.toCapabilities(): ProviderCapabilities {
+        val providerId = string("provider_id")
+        return ProviderCapabilities(
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            canAddSongToPlaylist = boolean("can_add_song_to_playlist"),
+            canRemoveSongFromPlaylist = boolean("can_remove_song_from_playlist"),
+            canFavoritePlaylist = boolean("can_favorite_playlist"),
+            canUnfavoritePlaylist = boolean("can_unfavorite_playlist"),
+            canFavoriteArtist = boolean("can_favorite_artist"),
+            canUnfavoriteArtist = boolean("can_unfavorite_artist"),
+            canFavoriteAlbum = boolean("can_favorite_album"),
+            canUnfavoriteAlbum = boolean("can_unfavorite_album"),
+        )
+    }
+
+    private fun JsonObject.toFeature(): ProviderFeature {
+        val providerId = string("provider_id")
+        return ProviderFeature(
+            id = string("id"),
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            title = string("title"),
+            category = ProviderFeatureCategory.valueOf(string("category")),
+            contentType = ProviderContentType.valueOf(string("content_type")),
+            requiresLogin = boolean("requires_login"),
+        )
+    }
+
+    private fun JsonObject.toContentSection(fallbackFeature: ProviderFeature): ProviderContentSection {
+        val parsedFeature = this["feature"]?.jsonObject?.toFeature() ?: fallbackFeature
+        return ProviderContentSection(
+            feature = parsedFeature,
+            tracks = array("tracks").map { it.jsonObject.toTrack() },
+            playlists = array("playlists").map { it.jsonObject.toPlaylist() },
+            mediaItems = array("media_items").map { it.jsonObject.toMediaItem() },
+            isLoginRequired = boolean("is_login_required"),
+            errorMessage = string("error_message").takeIf { it.isNotBlank() },
+            nextOffset = int("next_offset"),
+            hasMore = boolean("has_more"),
+        )
+    }
+
+    private fun JsonObject.toTrack(): MusicTrack {
+        val id = string("id")
+        val source = string("source")
+        return MusicTrack(
+            id = id,
+            title = string("title"),
+            artists = string("artists"),
+            album = string("album"),
+            source = source,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = string("cover_url").takeIf { it.isNotBlank() },
+            durationMs = longOrNull("duration_ms")?.takeIf { it > 0 },
+            providerId = id,
+            providerName = string("provider_name").ifBlank { source }.takeIf { it.isNotBlank() },
+            artistItemId = string("artist_item_id").takeIf { it.isNotBlank() },
+            albumItemId = string("album_item_id").takeIf { it.isNotBlank() },
+            providerUrl = string("provider_url").takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun JsonObject.toPlaylist(): ProviderPlaylist {
+        val providerId = string("provider_id")
+        return ProviderPlaylist(
+            id = string("id"),
+            title = string("title"),
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            coverUrl = string("cover_url").takeIf { it.isNotBlank() },
+            description = string("description"),
+            playCount = longOrNull("play_count")?.takeIf { it > 0 },
+            providerUrl = string("provider_url").takeIf { it.isNotBlank() },
+            trackCount = this["track_count"]?.jsonPrimitive?.intOrNull,
+        )
+    }
+
+    private fun JsonObject.toPlaylistDetail(fallbackPlaylist: ProviderPlaylist): ProviderPlaylistDetail {
+        return ProviderPlaylistDetail(
+            playlist = objectValue("playlist")?.toPlaylist() ?: fallbackPlaylist,
+            tracks = array("tracks").map { it.jsonObject.toTrack() },
+            tracksNextOffset = int("tracks_next_offset"),
+            tracksHasMore = boolean("tracks_has_more"),
+        )
+    }
+
+    private fun JsonObject.toMediaItem(): ProviderMediaItem {
+        val providerId = string("provider_id")
+        return ProviderMediaItem(
+            id = string("id"),
+            title = string("title"),
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            type = ProviderMediaItemType.valueOf(string("type")),
+            coverUrl = string("cover_url").takeIf { it.isNotBlank() },
+            description = string("description"),
+            providerUrl = string("provider_url").takeIf { it.isNotBlank() },
+            trackCount = this["track_count"]?.jsonPrimitive?.intOrNull,
+            albumCount = this["album_count"]?.jsonPrimitive?.intOrNull,
+        )
+    }
+
+    private fun JsonObject.toProviderVideo(): ProviderVideo {
+        val providerId = string("provider_id")
+        return ProviderVideo(
+            id = string("id"),
+            title = string("title"),
+            artists = string("artists"),
+            providerId = providerId,
+            providerName = string("provider_name").ifBlank { providerName(providerId) },
+            coverUrl = string("cover_url").takeIf { it.isNotBlank() },
+            durationMs = longOrNull("duration_ms")?.takeIf { it > 0 },
+            providerUrl = string("provider_url").takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun JsonObject.toProviderComment(): ProviderComment = ProviderComment(
+        id = string("id"),
+        userName = string("user_name"),
+        content = string("content"),
+        likedCount = longOrNull("liked_count") ?: 0,
+        timeSeconds = longOrNull("time") ?: 0,
+    )
+
+    private fun JsonObject.toMediaItemDetail(fallbackItem: ProviderMediaItem): ProviderMediaItemDetail {
+        return ProviderMediaItemDetail(
+            item = objectValue("item")?.toMediaItem() ?: fallbackItem,
+            tracks = array("tracks").map { it.jsonObject.toTrack() },
+            albums = array("albums").map { it.jsonObject.toMediaItem() },
+            tracksNextOffset = int("tracks_next_offset"),
+            tracksHasMore = boolean("tracks_has_more"),
+            albumsNextOffset = int("albums_next_offset"),
+            albumsHasMore = boolean("albums_has_more"),
+        )
+    }
+
+    private fun JsonObject.toVideoPlaybackPayload(fallbackVideo: ProviderVideo): VideoPlaybackPayload {
+        return VideoPlaybackPayload(
+            video = objectValue("video")?.toProviderVideo() ?: fallbackVideo,
+            url = string("url"),
+            videoUrl = string("video_url"),
+            audioUrl = string("audio_url"),
+            headers = objectValue("headers")?.mapValues { it.value.jsonPrimitive.contentOrNull.orEmpty() } ?: emptyMap(),
+            quality = string("quality").takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun JsonObject.toMutationResult(): ProviderMutationResult = ProviderMutationResult(
+        success = boolean("success"),
+        message = string("message"),
+    )
+
+    private fun JsonObject.toPayload(track: MusicTrack): PlaybackPayload {
+        val smartReplacement = boolean("smart_replacement")
+        return PlaybackPayload(
+            url = string("url"),
+            title = string("title").ifBlank { track.title },
+            artists = string("artists").ifBlank { track.artists },
+            album = string("album").ifBlank { track.album },
+            source = string("source").ifBlank { track.source },
+            headers = this["headers"]?.jsonObject?.mapValues { it.value.jsonPrimitive.contentOrNull.orEmpty() } ?: emptyMap(),
+            coverUrl = string("cover_url").takeIf { it.isNotBlank() } ?: track.coverUrl,
+            durationMs = longOrNull("duration_ms") ?: track.durationMs,
+            lyrics = string("lyrics").takeIf { it.isNotBlank() },
+            audioQuality = string("audio_quality").takeIf { it.isNotBlank() },
+            providerName = string("provider_name").takeIf { it.isNotBlank() } ?: track.providerName,
+            isSmartReplacement = smartReplacement,
+            originalTitle = string("original_title").takeIf { smartReplacement && it.isNotBlank() },
+            originalProviderName = string("original_provider_name").takeIf { smartReplacement && it.isNotBlank() },
+            originalCoverUrl = string("original_cover_url").takeIf { smartReplacement && it.isNotBlank() },
+            replacementTitle = string("replacement_title").takeIf { smartReplacement && it.isNotBlank() },
+            replacementArtists = string("replacement_artists").takeIf { smartReplacement && it.isNotBlank() },
+            replacementSource = string("replacement_source").takeIf { smartReplacement && it.isNotBlank() },
+            replacementProviderName = string("replacement_provider_name").takeIf { smartReplacement && it.isNotBlank() },
+            replacementCoverUrl = string("replacement_cover_url").takeIf { smartReplacement && it.isNotBlank() },
+            replacementStrategy = string("standby_strategy")
+                .ifBlank { string("replacement_strategy") }
+                .takeIf { smartReplacement && it.isNotBlank() },
+            replacementScore = (this["standby_score"] ?: this["replacement_score"])
+                ?.jsonPrimitive
+                ?.doubleOrNull
+                ?.takeIf { smartReplacement },
+            parts = array("parts").map { element ->
+                val part = element.jsonObject
+                PlaybackPart(
+                    id = part.string("id"),
+                    title = part.string("title"),
+                    durationMs = part.longOrNull("duration_ms")?.takeIf { it > 0 },
+                )
+            }.filter { it.id.isNotBlank() },
+            currentPartIndex = int("current_part_index").takeIf { it >= 0 } ?: -1,
+        )
+    }
+
+    private fun currentAudioQualityPolicy(): AudioQualityPolicy {
+        return wifiAudioQualityPolicy
+    }
+
+    private fun String.toAuthState(providerId: String): ProviderAuthState {
+        fun stringValue(key: String): String? = Regex("\"$key\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"")
+            .find(this)
+            ?.groupValues
+            ?.get(1)
+            ?.replace("\\\"", "\"")
+            ?.replace("\\\\", "\\")
+        fun booleanValue(key: String): Boolean = Regex("\"$key\"\\s*:\\s*(true|false)")
+            .find(this)
+            ?.groupValues
+            ?.get(1)
+            ?.toBoolean() == true
+        return ProviderAuthState(
+            providerId = providerId,
+            providerName = stringValue("provider_name") ?: providerName(providerId),
+            isLoggedIn = booleanValue("is_logged_in"),
+            userName = stringValue("user_name"),
+        )
     }
 
     private companion object {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
@@ -1,27 +1,120 @@
 package org.feeluown.mobile
 
-class IosLocalMusicRepository : LocalMusicRepository {
-    private var scanSettings = LocalMusicScanSettings()
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import platform.Foundation.NSUserDefaults
 
-    val hasPermission: Boolean = true
+class IosLocalMusicRepository(
+    private val mediaLibrary: IosMediaLibraryOutput,
+) : LocalMusicRepository {
+    private var scanSettings = LocalMusicScanSettings()
+    private var cachedTracks = emptyList<MusicTrack>()
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    val hasPermission: Boolean
+        get() = mediaLibrary.hasPermission()
 
     fun requestPermission(onGranted: () -> Unit) {
-        onGranted()
+        mediaLibrary.requestPermission { granted ->
+            if (granted) onGranted()
+        }
     }
 
     override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
         scanSettings = settings
+        cachedTracks = filterTracks(cachedTracks)
     }
 
-    override suspend fun isDatabaseReady(): Boolean = true
+    override suspend fun isDatabaseReady(): Boolean = hasPermission
 
-    override suspend fun isDatabaseStale(): Boolean = false
+    override suspend fun isDatabaseStale(): Boolean = cachedTracks.isEmpty() && hasPermission
 
-    override suspend fun directories(): List<LocalMusicDirectory> = emptyList()
+    override suspend fun directories(): List<LocalMusicDirectory> {
+        if (cachedTracks.isEmpty()) return emptyList()
+        return listOf(LocalMusicDirectory(LIBRARY_DIRECTORY_ID, "媒体资料库", cachedTracks.size))
+    }
 
-    override suspend fun tracks(): List<MusicTrack> = emptyList()
+    override suspend fun tracks(): List<MusicTrack> = cachedTracks.ifEmpty { refreshDatabase() }
 
-    override suspend fun refreshDatabase(): List<MusicTrack> = emptyList()
+    override suspend fun refreshDatabase(): List<MusicTrack> {
+        if (!hasPermission) return emptyList()
+        val root = Json.parseToJsonElement(mediaLibrary.tracksJson()).jsonObject
+        cachedTracks = filterTracks(root["tracks"]?.jsonArray.orEmpty().map { element ->
+            val item = element.jsonObject
+            val persistentId = item["id"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            applyOverrides(MusicTrack(
+                id = "ios-media:$persistentId",
+                title = item["title"]?.jsonPrimitive?.contentOrNull.orEmpty().ifBlank { "未知歌曲" },
+                artists = item["artists"]?.jsonPrimitive?.contentOrNull.orEmpty().ifBlank { "未知歌手" },
+                album = item["album"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+                source = "本地音乐",
+                sourceType = TrackSourceType.LocalMediaStore,
+                durationMs = item["duration_ms"]?.jsonPrimitive?.longOrNull,
+                localUri = item["local_uri"]?.jsonPrimitive?.contentOrNull,
+            ))
+        })
+        return cachedTracks
+    }
 
-    override suspend fun search(keyword: String): List<MusicTrack> = emptyList()
+    override suspend fun search(keyword: String): List<MusicTrack> {
+        val normalized = keyword.trim()
+        if (normalized.isEmpty()) return tracks()
+        return tracks().filter {
+            it.title.contains(normalized, ignoreCase = true) ||
+                it.artists.contains(normalized, ignoreCase = true) ||
+                it.album.contains(normalized, ignoreCase = true)
+        }
+    }
+
+    override suspend fun updateMetadata(track: MusicTrack, metadata: LocalTrackMetadata) {
+        defaults.setObject(
+            listOf(metadata.title, metadata.artists, metadata.album).joinToString(METADATA_SEPARATOR),
+            metadataKey(track.id),
+        )
+        defaults.synchronize()
+        cachedTracks = cachedTracks.map { item ->
+            if (item.id == track.id) {
+                item.copy(title = metadata.title, artists = metadata.artists, album = metadata.album)
+            } else {
+                item
+            }
+        }
+    }
+
+    override suspend fun saveLyrics(track: MusicTrack, lyrics: String) {
+        defaults.setObject(lyrics, lyricsKey(track.id))
+        defaults.synchronize()
+        cachedTracks = cachedTracks.map { item ->
+            if (item.id == track.id) item.copy(lyrics = lyrics) else item
+        }
+    }
+
+    private fun applyOverrides(track: MusicTrack): MusicTrack {
+        val metadata = defaults.stringForKey(metadataKey(track.id))?.split(METADATA_SEPARATOR, limit = 3)
+        return track.copy(
+            title = metadata?.getOrNull(0)?.takeIf { it.isNotBlank() } ?: track.title,
+            artists = metadata?.getOrNull(1)?.takeIf { it.isNotBlank() } ?: track.artists,
+            album = metadata?.getOrNull(2) ?: track.album,
+            lyrics = defaults.stringForKey(lyricsKey(track.id))?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun metadataKey(trackId: String) = "ios_local_metadata_$trackId"
+
+    private fun lyricsKey(trackId: String) = "ios_local_lyrics_$trackId"
+
+    private fun filterTracks(tracks: List<MusicTrack>): List<MusicTrack> {
+        if (LIBRARY_DIRECTORY_ID in scanSettings.excludedDirectoryIds) return emptyList()
+        val minDurationMs = scanSettings.minDurationSeconds.toLong() * 1_000L
+        return tracks.filter { (it.durationMs ?: 0) >= minDurationMs }
+    }
+
+    private companion object {
+        private const val LIBRARY_DIRECTORY_ID = "ios-media-library"
+        private const val METADATA_SEPARATOR = "\u001f"
+    }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
@@ -12,6 +12,7 @@ class IosLocalMusicRepository(
     private val mediaLibrary: IosMediaLibraryOutput,
 ) : LocalMusicRepository {
     private var scanSettings = LocalMusicScanSettings()
+    private var libraryTracks = emptyList<MusicTrack>()
     private var cachedTracks = emptyList<MusicTrack>()
     private val defaults = NSUserDefaults.standardUserDefaults
 
@@ -26,24 +27,24 @@ class IosLocalMusicRepository(
 
     override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
         scanSettings = settings
-        cachedTracks = filterTracks(cachedTracks)
+        cachedTracks = filterTracks(libraryTracks)
     }
 
     override suspend fun isDatabaseReady(): Boolean = hasPermission
 
-    override suspend fun isDatabaseStale(): Boolean = cachedTracks.isEmpty() && hasPermission
+    override suspend fun isDatabaseStale(): Boolean = libraryTracks.isEmpty() && hasPermission
 
     override suspend fun directories(): List<LocalMusicDirectory> {
         if (cachedTracks.isEmpty()) return emptyList()
         return listOf(LocalMusicDirectory(LIBRARY_DIRECTORY_ID, "媒体资料库", cachedTracks.size))
     }
 
-    override suspend fun tracks(): List<MusicTrack> = cachedTracks.ifEmpty { refreshDatabase() }
+    override suspend fun tracks(): List<MusicTrack> = if (libraryTracks.isEmpty()) refreshDatabase() else cachedTracks
 
     override suspend fun refreshDatabase(): List<MusicTrack> {
         if (!hasPermission) return emptyList()
         val root = Json.parseToJsonElement(mediaLibrary.tracksJson()).jsonObject
-        cachedTracks = filterTracks(root["tracks"]?.jsonArray.orEmpty().map { element ->
+        libraryTracks = root["tracks"]?.jsonArray.orEmpty().map { element ->
             val item = element.jsonObject
             val persistentId = item["id"]?.jsonPrimitive?.contentOrNull.orEmpty()
             applyOverrides(MusicTrack(
@@ -56,7 +57,8 @@ class IosLocalMusicRepository(
                 durationMs = item["duration_ms"]?.jsonPrimitive?.longOrNull,
                 localUri = item["local_uri"]?.jsonPrimitive?.contentOrNull,
             ))
-        })
+        }
+        cachedTracks = filterTracks(libraryTracks)
         return cachedTracks
     }
 
@@ -76,21 +78,23 @@ class IosLocalMusicRepository(
             metadataKey(track.id),
         )
         defaults.synchronize()
-        cachedTracks = cachedTracks.map { item ->
+        libraryTracks = libraryTracks.map { item ->
             if (item.id == track.id) {
                 item.copy(title = metadata.title, artists = metadata.artists, album = metadata.album)
             } else {
                 item
             }
         }
+        cachedTracks = filterTracks(libraryTracks)
     }
 
     override suspend fun saveLyrics(track: MusicTrack, lyrics: String) {
         defaults.setObject(lyrics, lyricsKey(track.id))
         defaults.synchronize()
-        cachedTracks = cachedTracks.map { item ->
+        libraryTracks = libraryTracks.map { item ->
             if (item.id == track.id) item.copy(lyrics = lyrics) else item
         }
+        cachedTracks = filterTracks(libraryTracks)
     }
 
     private fun applyOverrides(track: MusicTrack): MusicTrack {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosMediaLibraryOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosMediaLibraryOutput.kt
@@ -1,0 +1,7 @@
+package org.feeluown.mobile
+
+interface IosMediaLibraryOutput {
+    fun hasPermission(): Boolean
+    fun requestPermission(completionHandler: (Boolean) -> Unit)
+    fun tracksJson(): String
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
@@ -1,40 +1,87 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class IosNativeAudioEngine(
-    @Suppress("UNUSED_PARAMETER") scope: CoroutineScope,
+    scope: CoroutineScope,
+    private val output: IosAudioOutput,
 ) : PlaybackEngine {
     private val mutableState = MutableStateFlow(PlaybackState())
 
     override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
 
-    override fun play(track: MusicTrack, payload: PlaybackPayload) {
+    init {
+        scope.launch {
+            while (true) {
+                updateFromOutput()
+                delay(500)
+            }
+        }
+    }
+
+    override fun prepareLoading(track: MusicTrack) {
         mutableState.value = PlaybackState(
-            status = PlayerStatus.Playing,
+            status = PlayerStatus.Loading,
+            currentTrack = track,
+            durationMs = track.durationMs ?: 0,
+            lyrics = track.lyrics,
+        )
+    }
+
+    override fun play(track: MusicTrack, payload: PlaybackPayload) {
+        output.play(payload.url, payload.headers, payload.title, payload.artists, payload.album)
+        mutableState.value = PlaybackState(
+            status = PlayerStatus.Loading,
             currentTrack = track,
             durationMs = payload.durationMs ?: track.durationMs ?: 0,
             lyrics = payload.lyrics,
             audioQuality = payload.audioQuality,
+            playbackParts = payload.parts,
+            currentPartIndex = payload.currentPartIndex,
         )
     }
 
     override fun pause() {
+        output.pause()
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
     }
 
     override fun resume() {
+        output.resume()
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
     }
 
     override fun stop() {
+        output.stop()
         mutableState.value = PlaybackState(status = PlayerStatus.Idle)
     }
 
     override fun seekTo(positionMs: Long) {
+        output.seekTo(positionMs)
         mutableState.value = mutableState.value.copy(positionMs = positionMs.coerceAtLeast(0))
+    }
+
+    private fun updateFromOutput() {
+        if (mutableState.value.currentTrack == null) return
+        val status = when (output.playbackStatus()) {
+            "Loading" -> PlayerStatus.Loading
+            "Playing" -> PlayerStatus.Playing
+            "Paused" -> PlayerStatus.Paused
+            "Ended" -> PlayerStatus.Ended
+            "Error" -> PlayerStatus.Error
+            else -> PlayerStatus.Idle
+        }
+        mutableState.value = mutableState.value.copy(
+            status = status,
+            positionMs = output.positionMs().coerceAtLeast(0),
+            durationMs = output.durationMs().takeIf { it > 0 } ?: mutableState.value.durationMs,
+            bufferedMs = output.bufferedMs().coerceAtLeast(0),
+            errorMessage = output.errorMessage(),
+        )
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNetworkStatusOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNetworkStatusOutput.kt
@@ -1,0 +1,5 @@
+package org.feeluown.mobile
+
+interface IosNetworkStatusOutput {
+    fun isCellularConnection(): Boolean
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPythonRuntime.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPythonRuntime.kt
@@ -1,0 +1,16 @@
+package org.feeluown.mobile
+
+interface IosPythonRuntime {
+    fun createBridge(enabledProvidersJson: String): String
+
+    fun call(method: String, arguments: List<String>): String
+}
+
+internal fun IosPythonRuntime.checked(result: String): String {
+    if (result.startsWith(ERROR_PREFIX)) {
+        throw IllegalStateException(result.removePrefix(ERROR_PREFIX))
+    }
+    return result
+}
+
+internal const val ERROR_PREFIX = "__FUO_PYTHON_ERROR__:"

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosResourceCacheRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosResourceCacheRepository.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import platform.Foundation.NSURLCache
 
 class IosResourceCacheRepository : ResourceCacheRepository {
     private val mutableUsage = MutableStateFlow(CacheUsage())
@@ -13,13 +14,23 @@ class IosResourceCacheRepository : ResourceCacheRepository {
 
     override val usage: StateFlow<CacheUsage> = mutableUsage.asStateFlow()
 
-    override suspend fun refreshUsage() = Unit
+    override suspend fun refreshUsage() {
+        val cache = NSURLCache.sharedURLCache
+        mutableUsage.value = CacheUsage(
+            audioBytes = 0,
+            imageBytes = cache.currentDiskUsage.toLong() + cache.currentMemoryUsage.toLong(),
+        )
+    }
 
     override suspend fun clearAll() {
+        NSURLCache.sharedURLCache.removeAllCachedResponses()
         mutableUsage.value = CacheUsage()
     }
 
     override suspend fun updateLimit(limit: CacheLimit) {
         this.limit = limit
+        NSURLCache.sharedURLCache.diskCapacity = limit.imageMaxBytes.toULong()
+        NSURLCache.sharedURLCache.memoryCapacity = minOf(limit.imageMaxBytes / 4, 32L * 1024L * 1024L).toULong()
+        refreshUsage()
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosShareOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosShareOutput.kt
@@ -1,0 +1,5 @@
+package org.feeluown.mobile
+
+interface IosShareOutput {
+    fun share(text: String)
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosVideoOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosVideoOutput.kt
@@ -1,0 +1,15 @@
+package org.feeluown.mobile
+
+import platform.UIKit.UIViewController
+
+interface IosVideoOutput {
+    fun makePlayer(url: String, videoUrl: String, audioUrl: String, headers: Map<String, String>): UIViewController
+    fun updatePlayer(
+        viewController: UIViewController,
+        url: String,
+        videoUrl: String,
+        audioUrl: String,
+        headers: Map<String, String>,
+    )
+    fun releasePlayer(viewController: UIViewController)
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosWebLoginOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosWebLoginOutput.kt
@@ -1,0 +1,12 @@
+package org.feeluown.mobile
+
+interface IosWebLoginOutput {
+    fun open(
+        providerId: String,
+        providerName: String,
+        loginUrl: String,
+        cookieKeyGroupsJson: String,
+        completionHandler: (String?) -> Unit,
+    )
+    fun clear()
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
@@ -1,29 +1,77 @@
 package org.feeluown.mobile
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.reinterpret
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import platform.Foundation.NSData
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLSession
+import platform.Foundation.dataTaskWithURL
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 @Composable
-actual fun PlatformCoverArt(
-    title: String,
-    imageUrl: String?,
-    modifier: Modifier,
-) {
-    Surface(
-        modifier = modifier,
-        color = MaterialTheme.colorScheme.primaryContainer,
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Text(
-                text = title.firstOrNull()?.uppercase() ?: "F",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
+actual fun PlatformCoverArt(title: String, imageUrl: String?, modifier: Modifier) {
+    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(imageUrl) {
+        image = imageUrl?.takeIf { it.isNotBlank() }?.let { loadImage(it) }
+    }
+    val bitmap = image
+    if (bitmap != null) {
+        Image(bitmap, title, modifier, contentScale = ContentScale.Crop)
+    } else {
+        Surface(modifier = modifier, color = MaterialTheme.colorScheme.primaryContainer) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    title.firstOrNull()?.uppercase() ?: "F",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
         }
     }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private suspend fun loadImage(imageUrl: String): ImageBitmap? = withContext(Dispatchers.Default) {
+    val resolvedUrl = when {
+        imageUrl.startsWith("fuo-cover:") -> {
+            val query = imageUrl.substringAfter('?', "")
+            query.split('&').firstNotNullOfOrNull { entry ->
+                val parts = entry.split('=', limit = 2)
+                parts.getOrNull(1)?.takeIf { parts.firstOrNull() == "albumArt" && it.isNotBlank() }
+            }
+        }
+        else -> imageUrl
+    } ?: return@withContext null
+    val url = NSURL.URLWithString(resolvedUrl) ?: return@withContext null
+    val data = fetchData(url) ?: return@withContext null
+    val bytes = data.bytes?.reinterpret<ByteVar>()?.readBytes(data.length.toInt()) ?: return@withContext null
+    runCatching { Image.makeFromEncoded(bytes).toComposeImageBitmap() }.getOrNull()
+}
+
+private suspend fun fetchData(url: NSURL): NSData? = suspendCoroutine { continuation ->
+    NSURLSession.sharedSession.dataTaskWithURL(url) { data, _, _ ->
+        continuation.resume(data)
+    }.resume()
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.ios.kt
@@ -7,22 +7,39 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitViewController
+
+internal object IosVideoOutputHolder {
+    var output: IosVideoOutput? = null
+}
 
 @Composable
 actual fun PlatformVideoPlayer(
     payload: VideoPlaybackPayload?,
     modifier: Modifier,
 ) {
-    Surface(
+    val output = IosVideoOutputHolder.output
+    if (payload == null) {
+        VideoPlaceholder("正在加载视频", modifier)
+        return
+    }
+    if (output == null || (payload.url.isBlank() && payload.videoUrl.isBlank())) {
+        VideoPlaceholder("视频地址不可用", modifier)
+        return
+    }
+    UIKitViewController(
+        factory = { output.makePlayer(payload.url, payload.videoUrl, payload.audioUrl, payload.headers) },
         modifier = modifier,
-        color = MaterialTheme.colorScheme.surfaceVariant,
-    ) {
+        update = { output.updatePlayer(it, payload.url, payload.videoUrl, payload.audioUrl, payload.headers) },
+        onRelease = output::releasePlayer,
+    )
+}
+
+@Composable
+private fun VideoPlaceholder(text: String, modifier: Modifier) {
+    Surface(modifier = modifier, color = MaterialTheme.colorScheme.surfaceVariant) {
         Box(contentAlignment = Alignment.Center) {
-            Text(
-                text = "iOS 视频播放尚未接入",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }

--- a/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlatformRepositoriesTest.kt
+++ b/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlatformRepositoriesTest.kt
@@ -1,0 +1,101 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IosPlatformRepositoriesTest {
+    @Test
+    fun resolveUsesAudioQualityForCurrentNetwork() = runTest {
+        val runtime = RecordingPythonRuntime()
+        val networkStatus = FakeNetworkStatusOutput(isCellular = true)
+        val repository = IosFuoCoreBridge(runtime, networkStatus)
+        repository.updateAudioQualityPolicies(AudioQualityPolicy.Highest, AudioQualityPolicy.Low)
+
+        repository.resolve(providerTrack(), UnavailablePlaybackPolicy.Skip, emptySet(), 0.5, false, false)
+        assertEquals(AudioQualityPolicy.Low.policy, runtime.resolveArguments?.get(1))
+
+        networkStatus.isCellular = false
+        repository.resolve(providerTrack(), UnavailablePlaybackPolicy.Skip, emptySet(), 0.5, false, false)
+        assertEquals(AudioQualityPolicy.Highest.policy, runtime.resolveArguments?.get(1))
+    }
+
+    @Test
+    fun relaxedScanSettingsRestoreTracksFromUnfilteredCache() = runTest {
+        val mediaLibrary = FakeMediaLibraryOutput()
+        val repository = IosLocalMusicRepository(mediaLibrary)
+        repository.refreshDatabase()
+
+        repository.updateScanSettings(LocalMusicScanSettings(minDurationSeconds = 60))
+        assertEquals(listOf("Long track"), repository.tracks().map { it.title })
+
+        repository.updateScanSettings(
+            LocalMusicScanSettings(excludedDirectoryIds = setOf("ios-media-library")),
+        )
+        assertEquals(emptyList(), repository.tracks())
+
+        repository.updateScanSettings(LocalMusicScanSettings())
+        assertEquals(listOf("Short track", "Long track"), repository.tracks().map { it.title })
+        assertEquals(1, mediaLibrary.trackRequests)
+    }
+
+    private fun providerTrack() = MusicTrack(
+        id = "netease:1",
+        title = "Track",
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+
+    private class FakeNetworkStatusOutput(
+        var isCellular: Boolean,
+    ) : IosNetworkStatusOutput {
+        override fun isCellularConnection(): Boolean = isCellular
+    }
+
+    private class RecordingPythonRuntime : IosPythonRuntime {
+        var resolveArguments: List<String>? = null
+
+        override fun createBridge(enabledProvidersJson: String): String = "{}"
+
+        override fun call(method: String, arguments: List<String>): String {
+            if (method == "resolve") resolveArguments = arguments
+            return "{\"url\":\"https://example.com/audio.mp3\"}"
+        }
+    }
+
+    private class FakeMediaLibraryOutput : IosMediaLibraryOutput {
+        var trackRequests = 0
+
+        override fun hasPermission(): Boolean = true
+
+        override fun requestPermission(completionHandler: (Boolean) -> Unit) = completionHandler(true)
+
+        override fun tracksJson(): String {
+            trackRequests += 1
+            return """
+                {
+                  "tracks": [
+                    {
+                      "id": "short",
+                      "title": "Short track",
+                      "artists": "Artist",
+                      "album": "Album",
+                      "duration_ms": 30000,
+                      "local_uri": "ipod-library://short"
+                    },
+                    {
+                      "id": "long",
+                      "title": "Long track",
+                      "artists": "Artist",
+                      "album": "Album",
+                      "duration_ms": 120000,
+                      "local_uri": "ipod-library://long"
+                    }
+                  ]
+                }
+            """.trimIndent()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- embed and initialize the Python provider runtime on iOS
- implement iOS provider browsing, search, authentication and playback
- add native audio/video, local media, downloads, covers, caching and sharing
- fix physical-device Python signing, framework slice selection and writable user data
- make provider initialization state visible and WebView login reliable

## Validation

- `./gradlew :shared:iosSimulatorArm64Test :shared:testDebugUnitTest`
- iOS simulator Debug build
- physical iPhone Debug build and strict code-sign verification
- QQ Music login, search, resolve and AVPlayer playback on physical iPhone