### PR TITLE
[feat] enhance player spectrum visuals

### DIFF
--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -4,6 +4,9 @@ name: iOS Debug App
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -54,6 +54,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 false,
             ),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
+            showPlaybackSpectrum = preferences.getBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, true),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -89,6 +90,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 )
                 .putBoolean(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, settings.smartReplacementUseReplacementLyrics)
                 .putString(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
+                .putBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, settings.showPlaybackSpectrum)
                 .putString(KEY_THEME_MODE, settings.themeMode.name)
                 .putString(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)
                 .apply()
@@ -225,6 +227,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA = "smart_replacement_use_replacement_metadata"
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
+        private const val KEY_SHOW_PLAYBACK_SPECTRUM = "show_playback_spectrum"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -54,8 +54,11 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 false,
             ),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
-            showPlaybackSpectrum = preferences.getBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, true),
-            playbackSpectrumStyle = enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.Bars),
+            playbackSpectrumStyle = if (preferences.getBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, true)) {
+                enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.None)
+            } else {
+                PlaybackSpectrumStyle.None
+            },
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -91,7 +94,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 )
                 .putBoolean(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, settings.smartReplacementUseReplacementLyrics)
                 .putString(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
-                .putBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, settings.showPlaybackSpectrum)
+                .remove(KEY_SHOW_PLAYBACK_SPECTRUM)
                 .putString(KEY_PLAYBACK_SPECTRUM_STYLE, settings.playbackSpectrumStyle.name)
                 .putString(KEY_THEME_MODE, settings.themeMode.name)
                 .putString(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -55,6 +55,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
             ),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
             showPlaybackSpectrum = preferences.getBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, true),
