### PR TITLE
增强平台内容与歌单管理能力

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidFuoCoreBridge.kt
@@ -319,6 +319,33 @@ class AndroidFuoCoreBridge(
         }
     }
 
+    override suspend fun createPlaylist(providerId: String, name: String): ProviderMutationResult {
+        initialize()
+        return withContext(Dispatchers.IO) {
+            val raw = requireNotNull(bridge).callAttr("playlist_create", providerId, name).toString()
+            JSONObject(raw).optJSONObject("result")?.toMutationResult()
+                ?: JSONObject(raw).toMutationResult()
+        }
+    }
+
+    override suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderMutationResult {
+        initialize()
+        return withContext(Dispatchers.IO) {
+            val raw = requireNotNull(bridge).callAttr("playlist_delete", playlist.id).toString()
+            JSONObject(raw).toMutationResult()
+        }
+    }
+
+    override suspend fun setSongDisliked(track: MusicTrack, disliked: Boolean): ProviderMutationResult {
+        initialize()
+        return withContext(Dispatchers.IO) {
+            val raw = requireNotNull(bridge)
+                .callAttr("dislike_song", track.providerId ?: track.id, disliked)
+                .toString()
+            JSONObject(raw).toMutationResult()
+        }
+    }
+
     override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> {
         initialize()
         return withContext(Dispatchers.IO) {
@@ -442,6 +469,11 @@ class AndroidFuoCoreBridge(
             providerName = optString("provider_name").ifBlank { providerId },
             canAddSongToPlaylist = optBoolean("can_add_song_to_playlist"),
             canRemoveSongFromPlaylist = optBoolean("can_remove_song_from_playlist"),
+            canCreatePlaylist = optBoolean("can_create_playlist"),
+            canDeletePlaylist = optBoolean("can_delete_playlist"),
+            canListDislikedSongs = optBoolean("can_list_disliked_songs"),
+            canAddDislikedSong = optBoolean("can_add_disliked_song"),
+            canRemoveDislikedSong = optBoolean("can_remove_disliked_song"),
             canFavoritePlaylist = optBoolean("can_favorite_playlist"),
             canUnfavoritePlaylist = optBoolean("can_unfavorite_playlist"),
             canFavoriteArtist = optBoolean("can_favorite_artist"),
@@ -469,11 +501,13 @@ class AndroidFuoCoreBridge(
         val tracksArray = optJSONArray("tracks") ?: JSONArray()
         val playlistsArray = optJSONArray("playlists") ?: JSONArray()
         val mediaItemsArray = optJSONArray("media_items") ?: JSONArray()
+        val videosArray = optJSONArray("videos") ?: JSONArray()
         return ProviderContentSection(
             feature = parsedFeature,
             tracks = List(tracksArray.length()) { index -> tracksArray.getJSONObject(index).toTrack() },
             playlists = List(playlistsArray.length()) { index -> playlistsArray.getJSONObject(index).toPlaylist() },
             mediaItems = List(mediaItemsArray.length()) { index -> mediaItemsArray.getJSONObject(index).toMediaItem() },
+            videos = List(videosArray.length()) { index -> videosArray.getJSONObject(index).toProviderVideo() },
             isLoginRequired = optBoolean("is_login_required"),
             errorMessage = optString("error_message").takeIf { it.isNotBlank() },
             nextOffset = optInt("next_offset"),

--- a/androidApp/src/test/python/test_bridge_provider_operations.py
+++ b/androidApp/src/test/python/test_bridge_provider_operations.py
@@ -11,7 +11,7 @@ from feeluown.media import Media
 ROOT_DIR = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(ROOT_DIR / "shared" / "src" / "commonMain" / "python"))
 
-from fuo_mobile.bridge import FuoMobileBridge, provider_capabilities  # noqa: E402
+from fuo_mobile.bridge import FEATURE_DEFS, FuoMobileBridge, provider_capabilities  # noqa: E402
 
 
 class _Library:
@@ -83,6 +83,9 @@ class _Provider:
         )
         self.added = []
         self.removed = []
+        self.disliked = []
+        self.created = []
+        self.deleted = []
 
     def get_current_user_or_none(self):
         return self.user
@@ -106,6 +109,25 @@ class _Provider:
 
     def playlist_remove_song(self, playlist, song):
         self.removed.append((playlist.identifier, song.identifier))
+        return True
+
+    def playlist_create_by_name(self, name):
+        self.created.append(name)
+        return SimpleNamespace(source=self.identifier, identifier="created", name=name)
+
+    def playlist_delete(self, identifier):
+        self.deleted.append(identifier)
+        return True
+
+    def current_user_dislike_create_songs_rd(self):
+        return [self.song]
+
+    def current_user_dislike_add_song(self, song):
+        self.disliked.append(("add", song.identifier))
+        return True
+
+    def current_user_dislike_remove_song(self, song):
+        self.disliked.append(("remove", song.identifier))
         return True
 
     def song_list_similar(self, song):
@@ -134,6 +156,7 @@ class ProviderOperationBridgeTest(unittest.TestCase):
         bridge._playlists = {}
         bridge._media_items = {}
         bridge._videos = {}
+        bridge._dynamic_features = {}
         bridge.app = SimpleNamespace(library=_Library(provider))
         bridge._get_provider = lambda provider_id: provider
         return bridge
@@ -142,10 +165,35 @@ class ProviderOperationBridgeTest(unittest.TestCase):
         provider = _Provider()
         self.assertTrue(provider_capabilities(provider)["can_add_song_to_playlist"])
         self.assertTrue(provider_capabilities(provider)["can_remove_song_from_playlist"])
+        self.assertTrue(provider_capabilities(provider)["can_create_playlist"])
+        self.assertTrue(provider_capabilities(provider)["can_add_disliked_song"])
 
         provider.identifier = "ytmusic"
         self.assertTrue(provider_capabilities(provider)["can_add_song_to_playlist"])
         self.assertFalse(provider_capabilities(provider)["can_remove_song_from_playlist"])
+
+    def test_create_delete_and_dislike_operations(self):
+        provider = _Provider()
+        bridge = self.bridge(provider)
+
+        created = json.loads(bridge.playlist_create("netease", "New List"))
+        deleted = json.loads(bridge.playlist_delete("playlist:netease:playlist1"))
+        disliked = json.loads(bridge.dislike_song("netease:song1", True))
+        restored = json.loads(bridge.dislike_song("netease:song1", False))
+
+        self.assertTrue(created["result"]["success"])
+        self.assertTrue(deleted["success"])
+        self.assertTrue(disliked["success"])
+        self.assertTrue(restored["success"])
+        self.assertEqual(["New List"], provider.created)
+        self.assertEqual(["playlist1"], provider.deleted)
+        self.assertEqual([("add", "song1"), ("remove", "song1")], provider.disliked)
+
+    def test_new_provider_features_are_registered(self):
+        self.assertIn("current_user_cloud_songs", [item["action"] for item in FEATURE_DEFS["netease"]])
+        self.assertIn("current_user_dislike_create_songs_rd", [item["action"] for item in FEATURE_DEFS["qqmusic"]])
+        self.assertIn("most_popular_videos", [item["action"] for item in FEATURE_DEFS["bilibili"]])
+        self.assertIn("weekly_video_playlists", [item["action"] for item in FEATURE_DEFS["bilibili"]])
 
     def test_playlist_targets_require_login(self):
         bridge = self.bridge(_Provider(logged_in=False))

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
@@ -9,15 +9,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
@@ -38,25 +44,44 @@ actual fun PlatformVideoPlayer(
         return
     }
     val context = LocalContext.current
-    val player = remember { ExoPlayer.Builder(context).build() }
+    var playbackError by remember { mutableStateOf<String?>(null) }
+    val player = remember(context) {
+        val renderersFactory = DefaultRenderersFactory(context)
+            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
+        ExoPlayer.Builder(context)
+            .setRenderersFactory(renderersFactory)
+            .build()
+            .also { exoPlayer ->
+                exoPlayer.addListener(object : Player.Listener {
+                    override fun onPlayerError(error: PlaybackException) {
+                        playbackError = "视频播放失败：${error.errorCodeName}"
+                    }
+                })
+            }
+    }
     DisposableEffect(Unit) {
         onDispose { player.release() }
     }
     LaunchedEffect(payload.url, payload.videoUrl, payload.audioUrl, payload.headers) {
+        playbackError = null
         player.setMediaSource(payload.toMediaSource(context))
         player.prepare()
         player.playWhenReady = true
     }
-    AndroidView(
-        modifier = modifier,
-        factory = { viewContext ->
-            PlayerView(viewContext).apply {
-                this.player = player
-                useController = true
-            }
-        },
-        update = { it.player = player },
-    )
+    if (playbackError != null) {
+        VideoPlaceholder(playbackError.orEmpty(), modifier)
+    } else {
+        AndroidView(
+            modifier = modifier,
+            factory = { viewContext ->
+                PlayerView(viewContext).apply {
+                    this.player = player
+                    useController = true
+                }
+            },
+            update = { it.player = player },
+        )
+    }
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -448,6 +448,11 @@ data class ProviderCapabilities(
     val providerName: String,
     val canAddSongToPlaylist: Boolean = false,
     val canRemoveSongFromPlaylist: Boolean = false,
+    val canCreatePlaylist: Boolean = false,
+    val canDeletePlaylist: Boolean = false,
+    val canListDislikedSongs: Boolean = false,
+    val canAddDislikedSong: Boolean = false,
+    val canRemoveDislikedSong: Boolean = false,
     val canFavoritePlaylist: Boolean = false,
     val canUnfavoritePlaylist: Boolean = false,
     val canFavoriteArtist: Boolean = false,
@@ -494,6 +499,7 @@ enum class ProviderContentType {
     Playlists,
     Artists,
     Albums,
+    Videos,
 }
 
 data class ProviderFeature(
@@ -569,6 +575,7 @@ data class ProviderContentSection(
     val tracks: List<MusicTrack> = emptyList(),
     val playlists: List<ProviderPlaylist> = emptyList(),
     val mediaItems: List<ProviderMediaItem> = emptyList(),
+    val videos: List<ProviderVideo> = emptyList(),
     val isLoginRequired: Boolean = false,
     val errorMessage: String? = null,
     val nextOffset: Int = 0,
@@ -650,6 +657,12 @@ interface ProviderMusicRepository {
         ProviderMutationResult(false, "provider does not support playlist add song")
     suspend fun removeTrackFromPlaylist(playlist: ProviderPlaylist, track: MusicTrack): ProviderMutationResult =
         ProviderMutationResult(false, "provider does not support playlist remove song")
+    suspend fun createPlaylist(providerId: String, name: String): ProviderMutationResult =
+        ProviderMutationResult(false, "provider does not support playlist create")
+    suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderMutationResult =
+        ProviderMutationResult(false, "provider does not support playlist delete")
+    suspend fun setSongDisliked(track: MusicTrack, disliked: Boolean): ProviderMutationResult =
+        ProviderMutationResult(false, "provider does not support dislike operation")
     suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
         ProviderMediaItemDetail(item, mediaItemTracks(item))
     suspend fun mediaItemDetailPage(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -109,6 +109,8 @@ class FuoPlayerController(
         private set
     var selectedFeature by mutableStateOf<ProviderFeature?>(null)
         private set
+    var selectedFeatureContent by mutableStateOf<ProviderContentSection?>(null)
+        private set
     var selectedFeatureTracks by mutableStateOf<List<MusicTrack>>(emptyList())
         private set
     var selectedFeatureTracksHasMore by mutableStateOf(false)
@@ -1303,6 +1305,7 @@ class FuoPlayerController(
 
     fun openFeature(feature: ProviderFeature) {
         selectedFeature = feature
+        selectedFeatureContent = null
         selectedFeatureTracks = emptyList()
         selectedFeatureTracksNextOffset = 0
         selectedFeatureTracksHasMore = false
@@ -1322,6 +1325,7 @@ class FuoPlayerController(
             } else {
                 result.onSuccess { section ->
                     if (selectedFeature == feature) {
+                        selectedFeatureContent = section
                         selectedFeatureTracks = section.tracks
                         selectedFeatureTracksNextOffset = section.nextOffset
                         selectedFeatureTracksHasMore = section.hasMore
@@ -1332,8 +1336,8 @@ class FuoPlayerController(
                         }
                         message = when {
                             selectedFeatureError != null -> selectedFeatureError.orEmpty()
-                            section.tracks.isEmpty() -> "${feature.title} 暂无歌曲"
-                            else -> "${feature.title} · ${section.tracks.size} 首"
+                            section.contentCount() == 0 -> "${feature.title} 暂无内容"
+                            else -> "${feature.title} · ${section.contentCount()} 项"
                         }
                     }
                 }.onFailure {
@@ -1347,6 +1351,7 @@ class FuoPlayerController(
 
     fun closeFeature() {
         selectedFeature = null
+        selectedFeatureContent = null
         selectedFeatureTracks = emptyList()
         selectedFeatureTracksNextOffset = 0
         selectedFeatureTracksHasMore = false
@@ -1666,6 +1671,9 @@ class FuoPlayerController(
         musicSections = musicSections.withoutTrack(track.id)
         mineSections = mineSections.withoutTrack(track.id)
         selectedFeatureTracks = selectedFeatureTracks.filterNot { it.id == track.id }
+        selectedFeatureContent = selectedFeatureContent?.copy(
+            tracks = selectedFeatureContent.orEmptyTracks().filterNot { it.id == track.id },
+        )
         selectedPlaylistTracks = selectedPlaylistTracks.filterNot { it.id == track.id }
         updatePlaybackQueueState()
         persistPlaybackQueue()
@@ -1871,13 +1879,13 @@ class FuoPlayerController(
                 val newTracks = section.tracks.filter { seenIds.add(it.id) }
                 if (newTracks.isNotEmpty()) {
                     selectedFeatureTracks = selectedFeatureTracks + newTracks
-                    updateHomeFeatureSection(
-                        section.copy(
-                            tracks = selectedFeatureTracks,
-                            nextOffset = section.nextOffset,
-                            hasMore = section.hasMore,
-                        ),
+                    val updatedSection = section.copy(
+                        tracks = selectedFeatureTracks,
+                        nextOffset = section.nextOffset,
+                        hasMore = section.hasMore,
                     )
+                    selectedFeatureContent = updatedSection
+                    updateHomeFeatureSection(updatedSection)
                 }
                 selectedFeatureTracksNextOffset = section.nextOffset
                 selectedFeatureTracksHasMore = section.hasMore
@@ -2519,6 +2527,7 @@ class FuoPlayerController(
         minePlaylistSections = emptyList()
         mineFavoritePlaylistSections = emptyList()
         selectedFeature = null
+        selectedFeatureContent = null
         selectedTrack = null
         selectedPlaylist = null
         selectedPlaylistCategory = null
@@ -3136,13 +3145,23 @@ class FuoPlayerController(
         map { section -> section.copy(tracks = section.tracks.filterNot { it.id == trackId }) }
 
     private fun ProviderFeature.isDeferredHomeFeature(): Boolean {
-        return category == ProviderFeatureCategory.Recommend &&
-            (id.endsWith("_daily_songs") || isDynamicQueueFeature())
+        return category == ProviderFeatureCategory.Music ||
+            (category == ProviderFeatureCategory.Recommend &&
+                (id.endsWith("_daily_songs") || isDynamicQueueFeature() || isBilibiliRecommendedVideos()))
     }
 
     private fun ProviderFeature.isDynamicQueueFeature(): Boolean {
         return id.endsWith("_radio")
     }
+
+    private fun ProviderContentSection.contentCount(): Int = maxOf(
+        tracks.size,
+        playlists.size,
+        mediaItems.size,
+        videos.size,
+    )
+
+    private fun ProviderContentSection?.orEmptyTracks(): List<MusicTrack> = this?.tracks.orEmpty()
 
     private fun ProviderSearchResults.totalCount(): Int {
         return tracks.size + playlists.size + artists.size + albums.size + videos.size

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -35,6 +35,7 @@ enum class HomeSection {
 
 enum class MineSection {
     Playlists,
+    Songs,
     Artists,
     Albums,
     LocalMusic,
@@ -936,6 +937,7 @@ class FuoPlayerController(
         persistSettings()
         when (value) {
             MineSection.Playlists -> if (minePlaylistSections.isEmpty()) refreshMinePlaylistContent()
+            MineSection.Songs,
             MineSection.Artists,
             MineSection.Albums -> if (mineSections.isEmpty()) refreshMineContent()
             MineSection.LocalMusic -> ensureLocalMusic()
@@ -1237,15 +1239,13 @@ class FuoPlayerController(
     fun refreshMineContent() {
         scope.launch {
             isLoading = true
-            message = "正在加载歌手和专辑"
+            message = "正在加载我的内容"
             runCatching {
                 refreshProviderCatalog()
-                loadProviderSections(ProviderFeatureCategory.Mine) {
-                    it.contentType == ProviderContentType.Artists || it.contentType == ProviderContentType.Albums
-                }
+                loadProviderSections(ProviderFeatureCategory.Mine)
             }.onSuccess {
                 mineSections = it
-                message = if (it.isEmpty()) "歌手和专辑暂无内容" else "歌手和专辑已更新"
+                message = if (it.isEmpty()) "我的内容暂无内容" else "我的内容已更新"
             }.onFailure {
                 setError(it)
             }
@@ -1274,6 +1274,7 @@ class FuoPlayerController(
             MineSection.Playlists -> if (minePlaylistSections.isEmpty() && mineFavoritePlaylistSections.isEmpty()) {
                 refreshMinePlaylistContent()
             }
+            MineSection.Songs,
             MineSection.Artists,
             MineSection.Albums -> if (mineSections.isEmpty()) refreshMineContent()
             MineSection.LocalMusic -> ensureLocalMusic()
@@ -1283,6 +1284,7 @@ class FuoPlayerController(
     private fun refreshActiveMineSection() {
         when (mineSection) {
             MineSection.Playlists -> refreshMinePlaylistContent()
+            MineSection.Songs,
             MineSection.Artists,
             MineSection.Albums -> refreshMineContent()
             MineSection.LocalMusic -> ensureLocalMusic()
@@ -1292,6 +1294,7 @@ class FuoPlayerController(
     private fun refreshActiveMineProviderContent() {
         when (mineSection) {
             MineSection.Playlists -> refreshMinePlaylistContent()
+            MineSection.Songs,
             MineSection.Artists,
             MineSection.Albums -> refreshMineContent()
             MineSection.LocalMusic -> Unit
@@ -1509,6 +1512,52 @@ class FuoPlayerController(
             providerCapabilities[providerId]?.canAddSongToPlaylist == true
     }
 
+    fun creatablePlaylistProviders(): List<ProviderInfo> = providers.filter { provider ->
+        isProviderLoggedIn(provider.providerId) &&
+            providerCapabilities[provider.providerId]?.canCreatePlaylist == true
+    }
+
+    fun createPlaylist(providerId: String, name: String) {
+        if (name.isBlank() || providerId !in creatablePlaylistProviders().map { it.providerId }) return
+        scope.launch {
+            isLoading = true
+            message = "正在新建歌单"
+            runCatching { providerRepository.createPlaylist(providerId, name.trim()) }
+                .onSuccess { result ->
+                    message = result.message.ifBlank { if (result.success) "歌单已新建" else "新建歌单失败" }
+                    if (result.success) refreshAfterProviderMutation(providerId)
+                }
+                .onFailure(::setError)
+            isLoading = false
+        }
+    }
+
+    fun canDeleteSelectedPlaylist(): Boolean {
+        val playlist = selectedPlaylist ?: return false
+        return selectedPlaylistCategory == ProviderFeatureCategory.MinePlaylists &&
+            isProviderLoggedIn(playlist.providerId) &&
+            providerCapabilities[playlist.providerId]?.canDeletePlaylist == true
+    }
+
+    fun deleteSelectedPlaylist() {
+        val playlist = selectedPlaylist ?: return
+        if (!canDeleteSelectedPlaylist()) return
+        scope.launch {
+            isLoading = true
+            message = "正在删除歌单"
+            runCatching { providerRepository.deletePlaylist(playlist) }
+                .onSuccess { result ->
+                    message = result.message.ifBlank { if (result.success) "歌单已删除" else "删除歌单失败" }
+                    if (result.success) {
+                        closePlaylist()
+                        refreshAfterProviderMutation(playlist.providerId)
+                    }
+                }
+                .onFailure(::setError)
+            isLoading = false
+        }
+    }
+
     fun openPlaylistTargetPicker(track: MusicTrack) {
         if (!canAddTrackToProviderPlaylist(track)) return
         playlistTargetTrack = track
@@ -1571,6 +1620,52 @@ class FuoPlayerController(
             trackProviderId(track) == playlist.providerId &&
             isProviderLoggedIn(playlist.providerId) &&
             providerCapabilities[playlist.providerId]?.canRemoveSongFromPlaylist == true
+    }
+
+    fun canSetSongDisliked(track: MusicTrack, disliked: Boolean): Boolean {
+        val providerId = trackProviderId(track) ?: return false
+        val capabilities = providerCapabilities[providerId] ?: return false
+        return track.sourceType == TrackSourceType.Provider &&
+            isProviderLoggedIn(providerId) &&
+            if (disliked) capabilities.canAddDislikedSong else capabilities.canRemoveDislikedSong
+    }
+
+    fun setSongDisliked(track: MusicTrack, disliked: Boolean) {
+        if (!canSetSongDisliked(track, disliked)) return
+        scope.launch {
+            isLoading = true
+            message = if (disliked) "正在设为不喜欢" else "正在取消不喜欢"
+            runCatching { providerRepository.setSongDisliked(track, disliked) }
+                .onSuccess { result ->
+                    if (result.success) {
+                        if (disliked) removeDislikedTrack(track) else refreshMineContent()
+                        message = result.message.ifBlank { if (disliked) "已设为不喜欢" else "已取消不喜欢" }
+                    } else {
+                        message = result.message.ifBlank { "操作失败" }
+                    }
+                }
+                .onFailure(::setError)
+            isLoading = false
+        }
+    }
+
+    private fun removeDislikedTrack(track: MusicTrack) {
+        val isCurrent = currentQueueTrack()?.id == track.id
+        if (isCurrent) {
+            val hasNext = upNextQueue.isNotEmpty() || mainQueueIndex + 1 < mainQueue.size
+            if (hasNext) next() else playbackEngine.stop()
+        }
+        mainQueue = mainQueue.filterNot { it.id == track.id }
+        originalMainQueue = originalMainQueue.filterNot { it.id == track.id }
+        upNextQueue = upNextQueue.filterNot { it.id == track.id }
+        mainQueueIndex = mainQueueIndex.coerceIn(-1, mainQueue.lastIndex)
+        recommendSections = recommendSections.withoutTrack(track.id)
+        musicSections = musicSections.withoutTrack(track.id)
+        mineSections = mineSections.withoutTrack(track.id)
+        selectedFeatureTracks = selectedFeatureTracks.filterNot { it.id == track.id }
+        selectedPlaylistTracks = selectedPlaylistTracks.filterNot { it.id == track.id }
+        updatePlaybackQueueState()
+        persistPlaybackQueue()
     }
 
     fun removeTrackFromSelectedPlaylist(track: MusicTrack) {
@@ -3033,6 +3128,9 @@ class FuoPlayerController(
 
     private fun List<ProviderContentSection>.sortedSectionsByOrder(): List<ProviderContentSection> =
         sortedWith(compareBy<ProviderContentSection> { providerOrderIndex(it.feature.providerId) }.thenBy { it.feature.id })
+
+    private fun List<ProviderContentSection>.withoutTrack(trackId: String): List<ProviderContentSection> =
+        map { section -> section.copy(tracks = section.tracks.filterNot { it.id == trackId }) }
 
     private fun ProviderFeature.isDeferredHomeFeature(): Boolean {
         return category == ProviderFeatureCategory.Recommend &&

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -1655,10 +1655,13 @@ class FuoPlayerController(
             val hasNext = upNextQueue.isNotEmpty() || mainQueueIndex + 1 < mainQueue.size
             if (hasNext) next() else playbackEngine.stop()
         }
+        val removedBeforeCurrent = mainQueue
+            .take(mainQueueIndex.coerceIn(0, mainQueue.size))
+            .count { it.id == track.id }
         mainQueue = mainQueue.filterNot { it.id == track.id }
         originalMainQueue = originalMainQueue.filterNot { it.id == track.id }
         upNextQueue = upNextQueue.filterNot { it.id == track.id }
-        mainQueueIndex = mainQueueIndex.coerceIn(-1, mainQueue.lastIndex)
+        mainQueueIndex = (mainQueueIndex - removedBeforeCurrent).coerceIn(-1, mainQueue.lastIndex)
         recommendSections = recommendSections.withoutTrack(track.id)
         musicSections = musicSections.withoutTrack(track.id)
         mineSections = mineSections.withoutTrack(track.id)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -226,6 +226,7 @@ fun MinePlaylistsSection(
 ) {
     var showCreateDialog by remember { mutableStateOf(false) }
     var playlistName by remember { mutableStateOf("") }
+    var selectedCreateProviderId by remember { mutableStateOf<String?>(null) }
     val creatableProviders = controller.creatablePlaylistProviders()
     val userSections = controller.minePlaylistSections
     val favoriteSections = controller.mineFavoritePlaylistSections
@@ -246,7 +247,12 @@ fun MinePlaylistsSection(
     ) {
         if (creatableProviders.isNotEmpty()) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(onClick = { showCreateDialog = true }) { Text("新建歌单") }
+                TextButton(
+                    onClick = {
+                        selectedCreateProviderId = creatableProviders.singleOrNull()?.providerId
+                        showCreateDialog = true
+                    },
+                ) { Text("新建歌单") }
             }
         }
         if (showFilter) {
@@ -278,6 +284,9 @@ fun MinePlaylistsSection(
         }
     }
     if (showCreateDialog) {
+        val selectedCreateProvider = creatableProviders.firstOrNull {
+            it.providerId == selectedCreateProviderId
+        } ?: creatableProviders.singleOrNull()
         AlertDialog(
             onDismissRequest = { showCreateDialog = false },
             title = { Text("新建歌单") },
@@ -285,6 +294,20 @@ fun MinePlaylistsSection(
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     if (creatableProviders.size == 1) {
                         Text("将在 ${creatableProviders.first().providerName} 创建")
+                    } else {
+                        Text("创建到")
+                        Row(
+                            modifier = Modifier.horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            creatableProviders.forEach { provider ->
+                                FilterChip(
+                                    selected = provider.providerId == selectedCreateProvider?.providerId,
+                                    onClick = { selectedCreateProviderId = provider.providerId },
+                                    label = { Text(provider.providerName) },
+                                )
+                            }
+                        }
                     }
                     OutlinedTextField(
                         value = playlistName,
@@ -296,11 +319,13 @@ fun MinePlaylistsSection(
             },
             confirmButton = {
                 TextButton(
-                    enabled = playlistName.isNotBlank() && creatableProviders.size == 1,
+                    enabled = playlistName.isNotBlank() && selectedCreateProvider != null,
                     onClick = {
-                        controller.createPlaylist(creatableProviders.first().providerId, playlistName)
-                        playlistName = ""
-                        showCreateDialog = false
+                        selectedCreateProvider?.let { provider ->
+                            controller.createPlaylist(provider.providerId, playlistName)
+                            playlistName = ""
+                            showCreateDialog = false
+                        }
                     },
                 ) { Text("创建") }
             },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -11,15 +11,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -36,6 +43,7 @@ fun MineHomeSection(
     val refreshMineContent = {
         when (controller.mineSection) {
             MineSection.Playlists -> controller.refreshMinePlaylistContent()
+            MineSection.Songs,
             MineSection.Artists,
             MineSection.Albums -> controller.refreshMineContent()
             MineSection.LocalMusic -> if (hasAudioPermission) controller.refreshLocalMusic() else Unit
@@ -57,9 +65,13 @@ fun MineHomeSection(
                 .fillMaxWidth(),
         ) {
             when (controller.mineSection) {
-                MineSection.Playlists -> MinePlaylistsSection(
+            MineSection.Playlists -> MinePlaylistsSection(
                     controller = controller,
                     showFilter = !isWideLayout,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                MineSection.Songs -> MineSongSections(
+                    controller = controller,
                     modifier = Modifier.fillMaxSize(),
                 )
                 MineSection.Artists -> MineMediaItemsSection(
@@ -100,6 +112,11 @@ fun MineSectionChips(
             label = "歌单",
         )
         CompactFilterChip(
+            selected = controller.mineSection == MineSection.Songs,
+            onClick = { controller.onMineSectionChange(MineSection.Songs) },
+            label = "歌曲",
+        )
+        CompactFilterChip(
             selected = controller.mineSection == MineSection.Artists,
             onClick = { controller.onMineSectionChange(MineSection.Artists) },
             label = "歌手",
@@ -125,7 +142,55 @@ fun MineSectionChips(
                     LocalMusicViewModeTabs(controller)
                 }
                 MineSection.Artists,
-                MineSection.Albums -> Unit
+                MineSection.Albums,
+                MineSection.Songs -> Unit
+            }
+        }
+    }
+}
+
+@Composable
+fun MineSongSections(controller: FuoPlayerController, modifier: Modifier) {
+    val sections = controller.mineSections.filter { it.feature.contentType == ProviderContentType.Songs }
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (sections.isEmpty()) {
+            item { EmptyProviderContentHint("歌曲") }
+        } else {
+            sections.forEach { section ->
+                item(key = "header:${section.feature.id}") { ProviderFeatureHeader(feature = section.feature) }
+                when {
+                    section.isLoginRequired -> item(key = "locked:${section.feature.id}") {
+                        ProviderLockedSummary(listOf(section.feature)) { controller.openSettings(it.providerId) }
+                    }
+                    section.errorMessage != null -> item(key = "error:${section.feature.id}") {
+                        ProviderContentMessage(section.errorMessage)
+                    }
+                    else -> items(section.tracks, key = { "${section.feature.id}:${it.id}" }) { track ->
+                        TrackRow(
+                            track = track,
+                            downloadState = controller.downloadStates[track.id],
+                            onClick = { controller.playLocalTrack(track, section.tracks) },
+                            onAddToUpNext = { controller.addToUpNext(track) },
+                            onDownload = { controller.download(track) },
+                            onDeleteDownload = { controller.deleteDownload(track) },
+                            onOpenArtist = { controller.openTrackArtist(track) },
+                            onOpenAlbum = { controller.openTrackAlbum(track) },
+                            onOpenDetail = trackDetailAction(controller, track),
+                            onAddToProviderPlaylist = addToProviderPlaylistAction(controller, track),
+                            onSetDisliked = when (section.feature.id) {
+                                "qqmusic_disliked_songs" -> { { controller.setSongDisliked(track, false) } }
+                                else -> controller.canSetSongDisliked(track, true).takeIf { it }?.let {
+                                    { controller.setSongDisliked(track, true) }
+                                }
+                            },
+                            dislikedActionLabel = if (section.feature.id == "qqmusic_disliked_songs") "取消不喜欢" else "不喜欢",
+                        )
+                        HorizontalDivider()
+                    }
+                }
             }
         }
     }
@@ -159,6 +224,9 @@ fun MinePlaylistsSection(
     showFilter: Boolean,
     modifier: Modifier,
 ) {
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var playlistName by remember { mutableStateOf("") }
+    val creatableProviders = controller.creatablePlaylistProviders()
     val userSections = controller.minePlaylistSections
     val favoriteSections = controller.mineFavoritePlaylistSections
     val sections = when (controller.playlistFilter) {
@@ -176,6 +244,11 @@ fun MinePlaylistsSection(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        if (creatableProviders.isNotEmpty()) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = { showCreateDialog = true }) { Text("新建歌单") }
+            }
+        }
         if (showFilter) {
             PlaylistFilterChips(controller)
         }
@@ -203,6 +276,36 @@ fun MinePlaylistsSection(
                 }
             }
         }
+    }
+    if (showCreateDialog) {
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("新建歌单") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (creatableProviders.size == 1) {
+                        Text("将在 ${creatableProviders.first().providerName} 创建")
+                    }
+                    OutlinedTextField(
+                        value = playlistName,
+                        onValueChange = { playlistName = it },
+                        label = { Text("歌单名称") },
+                        singleLine = true,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = playlistName.isNotBlank() && creatableProviders.size == 1,
+                    onClick = {
+                        controller.createPlaylist(creatableProviders.first().providerId, playlistName)
+                        playlistName = ""
+                        showCreateDialog = false
+                    },
+                ) { Text("创建") }
+            },
+            dismissButton = { TextButton(onClick = { showCreateDialog = false }) { Text("取消") } },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -381,6 +381,10 @@ fun NowPlayingTrackAction(controller: FuoPlayerController, track: MusicTrack) {
         },
         onAddToProviderPlaylist = addToProviderPlaylistAction(controller, track),
         onRemoveFromProviderPlaylist = removeFromSelectedPlaylistAction(controller, track),
+        onSetDisliked = controller.canSetSongDisliked(track, true).takeIf { it }?.let {
+            { controller.setSongDisliked(track, true) }
+        },
+        dislikedActionLabel = "不喜欢",
         onShare = sharePayload?.let { payload -> { onShare(payload) } },
         roundButton = true,
     )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -502,6 +504,7 @@ fun ProviderVideoScreen(controller: FuoPlayerController, video: ProviderVideo?) 
 fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPlaylist?) {
     val displayPlaylist = controller.selectedPlaylist ?: playlist ?: return
     val sharePayload = displayPlaylist.toSharePayload()
+    var showDeleteDialog by remember(displayPlaylist.id) { mutableStateOf(false) }
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -518,6 +521,11 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
                     }
                 },
                 actions = {
+                    if (controller.canDeleteSelectedPlaylist()) {
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(Icons.Filled.Delete, contentDescription = "删除歌单")
+                        }
+                    }
                     val onShare = LocalShareHandler.current
                     IconButton(
                         onClick = { if (sharePayload != null) onShare(sharePayload) },
@@ -686,6 +694,20 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
                 }
             }
         }
+    }
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("删除歌单？") },
+            text = { Text("将删除《${displayPlaylist.title}》，此操作无法撤销。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteDialog = false
+                    controller.deleteSelectedPlaylist()
+                }) { Text("删除") }
+            },
+            dismissButton = { TextButton(onClick = { showDeleteDialog = false }) { Text("取消") } },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
@@ -52,6 +52,10 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeature?) {
     feature ?: return
+    val content = controller.selectedFeatureContent
+    val contentCount = content?.let {
+        maxOf(it.tracks.size, it.playlists.size, it.mediaItems.size, it.videos.size)
+    } ?: controller.selectedFeatureTracks.size
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -102,7 +106,7 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = listOf(feature.providerName, "${controller.selectedFeatureTracks.size} 首")
+                        text = listOf(feature.providerName, "${contentCount} 项")
                             .joinToString(" · "),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -129,8 +133,9 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
-                    SelectedFeatureTrackList(
+                    SelectedFeatureContent(
                         controller = controller,
+                        content = content,
                         modifier = Modifier
                             .weight(1f)
                             .fillMaxWidth(),
@@ -154,7 +159,7 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
             ) {
                 Text(
                     modifier = Modifier.weight(1f),
-                    text = listOf(feature.providerName, "${controller.selectedFeatureTracks.size} 首")
+                    text = listOf(feature.providerName, "${contentCount} 项")
                         .joinToString(" · "),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -176,51 +181,55 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            LazyColumn(
+            SelectedFeatureContent(
+                controller = controller,
+                content = content,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
-            ) {
-                if (controller.selectedFeatureTracks.isEmpty() && !controller.isLoading && controller.selectedFeatureError == null) {
-                    item {
-                        ProviderContentMessage("暂无歌曲")
-                    }
-                } else {
-                    itemsIndexed(controller.selectedFeatureTracks, key = { _, item -> item.id }) { index, track ->
-                        LaunchedEffect(index, controller.selectedFeatureTracks.size) {
-                            controller.prefetchSelectedFeatureIfNeeded(index)
-                        }
-                        TrackRow(
-                            track = track,
-                            downloadState = controller.downloadStates[track.id],
-                            onClick = { controller.playFromSelectedFeature(index) },
-                            onAddToUpNext = { controller.addToUpNext(track) },
-                            onDownload = { controller.download(track) },
-                            onDeleteDownload = { controller.deleteDownload(track) },
-                            onOpenArtist = { controller.openTrackArtist(track) },
-                            onOpenAlbum = { controller.openTrackAlbum(track) },
-                            onOpenDetail = trackDetailAction(controller, track),
-                            onAddToProviderPlaylist = addToProviderPlaylistAction(controller, track),
-                        )
-                        HorizontalDivider()
-                    }
-                }
-            }
+            )
         }
     }
 }
 
 @Composable
-fun SelectedFeatureTrackList(controller: FuoPlayerController, modifier: Modifier) {
-    TrackCollectionList(
-        controller = controller,
-        tracks = controller.selectedFeatureTracks,
-        emptyMessage = "暂无歌曲",
-        showEmpty = !controller.isLoading && controller.selectedFeatureError == null,
-        modifier = modifier,
-        onClick = controller::playFromSelectedFeature,
-        onItemVisible = controller::prefetchSelectedFeatureIfNeeded,
-    )
+fun SelectedFeatureContent(
+    controller: FuoPlayerController,
+    content: ProviderContentSection?,
+    modifier: Modifier,
+) {
+    when {
+        content?.playlists?.isNotEmpty() == true -> LazyColumn(modifier = modifier) {
+            item {
+                ProviderPlaylistGrid(
+                    playlists = content.playlists,
+                    onClick = { controller.openPlaylist(it, content.feature.category) },
+                )
+            }
+        }
+        content?.mediaItems?.isNotEmpty() == true -> LazyColumn(modifier = modifier) {
+            item {
+                ProviderMediaItemGrid(
+                    items = content.mediaItems,
+                    onClick = controller::openMediaItem,
+                )
+            }
+        }
+        content?.videos?.isNotEmpty() == true -> LazyColumn(modifier = modifier) {
+            item {
+                ProviderVideoList(videos = content.videos, onClick = controller::openVideo)
+            }
+        }
+        else -> TrackCollectionList(
+            controller = controller,
+            tracks = controller.selectedFeatureTracks,
+            emptyMessage = "暂无内容",
+            showEmpty = !controller.isLoading && controller.selectedFeatureError == null,
+            modifier = modifier,
+            onClick = controller::playFromSelectedFeature,
+            onItemVisible = controller::prefetchSelectedFeatureIfNeeded,
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -140,6 +140,22 @@ fun ProviderContentHomeSection(
                                     )
                                 }
                             }
+                            contentSection.mediaItems.isNotEmpty() -> {
+                                item(key = "media-items:${contentSection.feature.id}") {
+                                    ProviderMediaItemGrid(
+                                        items = contentSection.mediaItems,
+                                        onClick = controller::openMediaItem,
+                                    )
+                                }
+                            }
+                            contentSection.videos.isNotEmpty() -> {
+                                item(key = "videos:${contentSection.feature.id}") {
+                                    ProviderVideoList(
+                                        videos = contentSection.videos,
+                                        onClick = controller::openVideo,
+                                    )
+                                }
+                            }
                             else -> item(key = "empty:${contentSection.feature.id}") {
                                 ProviderContentMessage("暂无内容")
                             }
@@ -154,6 +170,39 @@ fun ProviderContentHomeSection(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun ProviderVideoList(videos: List<ProviderVideo>, onClick: (ProviderVideo) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        videos.forEach { video ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onClick(video) }
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                PlatformCoverArt(
+                    title = video.title,
+                    imageUrl = video.coverUrl,
+                    modifier = Modifier.size(48.dp),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(video.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text(
+                        video.artists.ifBlank { video.providerName },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Icon(Icons.Filled.PlayArrow, contentDescription = "播放视频")
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -70,12 +70,35 @@ fun ProviderContentHomeSection(
                     item {
                         EmptyProviderContentHint(title)
                     }
+                } else if (section == HomeSection.Music) {
+                    if (visibleSections.isNotEmpty()) {
+                        item(key = "header:explore") {
+                            ProviderFeatureHeader(
+                                feature = visibleSections.first().feature,
+                                title = "探索",
+                                providerLabel = visibleSections
+                                    .map { it.feature.providerName }
+                                    .distinct()
+                                    .joinToString(" / "),
+                            )
+                        }
+                        item(key = "explore-grid") {
+                            ProviderFeatureCoverGrid(
+                                features = visibleSections.map { it.feature },
+                                onClick = controller::openFeature,
+                            )
+                        }
+                    }
                 } else {
                     val forYouSections = visibleSections.filter {
-                        it.feature.isDailySongs() || it.feature.isPrivateFm()
+                        it.feature.isDailySongs() ||
+                            it.feature.isPrivateFm() ||
+                            it.feature.isBilibiliRecommendedVideos()
                     }
                     val otherSections = visibleSections.filterNot {
-                        it.feature.isDailySongs() || it.feature.isPrivateFm()
+                        it.feature.isDailySongs() ||
+                            it.feature.isPrivateFm() ||
+                            it.feature.isBilibiliRecommendedVideos()
                     }
                     if (forYouSections.isNotEmpty()) {
                         item(key = "header:for-you") {
@@ -245,6 +268,14 @@ fun ForYouRecommendGrid(
                                 modifier = Modifier.weight(1f),
                             )
                         }
+                        section.feature.isBilibiliRecommendedVideos() -> {
+                            RecommendationEntryButton(
+                                feature = section.feature,
+                                enabled = enabled,
+                                onClick = { onFeatureClick(section.feature) },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
                     }
                 }
                 repeat(columns - row.size) {
@@ -398,6 +429,29 @@ fun DailyRecommendationButton(
             text = "Daily",
             style = MaterialTheme.typography.displaySmall,
             fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+fun RecommendationEntryButton(
+    feature: ProviderFeature,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    RecommendationButton(
+        modifier = modifier
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
+        title = feature.title.ifBlank { "推荐视频" },
+        providerName = feature.providerName,
+    ) {
+        Icon(
+            Icons.Filled.PlayArrow,
+            contentDescription = "打开${feature.providerName}${feature.title}",
+            modifier = Modifier.size(if (isWideLayout) 28.dp else 32.dp),
         )
     }
 }
@@ -713,6 +767,10 @@ fun ProviderFeature.isPrivateFm(): Boolean {
 
 fun ProviderFeature.isDailySongs(): Boolean {
     return id.endsWith("_daily_songs")
+}
+
+fun ProviderFeature.isBilibiliRecommendedVideos(): Boolean {
+    return providerId == "bilibili" && id == "bilibili_recommended_videos"
 }
 
 fun ProviderFeature.toDisplayTrack(): MusicTrack {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
@@ -52,6 +52,8 @@ fun TrackRow(
     onEditLocalMetadata: (() -> Unit)? = null,
     onAddToProviderPlaylist: (() -> Unit)? = null,
     onRemoveFromProviderPlaylist: (() -> Unit)? = null,
+    onSetDisliked: (() -> Unit)? = null,
+    dislikedActionLabel: String = "不喜欢",
 ) {
     val onShare = LocalShareHandler.current
     val sharePayload = track.toSharePayload()
@@ -98,6 +100,8 @@ fun TrackRow(
             onEditLocalMetadata = onEditLocalMetadata,
             onAddToProviderPlaylist = onAddToProviderPlaylist,
             onRemoveFromProviderPlaylist = onRemoveFromProviderPlaylist,
+            onSetDisliked = onSetDisliked,
+            dislikedActionLabel = dislikedActionLabel,
             onShare = sharePayload?.let { payload -> { onShare(payload) } },
         )
     }
@@ -130,6 +134,8 @@ fun TrackAction(
     onEditLocalMetadata: (() -> Unit)?,
     onAddToProviderPlaylist: (() -> Unit)?,
     onRemoveFromProviderPlaylist: (() -> Unit)?,
+    onSetDisliked: (() -> Unit)?,
+    dislikedActionLabel: String,
     onShare: (() -> Unit)?,
     roundButton: Boolean = false,
 ) {
@@ -228,6 +234,16 @@ fun TrackAction(
                     onClick = {
                         expanded = false
                         onRemoveFromProviderPlaylist()
+                    },
+                )
+            }
+            if (onSetDisliked != null) {
+                DropdownMenuItem(
+                    text = { Text(dislikedActionLabel) },
+                    leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+                    onClick = {
+                        expanded = false
+                        onSetDisliked()
                     },
                 )
             }

--- a/shared/src/commonMain/python/fuo_mobile/bridge.py
+++ b/shared/src/commonMain/python/fuo_mobile/bridge.py
@@ -277,6 +277,14 @@ FEATURE_DEFS = {
             "action": "current_user_fav_create_songs_rd",
         },
         {
+            "id": "netease_cloud_songs",
+            "title": "云盘歌曲",
+            "category": "Mine",
+            "content_type": "Songs",
+            "requires_login": True,
+            "action": "current_user_cloud_songs",
+        },
+        {
             "id": "netease_favorite_playlists",
             "title": "收藏歌单",
             "category": "MineFavoritePlaylists",
@@ -351,6 +359,14 @@ FEATURE_DEFS = {
             "action": "current_user_fav_create_songs_rd",
         },
         {
+            "id": "qqmusic_disliked_songs",
+            "title": "不喜欢的歌曲",
+            "category": "Mine",
+            "content_type": "Songs",
+            "requires_login": True,
+            "action": "current_user_dislike_create_songs_rd",
+        },
+        {
             "id": "qqmusic_favorite_playlists",
             "title": "收藏歌单",
             "category": "MineFavoritePlaylists",
@@ -376,6 +392,30 @@ FEATURE_DEFS = {
         },
     ],
     "bilibili": [
+        {
+            "id": "bilibili_popular_videos",
+            "title": "热门视频",
+            "category": "Music",
+            "content_type": "Songs",
+            "requires_login": False,
+            "action": "most_popular_videos",
+        },
+        {
+            "id": "bilibili_weekly_video_playlists",
+            "title": "每周必看",
+            "category": "Music",
+            "content_type": "Playlists",
+            "requires_login": False,
+            "action": "weekly_video_playlists",
+        },
+        {
+            "id": "bilibili_recommended_videos",
+            "title": "推荐视频",
+            "category": "Recommend",
+            "content_type": "Videos",
+            "requires_login": True,
+            "action": "rec_a_collection_of_videos",
+        },
         {
             "id": "bilibili_user_playlists",
             "title": "我的歌单",
@@ -515,6 +555,7 @@ class FuoMobileBridge:
         self._playlists: Dict[str, Any] = {}
         self._media_items: Dict[str, Any] = {}
         self._videos: Dict[str, Any] = {}
+        self._dynamic_features: Dict[str, Dict[str, Any]] = {}
         self._saved_login_provider_ids = set()
         self._authenticated_provider_ids = set()
         self._restore_saved_logins()
@@ -535,11 +576,32 @@ class FuoMobileBridge:
 
     def features(self) -> str:
         features = []
+        self._dynamic_features = {}
         for provider_id in self.provider_registry.provider_ids:
             provider = self._raw_provider(provider_id)
             for feature in FEATURE_DEFS.get(provider_id, []):
                 if hasattr(provider, feature["action"]):
                     features.append(feature_to_dict(feature, provider))
+            if hasattr(provider, "rec_list_collections"):
+                try:
+                    for index, collection in enumerate(provider.rec_list_collections() or []):
+                        content_type = collection_content_type(getattr(collection, "type_", None))
+                        if content_type is None:
+                            continue
+                        feature = {
+                            "id": f"{provider_id}_collection_{index}",
+                            "provider_id": provider_id,
+                            "title": getattr(collection, "name", "推荐"),
+                            "category": "Recommend",
+                            "content_type": content_type,
+                            "requires_login": False,
+                            "action": "cached_collection",
+                            "collection": collection,
+                        }
+                        self._dynamic_features[feature["id"]] = feature
+                        features.append(feature_to_dict(feature, provider))
+                except Exception as exc:  # pylint: disable=broad-except
+                    bridge_log(f"load recommendation collections failed provider_id={provider_id}: {exc}")
         return json.dumps({"features": features}, ensure_ascii=False)
 
     def search(self, keyword: str, provider_id: str = "") -> str:
@@ -805,6 +867,7 @@ class FuoMobileBridge:
                     "tracks": [],
                     "playlists": [],
                     "media_items": [],
+                    "videos": [],
                     "is_login_required": True,
                     "error_message": "",
                     "next_offset": 0,
@@ -813,7 +876,7 @@ class FuoMobileBridge:
                 ensure_ascii=False,
             )
         try:
-            tracks, playlists, media_items, title, page = self._load_feature_content(provider, feature, offset, limit)
+            tracks, playlists, media_items, videos, title, page = self._load_feature_content(provider, feature, offset, limit)
             if title:
                 feature_payload["title"] = title
             payload = {
@@ -821,6 +884,7 @@ class FuoMobileBridge:
                 "tracks": tracks,
                 "playlists": playlists,
                 "media_items": media_items,
+                "videos": videos,
                 "is_login_required": False,
                 "error_message": "",
                 "next_offset": page["next_offset"],
@@ -832,6 +896,7 @@ class FuoMobileBridge:
                 "tracks": [],
                 "playlists": [],
                 "media_items": [],
+                "videos": [],
                 "is_login_required": False,
                 "error_message": str(exc) or exc.__class__.__name__,
                 "next_offset": offset,
@@ -914,6 +979,44 @@ class FuoMobileBridge:
         title = display(song, "title")
         message = f"已从歌单移除：{title}" if ok else f"移除失败：{title}"
         return json.dumps(mutation_result(ok, message), ensure_ascii=False)
+
+    def playlist_create(self, provider_id: str, name: str) -> str:
+        provider = self._get_provider(provider_id)
+        self._require_logged_in(provider)
+        create = getattr(provider, "playlist_create_by_name", None)
+        if create is None:
+            return json.dumps(mutation_result(False, "当前音源不支持新建歌单"), ensure_ascii=False)
+        title = (name or "").strip()
+        if not title:
+            return json.dumps(mutation_result(False, "歌单名称不能为空"), ensure_ascii=False)
+        playlist = create(title)
+        if playlist is None:
+            return json.dumps(mutation_result(False, "新建歌单失败"), ensure_ascii=False)
+        return json.dumps({"result": mutation_result(True, f"已新建：{title}"), "playlist": self._remember_playlist(playlist)}, ensure_ascii=False)
+
+    def playlist_delete(self, playlist_id: str) -> str:
+        playlist = self._playlist_from_id(playlist_id)
+        provider = self._get_provider(getattr(playlist, "source", ""))
+        self._require_logged_in(provider)
+        delete = getattr(provider, "playlist_delete", None)
+        if delete is None:
+            return json.dumps(mutation_result(False, "当前音源不支持删除歌单"), ensure_ascii=False)
+        ok = bool(delete(getattr(playlist, "identifier", "")))
+        if ok:
+            self._playlists.pop(playlist_id, None)
+        return json.dumps(mutation_result(ok, f"已删除：{display(playlist, 'name')}" if ok else "删除歌单失败"), ensure_ascii=False)
+
+    def dislike_song(self, track_id: str, disliked: bool) -> str:
+        song = self._song_for_operation(track_id)
+        provider = self._get_provider(getattr(song, "source", ""))
+        self._require_logged_in(provider)
+        action_name = "current_user_dislike_add_song" if disliked else "current_user_dislike_remove_song"
+        action = getattr(provider, action_name, None)
+        if action is None:
+            return json.dumps(mutation_result(False, "当前音源不支持不喜欢操作"), ensure_ascii=False)
+        ok = bool(action(song))
+        label = "已设为不喜欢" if disliked else "已取消不喜欢"
+        return json.dumps(mutation_result(ok, label if ok else "操作失败"), ensure_ascii=False)
 
     def resource_state(self, resource_type: str, resource_id: str) -> str:
         provider_id = resource_id.split(":", 2)[1] if ":" in resource_id else ""
@@ -1072,6 +1175,9 @@ class FuoMobileBridge:
         }
 
     def _feature_by_id(self, feature_id: str) -> Dict[str, Any]:
+        dynamic = getattr(self, "_dynamic_features", {}).get(feature_id)
+        if dynamic is not None:
+            return dynamic
         for provider_id, features in FEATURE_DEFS.items():
             for feature in features:
                 if feature["id"] == feature_id:
@@ -1082,10 +1188,10 @@ class FuoMobileBridge:
         action = feature["action"]
         if action == "rec_list_daily_songs":
             page = read_model_page(provider.rec_list_daily_songs(), offset=offset, limit=limit)
-            return [self._remember_song(song) for song in page["items"]], [], [], "", page
+            return [self._remember_song(song) for song in page["items"]], [], [], [], "", page
         if action == "rec_list_daily_playlists":
             page = read_model_page(provider.rec_list_daily_playlists(), offset=offset, limit=limit)
-            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], [], "", page
         if action == "current_user_list_radio_songs":
             songs = provider.current_user_list_radio_songs(max(1, min(int_limit(limit), 60)))
             page = {
@@ -1093,29 +1199,56 @@ class FuoMobileBridge:
                 "next_offset": offset + len(songs),
                 "has_more": bool(songs),
             }
-            return [self._remember_song(song) for song in songs], [], [], "", page
+            return [self._remember_song(song) for song in songs], [], [], [], "", page
         if action == "toplist_list":
             page = read_model_page(provider.toplist_list(), offset=offset, limit=limit)
-            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], [], "", page
         if action == "rec_a_collection_of_songs":
             collection = provider.rec_a_collection_of_songs()
             page = read_model_page(getattr(collection, "models", []) or [], offset=offset, limit=limit)
-            return [self._remember_song(song) for song in page["items"]], [], [], getattr(collection, "name", ""), page
+            return [self._remember_song(song) for song in page["items"]], [], [], [], getattr(collection, "name", ""), page
+        if action == "rec_a_collection_of_videos":
+            collection = provider.rec_a_collection_of_videos()
+            page = read_model_page(getattr(collection, "models", []) or [], offset=offset, limit=limit)
+            return [], [], [], [self._remember_video(video) for video in page["items"]], getattr(collection, "name", ""), page
+        if action == "cached_collection":
+            page = read_model_page(getattr(feature["collection"], "models", []) or [], offset=offset, limit=limit)
+            content_type = feature["content_type"]
+            if content_type == "Songs":
+                return [self._remember_song(item) for item in page["items"]], [], [], [], "", page
+            if content_type == "Playlists":
+                return [], [self._remember_playlist(item) for item in page["items"]], [], [], "", page
+            if content_type == "Videos":
+                return [], [], [], [self._remember_video(item) for item in page["items"]], "", page
+            item_type = "artist" if content_type == "Artists" else "album"
+            return [], [], [self._remember_media_item(item, item_type) for item in page["items"]], [], "", page
+        if action == "most_popular_videos":
+            page = read_model_page(provider.most_popular_videos(), offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], [], "", page
+        if action == "weekly_video_playlists":
+            page = read_model_page(provider.weekly_video_playlists(), offset=offset, limit=limit)
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], [], "", page
         if action == "current_user_fav_create_songs_rd":
             page = read_model_page(provider.current_user_fav_create_songs_rd(), offset=offset, limit=limit)
-            return [self._remember_song(song) for song in page["items"]], [], [], "", page
+            return [self._remember_song(song) for song in page["items"]], [], [], [], "", page
+        if action == "current_user_cloud_songs":
+            page = read_model_page(provider.current_user_cloud_songs(), offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], [], "", page
+        if action == "current_user_dislike_create_songs_rd":
+            page = read_model_page(provider.current_user_dislike_create_songs_rd(), offset=offset, limit=limit)
+            return [self._remember_song(song) for song in page["items"]], [], [], [], "", page
         if action == "current_user_fav_create_playlists_rd":
             page = read_model_page(provider.current_user_fav_create_playlists_rd(), offset=offset, limit=limit)
-            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], [], "", page
         if action == "current_user_list_playlists":
             page = read_model_page(provider.current_user_list_playlists(), offset=offset, limit=limit)
-            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], "", page
+            return [], [self._remember_playlist(playlist) for playlist in page["items"]], [], [], "", page
         if action == "current_user_fav_create_artists_rd":
             page = read_model_page(provider.current_user_fav_create_artists_rd(), offset=offset, limit=limit)
-            return [], [], [self._remember_media_item(artist, "artist") for artist in page["items"]], "", page
+            return [], [], [self._remember_media_item(artist, "artist") for artist in page["items"]], [], "", page
         if action == "current_user_fav_create_albums_rd":
             page = read_model_page(provider.current_user_fav_create_albums_rd(), offset=offset, limit=limit)
-            return [], [], [self._remember_media_item(album, "album") for album in page["items"]], "", page
+            return [], [], [self._remember_media_item(album, "album") for album in page["items"]], [], "", page
         raise RuntimeError(f"unsupported feature action: {action}")
 
     def _playlist_from_id(self, playlist_id: str):
@@ -1780,6 +1913,11 @@ def provider_capabilities(provider) -> Dict[str, Any]:
         "can_remove_song_from_playlist": (
             hasattr(provider, "playlist_remove_song") and provider_id != "ytmusic"
         ),
+        "can_create_playlist": hasattr(provider, "playlist_create_by_name"),
+        "can_delete_playlist": hasattr(provider, "playlist_delete"),
+        "can_list_disliked_songs": hasattr(provider, "current_user_dislike_create_songs_rd"),
+        "can_add_disliked_song": hasattr(provider, "current_user_dislike_add_song"),
+        "can_remove_disliked_song": hasattr(provider, "current_user_dislike_remove_song"),
         "can_favorite_playlist": False,
         "can_unfavorite_playlist": False,
         "can_favorite_artist": False,
@@ -1799,6 +1937,17 @@ def feature_to_dict(feature: Dict[str, Any], provider) -> Dict[str, Any]:
         "content_type": feature["content_type"],
         "requires_login": bool(feature.get("requires_login")),
     }
+
+
+def collection_content_type(type_) -> Optional[str]:
+    name = getattr(type_, "name", "")
+    return {
+        "only_songs": "Songs",
+        "only_playlists": "Playlists",
+        "only_artists": "Artists",
+        "only_albums": "Albums",
+        "only_videos": "Videos",
+    }.get(name)
 
 
 def mutation_result(success: bool, message: str) -> Dict[str, Any]:

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -2527,6 +2527,104 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun dislikingCurrentTrackKeepsNextTrackAsQueueCurrent() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+            providerTrack("provider:3", "Third"),
+            providerTrack("provider:4", "Fourth"),
+        )
+        val engine = FakePlaybackEngine()
+        val provider = FakeProviderRepository(
+            tracks = tracks,
+            capabilities = listOf(
+                ProviderCapabilities(
+                    providerId = "netease",
+                    providerName = "网易云音乐",
+                    canAddDislikedSong = true,
+                ),
+            ),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.next()
+            advanceUntilIdle()
+
+            controller.setSongDisliked(tracks[1], disliked = true)
+            advanceUntilIdle()
+
+            assertEquals("provider:3", engine.lastTrack?.id)
+            assertEquals("provider:3", controller.playbackState.currentTrack?.id)
+            assertEquals(listOf("provider:3", "provider:4"), controller.playbackState.queue.map { it.id })
+
+            controller.next()
+            advanceUntilIdle()
+
+            assertEquals("provider:4", engine.lastTrack?.id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun dislikingEarlierTrackKeepsCurrentTrackAtItsQueuePosition() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+            providerTrack("provider:3", "Third"),
+            providerTrack("provider:4", "Fourth"),
+        )
+        val engine = FakePlaybackEngine()
+        val provider = FakeProviderRepository(
+            tracks = tracks,
+            capabilities = listOf(
+                ProviderCapabilities(
+                    providerId = "netease",
+                    providerName = "网易云音乐",
+                    canAddDislikedSong = true,
+                ),
+            ),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.next()
+            controller.next()
+            advanceUntilIdle()
+
+            controller.setSongDisliked(tracks.first(), disliked = true)
+            advanceUntilIdle()
+
+            assertEquals("provider:3", engine.lastTrack?.id)
+            assertEquals("provider:3", controller.playbackState.currentTrack?.id)
+            assertEquals(listOf("provider:3", "provider:4"), controller.playbackState.queue.map { it.id })
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun upNextQueuePlaysBeforeMainQueueAndThenReturns() = runTest {
         val tracks = listOf(
             providerTrack("provider:1", "First"),
@@ -3067,6 +3165,11 @@ class FuoPlayerControllerTest {
             lastRemovedFromPlaylist = playlist to track
             return ProviderMutationResult(true, "已从歌单移除：${track.title}")
         }
+
+        override suspend fun setSongDisliked(
+            track: MusicTrack,
+            disliked: Boolean,
+        ): ProviderMutationResult = ProviderMutationResult(true, "操作成功")
 
         override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> {
             loadedMediaItemIds += item.id

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -251,6 +251,83 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun exploreEntriesLoadVideoAndPlaylistContentOnlyAfterOpeningSecondaryPage() = runTest {
+        val popularVideos = ProviderFeature(
+            id = "bilibili_recommended_videos",
+            providerId = "bilibili",
+            providerName = "哔哩哔哩",
+            title = "推荐视频",
+            category = ProviderFeatureCategory.Recommend,
+            contentType = ProviderContentType.Videos,
+            requiresLogin = false,
+        )
+        val weeklyVideos = ProviderFeature(
+            id = "bilibili_weekly_video_playlists",
+            providerId = "bilibili",
+            providerName = "哔哩哔哩",
+            title = "每周必看",
+            category = ProviderFeatureCategory.Music,
+            contentType = ProviderContentType.Playlists,
+            requiresLogin = false,
+        )
+        val video = ProviderVideo(
+            id = "video:bilibili:BV1",
+            title = "推荐视频",
+            providerId = "bilibili",
+            providerName = "哔哩哔哩",
+        )
+        val playlist = ProviderPlaylist(
+            id = "playlist:bilibili:weekly_1",
+            title = "每周必看",
+            providerId = "bilibili",
+            providerName = "哔哩哔哩",
+        )
+        val provider = FakeProviderRepository(
+            tracks = emptyList(),
+            features = listOf(popularVideos, weeklyVideos),
+            featureSections = mapOf(
+                popularVideos.id to ProviderContentSection(popularVideos, videos = listOf(video)),
+                weeklyVideos.id to ProviderContentSection(weeklyVideos, playlists = listOf(playlist)),
+            ),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.refreshHomeContent(HomeSection.Recommend)
+            advanceUntilIdle()
+
+            assertEquals(listOf(popularVideos.id), controller.recommendSections.map { it.feature.id })
+            assertEquals(emptyList(), provider.loadedFeatureIds)
+
+            controller.refreshHomeContent(HomeSection.Music)
+            advanceUntilIdle()
+
+            assertEquals(listOf(weeklyVideos.id), controller.musicSections.map { it.feature.id })
+            assertEquals(emptyList(), provider.loadedFeatureIds)
+
+            controller.openFeature(popularVideos)
+            advanceUntilIdle()
+
+            assertEquals(listOf(video), controller.selectedFeatureContent?.videos)
+
+            controller.openFeature(weeklyVideos)
+            advanceUntilIdle()
+
+            assertEquals(listOf(playlist), controller.selectedFeatureContent?.playlists)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun smartReplacementPayloadUpdatesCurrentPlaybackTrack() = runTest {
         val origin = providerTrack("provider:1", "First")
         val provider = FakeProviderRepository(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1658,10 +1658,13 @@ class FuoPlayerControllerTest {
             advanceUntilIdle()
 
             assertEquals(
-                listOf(favoriteArtistsFeature.id),
+                listOf(favoriteArtistsFeature.id, favoriteSongsFeature.id),
                 provider.loadedFeatureIds,
             )
-            assertEquals(favoriteArtists, controller.mineSections[0].mediaItems)
+            assertEquals(
+                favoriteArtists,
+                controller.mineSections.first { it.feature.id == favoriteArtistsFeature.id }.mediaItems,
+            )
         } finally {
             controllerScope.cancel()
         }
@@ -3004,17 +3007,20 @@ class FuoPlayerControllerTest {
             val tracks = section.tracks.drop(offset).take(limit)
             val playlists = section.playlists.drop(offset).take(limit)
             val mediaItems = section.mediaItems.drop(offset).take(limit)
+            val videos = section.videos.drop(offset).take(limit)
             val sourceSize = when (feature.contentType) {
                 ProviderContentType.Songs -> section.tracks.size
                 ProviderContentType.Playlists -> section.playlists.size
                 ProviderContentType.Artists,
                 ProviderContentType.Albums -> section.mediaItems.size
+                ProviderContentType.Videos -> section.videos.size
             }
-            val nextOffset = offset + maxOf(tracks.size, playlists.size, mediaItems.size)
+            val nextOffset = offset + maxOf(tracks.size, playlists.size, mediaItems.size, videos.size)
             return section.copy(
                 tracks = tracks,
                 playlists = playlists,
                 mediaItems = mediaItems,
+                videos = videos,
                 nextOffset = nextOffset,
                 hasMore = nextOffset < sourceSize,
             )


### PR DESCRIPTION
## Summary
- 为 Android 桥接补齐歌单创建、删除与歌曲“不喜欢”操作，并同步解析新增的 provider 能力与视频内容字段
- 在共享层扩展 `ProviderCapabilities`、`ProviderContentSection` 与仓库接口，支持歌单创建/删除、歌曲不喜欢与视频内容
- 更新“我的”与内容页 UI，新增“歌曲”分区、歌单创建/删除入口，以及视频列表展示
- 扩充 Python 桥接特性定义与单测，覆盖云盘歌曲、不喜欢歌曲和视频相关能力

## Testing
- 新增/更新 Python 桥接单元测试，覆盖歌单创建、删除、不喜欢操作与特性注册
- 未运行完整 Gradle 或 Android 集成测试（未请求）