+            playbackSpectrumStyle = enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.Bars),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -91,6 +92,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putBoolean(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, settings.smartReplacementUseReplacementLyrics)
                 .putString(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
                 .putBoolean(KEY_SHOW_PLAYBACK_SPECTRUM, settings.showPlaybackSpectrum)
+                .putString(KEY_PLAYBACK_SPECTRUM_STYLE, settings.playbackSpectrumStyle.name)
                 .putString(KEY_THEME_MODE, settings.themeMode.name)
                 .putString(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)
                 .apply()
@@ -228,6 +230,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
         private const val KEY_SHOW_PLAYBACK_SPECTRUM = "show_playback_spectrum"
+        private const val KEY_PLAYBACK_SPECTRUM_STYLE = "playback_spectrum_style"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -47,6 +47,11 @@ class AndroidNativeAudioEngine(
             }
         }
         scope.launch {
+            FuoPlaybackService.spectrumLevels.collect { spectrumLevels ->
+                mutableState.value = mutableState.value.copy(spectrumLevels = spectrumLevels)
+            }
+        }
+        scope.launch {
             while (true) {
                 updatePosition()
                 delay(1_000)
@@ -69,6 +74,7 @@ class AndroidNativeAudioEngine(
             lyrics = track.lyrics,
             audioQuality = null,
             audioFormatInfo = null,
+            spectrumLevels = emptyList(),
             playbackParts = emptyList(),
             currentPartIndex = -1,
             errorMessage = null,
@@ -90,6 +96,7 @@ class AndroidNativeAudioEngine(
             lyrics = payload.lyrics,
             audioQuality = payload.audioQuality,
             audioFormatInfo = null,
+            spectrumLevels = emptyList(),
             playbackParts = payload.parts,
             currentPartIndex = payload.currentPartIndex,
             errorMessage = null,
@@ -127,7 +134,7 @@ class AndroidNativeAudioEngine(
         cancelPlaybackRetry()
         mediaController?.stop()
         FuoPlaybackService.stop(context)
-        mutableState.value = mutableState.value.copy(status = PlayerStatus.Idle, positionMs = 0)
+        mutableState.value = mutableState.value.copy(status = PlayerStatus.Idle, positionMs = 0, spectrumLevels = emptyList())
     }
 
     override fun seekTo(positionMs: Long) {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AudioSpectrumAnalyzer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AudioSpectrumAnalyzer.kt
@@ -1,0 +1,98 @@
+package org.feeluown.mobile
+
+import android.media.AudioFormat
+import androidx.media3.exoplayer.audio.TeeAudioProcessor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+class AudioSpectrumAnalyzer(
+    private val onSpectrum: (List<Float>) -> Unit,
+) : TeeAudioProcessor.AudioBufferSink {
+    private var sampleRateHz = 0
+    private var channelCount = 0
+    private var encoding = AudioFormat.ENCODING_INVALID
+    private var frameIndex = 0
+    private var lastPublishedAtMs = 0L
+    private val window = FloatArray(WINDOW_SIZE)
+
+    override fun flush(sampleRateHz: Int, channelCount: Int, encoding: Int) {
+        this.sampleRateHz = sampleRateHz
+        this.channelCount = channelCount
+        this.encoding = encoding
+        clear()
+    }
+
+    override fun handleBuffer(buffer: ByteBuffer) {
+        if (sampleRateHz <= 0 || channelCount <= 0) return
+        val input = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN)
+        val bytesPerSample = when (encoding) {
+            AudioFormat.ENCODING_PCM_16BIT -> 2
+            AudioFormat.ENCODING_PCM_FLOAT -> 4
+            else -> return
+        }
+        val bytesPerFrame = bytesPerSample * channelCount
+        while (input.remaining() >= bytesPerFrame) {
+            var sample = 0f
+            repeat(channelCount) {
+                sample += when (encoding) {
+                    AudioFormat.ENCODING_PCM_16BIT -> input.short / 32768f
+                    AudioFormat.ENCODING_PCM_FLOAT -> input.float
+                    else -> 0f
+                }
+            }
+            window[frameIndex++] = sample / channelCount
+            if (frameIndex == WINDOW_SIZE) {
+                publishIfDue()
+                frameIndex = 0
+            }
+        }
+    }
+
+    fun clear() {
+        frameIndex = 0
+        lastPublishedAtMs = 0L
+        window.fill(0f)
+        onSpectrum(emptyList())
+    }
+
+    private fun publishIfDue() {
+        val now = System.currentTimeMillis()
+        if (now - lastPublishedAtMs < PUBLISH_INTERVAL_MS) return
+        lastPublishedAtMs = now
+        val nyquist = sampleRateHz / 2f
+        onSpectrum(BAND_CENTERS_HZ.map { centerHz ->
+            if (centerHz >= nyquist) {
+                0f
+            } else {
+                val normalized = goertzelMagnitude(centerHz) * 18f
+                (ln(1f + normalized) / ln(19f)).coerceIn(0f, 1f)
+            }
+        })
+    }
+
+    private fun goertzelMagnitude(frequencyHz: Float): Float {
+        val omega = 2.0 * PI * frequencyHz / sampleRateHz
+        val coefficient = 2.0 * cos(omega)
+        var previous = 0.0
+        var previousPrevious = 0.0
+        window.forEachIndexed { index, sample ->
+            val hann = 0.5 - 0.5 * cos(2.0 * PI * index / (WINDOW_SIZE - 1))
+            val current = sample * hann + coefficient * previous - previousPrevious
+            previousPrevious = previous
+            previous = current
+        }
+        val power = previousPrevious * previousPrevious + previous * previous - coefficient * previous * previousPrevious
+        return (sqrt(power.coerceAtLeast(0.0)) / WINDOW_SIZE).toFloat()
+    }
+
+    private companion object {
+        const val WINDOW_SIZE = 512
+        const val PUBLISH_INTERVAL_MS = 50L
+        val BAND_CENTERS_HZ = floatArrayOf(60f, 120f, 250f, 500f, 1_000f, 2_000f, 3_500f, 5_000f, 7_000f, 9_000f, 12_000f, 15_000f)
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -23,6 +23,9 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.TeeAudioProcessor
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.session.CommandButton
 import androidx.media3.session.MediaSession
@@ -35,13 +38,14 @@ import org.json.JSONObject
 class FuoPlaybackService : MediaSessionService() {
     private var player: ExoPlayer? = null
     private var mediaSession: MediaSession? = null
+    private val spectrumAnalyzer = AudioSpectrumAnalyzer { levels ->
+        mutableSpectrumLevels.value = levels
+    }
 
     @OptIn(UnstableApi::class)
     override fun onCreate() {
         super.onCreate()
-        val renderersFactory = DefaultRenderersFactory(this)
-            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
-            .setEnableDecoderFallback(true)
+        val renderersFactory = spectrumRenderersFactory()
         val exoPlayer = ExoPlayer.Builder(this)
             .setRenderersFactory(renderersFactory)
             .build()
@@ -125,6 +129,7 @@ class FuoPlaybackService : MediaSessionService() {
                 player?.stop()
                 mutableAudioDecoderInfo.value = null
                 mutableAudioFormatInfo.value = null
+                spectrumAnalyzer.clear()
                 stopSelf()
             }
         }
@@ -140,6 +145,7 @@ class FuoPlaybackService : MediaSessionService() {
         player = null
         mutableAudioDecoderInfo.value = null
         mutableAudioFormatInfo.value = null
+        spectrumAnalyzer.clear()
         super.onDestroy()
     }
 
@@ -336,6 +342,9 @@ class FuoPlaybackService : MediaSessionService() {
         private val mutableAudioFormatInfo = MutableStateFlow<AudioFormatInfo?>(null)
         val audioFormatInfo: StateFlow<AudioFormatInfo?> = mutableAudioFormatInfo.asStateFlow()
 
+        private val mutableSpectrumLevels = MutableStateFlow<List<Float>>(emptyList())
+        val spectrumLevels: StateFlow<List<Float>> = mutableSpectrumLevels.asStateFlow()
+
         fun play(context: Context, payload: String) {
             start(context, Intent(context, FuoPlaybackService::class.java).apply {
                 action = ACTION_PLAY
@@ -409,5 +418,22 @@ class FuoPlaybackService : MediaSessionService() {
         fun pause()
         fun previous()
         fun next()
+    }
+
+    private fun spectrumRenderersFactory(): DefaultRenderersFactory {
+        return object : DefaultRenderersFactory(this@FuoPlaybackService) {
+            override fun buildAudioSink(
+                context: Context,
+                enableFloatOutput: Boolean,
+                enableAudioTrackPlaybackParams: Boolean,
+            ): AudioSink {
+                return DefaultAudioSink.Builder(context)
+                    .setEnableFloatOutput(enableFloatOutput)
+                    .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                    .setAudioProcessors(arrayOf(TeeAudioProcessor(spectrumAnalyzer)))
+                    .build()
+            }
+        }.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+            .setEnableDecoderFallback(true)
     }
 }

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -1,6 +1,8 @@
 import AVFoundation
 import AVKit
+import AudioToolbox
 import CoreMedia
+import MediaToolbox
 import MediaPlayer
 import Network
 import Shared
@@ -13,6 +15,7 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
     private var didReachEnd = false
     private var playbackError: String?
     private var endObserver: NSObjectProtocol?
+    private let spectrumAnalyzer = AudioTapSpectrumAnalyzer()
 
     override init() {
         super.init()
@@ -47,7 +50,7 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
             assetOptions["AVURLAssetHTTPHeaderFieldsKey"] = payload.headers
         }
         let asset = AVURLAsset(url: url, options: assetOptions)
-        player.replaceCurrentItem(with: AVPlayerItem(asset: asset))
+        player.replaceCurrentItem(with: playerItem(asset: asset))
         updateNowPlaying(payload: payload)
         player.play()
     }
@@ -69,6 +72,7 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         player.replaceCurrentItem(with: nil)
         didReachEnd = false
         playbackError = nil
+        spectrumAnalyzer.clear()
     }
 
     func seekTo(positionMs: Int64) {
@@ -128,6 +132,67 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
             averageBitrate: averageBitrate,
             peakBitrate: nil
         )
+    }
+
+    func spectrumLevels() -> [NSNumber] {
+        spectrumAnalyzer.levels().map(NSNumber.init(value:))
+    }
+
+    private func playerItem(asset: AVURLAsset) -> AVPlayerItem {
+        let item = AVPlayerItem(asset: asset)
+        guard let audioTrack = asset.tracks(withMediaType: .audio).first, let tap = makeAudioTap() else {
+            spectrumAnalyzer.clear()
+            return item
+        }
+        let parameters = AVMutableAudioMixInputParameters(track: audioTrack)
+        parameters.audioTapProcessor = tap
+        let mix = AVMutableAudioMix()
+        mix.inputParameters = [parameters]
+        item.audioMix = mix
+        return item
+    }
+
+    private func makeAudioTap() -> MTAudioProcessingTap? {
+        var callbacks = MTAudioProcessingTapCallbacks(
+            version: kMTAudioProcessingTapCallbacksVersion_0,
+            clientInfo: Unmanaged.passUnretained(spectrumAnalyzer).toOpaque(),
+            init: { _, clientInfo, storageOut in
+                storageOut.pointee = clientInfo
+            },
+            finalize: { _ in },
+            prepare: { tap, _, processingFormat in
+                let analyzer = Unmanaged<AudioTapSpectrumAnalyzer>
+                    .fromOpaque(MTAudioProcessingTapGetStorage(tap))
+                    .takeUnretainedValue()
+                analyzer.prepare(processingFormat.pointee)
+            },
+            unprepare: { _ in },
+            process: { tap, frameCount, _, bufferList, framesOut, flagsOut in
+                let status = MTAudioProcessingTapGetSourceAudio(
+                    tap,
+                    frameCount,
+                    bufferList,
+                    flagsOut,
+                    nil,
+                    framesOut,
+                )
+                guard status == noErr else { return }
+                let analyzer = Unmanaged<AudioTapSpectrumAnalyzer>
+                    .fromOpaque(MTAudioProcessingTapGetStorage(tap))
+                    .takeUnretainedValue()
+                analyzer.consume(bufferList)
+            },
+        )
+        var tap: MTAudioProcessingTap?
+        guard MTAudioProcessingTapCreate(
+            kCFAllocatorDefault,
+            &callbacks,
+            kMTAudioProcessingTapCreationFlag_PostEffects,
+            &tap,
+        ) == noErr else {
+            return nil
+        }
+        return tap
     }
 
     private func milliseconds(_ time: CMTime) -> Int64 {
@@ -192,6 +257,90 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
             MPMediaItemPropertyArtist: payload.artists,
             MPMediaItemPropertyAlbumTitle: payload.album,
         ]
+    }
+}
+
+private final class AudioTapSpectrumAnalyzer {
+    private static let windowSize = 512
+    private static let bandCenters: [Double] = [60, 120, 250, 500, 1_000, 2_000, 3_500, 5_000, 7_000, 9_000, 12_000, 15_000]
+    private let lock = NSLock()
+    private var sampleRate = 0.0
+    private var isFloat = true
+    private var samples = Array(repeating: Float.zero, count: windowSize)
+    private var sampleIndex = 0
+    private var lastPublishedAt = Date.distantPast
+    private var currentLevels: [Float] = []
+
+    func prepare(_ format: AudioStreamBasicDescription) {
+        lock.lock()
+        sampleRate = format.mSampleRate
+        isFloat = format.mFormatFlags & kAudioFormatFlagIsFloat != 0
+        clearLocked()
+        lock.unlock()
+    }
+
+    func consume(_ bufferList: UnsafeMutablePointer<AudioBufferList>) {
+        let buffers = UnsafeMutableAudioBufferListPointer(bufferList)
+        guard let buffer = buffers.first, let data = buffer.mData else { return }
+        let sampleCount = Int(buffer.mDataByteSize) / (isFloat ? MemoryLayout<Float>.size : MemoryLayout<Int16>.size)
+        lock.lock()
+        if isFloat {
+            let pointer = data.assumingMemoryBound(to: Float.self)
+            for index in 0..<sampleCount { append(pointer[index]) }
+        } else {
+            let pointer = data.assumingMemoryBound(to: Int16.self)
+            for index in 0..<sampleCount { append(Float(pointer[index]) / 32768) }
+        }
+        lock.unlock()
+    }
+
+    func levels() -> [Float] {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentLevels
+    }
+
+    func clear() {
+        lock.lock()
+        clearLocked()
+        lock.unlock()
+    }
+
+    private func append(_ sample: Float) {
+        samples[sampleIndex] = sample
+        sampleIndex += 1
+        guard sampleIndex == Self.windowSize else { return }
+        sampleIndex = 0
+        guard Date().timeIntervalSince(lastPublishedAt) >= 0.05, sampleRate > 0 else { return }
+        lastPublishedAt = Date()
+        let nyquist = sampleRate / 2
+        currentLevels = Self.bandCenters.map { frequency in
+            guard frequency < nyquist else { return 0 }
+            let normalized = goertzelMagnitude(frequency) * 18
+            return min(1, max(0, log(1 + normalized) / log(19)))
+        }.map(Float.init)
+    }
+
+    private func goertzelMagnitude(_ frequency: Double) -> Double {
+        let omega = 2 * Double.pi * frequency / sampleRate
+        let coefficient = 2 * cos(omega)
+        var previous = 0.0
+        var previousPrevious = 0.0
+        for (index, sample) in samples.enumerated() {
+            let hann = 0.5 - 0.5 * cos(2 * Double.pi * Double(index) / Double(Self.windowSize - 1))
+            let current = Double(sample) * hann + coefficient * previous - previousPrevious
+            previousPrevious = previous
+            previous = current
+        }
+        let power = previousPrevious * previousPrevious + previous * previous - coefficient * previous * previousPrevious
+        return sqrt(max(0, power)) / Double(Self.windowSize)
+    }
+
+    private func clearLocked() {
+        samples = Array(repeating: 0, count: Self.windowSize)
+        sampleIndex = 0
+        lastPublishedAt = .distantPast
+        currentLevels = []
     }
 }
 

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -120,13 +120,13 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         playbackError ?? player.currentItem?.error?.localizedDescription
     }
 
-    func audioFormatInfo() -> SharedAudioFormatInfo? {
+    func audioFormatInfo() -> AudioFormatInfo? {
         guard let track = player.currentItem?.asset.tracks(withMediaType: .audio).first else { return nil }
         let codec = track.formatDescriptions.first
             .map { CMFormatDescriptionGetMediaSubType($0 as! CMFormatDescription) }
             .map(fourCharacterCode)
         let averageBitrate = track.estimatedDataRate > 0 ? Int64(track.estimatedDataRate.rounded()) : nil
-        return SharedAudioFormatInfo(
+        return AudioFormatInfo(
             format: codec.map(audioFormatName),
             codec: codec,
             averageBitrate: averageBitrate,
@@ -134,8 +134,8 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         )
     }
 
-    func spectrumLevels() -> [NSNumber] {
-        spectrumAnalyzer.levels().map(NSNumber.init(value:))
+    func spectrumLevels() -> [KotlinFloat] {
+        spectrumAnalyzer.levels().map { KotlinFloat(float: $0) }
     }
 
     private func playerItem(asset: AVURLAsset) -> AVPlayerItem {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -2,6 +2,9 @@ package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
@@ -137,6 +140,8 @@ import kotlin.math.roundToInt
 
 val LocalShareHandler = staticCompositionLocalOf<(SharePayload) -> Unit> { {} }
 val LocalAppLayoutInfo = staticCompositionLocalOf { AppLayoutInfo() }
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalPlayerSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope?> { null }
 
 data class AppLayoutInfo(
     val isLandscape: Boolean = false,
@@ -144,7 +149,7 @@ data class AppLayoutInfo(
     val gridColumns: Int = 3,
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun AppRoot(
     controller: FuoPlayerController,
@@ -224,63 +229,67 @@ fun AppRoot(
                 LocalShareHandler provides { onShareText(it.text) },
                 LocalAppLayoutInfo provides layoutInfo,
             ) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    AnimatedContent(
-                        targetState = destination,
-                        modifier = Modifier.fillMaxSize(),
-                        transitionSpec = {
-                            val direction = if (targetState.ordinal >= initialState.ordinal) 1 else -1
-                            (slideInHorizontally(animationSpec = tween(220)) { it / 5 * direction } + fadeIn(tween(180)))
-                                .togetherWith(
-                                    slideOutHorizontally(animationSpec = tween(180)) { -it / 6 * direction } +
-                                        fadeOut(tween(160)),
-                                )
-                                .using(SizeTransform(clip = false))
-                        },
-                    ) { target ->
-                        when (target) {
-                            AppDestination.Home -> HomeScreen(
-                                controller = controller,
-                                hasAudioPermission = hasAudioPermission,
-                                onRequestAudioPermission = onRequestAudioPermission,
+                SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
+                    CompositionLocalProvider(LocalPlayerSharedTransitionScope provides this) {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            AnimatedContent(
+                                targetState = destination,
+                                modifier = Modifier.fillMaxSize(),
+                                transitionSpec = {
+                                    val direction = if (targetState.ordinal >= initialState.ordinal) 1 else -1
+                                    (slideInHorizontally(animationSpec = tween(220)) { it / 5 * direction } + fadeIn(tween(180)))
+                                        .togetherWith(
+                                            slideOutHorizontally(animationSpec = tween(180)) { -it / 6 * direction } +
+                                                fadeOut(tween(160)),
+                                        )
+                                        .using(SizeTransform(clip = false))
+                                },
+                            ) { target ->
+                                when (target) {
+                                    AppDestination.Home -> HomeScreen(
+                                        controller = controller,
+                                        hasAudioPermission = hasAudioPermission,
+                                        onRequestAudioPermission = onRequestAudioPermission,
+                                    )
+                                    AppDestination.DebugLogs -> DebugLogScreen(controller)
+                                    AppDestination.Settings -> SettingsScreen(
+                                        controller,
+                                        onOpenProviderWebLogin,
+                                        onLogoutProvider,
+                                        onImportYtmusicHeaderFile,
+                                        appVersionInfo,
+                                    )
+                                    AppDestination.Search -> SearchScreen(controller)
+                                    AppDestination.Feature -> ProviderFeatureScreen(controller, currentFeature ?: lastFeature)
+                                    AppDestination.Track -> ProviderTrackScreen(controller, currentTrack ?: lastTrack)
+                                    AppDestination.Video -> ProviderVideoScreen(controller, currentVideo ?: lastVideo)
+                                    AppDestination.Playlist -> ProviderPlaylistScreen(controller, currentPlaylist ?: lastPlaylist)
+                                    AppDestination.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
+                                }
+                            }
+                            AnimatedVisibility(
+                                visible = controller.isFullPlayerOpen,
+                                modifier = Modifier.fillMaxSize(),
+                                enter = slideInVertically(animationSpec = tween(260)) { it / 2 } + fadeIn(tween(180)),
+                                exit = slideOutVertically(animationSpec = tween(220)) { it / 2 } + fadeOut(tween(160)),
+                            ) {
+                                FullPlayer(controller)
+                            }
+                            controller.localMetadataEditorTrack?.let { track ->
+                                LocalMetadataDialog(controller = controller, track = track)
+                            }
+                            controller.playlistTargetTrack?.let { track ->
+                                ProviderPlaylistTargetDialog(controller = controller, track = track)
+                            }
+                            SnackbarHost(
+                                hostState = snackbarHostState,
+                                modifier = Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .navigationBarsPadding()
+                                    .padding(16.dp),
                             )
-                            AppDestination.DebugLogs -> DebugLogScreen(controller)
-                            AppDestination.Settings -> SettingsScreen(
-                                controller,
-                                onOpenProviderWebLogin,
-                                onLogoutProvider,
-                                onImportYtmusicHeaderFile,
-                                appVersionInfo,
-                            )
-                            AppDestination.Search -> SearchScreen(controller)
-                            AppDestination.Feature -> ProviderFeatureScreen(controller, currentFeature ?: lastFeature)
-                            AppDestination.Track -> ProviderTrackScreen(controller, currentTrack ?: lastTrack)
-                            AppDestination.Video -> ProviderVideoScreen(controller, currentVideo ?: lastVideo)
-                            AppDestination.Playlist -> ProviderPlaylistScreen(controller, currentPlaylist ?: lastPlaylist)
-                            AppDestination.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
                         }
                     }
-                    AnimatedVisibility(
-                        visible = controller.isFullPlayerOpen,
-                        modifier = Modifier.fillMaxSize(),
-                        enter = slideInVertically(animationSpec = tween(260)) { it / 2 } + fadeIn(tween(180)),
-                        exit = slideOutVertically(animationSpec = tween(220)) { it / 2 } + fadeOut(tween(160)),
-                    ) {
-                        FullPlayer(controller)
-                    }
-                    controller.localMetadataEditorTrack?.let { track ->
-                        LocalMetadataDialog(controller = controller, track = track)
-                    }
-                    controller.playlistTargetTrack?.let { track ->
-                        ProviderPlaylistTargetDialog(controller = controller, track = track)
-                    }
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .navigationBarsPadding()
-                            .padding(16.dp),
-                    )
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -95,6 +95,7 @@ data class AppSettings(
     val smartReplacementUseReplacementMetadata: Boolean = false,
     val smartReplacementUseReplacementLyrics: Boolean = false,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
+    val showPlaybackSpectrum: Boolean = true,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
 )
@@ -239,6 +240,7 @@ data class PlaybackState(
     val audioQuality: String? = null,
     val audioFormatInfo: AudioFormatInfo? = null,
     val audioDecoderInfo: AudioDecoderInfo? = null,
+    val spectrumLevels: List<Float> = emptyList(),
     val playbackParts: List<PlaybackPart> = emptyList(),
     val currentPartIndex: Int = -1,
     val errorMessage: String? = null,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -73,6 +73,7 @@ enum class ThemeColorScheme(
 enum class PlaybackSpectrumStyle(
     val label: String,
 ) {
+    None("无频谱"),
     Bars("柱状"),
     MirrorBars("镜像"),
     Wave("波形"),
@@ -103,8 +104,7 @@ data class AppSettings(
     val smartReplacementUseReplacementMetadata: Boolean = false,
     val smartReplacementUseReplacementLyrics: Boolean = false,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
-    val showPlaybackSpectrum: Boolean = true,
-    val playbackSpectrumStyle: PlaybackSpectrumStyle = PlaybackSpectrumStyle.Bars,
+    val playbackSpectrumStyle: PlaybackSpectrumStyle = PlaybackSpectrumStyle.None,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
 )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -70,6 +70,14 @@ enum class ThemeColorScheme(
     Amber("琥珀"),
 }
 
+enum class PlaybackSpectrumStyle(
+    val label: String,
+) {
+    Bars("柱状"),
+    MirrorBars("镜像"),
+    Wave("波形"),
+}
+
 data class AppSettings(
     val homeSection: HomeSection = HomeSection.Recommend,
     val mineSection: MineSection = MineSection.Playlists,
@@ -96,6 +104,7 @@ data class AppSettings(
     val smartReplacementUseReplacementLyrics: Boolean = false,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
     val showPlaybackSpectrum: Boolean = true,
+    val playbackSpectrumStyle: PlaybackSpectrumStyle = PlaybackSpectrumStyle.Bars,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
 )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -229,9 +229,7 @@ class FuoPlayerController(
         private set
     var lyricFontSize by mutableStateOf(LyricFontSize.Small)
         private set
-    var showPlaybackSpectrum by mutableStateOf(true)
-        private set
-    var playbackSpectrumStyle by mutableStateOf(PlaybackSpectrumStyle.Bars)
+    var playbackSpectrumStyle by mutableStateOf(PlaybackSpectrumStyle.None)
         private set
     var themeMode by mutableStateOf(ThemeMode.System)
         private set
@@ -919,11 +917,6 @@ class FuoPlayerController(
 
     fun onLyricFontSizeChange(value: LyricFontSize) {
         lyricFontSize = value
-        persistSettings()
-    }
-
-    fun onShowPlaybackSpectrumChange(value: Boolean) {
-        showPlaybackSpectrum = value
         persistSettings()
     }
 
@@ -3240,7 +3233,6 @@ class FuoPlayerController(
         smartReplacementUseReplacementMetadata = settings.smartReplacementUseReplacementMetadata
         smartReplacementUseReplacementLyrics = settings.smartReplacementUseReplacementLyrics
         lyricFontSize = settings.lyricFontSize
-        showPlaybackSpectrum = settings.showPlaybackSpectrum
         playbackSpectrumStyle = settings.playbackSpectrumStyle
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
@@ -3272,7 +3264,6 @@ class FuoPlayerController(
             smartReplacementUseReplacementMetadata = smartReplacementUseReplacementMetadata,
             smartReplacementUseReplacementLyrics = smartReplacementUseReplacementLyrics,
             lyricFontSize = lyricFontSize,
-            showPlaybackSpectrum = showPlaybackSpectrum,
             playbackSpectrumStyle = playbackSpectrumStyle,
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -229,6 +229,8 @@ class FuoPlayerController(
         private set
     var lyricFontSize by mutableStateOf(LyricFontSize.Small)
         private set
+    var showPlaybackSpectrum by mutableStateOf(true)
+        private set
     var themeMode by mutableStateOf(ThemeMode.System)
         private set
     var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
@@ -915,6 +917,11 @@ class FuoPlayerController(
 
     fun onLyricFontSizeChange(value: LyricFontSize) {
         lyricFontSize = value
+        persistSettings()
+    }
+
+    fun onShowPlaybackSpectrumChange(value: Boolean) {
+        showPlaybackSpectrum = value
         persistSettings()
     }
 
@@ -3226,6 +3233,7 @@ class FuoPlayerController(
         smartReplacementUseReplacementMetadata = settings.smartReplacementUseReplacementMetadata
         smartReplacementUseReplacementLyrics = settings.smartReplacementUseReplacementLyrics
         lyricFontSize = settings.lyricFontSize
+        showPlaybackSpectrum = settings.showPlaybackSpectrum
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
     }
@@ -3256,6 +3264,7 @@ class FuoPlayerController(
             smartReplacementUseReplacementMetadata = smartReplacementUseReplacementMetadata,
             smartReplacementUseReplacementLyrics = smartReplacementUseReplacementLyrics,
             lyricFontSize = lyricFontSize,
+            showPlaybackSpectrum = showPlaybackSpectrum,
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
         )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -231,6 +231,8 @@ class FuoPlayerController(
         private set
     var showPlaybackSpectrum by mutableStateOf(true)
         private set
+    var playbackSpectrumStyle by mutableStateOf(PlaybackSpectrumStyle.Bars)
+        private set
     var themeMode by mutableStateOf(ThemeMode.System)
         private set
     var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
@@ -922,6 +924,11 @@ class FuoPlayerController(
 
     fun onShowPlaybackSpectrumChange(value: Boolean) {
         showPlaybackSpectrum = value
+        persistSettings()
+    }
+
+    fun onPlaybackSpectrumStyleChange(value: PlaybackSpectrumStyle) {
+        playbackSpectrumStyle = value
         persistSettings()
     }
 
@@ -3234,6 +3241,7 @@ class FuoPlayerController(
         smartReplacementUseReplacementLyrics = settings.smartReplacementUseReplacementLyrics
         lyricFontSize = settings.lyricFontSize
         showPlaybackSpectrum = settings.showPlaybackSpectrum
+        playbackSpectrumStyle = settings.playbackSpectrumStyle
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
     }
@@ -3265,6 +3273,7 @@ class FuoPlayerController(
             smartReplacementUseReplacementLyrics = smartReplacementUseReplacementLyrics,
             lyricFontSize = lyricFontSize,
             showPlaybackSpectrum = showPlaybackSpectrum,
+            playbackSpectrumStyle = playbackSpectrumStyle,
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
         )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -227,7 +227,6 @@ fun MinePlaylistsSection(
     var showCreateDialog by remember { mutableStateOf(false) }
     var playlistName by remember { mutableStateOf("") }
     var selectedCreateProviderId by remember { mutableStateOf<String?>(null) }
-    val creatableProviders = controller.creatablePlaylistProviders()
     val userSections = controller.minePlaylistSections
     val favoriteSections = controller.mineFavoritePlaylistSections
     val sections = when (controller.playlistFilter) {
@@ -245,16 +244,6 @@ fun MinePlaylistsSection(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        if (creatableProviders.isNotEmpty()) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                TextButton(
-                    onClick = {
-                        selectedCreateProviderId = creatableProviders.singleOrNull()?.providerId
-                        showCreateDialog = true
-                    },
-                ) { Text("新建歌单") }
-            }
-        }
         if (showFilter) {
             PlaylistFilterChips(controller)
         }
@@ -270,7 +259,14 @@ fun MinePlaylistsSection(
                 }
             } else {
                 visibleSections.forEach { contentSection ->
-                    playlistSectionItems(controller, contentSection)
+                    playlistSectionItems(
+                        controller = controller,
+                        contentSection = contentSection,
+                        onCreatePlaylist = { providerId ->
+                            selectedCreateProviderId = providerId
+                            showCreateDialog = true
+                        },
+                    )
                 }
                 if (lockedProviders.isNotEmpty()) {
                     item(key = "locked-providers:mine-playlists") {
@@ -284,31 +280,15 @@ fun MinePlaylistsSection(
         }
     }
     if (showCreateDialog) {
-        val selectedCreateProvider = creatableProviders.firstOrNull {
+        val selectedCreateProvider = controller.creatablePlaylistProviders().firstOrNull {
             it.providerId == selectedCreateProviderId
-        } ?: creatableProviders.singleOrNull()
+        }
         AlertDialog(
             onDismissRequest = { showCreateDialog = false },
             title = { Text("新建歌单") },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (creatableProviders.size == 1) {
-                        Text("将在 ${creatableProviders.first().providerName} 创建")
-                    } else {
-                        Text("创建到")
-                        Row(
-                            modifier = Modifier.horizontalScroll(rememberScrollState()),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            creatableProviders.forEach { provider ->
-                                FilterChip(
-                                    selected = provider.providerId == selectedCreateProvider?.providerId,
-                                    onClick = { selectedCreateProviderId = provider.providerId },
-                                    label = { Text(provider.providerName) },
-                                )
-                            }
-                        }
-                    }
+                    Text("将在 ${selectedCreateProvider?.providerName.orEmpty()} 创建")
                     OutlinedTextField(
                         value = playlistName,
                         onValueChange = { playlistName = it },
@@ -366,9 +346,20 @@ fun PlaylistFilter.emptyTitle(): String {
 fun androidx.compose.foundation.lazy.LazyListScope.playlistSectionItems(
     controller: FuoPlayerController,
     contentSection: ProviderContentSection,
+    onCreatePlaylist: (String) -> Unit,
 ) {
     item(key = "header:${contentSection.feature.id}") {
-        ProviderFeatureHeader(feature = contentSection.feature)
+        ProviderFeatureHeader(
+            feature = contentSection.feature,
+            action = if (contentSection.feature.category == ProviderFeatureCategory.MinePlaylists) {
+                controller.creatablePlaylistProviders()
+                    .firstOrNull { it.providerId == contentSection.feature.providerId }
+                    ?.let { provider -> { onCreatePlaylist(provider.providerId) } }
+            } else {
+                null
+            },
+            actionLabel = "新建歌单",
+        )
     }
     when {
         contentSection.errorMessage != null -> item(key = "error:${contentSection.feature.id}") {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1,6 +1,7 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -11,6 +12,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.background
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -70,6 +72,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -78,6 +81,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 @Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
 fun MiniPlayer(controller: FuoPlayerController) {
     val state = controller.playbackState
     val isLoadingAudio = state.status == PlayerStatus.Loading
@@ -87,16 +91,22 @@ fun MiniPlayer(controller: FuoPlayerController) {
             .fillMaxWidth()
             .animateContentSize(animationSpec = tween(220))
             .clickable(onClick = controller::openFullPlayer),
+        shape = RoundedCornerShape(if (isWideLayout) 12.dp else 18.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
         tonalElevation = 3.dp,
     ) {
         Column {
             Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = if (isWideLayout) 6.dp else 10.dp),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = if (isWideLayout) 8.dp else 10.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 state.currentTrack?.let {
-                    CoverBox(it, modifier = Modifier.size(if (isWideLayout) 40.dp else 48.dp))
+                    PlayerSharedCover(
+                        track = it,
+                        visible = !controller.isFullPlayerOpen,
+                        modifier = Modifier.size(if (isWideLayout) 44.dp else 56.dp),
+                    )
                 }
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
@@ -120,6 +130,23 @@ fun MiniPlayer(controller: FuoPlayerController) {
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    state.audioQuality?.takeIf { it.isNotBlank() }?.let { quality ->
+                        Text(
+                            text = quality.uppercase(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                        )
+                    }
+                    if (controller.showPlaybackSpectrum) {
+                        AudioSpectrumLines(
+                            levels = state.spectrumLevels,
+                            isPlaying = state.status == PlayerStatus.Playing,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(14.dp),
+                        )
+                    }
                 }
                 PlayerControls(
                     state = state,
@@ -129,14 +156,24 @@ fun MiniPlayer(controller: FuoPlayerController) {
                     compact = true,
                 )
             }
-            if (isLoadingAudio) {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
+            MiniPlayerProgress(state, isLoadingAudio)
         }
     }
 }
 
 @Composable
+private fun MiniPlayerProgress(state: PlaybackState, isLoadingAudio: Boolean) {
+    val duration = state.durationMs.takeIf { it > 0 }
+    if (isLoadingAudio || duration != null) {
+        LinearProgressIndicator(
+            progress = { duration?.let { state.positionMs.coerceIn(0, it).toFloat() / it } ?: 0f },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
 fun FullPlayer(controller: FuoPlayerController) {
     val state = controller.playbackState
     val currentTrack = state.currentTrack
@@ -214,7 +251,7 @@ fun FullPlayer(controller: FuoPlayerController) {
                                     pageSpacing = 16.dp,
                                 ) { page ->
                                     when (PlayerVisualTab.entries[page]) {
-                                        PlayerVisualTab.Cover -> PlayerCoverPage(currentTrack)
+                                        PlayerVisualTab.Cover -> PlayerCoverPage(currentTrack, controller)
                                         PlayerVisualTab.Lyrics -> LyricsPanel(
                                             state = state,
                                             fontSize = controller.lyricFontSize,
@@ -315,7 +352,7 @@ fun FullPlayer(controller: FuoPlayerController) {
                     pageSpacing = 16.dp,
                 ) { page ->
                     when (PlayerVisualTab.entries[page]) {
-                        PlayerVisualTab.Cover -> PlayerCoverPage(currentTrack)
+                        PlayerVisualTab.Cover -> PlayerCoverPage(currentTrack, controller)
                         PlayerVisualTab.Lyrics -> LyricsPanel(
                             state = state,
                             fontSize = controller.lyricFontSize,
@@ -403,15 +440,69 @@ fun NowPlayingTrackAction(controller: FuoPlayerController, track: MusicTrack) {
 }
 
 @Composable
-fun PlayerCoverPage(track: MusicTrack?) {
-    BoxWithConstraints(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        CoverBox(
-            track = track ?: emptyDisplayTrack(),
-            modifier = Modifier.size(minOf(maxWidth, maxHeight)),
-        )
+@OptIn(ExperimentalSharedTransitionApi::class)
+fun PlayerCoverPage(track: MusicTrack?, controller: FuoPlayerController) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val coverSize = minOf(maxWidth, maxHeight * 0.82f)
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PlayerSharedCover(
+                track = track ?: emptyDisplayTrack(),
+                visible = controller.isFullPlayerOpen,
+                modifier = Modifier.size(coverSize),
+            )
+            if (controller.showPlaybackSpectrum) {
+                AudioSpectrumLines(
+                    levels = controller.playbackState.spectrumLevels,
+                    isPlaying = controller.playbackState.status == PlayerStatus.Playing,
+                    modifier = Modifier
+                        .fillMaxWidth(0.72f)
+                        .height(42.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+fun PlayerSharedCover(track: MusicTrack, visible: Boolean, modifier: Modifier = Modifier) {
+    val sharedTransitionScope = LocalPlayerSharedTransitionScope.current
+    val sharedModifier = if (sharedTransitionScope == null) {
+        modifier
+    } else {
+        with(sharedTransitionScope) {
+            modifier.sharedElementWithCallerManagedVisibility(
+                sharedContentState = rememberSharedContentState("player-cover:${track.id}"),
+                visible = visible,
+            )
+        }
+    }
+    CoverBox(track = track, modifier = sharedModifier)
+}
+
+@Composable
+fun AudioSpectrumLines(levels: List<Float>, isPlaying: Boolean, modifier: Modifier = Modifier) {
+    if (!isPlaying || levels.isEmpty()) return
+    val color = MaterialTheme.colorScheme.primary
+    Canvas(modifier = modifier) {
+        val count = levels.size
+        val spacing = size.width / (count * 2f)
+        val strokeWidth = (spacing * 0.48f).coerceAtLeast(1f)
+        levels.forEachIndexed { index, level ->
+            val height = size.height * (0.18f + level.coerceIn(0f, 1f) * 0.82f)
+            val x = spacing * (index * 2 + 1)
+            drawLine(
+                color = color,
+                start = androidx.compose.ui.geometry.Offset(x, (size.height - height) / 2f),
+                end = androidx.compose.ui.geometry.Offset(x, (size.height + height) / 2f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -493,7 +493,7 @@ fun FullPlayerSpectrum(controller: FuoPlayerController, modifier: Modifier = Mod
         style = controller.playbackSpectrumStyle,
         modifier = modifier
             .fillMaxWidth()
-            .height(48.dp),
+            .height(64.dp),
     )
 }
 
@@ -514,7 +514,7 @@ fun AudioSpectrumLines(
             PlaybackSpectrumStyle.None -> Unit
             PlaybackSpectrumStyle.Bars,
             PlaybackSpectrumStyle.MirrorBars -> levels.forEachIndexed { index, level ->
-                val normalized = 0.18f + level.coerceIn(0f, 1f) * 0.82f
+                val normalized = 0.12f + level.coerceIn(0f, 1f) * 0.88f
                 val height = size.height * if (style == PlaybackSpectrumStyle.Bars) normalized else normalized / 2f
                 val x = spacing * (index * 2 + 1)
                 drawLine(
@@ -533,12 +533,27 @@ fun AudioSpectrumLines(
             }
             PlaybackSpectrumStyle.Wave -> {
                 val path = Path()
-                levels.forEachIndexed { index, level ->
-                    val x = if (count == 1) size.width / 2f else size.width * index / (count - 1f)
-                    val y = size.height * (1f - (0.1f + level.coerceIn(0f, 1f) * 0.8f))
-                    if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                val points = levels.mapIndexed { index, level ->
+                    androidx.compose.ui.geometry.Offset(
+                        x = if (count == 1) size.width / 2f else size.width * index / (count - 1f),
+                        y = size.height * (1f - (0.04f + level.coerceIn(0f, 1f) * 0.92f)),
+                    )
                 }
-                drawPath(path = path, color = color, style = Stroke(width = strokeWidth, cap = StrokeCap.Round))
+                path.moveTo(points.first().x, points.first().y)
+                points.zipWithNext().forEach { (previous, current) ->
+                    path.quadraticTo(
+                        x1 = previous.x,
+                        y1 = previous.y,
+                        x2 = (previous.x + current.x) / 2f,
+                        y2 = (previous.y + current.y) / 2f,
+                    )
+                }
+                points.last().let { point -> path.lineTo(point.x, point.y) }
+                drawPath(
+                    path = path,
+                    color = color,
+                    style = Stroke(width = (strokeWidth * 0.75f).coerceAtLeast(1f), cap = StrokeCap.Round),
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -72,7 +72,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -104,7 +106,7 @@ fun MiniPlayer(controller: FuoPlayerController) {
                 state.currentTrack?.let {
                     PlayerSharedCover(
                         track = it,
-                        visible = !controller.isFullPlayerOpen,
+                        heroEnabled = !controller.isFullPlayerOpen,
                         modifier = Modifier.size(if (isWideLayout) 44.dp else 56.dp),
                     )
                 }
@@ -136,15 +138,6 @@ fun MiniPlayer(controller: FuoPlayerController) {
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.primary,
                             maxLines = 1,
-                        )
-                    }
-                    if (controller.showPlaybackSpectrum) {
-                        AudioSpectrumLines(
-                            levels = state.spectrumLevels,
-                            isPlaying = state.status == PlayerStatus.Playing,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(14.dp),
                         )
                     }
                 }
@@ -190,7 +183,7 @@ fun FullPlayer(controller: FuoPlayerController) {
                         .fillMaxSize()
                         .statusBarsPadding()
                         .navigationBarsPadding()
-                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                        .padding(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 68.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     Row(
@@ -301,6 +294,14 @@ fun FullPlayer(controller: FuoPlayerController) {
                         }
                     }
                 }
+                FullPlayerSpectrum(
+                    controller = controller,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .navigationBarsPadding()
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 8.dp),
+                )
                 QueueBottomSheet(controller)
             }
         }
@@ -315,7 +316,7 @@ fun FullPlayer(controller: FuoPlayerController) {
                     .statusBarsPadding()
                     .navigationBarsPadding()
                     .padding(horizontal = 20.dp)
-                    .padding(bottom = 36.dp),
+                    .padding(bottom = 82.dp),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 Row(
@@ -392,6 +393,14 @@ fun FullPlayer(controller: FuoPlayerController) {
                     },
                 )
             }
+            FullPlayerSpectrum(
+                controller = controller,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 8.dp),
+            )
             QueueBottomSheet(controller)
         }
     }
@@ -451,33 +460,24 @@ fun PlayerCoverPage(track: MusicTrack?, controller: FuoPlayerController) {
         ) {
             PlayerSharedCover(
                 track = track ?: emptyDisplayTrack(),
-                visible = controller.isFullPlayerOpen,
+                heroEnabled = controller.isFullPlayerOpen,
                 modifier = Modifier.size(coverSize),
             )
-            if (controller.showPlaybackSpectrum) {
-                AudioSpectrumLines(
-                    levels = controller.playbackState.spectrumLevels,
-                    isPlaying = controller.playbackState.status == PlayerStatus.Playing,
-                    modifier = Modifier
-                        .fillMaxWidth(0.72f)
-                        .height(42.dp),
-                )
-            }
         }
     }
 }
 
 @Composable
 @OptIn(ExperimentalSharedTransitionApi::class)
-fun PlayerSharedCover(track: MusicTrack, visible: Boolean, modifier: Modifier = Modifier) {
+fun PlayerSharedCover(track: MusicTrack, heroEnabled: Boolean, modifier: Modifier = Modifier) {
     val sharedTransitionScope = LocalPlayerSharedTransitionScope.current
-    val sharedModifier = if (sharedTransitionScope == null) {
+    val sharedModifier = if (!heroEnabled || sharedTransitionScope == null) {
         modifier
     } else {
         with(sharedTransitionScope) {
             modifier.sharedElementWithCallerManagedVisibility(
                 sharedContentState = rememberSharedContentState("player-cover:${track.id}"),
-                visible = visible,
+                visible = true,
             )
         }
     }
@@ -485,23 +485,60 @@ fun PlayerSharedCover(track: MusicTrack, visible: Boolean, modifier: Modifier = 
 }
 
 @Composable
-fun AudioSpectrumLines(levels: List<Float>, isPlaying: Boolean, modifier: Modifier = Modifier) {
+fun FullPlayerSpectrum(controller: FuoPlayerController, modifier: Modifier = Modifier) {
+    if (!controller.showPlaybackSpectrum) return
+    AudioSpectrumLines(
+        levels = controller.playbackState.spectrumLevels,
+        isPlaying = controller.playbackState.status == PlayerStatus.Playing,
+        style = controller.playbackSpectrumStyle,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp),
+    )
+}
+
+@Composable
+fun AudioSpectrumLines(
+    levels: List<Float>,
+    isPlaying: Boolean,
+    style: PlaybackSpectrumStyle,
+    modifier: Modifier = Modifier,
+) {
     if (!isPlaying || levels.isEmpty()) return
     val color = MaterialTheme.colorScheme.primary
     Canvas(modifier = modifier) {
         val count = levels.size
         val spacing = size.width / (count * 2f)
         val strokeWidth = (spacing * 0.48f).coerceAtLeast(1f)
-        levels.forEachIndexed { index, level ->
-            val height = size.height * (0.18f + level.coerceIn(0f, 1f) * 0.82f)
-            val x = spacing * (index * 2 + 1)
-            drawLine(
-                color = color,
-                start = androidx.compose.ui.geometry.Offset(x, (size.height - height) / 2f),
-                end = androidx.compose.ui.geometry.Offset(x, (size.height + height) / 2f),
-                strokeWidth = strokeWidth,
-                cap = StrokeCap.Round,
-            )
+        when (style) {
+            PlaybackSpectrumStyle.Bars,
+            PlaybackSpectrumStyle.MirrorBars -> levels.forEachIndexed { index, level ->
+                val normalized = 0.18f + level.coerceIn(0f, 1f) * 0.82f
+                val height = size.height * if (style == PlaybackSpectrumStyle.Bars) normalized else normalized / 2f
+                val x = spacing * (index * 2 + 1)
+                drawLine(
+                    color = color,
+                    start = androidx.compose.ui.geometry.Offset(
+                        x,
+                        if (style == PlaybackSpectrumStyle.Bars) size.height else size.height / 2f - height,
+                    ),
+                    end = androidx.compose.ui.geometry.Offset(
+                        x,
+                        if (style == PlaybackSpectrumStyle.Bars) size.height - height else size.height / 2f + height,
+                    ),
+                    strokeWidth = strokeWidth,
+                    cap = StrokeCap.Round,
+                )
+            }
+            PlaybackSpectrumStyle.Wave -> {
+                val path = Path()
+                levels.forEachIndexed { index, level ->
+                    val x = if (count == 1) size.width / 2f else size.width * index / (count - 1f)
+                    val y = size.height * (1f - (0.1f + level.coerceIn(0f, 1f) * 0.8f))
+                    if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                }
+                drawPath(path = path, color = color, style = Stroke(width = strokeWidth, cap = StrokeCap.Round))
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -486,7 +486,7 @@ fun PlayerSharedCover(track: MusicTrack, heroEnabled: Boolean, modifier: Modifie
 
 @Composable
 fun FullPlayerSpectrum(controller: FuoPlayerController, modifier: Modifier = Modifier) {
-    if (!controller.showPlaybackSpectrum) return
+    if (controller.playbackSpectrumStyle == PlaybackSpectrumStyle.None) return
     AudioSpectrumLines(
         levels = controller.playbackState.spectrumLevels,
         isPlaying = controller.playbackState.status == PlayerStatus.Playing,
@@ -511,6 +511,7 @@ fun AudioSpectrumLines(
         val spacing = size.width / (count * 2f)
         val strokeWidth = (spacing * 0.48f).coerceAtLeast(1f)
         when (style) {
+            PlaybackSpectrumStyle.None -> Unit
             PlaybackSpectrumStyle.Bars,
             PlaybackSpectrumStyle.MirrorBars -> levels.forEachIndexed { index, level ->
                 val normalized = 0.18f + level.coerceIn(0f, 1f) * 0.82f

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -650,6 +650,8 @@ fun ProviderFeatureHeader(
     title: String = feature.title,
     providerLabel: String = feature.providerName,
     onPlayAll: (() -> Unit)? = null,
+    action: (() -> Unit)? = null,
+    actionLabel: String = "",
 ) {
     Row(
         modifier = Modifier
@@ -676,6 +678,9 @@ fun ProviderFeatureHeader(
             )
             if (onPlayAll != null) {
                 PlayAllButton(onClick = onPlayAll)
+            }
+            if (action != null) {
+                TextButton(onClick = action) { Text(actionLabel) }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -710,6 +710,28 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     onCheckedChange = controller::onShowPlaybackSpectrumChange,
                 )
             }
+            if (controller.showPlaybackSpectrum) {
+                Text(
+                    text = "频谱样式",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    PlaybackSpectrumStyle.entries.forEachIndexed { index, style ->
+                        SegmentedButton(
+                            selected = controller.playbackSpectrumStyle == style,
+                            onClick = { controller.onPlaybackSpectrumStyleChange(style) },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = PlaybackSpectrumStyle.entries.size,
+                            ),
+                            colors = settingsSegmentedButtonColors(),
+                        ) {
+                            Text(style.label)
+                        }
+                    }
+                }
+            }
             Text(
                 text = "外观模式",
                 style = MaterialTheme.typography.bodyMedium,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -695,40 +695,23 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = "显示播放频谱",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Checkbox(
-                    checked = controller.showPlaybackSpectrum,
-                    onCheckedChange = controller::onShowPlaybackSpectrumChange,
-                )
-            }
-            if (controller.showPlaybackSpectrum) {
-                Text(
-                    text = "频谱样式",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    PlaybackSpectrumStyle.entries.forEachIndexed { index, style ->
-                        SegmentedButton(
-                            selected = controller.playbackSpectrumStyle == style,
-                            onClick = { controller.onPlaybackSpectrumStyleChange(style) },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = PlaybackSpectrumStyle.entries.size,
-                            ),
-                            colors = settingsSegmentedButtonColors(),
-                        ) {
-                            Text(style.label)
-                        }
+            Text(
+                text = "频谱样式",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                PlaybackSpectrumStyle.entries.forEachIndexed { index, style ->
+                    SegmentedButton(
+                        selected = controller.playbackSpectrumStyle == style,
+                        onClick = { controller.onPlaybackSpectrumStyleChange(style) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = PlaybackSpectrumStyle.entries.size,
+                        ),
+                        colors = settingsSegmentedButtonColors(),
+                    ) {
+                        Text(style.label)
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -695,6 +695,21 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = "显示播放频谱",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Checkbox(
+                    checked = controller.showPlaybackSpectrum,
+                    onCheckedChange = controller::onShowPlaybackSpectrumChange,
+                )
+            }
             Text(
                 text = "外观模式",
                 style = MaterialTheme.typography.bodyMedium,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1869,6 +1869,7 @@ class FuoPlayerControllerTest {
 
     @Test
     fun restoresAndPersistsSettings() = runTest {
+        assertEquals(PlaybackSpectrumStyle.None, AppSettings().playbackSpectrumStyle)
         val store = FakeSettingsStore(
             AppSettings(
                 homeSection = HomeSection.Mine,
@@ -1895,8 +1896,7 @@ class FuoPlayerControllerTest {
                 smartReplacementUseReplacementMetadata = true,
                 smartReplacementUseReplacementLyrics = true,
                 lyricFontSize = LyricFontSize.Large,
-                showPlaybackSpectrum = false,
-                playbackSpectrumStyle = PlaybackSpectrumStyle.MirrorBars,
+                playbackSpectrumStyle = PlaybackSpectrumStyle.None,
                 themeMode = ThemeMode.Dark,
                 themeColorScheme = ThemeColorScheme.OceanBlue,
             ),
@@ -1946,8 +1946,7 @@ class FuoPlayerControllerTest {
             assertEquals(true, controller.smartReplacementUseReplacementMetadata)
             assertEquals(true, controller.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Large, controller.lyricFontSize)
-            assertEquals(false, controller.showPlaybackSpectrum)
-            assertEquals(PlaybackSpectrumStyle.MirrorBars, controller.playbackSpectrumStyle)
+            assertEquals(PlaybackSpectrumStyle.None, controller.playbackSpectrumStyle)
             assertEquals(ThemeMode.Dark, controller.themeMode)
             assertEquals(ThemeColorScheme.OceanBlue, controller.themeColorScheme)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
@@ -1969,7 +1968,6 @@ class FuoPlayerControllerTest {
             controller.onSmartReplacementUseReplacementMetadataChange(false)
             controller.onSmartReplacementUseReplacementLyricsChange(false)
             controller.onLyricFontSizeChange(LyricFontSize.Medium)
-            controller.onShowPlaybackSpectrumChange(true)
             controller.onPlaybackSpectrumStyleChange(PlaybackSpectrumStyle.Wave)
             controller.onThemeModeChange(ThemeMode.Light)
             controller.onThemeColorSchemeChange(ThemeColorScheme.FuoGreen)
@@ -1997,7 +1995,6 @@ class FuoPlayerControllerTest {
             assertEquals(false, store.saved.smartReplacementUseReplacementMetadata)
             assertEquals(false, store.saved.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Medium, store.saved.lyricFontSize)
-            assertEquals(true, store.saved.showPlaybackSpectrum)
             assertEquals(PlaybackSpectrumStyle.Wave, store.saved.playbackSpectrumStyle)
             assertEquals(ThemeMode.Light, store.saved.themeMode)
             assertEquals(ThemeColorScheme.FuoGreen, store.saved.themeColorScheme)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1896,6 +1896,7 @@ class FuoPlayerControllerTest {
                 smartReplacementUseReplacementLyrics = true,
                 lyricFontSize = LyricFontSize.Large,
                 showPlaybackSpectrum = false,
+                playbackSpectrumStyle = PlaybackSpectrumStyle.MirrorBars,
                 themeMode = ThemeMode.Dark,
                 themeColorScheme = ThemeColorScheme.OceanBlue,
             ),
@@ -1946,6 +1947,7 @@ class FuoPlayerControllerTest {
             assertEquals(true, controller.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Large, controller.lyricFontSize)
             assertEquals(false, controller.showPlaybackSpectrum)
+            assertEquals(PlaybackSpectrumStyle.MirrorBars, controller.playbackSpectrumStyle)
             assertEquals(ThemeMode.Dark, controller.themeMode)
             assertEquals(ThemeColorScheme.OceanBlue, controller.themeColorScheme)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
@@ -1968,6 +1970,7 @@ class FuoPlayerControllerTest {
             controller.onSmartReplacementUseReplacementLyricsChange(false)
             controller.onLyricFontSizeChange(LyricFontSize.Medium)
             controller.onShowPlaybackSpectrumChange(true)
+            controller.onPlaybackSpectrumStyleChange(PlaybackSpectrumStyle.Wave)
             controller.onThemeModeChange(ThemeMode.Light)
             controller.onThemeColorSchemeChange(ThemeColorScheme.FuoGreen)
             advanceUntilIdle()
@@ -1995,6 +1998,7 @@ class FuoPlayerControllerTest {
             assertEquals(false, store.saved.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Medium, store.saved.lyricFontSize)
             assertEquals(true, store.saved.showPlaybackSpectrum)
+            assertEquals(PlaybackSpectrumStyle.Wave, store.saved.playbackSpectrumStyle)
             assertEquals(ThemeMode.Light, store.saved.themeMode)
             assertEquals(ThemeColorScheme.FuoGreen, store.saved.themeColorScheme)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1895,6 +1895,7 @@ class FuoPlayerControllerTest {
                 smartReplacementUseReplacementMetadata = true,
                 smartReplacementUseReplacementLyrics = true,
                 lyricFontSize = LyricFontSize.Large,
+                showPlaybackSpectrum = false,
                 themeMode = ThemeMode.Dark,
                 themeColorScheme = ThemeColorScheme.OceanBlue,
             ),
@@ -1944,6 +1945,7 @@ class FuoPlayerControllerTest {
             assertEquals(true, controller.smartReplacementUseReplacementMetadata)
             assertEquals(true, controller.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Large, controller.lyricFontSize)
+            assertEquals(false, controller.showPlaybackSpectrum)
             assertEquals(ThemeMode.Dark, controller.themeMode)
             assertEquals(ThemeColorScheme.OceanBlue, controller.themeColorScheme)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
@@ -1965,6 +1967,7 @@ class FuoPlayerControllerTest {
             controller.onSmartReplacementUseReplacementMetadataChange(false)
             controller.onSmartReplacementUseReplacementLyricsChange(false)
             controller.onLyricFontSizeChange(LyricFontSize.Medium)
+            controller.onShowPlaybackSpectrumChange(true)
             controller.onThemeModeChange(ThemeMode.Light)
             controller.onThemeColorSchemeChange(ThemeColorScheme.FuoGreen)
             advanceUntilIdle()
@@ -1991,6 +1994,7 @@ class FuoPlayerControllerTest {
             assertEquals(false, store.saved.smartReplacementUseReplacementMetadata)
             assertEquals(false, store.saved.smartReplacementUseReplacementLyrics)
             assertEquals(LyricFontSize.Medium, store.saved.lyricFontSize)
+            assertEquals(true, store.saved.showPlaybackSpectrum)
             assertEquals(ThemeMode.Light, store.saved.themeMode)
             assertEquals(ThemeColorScheme.FuoGreen, store.saved.themeColorScheme)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -37,6 +37,7 @@ class IosAppSettingsStore : AppSettingsStore {
             smartReplacementUseReplacementMetadata = boolValue(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA, false),
             smartReplacementUseReplacementLyrics = boolValue(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, false),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
+            showPlaybackSpectrum = boolValue(KEY_SHOW_PLAYBACK_SPECTRUM, true),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -66,6 +67,7 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setBool(settings.smartReplacementUseReplacementMetadata, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA)
             defaults.setBool(settings.smartReplacementUseReplacementLyrics, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS)
             defaults.setObject(settings.lyricFontSize.name, KEY_LYRIC_FONT_SIZE)
+            defaults.setBool(settings.showPlaybackSpectrum, KEY_SHOW_PLAYBACK_SPECTRUM)
             defaults.setObject(settings.themeMode.name, KEY_THEME_MODE)
             defaults.setObject(settings.themeColorScheme.name, KEY_THEME_COLOR_SCHEME)
             defaults.synchronize()
@@ -175,6 +177,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA = "smart_replacement_use_replacement_metadata"
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
+        private const val KEY_SHOW_PLAYBACK_SPECTRUM = "show_playback_spectrum"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -37,8 +37,11 @@ class IosAppSettingsStore : AppSettingsStore {
             smartReplacementUseReplacementMetadata = boolValue(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA, false),
             smartReplacementUseReplacementLyrics = boolValue(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, false),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
-            showPlaybackSpectrum = boolValue(KEY_SHOW_PLAYBACK_SPECTRUM, true),
-            playbackSpectrumStyle = enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.Bars),
+            playbackSpectrumStyle = if (boolValue(KEY_SHOW_PLAYBACK_SPECTRUM, true)) {
+                enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.None)
+            } else {
+                PlaybackSpectrumStyle.None
+            },
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -68,7 +71,7 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setBool(settings.smartReplacementUseReplacementMetadata, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA)
             defaults.setBool(settings.smartReplacementUseReplacementLyrics, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS)
             defaults.setObject(settings.lyricFontSize.name, KEY_LYRIC_FONT_SIZE)
-            defaults.setBool(settings.showPlaybackSpectrum, KEY_SHOW_PLAYBACK_SPECTRUM)
+            defaults.removeObjectForKey(KEY_SHOW_PLAYBACK_SPECTRUM)
             defaults.setObject(settings.playbackSpectrumStyle.name, KEY_PLAYBACK_SPECTRUM_STYLE)
             defaults.setObject(settings.themeMode.name, KEY_THEME_MODE)
             defaults.setObject(settings.themeColorScheme.name, KEY_THEME_COLOR_SCHEME)

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -38,6 +38,7 @@ class IosAppSettingsStore : AppSettingsStore {
             smartReplacementUseReplacementLyrics = boolValue(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, false),
             lyricFontSize = enumValue(KEY_LYRIC_FONT_SIZE, LyricFontSize.Small),
             showPlaybackSpectrum = boolValue(KEY_SHOW_PLAYBACK_SPECTRUM, true),
+            playbackSpectrumStyle = enumValue(KEY_PLAYBACK_SPECTRUM_STYLE, PlaybackSpectrumStyle.Bars),
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
@@ -68,6 +69,7 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setBool(settings.smartReplacementUseReplacementLyrics, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS)
             defaults.setObject(settings.lyricFontSize.name, KEY_LYRIC_FONT_SIZE)
             defaults.setBool(settings.showPlaybackSpectrum, KEY_SHOW_PLAYBACK_SPECTRUM)
+            defaults.setObject(settings.playbackSpectrumStyle.name, KEY_PLAYBACK_SPECTRUM_STYLE)
             defaults.setObject(settings.themeMode.name, KEY_THEME_MODE)
             defaults.setObject(settings.themeColorScheme.name, KEY_THEME_COLOR_SCHEME)
             defaults.synchronize()
@@ -178,6 +180,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"
         private const val KEY_LYRIC_FONT_SIZE = "lyric_font_size"
         private const val KEY_SHOW_PLAYBACK_SPECTRUM = "show_playback_spectrum"
+        private const val KEY_PLAYBACK_SPECTRUM_STYLE = "playback_spectrum_style"
         private const val KEY_THEME_MODE = "theme_mode"
         private const val KEY_THEME_COLOR_SCHEME = "theme_color_scheme"
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAudioOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAudioOutput.kt
@@ -12,4 +12,5 @@ interface IosAudioOutput {
     fun bufferedMs(): Long
     fun errorMessage(): String?
     fun audioFormatInfo(): AudioFormatInfo?
+    fun spectrumLevels(): List<Float>
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
@@ -19,7 +19,7 @@ class IosNativeAudioEngine(
         scope.launch {
             while (true) {
                 updateFromOutput()
-                delay(500)
+                delay(50)
             }
         }
     }
@@ -82,6 +82,7 @@ class IosNativeAudioEngine(
             durationMs = output.durationMs().takeIf { it > 0 } ?: mutableState.value.durationMs,
             bufferedMs = output.bufferedMs().coerceAtLeast(0),
             audioFormatInfo = output.audioFormatInfo(),
+            spectrumLevels = if (status == PlayerStatus.Playing) output.spectrumLevels() else emptyList(),
             errorMessage = output.errorMessage(),
         )
     }


### PR DESCRIPTION
## Summary

- Move playlist creation into each eligible provider's "My Playlists" header.
- Refresh the mini player with playback progress, shared-cover Hero transitions, and a persisted spectrum setting.
- Add real PCM spectrum sampling for Android Media3 and iOS AVPlayer.
- Run the iOS debug-app workflow for pull requests targeting `master`.

## Validation

- `./gradlew :shared:allTests`
- `./gradlew :androidApp:compileDebugKotlin`
- `./gradlew :androidApp:assembleDebug`
- Workflow YAML parsed successfully.

`./gradlew :androidApp:lint :shared:lint` remains blocked by an existing Compose lint detector crash in `AndroidResourceCache.kt` (`FrequentlyChangingValueDetector`).

## Notes

- iOS native compilation is delegated to the newly enabled macOS pull-request workflow because this environment has no Xcode.