### PR TITLE
[feat] add download manager

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
@@ -75,5 +76,9 @@
                 <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
         </service>
+        <service
+            android:name=".FuoDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 </manifest>

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -31,6 +31,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
             providerOrderIds = readStringList(KEY_PROVIDER_ORDER_IDS).ifEmpty { DEFAULT_PROVIDER_ORDER_IDS },
             audioCacheLimitMb = preferences.getInt(KEY_AUDIO_CACHE_LIMIT_MB, DEFAULT_AUDIO_CACHE_LIMIT_MB),
             imageCacheLimitMb = preferences.getInt(KEY_IMAGE_CACHE_LIMIT_MB, DEFAULT_IMAGE_CACHE_LIMIT_MB),
+            downloadParallelism = preferences.getInt(KEY_DOWNLOAD_PARALLELISM, DEFAULT_DOWNLOAD_PARALLELISM).coerceIn(1, 5),
             wifiAudioQualityPolicy = enumValue(KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
             cellularAudioQualityPolicy = enumValue(
                 KEY_CELLULAR_AUDIO_QUALITY_POLICY,
@@ -78,6 +79,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .putString(KEY_PROVIDER_ORDER_IDS, stringListJson(settings.providerOrderIds))
                 .putInt(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb)
                 .putInt(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb)
+                .putInt(KEY_DOWNLOAD_PARALLELISM, settings.downloadParallelism.coerceIn(1, 5))
                 .putString(KEY_WIFI_AUDIO_QUALITY_POLICY, settings.wifiAudioQualityPolicy.name)
                 .putString(KEY_CELLULAR_AUDIO_QUALITY_POLICY, settings.cellularAudioQualityPolicy.name)
                 .putString(KEY_UNAVAILABLE_PLAYBACK_POLICY, settings.unavailablePlaybackPolicy.name)
@@ -217,6 +219,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         private const val KEY_PROVIDER_ORDER_IDS = "provider_order_ids"
         private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
         private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
+        private const val KEY_DOWNLOAD_PARALLELISM = "download_parallelism"
         private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"
         private const val KEY_CELLULAR_AUDIO_QUALITY_POLICY = "cellular_audio_quality_policy"
         private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
@@ -28,6 +29,7 @@ import java.io.FileOutputStream
 import java.io.InputStream
 import java.net.URL
 import java.net.HttpURLConnection
+import kotlin.coroutines.coroutineContext
 
 class AndroidDownloadRepository(
     private val context: Context,
@@ -40,6 +42,7 @@ class AndroidDownloadRepository(
     private val mutableTasks = MutableStateFlow<List<DownloadTask>>(emptyList())
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val taskJobs = mutableMapOf<String, Job>()
+    private val taskConnections = mutableMapOf<String, HttpURLConnection>()
     private val taskPayloads = mutableMapOf<String, PlaybackPayload>()
     private val taskMutex = Mutex()
     private var parallelism = DEFAULT_DOWNLOAD_PARALLELISM
@@ -123,6 +126,7 @@ class AndroidDownloadRepository(
         taskMutex.withLock {
             val task = taskRecords[taskId] ?: return
             if (task.status !in setOf(DownloadTaskStatus.Queued, DownloadTaskStatus.Downloading)) return
+            taskConnections.remove(taskId)?.disconnect()
             taskJobs.remove(taskId)?.cancel()
             updateTask(task.copy(status = DownloadTaskStatus.Paused, updatedAt = System.currentTimeMillis()))
         }
@@ -134,6 +138,7 @@ class AndroidDownloadRepository(
 
     override suspend fun deleteTask(taskId: String, deleteFile: Boolean) {
         taskMutex.withLock {
+            taskConnections.remove(taskId)?.disconnect()
             taskJobs.remove(taskId)?.cancel()
             val task = taskRecords.remove(taskId) ?: return
             temporaryFile(task.id).delete()
@@ -149,11 +154,9 @@ class AndroidDownloadRepository(
     override suspend fun deleteDownloaded(track: MusicTrack) {
         withContext(Dispatchers.IO) {
             val key = track.providerId ?: track.id
-            val record = records.remove(key)
-                ?: track.localUri?.let { uri ->
-                    val matched = records.entries.firstOrNull { it.value.uri == uri }
-                    if (matched != null) records.remove(matched.key) else null
-                }
+            val recordKey = records[key]?.let { key }
+                ?: track.localUri?.let { uri -> records.entries.firstOrNull { it.value.uri == uri }?.key }
+            val record = recordKey?.let(records::remove)
             val uri = record?.uri ?: track.localUri
             if ((record != null || track.sourceType == TrackSourceType.Downloaded) && uri != null) {
                 runCatching { context.contentResolver.delete(Uri.parse(uri), null, null) }
@@ -162,7 +165,7 @@ class AndroidDownloadRepository(
                 }
             }
             saveRecords()
-            taskRecords.remove(key)
+            taskRecords.remove(recordKey ?: key)
             saveTasks()
             publishTasks()
             publishStates()
@@ -245,34 +248,47 @@ class AndroidDownloadRepository(
         }
     }
 
-    private fun writePayload(taskId: String, payload: PlaybackPayload, targetFile: File): Long {
+    private suspend fun writePayload(taskId: String, payload: PlaybackPayload, targetFile: File): Long {
+        coroutineContext.ensureActive()
         val connection = URL(payload.url).openConnection()
-        payload.headers.forEach { (key, value) -> connection.setRequestProperty(key, value) }
-        val existing = targetFile.length()
-        if (existing > 0) connection.setRequestProperty("Range", "bytes=$existing-")
-        val responseCode = (connection as? HttpURLConnection)?.responseCode
-        val append = existing > 0 && responseCode == HttpURLConnection.HTTP_PARTIAL
-        val start = if (append) existing else 0L
-        val total = connection.contentLengthLong.takeIf { it > 0 }?.plus(start)
-        var written = start
-        connection.getInputStream().use { input ->
-            FileOutputStream(targetFile, append).use { output ->
-                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                while (true) {
-                    val read = input.read(buffer)
-                    if (read < 0) break
-                    output.write(buffer, 0, read)
-                    written += read
-                    if (total != null) {
-                        val progress = (written.toFloat() / total.toFloat()).coerceIn(0f, 1f)
-                        scope.launch { taskMutex.withLock {
-                            taskRecords[taskId]?.let { updateTask(it.copy(downloadedBytes = written, totalBytes = total, updatedAt = System.currentTimeMillis())) }
-                        } }
+        val httpConnection = connection as? HttpURLConnection
+        taskMutex.withLock { httpConnection?.let { taskConnections[taskId] = it } }
+        try {
+            coroutineContext.ensureActive()
+            payload.headers.forEach { (key, value) -> connection.setRequestProperty(key, value) }
+            val existing = targetFile.length()
+            if (existing > 0) connection.setRequestProperty("Range", "bytes=$existing-")
+            val responseCode = httpConnection?.responseCode
+            val append = existing > 0 && responseCode == HttpURLConnection.HTTP_PARTIAL
+            val start = if (append) existing else 0L
+            val total = connection.contentLengthLong.takeIf { it > 0 }?.plus(start)
+            var written = start
+            connection.getInputStream().use { input ->
+                FileOutputStream(targetFile, append).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        coroutineContext.ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        written += read
+                        if (total != null) {
+                            val progress = (written.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+                            scope.launch { taskMutex.withLock {
+                                taskRecords[taskId]?.let { updateTask(it.copy(downloadedBytes = written, totalBytes = total, updatedAt = System.currentTimeMillis())) }
+                            } }
+                        }
                     }
                 }
             }
+            return written
+        } catch (throwable: Throwable) {
+            coroutineContext.ensureActive()
+            throw throwable
+        } finally {
+            taskMutex.withLock { taskConnections.remove(taskId) }
+            httpConnection?.disconnect()
         }
-        return written
     }
 
     private fun copyToTarget(taskId: String, sourceFile: File, targetUri: Uri): Long {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -9,10 +9,16 @@ import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -21,19 +27,29 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.net.URL
+import java.net.HttpURLConnection
 
 class AndroidDownloadRepository(
     private val context: Context,
     private val providerRepository: ProviderMusicRepository,
+    private val onBackgroundWorkChanged: (List<DownloadTask>) -> Unit = {},
 ) : DownloadRepository {
     private val records = linkedMapOf<String, DownloadRecord>()
+    private val taskRecords = linkedMapOf<String, DownloadTask>()
     private val mutableStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
+    private val mutableTasks = MutableStateFlow<List<DownloadTask>>(emptyList())
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val taskJobs = mutableMapOf<String, Job>()
+    private val taskMutex = Mutex()
+    private var parallelism = DEFAULT_DOWNLOAD_PARALLELISM
 
     override val states: StateFlow<Map<String, DownloadState>> = mutableStates.asStateFlow()
+    override val tasks: StateFlow<List<DownloadTask>> = mutableTasks.asStateFlow()
 
     override suspend fun load() {
         withContext(Dispatchers.IO) {
             records.clear()
+            taskRecords.clear()
             val file = indexFile()
             if (file.exists()) {
                 val array = JSONArray(file.readText())
@@ -42,48 +58,80 @@ class AndroidDownloadRepository(
                     records[record.trackId] = record
                 }
             }
+            val tasksFile = taskIndexFile()
+            if (tasksFile.exists()) {
+                val array = JSONArray(tasksFile.readText())
+                for (index in 0 until array.length()) {
+                    val task = array.getJSONObject(index).toTask()
+                    taskRecords[task.id] = if (task.status == DownloadTaskStatus.Downloading) {
+                        task.copy(status = DownloadTaskStatus.Paused, updatedAt = System.currentTimeMillis())
+                    } else {
+                        task
+                    }
+                }
+            } else {
+                records.values.forEach { record ->
+                    taskRecords[record.trackId] = record.toCompletedTask()
+                }
+                saveTasks()
+            }
             publishStates()
+            publishTasks()
+            schedule()
         }
     }
 
     override suspend fun download(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
-        withContext(Dispatchers.IO) {
-            val payload = providerRepository.resolve(track)
-            mutableStates.update { it + (track.id to DownloadState.Downloading(0f)) }
-            val extension = extension(payload.url)
-            val tempFile = File.createTempFile("fuo-download-", ".$extension", context.cacheDir)
-            var target: DownloadTarget? = null
-            try {
-                writePayload(track.id, payload, tempFile)
-                writeId3TagIfNeeded(tempFile, extension, track, payload)
-                target = createTarget(track, payload, extension)
-                val bytes = copyToTarget(track.id, tempFile, target.uri)
-                writeLyricsFileIfNeeded(payload, target)
-                val finalUri = finishTarget(target, success = true)
-                val record = DownloadRecord(
-                    trackId = track.id,
-                    title = track.title,
-                    artists = track.artists,
-                    album = track.album,
-                    source = track.source,
-                    uri = finalUri.toString(),
-                    coverUrl = payload.coverUrl,
-                    durationMs = payload.durationMs ?: track.durationMs,
-                    fileSize = bytes,
-                    createdAt = System.currentTimeMillis(),
+        taskMutex.withLock {
+            val existing = taskRecords[track.id]
+            when (existing?.status) {
+                DownloadTaskStatus.Queued, DownloadTaskStatus.Downloading -> return
+                DownloadTaskStatus.Paused, DownloadTaskStatus.Failed -> updateTask(
+                    existing.copy(status = DownloadTaskStatus.Queued, failureMessage = null, updatedAt = System.currentTimeMillis()),
                 )
-                records[track.id] = record
-                saveRecords()
-                publishStates()
-            } catch (throwable: Throwable) {
-                target?.let { finishTarget(it, success = false) }
-                Log.e(TAG, "download failed trackId=${track.id} title=${track.title}", throwable)
-                mutableStates.update { it + (track.id to DownloadState.Failed(throwable.message ?: "下载失败")) }
-                throw throwable
-            } finally {
-                tempFile.delete()
+                else -> updateTask(
+                    DownloadTask(
+                        id = track.id,
+                        track = track,
+                        status = DownloadTaskStatus.Queued,
+                        createdAt = System.currentTimeMillis(),
+                    ),
+                )
             }
+        }
+        schedule()
+    }
+
+    override suspend fun updateParallelism(parallelism: Int) {
+        this.parallelism = parallelism.coerceIn(1, 5)
+        schedule()
+    }
+
+    override suspend fun pause(taskId: String) {
+        taskMutex.withLock {
+            val task = taskRecords[taskId] ?: return
+            if (task.status !in setOf(DownloadTaskStatus.Queued, DownloadTaskStatus.Downloading)) return
+            taskJobs.remove(taskId)?.cancel()
+            updateTask(task.copy(status = DownloadTaskStatus.Paused, updatedAt = System.currentTimeMillis()))
+        }
+    }
+
+    override suspend fun resume(taskId: String) = restart(taskId)
+
+    override suspend fun retry(taskId: String) = restart(taskId)
+
+    override suspend fun deleteTask(taskId: String, deleteFile: Boolean) {
+        taskMutex.withLock {
+            taskJobs.remove(taskId)?.cancel()
+            val task = taskRecords.remove(taskId) ?: return
+            temporaryFile(task.id).delete()
+            val record = records.remove(task.id)
+            if (deleteFile) record?.uri?.let(::deleteUri)
+            saveRecords()
+            saveTasks()
+            publishTasks()
+            publishStates()
         }
     }
 
@@ -103,17 +151,101 @@ class AndroidDownloadRepository(
                 }
             }
             saveRecords()
+            taskRecords.remove(key)
+            saveTasks()
+            publishTasks()
             publishStates()
         }
     }
 
-    private fun writePayload(trackId: String, payload: PlaybackPayload, targetFile: File): Long {
+    private suspend fun restart(taskId: String) {
+        taskMutex.withLock {
+            val task = taskRecords[taskId] ?: return
+            if (task.status == DownloadTaskStatus.Completed) return
+            updateTask(task.copy(status = DownloadTaskStatus.Queued, failureMessage = null, updatedAt = System.currentTimeMillis()))
+        }
+        schedule()
+    }
+
+    private fun schedule() {
+        scope.launch {
+            val ids = taskMutex.withLock {
+                val capacity = parallelism - taskJobs.values.count { it.isActive }
+                if (capacity <= 0) return@withLock emptyList()
+                taskRecords.values
+                    .filter { it.status == DownloadTaskStatus.Queued && it.id !in taskJobs }
+                    .sortedBy { it.createdAt }
+                    .take(capacity)
+                    .map { it.id }
+            }
+            ids.forEach { taskId ->
+                taskJobs[taskId] = scope.launch { runTask(taskId) }
+            }
+        }
+    }
+
+    private suspend fun runTask(taskId: String) {
+        var target: DownloadTarget? = null
+        try {
+            val task = taskMutex.withLock {
+                val current = taskRecords[taskId] ?: return
+                val downloading = current.copy(status = DownloadTaskStatus.Downloading, updatedAt = System.currentTimeMillis())
+                updateTask(downloading)
+                downloading
+            }
+            val payload = providerRepository.resolve(task.track)
+            val extension = extension(payload.url)
+            val tempFile = temporaryFile(taskId, extension)
+            writePayload(taskId, payload, tempFile)
+            writeId3TagIfNeeded(tempFile, extension, task.track, payload)
+            target = createTarget(task.track, payload, extension)
+            val bytes = copyToTarget(taskId, tempFile, target.uri)
+            writeLyricsFileIfNeeded(payload, target)
+            val finalUri = finishTarget(target, success = true)
+            val record = DownloadRecord(
+                trackId = task.id, title = task.track.title, artists = task.track.artists, album = task.track.album,
+                source = task.track.source, uri = finalUri.toString(), coverUrl = payload.coverUrl,
+                durationMs = payload.durationMs ?: task.track.durationMs, fileSize = bytes, createdAt = System.currentTimeMillis(),
+            )
+            taskMutex.withLock {
+                records[task.id] = record
+                updateTask(taskRecords.getValue(task.id).copy(
+                    status = DownloadTaskStatus.Completed, completedUri = finalUri.toString(), downloadedBytes = bytes,
+                    totalBytes = bytes, failureMessage = null, updatedAt = System.currentTimeMillis(),
+                ))
+                saveRecords()
+            }
+            tempFile.delete()
+        } catch (cancelled: CancellationException) {
+            // pause() has already persisted the paused state and intentionally retains the partial file.
+        } catch (throwable: Throwable) {
+            target?.let { finishTarget(it, success = false) }
+            Log.e(TAG, "download failed taskId=$taskId", throwable)
+            taskMutex.withLock {
+                taskRecords[taskId]?.let { updateTask(it.copy(
+                    status = DownloadTaskStatus.Failed,
+                    failureMessage = throwable.message ?: "下载失败",
+                    updatedAt = System.currentTimeMillis(),
+                )) }
+            }
+        } finally {
+            taskMutex.withLock { taskJobs.remove(taskId) }
+            schedule()
+        }
+    }
+
+    private fun writePayload(taskId: String, payload: PlaybackPayload, targetFile: File): Long {
         val connection = URL(payload.url).openConnection()
         payload.headers.forEach { (key, value) -> connection.setRequestProperty(key, value) }
-        val total = connection.contentLengthLong.takeIf { it > 0 }
-        var written = 0L
+        val existing = targetFile.length()
+        if (existing > 0) connection.setRequestProperty("Range", "bytes=$existing-")
+        val responseCode = (connection as? HttpURLConnection)?.responseCode
+        val append = existing > 0 && responseCode == HttpURLConnection.HTTP_PARTIAL
+        val start = if (append) existing else 0L
+        val total = connection.contentLengthLong.takeIf { it > 0 }?.plus(start)
+        var written = start
         connection.getInputStream().use { input ->
-            FileOutputStream(targetFile).use { output ->
+            FileOutputStream(targetFile, append).use { output ->
                 val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
                 while (true) {
                     val read = input.read(buffer)
@@ -122,9 +254,9 @@ class AndroidDownloadRepository(
                     written += read
                     if (total != null) {
                         val progress = (written.toFloat() / total.toFloat()).coerceIn(0f, 1f)
-                        mutableStates.update { current ->
-                            current + (trackId to DownloadState.Downloading(progress))
-                        }
+                        scope.launch { taskMutex.withLock {
+                            taskRecords[taskId]?.let { updateTask(it.copy(downloadedBytes = written, totalBytes = total, updatedAt = System.currentTimeMillis())) }
+                        } }
                     }
                 }
             }
@@ -132,7 +264,7 @@ class AndroidDownloadRepository(
         return written
     }
 
-    private fun copyToTarget(trackId: String, sourceFile: File, targetUri: Uri): Long {
+    private fun copyToTarget(taskId: String, sourceFile: File, targetUri: Uri): Long {
         var written = 0L
         sourceFile.inputStream().use { input ->
             val outputStream = if (targetUri.scheme == "file") {
@@ -150,7 +282,6 @@ class AndroidDownloadRepository(
                 }
             } ?: error("无法写入下载文件")
         }
-        mutableStates.update { it + (trackId to DownloadState.Downloading(1f)) }
         return written
     }
 
@@ -233,10 +364,54 @@ class AndroidDownloadRepository(
     }
 
     private fun publishStates() {
-        mutableStates.value = records.mapValues { DownloadState.Downloaded(it.value.uri) }
+        val active = taskRecords.values.associate { task ->
+            task.id to when (task.status) {
+                DownloadTaskStatus.Queued -> DownloadState.Queued
+                DownloadTaskStatus.Downloading -> DownloadState.Downloading(
+                    task.totalBytes?.takeIf { it > 0 }?.let { task.downloadedBytes.toFloat() / it } ?: 0f,
+                )
+                DownloadTaskStatus.Paused -> DownloadState.Paused
+                DownloadTaskStatus.Failed -> DownloadState.Failed(task.failureMessage ?: "下载失败")
+                DownloadTaskStatus.Completed -> DownloadState.Downloaded(task.completedUri ?: records[task.id]?.uri.orEmpty())
+            }
+        }
+        mutableStates.value = records.mapValues { DownloadState.Downloaded(it.value.uri) } + active
+    }
+
+    private fun publishTasks() {
+        mutableTasks.value = taskRecords.values.sortedWith(
+            compareBy<DownloadTask> { if (it.status == DownloadTaskStatus.Downloading) 0 else 1 }
+                .thenByDescending { it.createdAt },
+        )
+        onBackgroundWorkChanged(mutableTasks.value)
+    }
+
+    private fun updateTask(task: DownloadTask) {
+        taskRecords[task.id] = task
+        saveTasks()
+        publishTasks()
+        publishStates()
     }
 
     private fun indexFile(): File = File(context.filesDir, "downloads.json")
+    private fun taskIndexFile(): File = File(context.filesDir, "download_tasks.json")
+
+    private fun temporaryFile(taskId: String, extension: String = "part"): File {
+        val directory = File(context.filesDir, "download_parts")
+        if (!directory.exists()) directory.mkdirs()
+        return File(directory, "${taskId.hashCode().toUInt().toString(16)}.$extension.part")
+    }
+
+    private fun deleteUri(uri: String) {
+        runCatching { context.contentResolver.delete(Uri.parse(uri), null, null) }
+        if (uri.startsWith("file:")) runCatching { File(requireNotNull(Uri.parse(uri).path)).delete() }
+    }
+
+    private fun saveTasks() {
+        val array = JSONArray()
+        taskRecords.values.forEach { array.put(it.toJson()) }
+        taskIndexFile().writeText(array.toString())
+    }
 
     private fun JSONObject.toRecord(): DownloadRecord = DownloadRecord(
         trackId = getString("trackId"),
@@ -262,6 +437,64 @@ class AndroidDownloadRepository(
         .put("durationMs", durationMs ?: 0)
         .put("fileSize", fileSize)
         .put("createdAt", createdAt)
+
+    private fun DownloadRecord.toCompletedTask(): DownloadTask = DownloadTask(
+        id = trackId,
+        track = MusicTrack(
+            id = trackId, title = title, artists = artists, album = album, source = source,
+            sourceType = TrackSourceType.Provider, coverUrl = coverUrl, durationMs = durationMs,
+        ),
+        status = DownloadTaskStatus.Completed,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+        downloadedBytes = fileSize,
+        totalBytes = fileSize.takeIf { it > 0 },
+        completedUri = uri,
+    )
+
+    private fun DownloadTask.toJson(): JSONObject = JSONObject()
+        .put("id", id)
+        .put("trackId", track.id)
+        .put("title", track.title)
+        .put("artists", track.artists)
+        .put("album", track.album)
+        .put("source", track.source)
+        .put("sourceType", track.sourceType.name)
+        .put("coverUrl", track.coverUrl ?: "")
+        .put("durationMs", track.durationMs ?: 0)
+        .put("providerId", track.providerId ?: "")
+        .put("providerName", track.providerName ?: "")
+        .put("status", status.name)
+        .put("createdAt", createdAt)
+        .put("updatedAt", updatedAt)
+        .put("downloadedBytes", downloadedBytes)
+        .put("totalBytes", totalBytes ?: 0)
+        .put("failureMessage", failureMessage ?: "")
+        .put("completedUri", completedUri ?: "")
+
+    private fun JSONObject.toTask(): DownloadTask {
+        val trackId = optString("trackId").ifBlank { getString("id") }
+        return DownloadTask(
+            id = getString("id"),
+            track = MusicTrack(
+                id = trackId,
+                title = optString("title"), artists = optString("artists"), album = optString("album"),
+                source = optString("source"),
+                sourceType = runCatching { TrackSourceType.valueOf(optString("sourceType")) }.getOrDefault(TrackSourceType.Provider),
+                coverUrl = optString("coverUrl").takeIf { it.isNotBlank() },
+                durationMs = optLong("durationMs").takeIf { it > 0 },
+                providerId = optString("providerId").takeIf { it.isNotBlank() },
+                providerName = optString("providerName").takeIf { it.isNotBlank() },
+            ),
+            status = runCatching { DownloadTaskStatus.valueOf(optString("status")) }.getOrDefault(DownloadTaskStatus.Paused),
+            createdAt = optLong("createdAt").takeIf { it > 0 } ?: System.currentTimeMillis(),
+            updatedAt = optLong("updatedAt").takeIf { it > 0 } ?: System.currentTimeMillis(),
+            downloadedBytes = optLong("downloadedBytes"),
+            totalBytes = optLong("totalBytes").takeIf { it > 0 },
+            failureMessage = optString("failureMessage").takeIf { it.isNotBlank() },
+            completedUri = optString("completedUri").takeIf { it.isNotBlank() },
+        )
+    }
 
     private fun sanitize(value: String): String {
         val sanitized = value.replace(Regex("""[\\/:*?"<>|]"""), "_").trim()

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -529,6 +529,7 @@ class AndroidDownloadRepository(
     }
 
     private fun extension(url: String): String {
+        if (M4S_EXTENSION_PATTERN.containsMatchIn(url)) return "m4a"
         val clean = url.substringBefore('?').substringAfterLast('/', "")
         val ext = clean.substringAfterLast('.', "mp3").lowercase()
         return ext.takeIf { it.length in 2..5 } ?: "mp3"
@@ -741,6 +742,7 @@ class AndroidDownloadRepository(
     )
 
     private companion object {
+        val M4S_EXTENSION_PATTERN = Regex("\\.m4s(?:[./?#]|$)", RegexOption.IGNORE_CASE)
         private const val ID3_HEADER_SIZE = 10
         private const val MAX_COVER_BYTES = 5 * 1024 * 1024
         private const val COVER_CONNECT_TIMEOUT_MS = 10_000

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -8,6 +8,8 @@ import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
+import android.util.Base64
+import com.chaquo.python.Python
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -211,7 +213,7 @@ class AndroidDownloadRepository(
             val extension = extension(payload.url)
             val tempFile = temporaryFile(taskId, extension)
             writePayload(taskId, payload, tempFile)
-            writeId3TagIfNeeded(tempFile, extension, task.track, payload)
+            writeEmbeddedMetadataIfNeeded(tempFile, extension, task.track, payload)
             target = createTarget(task.track, payload, extension)
             val bytes = copyToTarget(taskId, tempFile, target.uri)
             writeLyricsFileIfNeeded(payload, target)
@@ -546,13 +548,19 @@ class AndroidDownloadRepository(
         }
     }
 
-    private fun writeId3TagIfNeeded(
+    private fun writeEmbeddedMetadataIfNeeded(
         file: File,
         extension: String,
         track: MusicTrack,
         payload: PlaybackPayload,
     ) {
-        if (extension.lowercase() != "mp3") return
+        when (extension.lowercase()) {
+            "mp3" -> writeId3Tag(file, track, payload)
+            "m4a" -> writeM4aTag(file, track, payload)
+        }
+    }
+
+    private fun writeId3Tag(file: File, track: MusicTrack, payload: PlaybackPayload) {
         val title = payload.title.ifBlank { track.title }
         val artists = payload.artists.ifBlank { track.artists }
         val album = payload.album.ifBlank { track.album }
@@ -569,6 +577,28 @@ class AndroidDownloadRepository(
         FileOutputStream(file, false).use { output ->
             output.write(tagBytes)
             output.write(audioBytes)
+        }
+    }
+
+    private fun writeM4aTag(file: File, track: MusicTrack, payload: PlaybackPayload) {
+        val title = payload.title.ifBlank { track.title }
+        val artists = payload.artists.ifBlank { track.artists }
+        val album = payload.album.ifBlank { track.album }
+        val coverImage = loadCoverImage(payload.coverUrl ?: track.coverUrl)
+        if (title.isBlank() && artists.isBlank() && album.isBlank() && coverImage == null) return
+
+        runCatching {
+            Python.getInstance().getModule("fuo_mobile.bridge").callAttr(
+                "write_m4a_tags",
+                file.absolutePath,
+                title,
+                artists,
+                album,
+                coverImage?.mimeType.orEmpty(),
+                coverImage?.bytes?.let { Base64.encodeToString(it, Base64.NO_WRAP) }.orEmpty(),
+            )
+        }.onFailure { throwable ->
+            Log.w(TAG, "failed to write m4a metadata file=${file.name}", throwable)
         }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoDownloadService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoDownloadService.kt
@@ -1,0 +1,50 @@
+package org.feeluown.mobile
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+class FuoDownloadService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val active = intent?.getIntExtra(EXTRA_ACTIVE_COUNT, 0) ?: 0
+        val title = if (active > 0) "正在下载 $active 个任务" else "下载队列"
+        startForeground(NOTIFICATION_ID, notification(title))
+        return START_NOT_STICKY
+    }
+
+    private fun notification(title: String) = NotificationCompat.Builder(this, CHANNEL_ID)
+        .setSmallIcon(android.R.drawable.stat_sys_download)
+        .setContentTitle("FeelUOwn 下载")
+        .setContentText(title)
+        .setOngoing(true)
+        .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(NotificationChannel(CHANNEL_ID, "下载任务", NotificationManager.IMPORTANCE_LOW))
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "fuo_downloads"
+        private const val NOTIFICATION_ID = 1002
+        private const val EXTRA_ACTIVE_COUNT = "active_count"
+
+        fun update(context: Context, tasks: List<DownloadTask>) {
+            val active = tasks.count { it.status == DownloadTaskStatus.Downloading || it.status == DownloadTaskStatus.Queued }
+            if (active == 0) {
+                context.stopService(Intent(context, FuoDownloadService::class.java))
+                return
+            }
+            val intent = Intent(context, FuoDownloadService::class.java).putExtra(EXTRA_ACTIVE_COUNT, active)
+            ContextCompat.startForegroundService(context, intent)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -19,7 +19,9 @@ class FuoEvolveApplication : PyApplication() {
     }
 
     private val downloadRepository: AndroidDownloadRepository by lazy {
-        AndroidDownloadRepository(applicationContext, providerRepository)
+        AndroidDownloadRepository(applicationContext, providerRepository) { tasks ->
+            FuoDownloadService.update(applicationContext, tasks)
+        }
     }
 
     private val playbackEngine: AndroidNativeAudioEngine by lazy {

--- a/androidApp/src/test/python/test_bridge_m4a_tags.py
+++ b/androidApp/src/test/python/test_bridge_m4a_tags.py
@@ -1,0 +1,66 @@
+import base64
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT_DIR = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT_DIR / "shared" / "src" / "commonMain" / "python"))
+
+from fuo_mobile.bridge import write_m4a_tags  # noqa: E402
+
+
+class _FakeMP4:
+    latest = None
+
+    def __init__(self, path):
+        self.path = path
+        self.tags = None
+        self.saved = False
+        type(self).latest = self
+
+    def add_tags(self):
+        self.tags = {}
+
+    def save(self):
+        self.saved = True
+
+
+class _FakeMP4Cover:
+    FORMAT_JPEG = "jpeg"
+    FORMAT_PNG = "png"
+
+    def __init__(self, data, imageformat):
+        self.data = data
+        self.imageformat = imageformat
+
+
+class M4aTagsTest(unittest.TestCase):
+    def test_write_m4a_tags_includes_text_and_png_artwork(self):
+        with (
+            patch("mutagen.mp4.MP4", _FakeMP4),
+            patch("mutagen.mp4.MP4Cover", _FakeMP4Cover),
+        ):
+            result = write_m4a_tags(
+                "/tmp/song.m4a",
+                "Song",
+                "Artist",
+                "Album",
+                "image/png",
+                base64.b64encode(b"cover").decode(),
+            )
+
+        audio = _FakeMP4.latest
+        self.assertTrue(result)
+        self.assertTrue(audio.saved)
+        self.assertEqual(["Song"], audio.tags["\xa9nam"])
+        self.assertEqual(["Artist"], audio.tags["\xa9ART"])
+        self.assertEqual(["Album"], audio.tags["\xa9alb"])
+        cover = audio.tags["covr"][0]
+        self.assertEqual(b"cover", cover.data)
+        self.assertEqual(_FakeMP4Cover.FORMAT_PNG, cover.imageformat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/iosApp/FuoEvolve/FuoEvolveApp.swift
+++ b/iosApp/FuoEvolve/FuoEvolveApp.swift
@@ -1,13 +1,29 @@
 import SwiftUI
+import UIKit
 import Shared
 
 @main
 struct FuoEvolveApp: App {
+    @UIApplicationDelegateAdaptor(FuoEvolveAppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             SharedComposeRoot()
                 .ignoresSafeArea()
         }
+    }
+}
+
+private final class FuoEvolveAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        IOSDownloadOutput.shared.handleBackgroundEvents(
+            identifier: identifier,
+            completionHandler: completionHandler
+        )
     }
 }
 

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -502,9 +502,10 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
     }
 }
 
-final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDelegate {
+final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDownloadDelegate {
     static let shared = IOSDownloadOutput()
     private var tasks: [String: URLSessionDownloadTask] = [:]
+    private var taskContexts: [String: DownloadContext] = [:]
     private let resumePrefix = "ios_download_resume_"
     private var backgroundCompletionHandler: (() -> Void)?
     private lazy var session: URLSession = {
@@ -528,45 +529,26 @@ final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDelegate {
         var request = URLRequest(url: sourceURL)
         headers.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
         let resumeKey = resumePrefix + taskId
-        let completion: (URL?, URLResponse?, Error?) -> Void = { temporaryURL, _, error in
-            self.tasks.removeValue(forKey: taskId)
-            if let error {
-                DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
-                return
-            }
-            guard let temporaryURL else {
-                DispatchQueue.main.async { completionHandler(nil, "下载文件为空") }
-                return
-            }
-            do {
-                let directory = try self.downloadDirectory()
-                let target = directory.appendingPathComponent(fileName)
-                if FileManager.default.fileExists(atPath: target.path) {
-                    try FileManager.default.removeItem(at: target)
-                }
-                try FileManager.default.moveItem(at: temporaryURL, to: target)
-                if let lyrics, !lyrics.isEmpty {
-                    let lyricsURL = target.deletingPathExtension().appendingPathExtension("lrc")
-                    try? lyrics.write(to: lyricsURL, atomically: true, encoding: .utf8)
-                }
-                DispatchQueue.main.async { completionHandler(target.absoluteString, nil) }
-            } catch {
-                DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
-            }
-        }
         let task: URLSessionDownloadTask
         if let resumeData = UserDefaults.standard.data(forKey: resumeKey) {
-            task = session.downloadTask(withResumeData: resumeData, completionHandler: completion)
+            task = session.downloadTask(withResumeData: resumeData)
             UserDefaults.standard.removeObject(forKey: resumeKey)
         } else {
-            task = session.downloadTask(with: request, completionHandler: completion)
+            task = session.downloadTask(with: request)
         }
+        task.taskDescription = taskId
         tasks[taskId] = task
+        taskContexts[taskId] = DownloadContext(
+            fileName: fileName,
+            lyrics: lyrics,
+            completionHandler: completionHandler
+        )
         task.resume()
     }
 
     func pause(taskId: String) {
         guard let task = tasks.removeValue(forKey: taskId) else { return }
+        taskContexts.removeValue(forKey: taskId)
         task.cancel(byProducingResumeData: { [resumePrefix] data in
             guard let data else { return }
             UserDefaults.standard.set(data, forKey: resumePrefix + taskId)
@@ -575,7 +557,49 @@ final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDelegate {
 
     func deleteTemporary(taskId: String) {
         tasks.removeValue(forKey: taskId)?.cancel()
+        taskContexts.removeValue(forKey: taskId)
         UserDefaults.standard.removeObject(forKey: resumePrefix + taskId)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard
+            let taskId = downloadTask.taskDescription,
+            let context = taskContexts.removeValue(forKey: taskId)
+        else {
+            return
+        }
+        tasks.removeValue(forKey: taskId)
+        do {
+            let directory = try downloadDirectory()
+            let target = directory.appendingPathComponent(context.fileName)
+            if FileManager.default.fileExists(atPath: target.path) {
+                try FileManager.default.removeItem(at: target)
+            }
+            try FileManager.default.moveItem(at: location, to: target)
+            if let lyrics = context.lyrics, !lyrics.isEmpty {
+                let lyricsURL = target.deletingPathExtension().appendingPathExtension("lrc")
+                try? lyrics.write(to: lyricsURL, atomically: true, encoding: .utf8)
+            }
+            DispatchQueue.main.async { context.completionHandler(target.absoluteString, nil) }
+        } catch {
+            DispatchQueue.main.async { context.completionHandler(nil, error.localizedDescription) }
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard
+            let error,
+            let taskId = task.taskDescription,
+            let context = taskContexts.removeValue(forKey: taskId)
+        else {
+            return
+        }
+        tasks.removeValue(forKey: taskId)
+        DispatchQueue.main.async { context.completionHandler(nil, error.localizedDescription) }
     }
 
     func handleBackgroundEvents(identifier: String, completionHandler: @escaping () -> Void) {
@@ -614,6 +638,12 @@ final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDelegate {
         let directory = documents.appendingPathComponent("FeelUOwn", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private struct DownloadContext {
+        let fileName: String
+        let lyrics: String?
+        let completionHandler: (String?, String?) -> Void
     }
 }
 

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -353,10 +353,19 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
     }
 }
 
-final class IOSDownloadOutput: NSObject, IosDownloadOutput {
+final class IOSDownloadOutput: NSObject, IosDownloadOutput, URLSessionDelegate {
     static let shared = IOSDownloadOutput()
+    private var tasks: [String: URLSessionDownloadTask] = [:]
+    private let resumePrefix = "ios_download_resume_"
+    private var backgroundCompletionHandler: (() -> Void)?
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: "org.feeluown.mobile.downloads")
+        configuration.sessionSendsLaunchEvents = true
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
 
     func download(
+        taskId: String,
         url: String,
         headers: [String: String],
         fileName: String,
@@ -369,7 +378,9 @@ final class IOSDownloadOutput: NSObject, IosDownloadOutput {
         }
         var request = URLRequest(url: sourceURL)
         headers.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
-        URLSession.shared.downloadTask(with: request) { temporaryURL, _, error in
+        let resumeKey = resumePrefix + taskId
+        let completion: (URL?, URLResponse?, Error?) -> Void = { temporaryURL, _, error in
+            self.tasks.removeValue(forKey: taskId)
             if let error {
                 DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
                 return
@@ -393,7 +404,44 @@ final class IOSDownloadOutput: NSObject, IosDownloadOutput {
             } catch {
                 DispatchQueue.main.async { completionHandler(nil, error.localizedDescription) }
             }
-        }.resume()
+        }
+        let task: URLSessionDownloadTask
+        if let resumeData = UserDefaults.standard.data(forKey: resumeKey) {
+            task = session.downloadTask(withResumeData: resumeData, completionHandler: completion)
+            UserDefaults.standard.removeObject(forKey: resumeKey)
+        } else {
+            task = session.downloadTask(with: request, completionHandler: completion)
+        }
+        tasks[taskId] = task
+        task.resume()
+    }
+
+    func pause(taskId: String) {
+        guard let task = tasks.removeValue(forKey: taskId) else { return }
+        task.cancel(byProducingResumeData: { [resumePrefix] data in
+            guard let data else { return }
+            UserDefaults.standard.set(data, forKey: resumePrefix + taskId)
+        })
+    }
+
+    func deleteTemporary(taskId: String) {
+        tasks.removeValue(forKey: taskId)?.cancel()
+        UserDefaults.standard.removeObject(forKey: resumePrefix + taskId)
+    }
+
+    func handleBackgroundEvents(identifier: String, completionHandler: @escaping () -> Void) {
+        guard identifier == session.configuration.identifier else {
+            completionHandler()
+            return
+        }
+        backgroundCompletionHandler = completionHandler
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        DispatchQueue.main.async {
+            self.backgroundCompletionHandler?()
+            self.backgroundCompletionHandler = nil
+        }
     }
 
     func delete(uri: String) -> Bool {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -162,10 +162,16 @@ fun AppRoot(
     ) {
         val snackbarHostState = remember { SnackbarHostState() }
         val playlistOperationFeedback = controller.playlistOperationFeedback
+        val downloadQueueFeedback = controller.downloadQueueFeedback
         LaunchedEffect(playlistOperationFeedback) {
             playlistOperationFeedback ?: return@LaunchedEffect
             snackbarHostState.showSnackbar(playlistOperationFeedback)
             controller.dismissPlaylistOperationFeedback(playlistOperationFeedback)
+        }
+        LaunchedEffect(downloadQueueFeedback) {
+            downloadQueueFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(downloadQueueFeedback)
+            controller.dismissDownloadQueueFeedback(downloadQueueFeedback)
         }
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) {
@@ -244,7 +250,8 @@ fun AppRoot(
                                 hasAudioPermission = hasAudioPermission,
                                 onRequestAudioPermission = onRequestAudioPermission,
                             )
-                            AppDestination.DebugLogs -> DebugLogScreen(controller)
+                                    AppDestination.DebugLogs -> DebugLogScreen(controller)
+                                    AppDestination.DownloadManager -> DownloadManagerScreen(controller)
                             AppDestination.Settings -> SettingsScreen(
                                 controller,
                                 onOpenProviderWebLogin,
@@ -373,12 +380,14 @@ private enum class AppDestination {
     Search,
     Settings,
     DebugLogs,
+    DownloadManager,
     MediaItem,
 }
 
 private fun appDestination(controller: FuoPlayerController): AppDestination {
     return when {
         controller.isDebugLogOpen -> AppDestination.DebugLogs
+        controller.isDownloadManagerOpen -> AppDestination.DownloadManager
         controller.isSettingsOpen -> AppDestination.Settings
         controller.selectedVideo != null -> AppDestination.Video
         controller.selectedTrack != null -> AppDestination.Track

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadManagerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadManagerScreen.kt
@@ -1,0 +1,186 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DownloadManagerScreen(controller: FuoPlayerController) {
+    var completedLimit by remember { mutableStateOf(5) }
+    var pendingDelete by remember { mutableStateOf<DownloadTask?>(null) }
+    var deleteFile by remember { mutableStateOf(true) }
+    val tasks = controller.downloadTasks
+    val active = tasks.filter { it.status != DownloadTaskStatus.Completed }
+    val completed = tasks.filter { it.status == DownloadTaskStatus.Completed }
+        .sortedByDescending { it.createdAt }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("下载管理") },
+                navigationIcon = {
+                    IconButton(onClick = controller::closeDownloadManager) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(paddingValues).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (active.isNotEmpty()) {
+                item { DownloadSectionTitle("下载任务") }
+                items(active, key = { it.id }) { task ->
+                    DownloadTaskCard(
+                        task = task,
+                        onPause = { controller.pauseDownload(task.id) },
+                        onResume = { controller.resumeDownload(task.id) },
+                        onRetry = { controller.retryDownload(task.id) },
+                        onDelete = { pendingDelete = task; deleteFile = true },
+                    )
+                }
+            }
+            item { DownloadSectionTitle("已完成") }
+            if (completed.isEmpty()) {
+                item { Text("暂无已完成下载", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            } else {
+                items(completed.take(completedLimit), key = { it.id }) { task ->
+                    DownloadTaskCard(
+                        task = task,
+                        onPause = {}, onResume = {}, onRetry = {},
+                        onDelete = { pendingDelete = task; deleteFile = true },
+                    )
+                }
+                if (completed.size > completedLimit) {
+                    item {
+                        TextButton(onClick = { completedLimit += 20 }) {
+                            Text(if (completedLimit == 5) "展开更多" else "加载更多")
+                        }
+                    }
+                }
+            }
+        }
+    }
+    pendingDelete?.let { task ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("删除下载") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(task.track.title.ifBlank { "该下载任务" })
+                    if (task.status == DownloadTaskStatus.Completed) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(checked = deleteFile, onCheckedChange = { deleteFile = it })
+                            Text("同时删除本地文件")
+                        }
+                    } else {
+                        Text("删除后将清理保留的临时文件，无法继续下载。")
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    controller.deleteDownloadTask(task.id, deleteFile || task.status != DownloadTaskStatus.Completed)
+                    pendingDelete = null
+                }) { Text("删除") }
+            },
+            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("取消") } },
+        )
+    }
+}
+
+@Composable
+private fun DownloadSectionTitle(text: String) {
+    Text(text, style = MaterialTheme.typography.titleMedium)
+}
+
+@Composable
+private fun DownloadTaskCard(
+    task: DownloadTask,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onRetry: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surfaceVariant, shape = RoundedCornerShape(10.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(task.track.title.ifBlank { "未知歌曲" }, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    listOf(task.track.artists, downloadTaskStatusText(task)).filter { it.isNotBlank() }.joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (task.status == DownloadTaskStatus.Downloading) {
+                    val progress = task.totalBytes?.takeIf { it > 0 }?.let { task.downloadedBytes.toFloat() / it }
+                    if (progress != null) LinearProgressIndicator(progress = { progress.coerceIn(0f, 1f) }, modifier = Modifier.fillMaxWidth())
+                }
+            }
+            when (task.status) {
+                DownloadTaskStatus.Downloading, DownloadTaskStatus.Queued -> IconButton(onClick = onPause) {
+                    Icon(Icons.Filled.Pause, contentDescription = "暂停下载")
+                }
+                DownloadTaskStatus.Paused -> IconButton(onClick = onResume) {
+                    Icon(Icons.Filled.PlayArrow, contentDescription = "继续下载")
+                }
+                DownloadTaskStatus.Failed -> IconButton(onClick = onRetry) {
+                    Icon(Icons.Filled.Refresh, contentDescription = "重试下载")
+                }
+                DownloadTaskStatus.Completed -> Unit
+            }
+            IconButton(onClick = onDelete) { Icon(Icons.Filled.Delete, contentDescription = "删除下载") }
+        }
+    }
+}
+
+private fun downloadTaskStatusText(task: DownloadTask): String = when (task.status) {
+    DownloadTaskStatus.Queued -> "等待下载"
+    DownloadTaskStatus.Downloading -> task.totalBytes?.let { "${formatBytes(task.downloadedBytes)} / ${formatBytes(it)}" } ?: "下载中"
+    DownloadTaskStatus.Paused -> "已暂停，可继续"
+    DownloadTaskStatus.Failed -> task.failureMessage ?: "下载失败"
+    DownloadTaskStatus.Completed -> "已完成"
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -87,6 +87,7 @@ data class AppSettings(
     val providerOrderIds: List<String> = DEFAULT_PROVIDER_ORDER_IDS,
     val audioCacheLimitMb: Int = DEFAULT_AUDIO_CACHE_LIMIT_MB,
     val imageCacheLimitMb: Int = DEFAULT_IMAGE_CACHE_LIMIT_MB,
+    val downloadParallelism: Int = DEFAULT_DOWNLOAD_PARALLELISM,
     val wifiAudioQualityPolicy: AudioQualityPolicy = DEFAULT_WIFI_AUDIO_QUALITY_POLICY,
     val cellularAudioQualityPolicy: AudioQualityPolicy = DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY,
     val unavailablePlaybackPolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
@@ -106,6 +107,7 @@ data class ProviderHeaderInput(
 
 const val DEFAULT_AUDIO_CACHE_LIMIT_MB = 512
 const val DEFAULT_IMAGE_CACHE_LIMIT_MB = 128
+const val DEFAULT_DOWNLOAD_PARALLELISM = 2
 const val DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS = 0
 val DEFAULT_ENABLED_PROVIDER_IDS = setOf("netease")
 val DEFAULT_PROVIDER_ORDER_IDS = listOf("netease", "qqmusic", "bilibili", "ytmusic")
@@ -451,9 +453,30 @@ sealed class DownloadState {
     data object NotDownloaded : DownloadState()
     data object Queued : DownloadState()
     data class Downloading(val progress: Float) : DownloadState()
+    data object Paused : DownloadState()
     data class Downloaded(val uri: String) : DownloadState()
     data class Failed(val message: String) : DownloadState()
 }
+
+enum class DownloadTaskStatus {
+    Queued,
+    Downloading,
+    Paused,
+    Failed,
+    Completed,
+}
+
+data class DownloadTask(
+    val id: String,
+    val track: MusicTrack,
+    val status: DownloadTaskStatus,
+    val createdAt: Long,
+    val updatedAt: Long = createdAt,
+    val downloadedBytes: Long = 0,
+    val totalBytes: Long? = null,
+    val failureMessage: String? = null,
+    val completedUri: String? = null,
+)
 
 data class ProviderAuthState(
     val providerId: String,
@@ -723,10 +746,19 @@ interface LocalMusicRepository {
 
 interface DownloadRepository {
     val states: StateFlow<Map<String, DownloadState>>
+    val tasks: StateFlow<List<DownloadTask>>
+        get() = EMPTY_DOWNLOAD_TASKS
     suspend fun load()
     suspend fun download(track: MusicTrack)
+    suspend fun updateParallelism(parallelism: Int) = Unit
+    suspend fun pause(taskId: String) = Unit
+    suspend fun resume(taskId: String) = Unit
+    suspend fun retry(taskId: String) = Unit
+    suspend fun deleteTask(taskId: String, deleteFile: Boolean = true) = Unit
     suspend fun deleteDownloaded(track: MusicTrack)
 }
+
+private val EMPTY_DOWNLOAD_TASKS = MutableStateFlow<List<DownloadTask>>(emptyList())
 
 interface PlaybackEngine {
     val state: StateFlow<PlaybackState>

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -197,6 +197,8 @@ class FuoPlayerController(
         private set
     var isDebugLogOpen by mutableStateOf(false)
         private set
+    var isDownloadManagerOpen by mutableStateOf(false)
+        private set
     var isQueueOpen by mutableStateOf(false)
         private set
     var isLoading by mutableStateOf(false)
@@ -205,6 +207,10 @@ class FuoPlayerController(
         private set
     var downloadStates by mutableStateOf<Map<String, DownloadState>>(emptyMap())
         private set
+    var downloadTasks by mutableStateOf<List<DownloadTask>>(emptyList())
+        private set
+    var downloadQueueFeedback by mutableStateOf<String?>(null)
+        private set
     var playbackState by mutableStateOf(PlaybackState())
         private set
     var cacheUsage by mutableStateOf(CacheUsage())
@@ -212,6 +218,8 @@ class FuoPlayerController(
     var audioCacheLimitMb by mutableStateOf(DEFAULT_AUDIO_CACHE_LIMIT_MB)
         private set
     var imageCacheLimitMb by mutableStateOf(DEFAULT_IMAGE_CACHE_LIMIT_MB)
+        private set
+    var downloadParallelism by mutableStateOf(DEFAULT_DOWNLOAD_PARALLELISM)
         private set
     var wifiAudioQualityPolicy by mutableStateOf(DEFAULT_WIFI_AUDIO_QUALITY_POLICY)
         private set
@@ -296,6 +304,7 @@ class FuoPlayerController(
     private var playRequestSerial: Long = 0
     private var localMusicRefreshSerial: Long = 0
     private var hasLocalMusicPermission: Boolean = false
+    private var observedCompletedDownloadTaskIds = emptySet<String>()
     private var pendingLocalMusicMediaRefresh: Job? = null
     private var playbackParts: List<PlaybackPart> = emptyList()
     private var currentPartIndex: Int = -1
@@ -330,6 +339,20 @@ class FuoPlayerController(
         scope.launch {
             downloadRepository.states.collect {
                 downloadStates = it
+            }
+        }
+        scope.launch {
+            downloadRepository.tasks.collect {
+                downloadTasks = it
+                val completedIds = it.filter { task -> task.status == DownloadTaskStatus.Completed }.map { task -> task.id }.toSet()
+                val newlyCompleted = completedIds - observedCompletedDownloadTaskIds
+                observedCompletedDownloadTaskIds = completedIds
+                if (newlyCompleted.isNotEmpty() && hasLocalMusicPermission) {
+                    refreshLocalMusic(
+                        forceRefresh = true,
+                        showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic,
+                    )
+                }
             }
         }
         scope.launch {
@@ -533,6 +556,10 @@ class FuoPlayerController(
                 closeDebugLogs()
                 true
             }
+            isDownloadManagerOpen -> {
+                closeDownloadManager()
+                true
+            }
             isSettingsOpen && settingsLoginProviderId != null -> {
                 closeSettingsProviderLogin()
                 true
@@ -581,6 +608,7 @@ class FuoPlayerController(
     fun closeSettings() {
         isSettingsOpen = false
         isDebugLogOpen = false
+        isDownloadManagerOpen = false
         settingsLoginProviderId = null
     }
 
@@ -602,6 +630,24 @@ class FuoPlayerController(
 
     fun closeDebugLogs() {
         isDebugLogOpen = false
+    }
+
+    fun openDownloadManager() {
+        isDownloadManagerOpen = true
+    }
+
+    fun closeDownloadManager() {
+        isDownloadManagerOpen = false
+    }
+
+    fun dismissDownloadQueueFeedback(feedback: String) {
+        if (downloadQueueFeedback == feedback) downloadQueueFeedback = null
+    }
+
+    fun onDownloadParallelismChange(value: Int) {
+        downloadParallelism = value.coerceIn(1, 5)
+        persistSettings()
+        scope.launch { downloadRepository.updateParallelism(downloadParallelism) }
     }
 
     fun refreshDebugLogs() {
@@ -2425,16 +2471,19 @@ class FuoPlayerController(
 
     fun download(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
+        downloadQueueFeedback = "已加入下载队列：${track.title}"
         scope.launch {
             runCatching { downloadRepository.download(track) }
-                .onSuccess {
-                    if (hasLocalMusicPermission) {
-                        refreshLocalMusic(forceRefresh = true, showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic)
-                    }
-                    message = "已下载：${track.title}"
-                }
                 .onFailure { setError(it) }
         }
+    }
+
+    fun pauseDownload(taskId: String) = runDownloadAction { downloadRepository.pause(taskId) }
+    fun resumeDownload(taskId: String) = runDownloadAction { downloadRepository.resume(taskId) }
+    fun retryDownload(taskId: String) = runDownloadAction { downloadRepository.retry(taskId) }
+
+    fun deleteDownloadTask(taskId: String, deleteFile: Boolean) = runDownloadAction {
+        downloadRepository.deleteTask(taskId, deleteFile)
     }
 
     fun deleteDownload(track: MusicTrack) {
@@ -2446,6 +2495,13 @@ class FuoPlayerController(
                     }
                     message = "已删除下载：${track.title}"
                 }
+                .onFailure { setError(it) }
+        }
+    }
+
+    private fun runDownloadAction(action: suspend () -> Unit) {
+        scope.launch {
+            runCatching { action() }
                 .onFailure { setError(it) }
         }
     }
@@ -3218,6 +3274,7 @@ class FuoPlayerController(
         providerOrderIds = settings.providerOrderIds.ifEmpty { DEFAULT_PROVIDER_ORDER_IDS }
         audioCacheLimitMb = settings.audioCacheLimitMb
         imageCacheLimitMb = settings.imageCacheLimitMb
+        downloadParallelism = settings.downloadParallelism.coerceIn(1, 5)
         wifiAudioQualityPolicy = settings.wifiAudioQualityPolicy
         cellularAudioQualityPolicy = settings.cellularAudioQualityPolicy
         unavailablePlaybackPolicy = settings.unavailablePlaybackPolicy
@@ -3248,6 +3305,7 @@ class FuoPlayerController(
             providerOrderIds = providerOrderIds,
             audioCacheLimitMb = audioCacheLimitMb,
             imageCacheLimitMb = imageCacheLimitMb,
+            downloadParallelism = downloadParallelism,
             wifiAudioQualityPolicy = wifiAudioQualityPolicy,
             cellularAudioQualityPolicy = cellularAudioQualityPolicy,
             unavailablePlaybackPolicy = unavailablePlaybackPolicy,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -330,7 +330,10 @@ class FuoPlayerController(
     init {
         scope.launch {
             val loadedSettings = runCatching { settingsStore.load() }
-            loadedSettings.onSuccess { applySettings(it) }
+            loadedSettings.getOrNull()?.let {
+                applySettings(it)
+                downloadRepository.updateParallelism(downloadParallelism)
+            }
             runCatching { playbackQueueStore.load() }
                 .onSuccess { restorePlaybackQueue(it) }
             updateLocalMusicScanSettings()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1231,6 +1231,7 @@ fun sourceLabel(track: MusicTrack, downloadState: DownloadState?): String {
     val state = when (downloadState) {
         is DownloadState.Downloaded -> "已下载"
         is DownloadState.Downloading -> "下载中"
+        DownloadState.Paused -> "下载已暂停"
         is DownloadState.Failed -> "下载失败"
         DownloadState.Queued -> "等待下载"
         else -> null

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -161,6 +161,7 @@ fun SettingsScreen(
                 ) {
                     PlayerDisplaySettingsPanel(controller)
                     LocalMusicScanSettingsPanel(controller)
+                    DownloadSettingsPanel(controller)
                     CacheSettingsPanel(controller)
                     if (controller.isDebugLogViewerAvailable) {
                         DebugSettingsPanel(controller)
@@ -185,6 +186,7 @@ fun SettingsScreen(
                 PlaybackPolicySettingsPanel(controller)
                 PlayerDisplaySettingsPanel(controller)
                 LocalMusicScanSettingsPanel(controller)
+                DownloadSettingsPanel(controller)
                 CacheSettingsPanel(controller)
                 if (controller.isDebugLogViewerAvailable) {
                     DebugSettingsPanel(controller)
@@ -941,6 +943,46 @@ fun LocalMusicDurationFilterRow(
                     label = { Text(if (seconds == 0) "不过滤" else "${seconds} 秒") },
                     colors = settingsFilterChipColors(),
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun DownloadSettingsPanel(controller: FuoPlayerController) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(onClick = controller::openDownloadManager),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.Filled.Download, contentDescription = null)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("下载管理", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        text = "${controller.downloadTasks.count { it.status == DownloadTaskStatus.Downloading }} 个下载中",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Text("并行下载数量", style = MaterialTheme.typography.bodyMedium)
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                (1..5).forEach { value ->
+                    SegmentedButton(
+                        selected = controller.downloadParallelism == value,
+                        onClick = { controller.onDownloadParallelismChange(value) },
+                        shape = SegmentedButtonDefaults.itemShape(index = value - 1, count = 5),
+                    ) { Text(value.toString()) }
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
@@ -185,6 +185,16 @@ fun TrackAction(
                         onClick = {},
                     )
                 }
+                track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Paused -> {
+                    DropdownMenuItem(
+                        text = { Text("继续下载") },
+                        leadingIcon = { Icon(Icons.Filled.Download, contentDescription = null) },
+                        onClick = {
+                            expanded = false
+                            onDownload()
+                        },
+                    )
+                }
                 (track.sourceType == TrackSourceType.Provider && downloadState is DownloadState.Downloaded) ||
                     track.sourceType == TrackSourceType.Downloaded -> {
                     DropdownMenuItem(

--- a/shared/src/commonMain/python/fuo_mobile/bridge.py
+++ b/shared/src/commonMain/python/fuo_mobile/bridge.py
@@ -2278,6 +2278,34 @@ def media_to_payload(media: Media, metadata: Optional[Dict[str, Any]] = None) ->
     }
 
 
+def write_m4a_tags(
+    path: str,
+    title: str,
+    artists: str,
+    album: str,
+    cover_mime_type: str = "",
+    cover_base64: str = "",
+) -> bool:
+    from base64 import b64decode
+
+    from mutagen.mp4 import MP4, MP4Cover
+
+    audio = MP4(path)
+    if audio.tags is None:
+        audio.add_tags()
+    if title:
+        audio.tags["\xa9nam"] = [title]
+    if artists:
+        audio.tags["\xa9ART"] = [artists]
+    if album:
+        audio.tags["\xa9alb"] = [album]
+    if cover_base64:
+        image_format = MP4Cover.FORMAT_PNG if cover_mime_type == "image/png" else MP4Cover.FORMAT_JPEG
+        audio.tags["covr"] = [MP4Cover(b64decode(cover_base64), imageformat=image_format)]
+    audio.save()
+    return True
+
+
 def video_media_to_payload(video, media: Media, quality, library: Library) -> Dict[str, Any]:
     video_data = video_to_dict(video, library)
     manifest = getattr(media, "manifest", None)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -171,6 +171,29 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun downloadImmediatelyPublishesQueueFeedback() = runTest {
+        val track = providerTrack("netease:1", "Queue Song")
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(listOf(track)),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            controller.download(track)
+
+            assertEquals("已加入下载队列：Queue Song", controller.downloadQueueFeedback)
+            controller.dismissDownloadQueueFeedback("已加入下载队列：Queue Song")
+            assertNull(controller.downloadQueueFeedback)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun providerSearchAllStoresTypedResults() = runTest {
         val song = providerTrack("netease:1", "Song")
         val playlist = ProviderPlaylist("playlist:netease:10", "Playlist", "netease", "网易云音乐")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1928,6 +1928,28 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun appliesSavedDownloadParallelismToRepositoryOnStartup() = runTest {
+        val downloads = FakeDownloadRepository(emptyMap())
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = downloads,
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = FakeSettingsStore(AppSettings(downloadParallelism = 4)),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertEquals(4, downloads.lastParallelism)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun restoresAndPersistsSettings() = runTest {
         assertEquals(PlaybackSpectrumStyle.None, AppSettings().playbackSpectrumStyle)
         val store = FakeSettingsStore(
@@ -3450,6 +3472,7 @@ class FuoPlayerControllerTest {
         override val states = mutableStates
         var lastTrack: MusicTrack? = null
         var lastPayload: PlaybackPayload? = null
+        var lastParallelism: Int? = null
 
         override suspend fun load() = Unit
 
@@ -3458,6 +3481,10 @@ class FuoPlayerControllerTest {
         override suspend fun download(track: MusicTrack, payload: PlaybackPayload) {
             lastTrack = track
             lastPayload = payload
+        }
+
+        override suspend fun updateParallelism(parallelism: Int) {
+            lastParallelism = parallelism
         }
 
         override suspend fun deleteDownloaded(track: MusicTrack) = Unit

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -27,6 +27,7 @@ class IosAppSettingsStore : AppSettingsStore {
             providerOrderIds = readStringList(KEY_PROVIDER_ORDER_IDS).ifEmpty { DEFAULT_PROVIDER_ORDER_IDS },
             audioCacheLimitMb = intValue(KEY_AUDIO_CACHE_LIMIT_MB, DEFAULT_AUDIO_CACHE_LIMIT_MB),
             imageCacheLimitMb = intValue(KEY_IMAGE_CACHE_LIMIT_MB, DEFAULT_IMAGE_CACHE_LIMIT_MB),
+            downloadParallelism = intValue(KEY_DOWNLOAD_PARALLELISM, DEFAULT_DOWNLOAD_PARALLELISM).coerceIn(1, 5),
             wifiAudioQualityPolicy = enumValue(KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
             cellularAudioQualityPolicy = enumValue(KEY_CELLULAR_AUDIO_QUALITY_POLICY, DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY),
             unavailablePlaybackPolicy = enumValue(KEY_UNAVAILABLE_PLAYBACK_POLICY, DEFAULT_UNAVAILABLE_PLAYBACK_POLICY),
@@ -59,6 +60,7 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setObject(settings.providerOrderIds.joinToString(LIST_SEPARATOR), KEY_PROVIDER_ORDER_IDS)
             defaults.setInteger(settings.audioCacheLimitMb.toLong(), KEY_AUDIO_CACHE_LIMIT_MB)
             defaults.setInteger(settings.imageCacheLimitMb.toLong(), KEY_IMAGE_CACHE_LIMIT_MB)
+            defaults.setInteger(settings.downloadParallelism.coerceIn(1, 5).toLong(), KEY_DOWNLOAD_PARALLELISM)
             defaults.setObject(settings.wifiAudioQualityPolicy.name, KEY_WIFI_AUDIO_QUALITY_POLICY)
             defaults.setObject(settings.cellularAudioQualityPolicy.name, KEY_CELLULAR_AUDIO_QUALITY_POLICY)
             defaults.setObject(settings.unavailablePlaybackPolicy.name, KEY_UNAVAILABLE_PLAYBACK_POLICY)
@@ -168,6 +170,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_PROVIDER_ORDER_IDS = "provider_order_ids"
         private const val KEY_AUDIO_CACHE_LIMIT_MB = "audio_cache_limit_mb"
         private const val KEY_IMAGE_CACHE_LIMIT_MB = "image_cache_limit_mb"
+        private const val KEY_DOWNLOAD_PARALLELISM = "download_parallelism"
         private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"
         private const val KEY_CELLULAR_AUDIO_QUALITY_POLICY = "cellular_audio_quality_policy"
         private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadOutput.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadOutput.kt
@@ -2,11 +2,14 @@ package org.feeluown.mobile
 
 interface IosDownloadOutput {
     fun download(
+        taskId: String,
         url: String,
         headers: Map<String, String>,
         fileName: String,
         lyrics: String?,
         completionHandler: (String?, String?) -> Unit,
     )
+    fun pause(taskId: String)
+    fun deleteTemporary(taskId: String)
     fun delete(uri: String): Boolean
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
@@ -3,6 +3,10 @@ package org.feeluown.mobile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSUserDefaults
 import kotlin.coroutines.resume
@@ -12,28 +16,80 @@ class IosDownloadRepository(
     private val output: IosDownloadOutput,
 ) : DownloadRepository {
     private val mutableStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
+    private val mutableTasks = MutableStateFlow<List<DownloadTask>>(emptyList())
     private val defaults = NSUserDefaults.standardUserDefaults
+    private val taskRecords = linkedMapOf<String, DownloadTask>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val activeTaskIds = mutableSetOf<String>()
+    private var parallelism = DEFAULT_DOWNLOAD_PARALLELISM
 
     override val states: StateFlow<Map<String, DownloadState>> = mutableStates.asStateFlow()
+    override val tasks: StateFlow<List<DownloadTask>> = mutableTasks.asStateFlow()
 
     override suspend fun load() {
-        mutableStates.value = readRecords().mapValues { DownloadState.Downloaded(it.value) }
+        taskRecords.clear()
+        readTasks().forEach { task ->
+            taskRecords[task.id] = if (task.status == DownloadTaskStatus.Downloading) {
+                task.copy(status = DownloadTaskStatus.Paused)
+            } else task
+        }
+        readRecords().forEach { (id, uri) ->
+            if (id in taskRecords) return@forEach
+            taskRecords[id] = DownloadTask(
+                id = id,
+                track = MusicTrack(id, id, "", "", "", TrackSourceType.Provider),
+                status = DownloadTaskStatus.Completed,
+                createdAt = 0,
+                completedUri = uri,
+            )
+        }
+        writeTasks()
+        publish()
     }
 
     override suspend fun download(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
-        mutableStates.value = mutableStates.value + (track.id to DownloadState.Queued)
-        val payload = runCatching { providerRepository.resolve(track) }.getOrElse { throwable ->
-            mutableStates.value = mutableStates.value +
-                (track.id to DownloadState.Failed(throwable.message ?: "下载解析失败"))
-            throw throwable
+        val existing = taskRecords[track.id]
+        if (existing?.status == DownloadTaskStatus.Downloading || existing?.status == DownloadTaskStatus.Queued) return
+        updateTask(
+            (existing ?: DownloadTask(track.id, track, DownloadTaskStatus.Queued, System.currentTimeMillis()))
+                .copy(status = DownloadTaskStatus.Queued, failureMessage = null, updatedAt = System.currentTimeMillis()),
+        )
+        schedule()
+    }
+
+    override suspend fun updateParallelism(parallelism: Int) {
+        this.parallelism = parallelism.coerceIn(1, 5)
+        schedule()
+    }
+
+    private fun schedule() {
+        val ids = taskRecords.values
+            .filter { it.status == DownloadTaskStatus.Queued && it.id !in activeTaskIds }
+            .sortedBy { it.createdAt }
+            .take((parallelism - activeTaskIds.size).coerceAtLeast(0))
+            .map { it.id }
+        ids.forEach { id ->
+            activeTaskIds += id
+            scope.launch { runTask(id) }
         }
-        mutableStates.value = mutableStates.value + (track.id to DownloadState.Downloading(0f))
+    }
+
+    private suspend fun runTask(taskId: String) {
+        val task = taskRecords[taskId] ?: return
+        updateTask(task.copy(status = DownloadTaskStatus.Downloading, failureMessage = null))
+        val payload = runCatching { providerRepository.resolve(task.track) }.getOrElse { throwable ->
+            updateTask(taskRecords.getValue(taskId).copy(status = DownloadTaskStatus.Failed, failureMessage = throwable.message ?: "下载解析失败"))
+            activeTaskIds -= taskId
+            schedule()
+            return
+        }
         val result = suspendCancellableCoroutine<Result<String>> { continuation ->
             output.download(
+                taskId = taskId,
                 url = payload.url,
                 headers = payload.headers,
-                fileName = downloadFileName(track, payload),
+                fileName = downloadFileName(task.track, payload),
                 lyrics = payload.lyrics,
             ) { uri, error ->
                 if (!continuation.isActive) return@download
@@ -42,14 +98,43 @@ class IosDownloadRepository(
             }
         }
         result.onSuccess { uri ->
-            val records = readRecords() + (track.id to uri)
+            val records = readRecords() + (taskId to uri)
             writeRecords(records)
-            mutableStates.value = mutableStates.value + (track.id to DownloadState.Downloaded(uri))
+            updateTask(taskRecords.getValue(taskId).copy(status = DownloadTaskStatus.Completed, completedUri = uri, failureMessage = null))
         }.onFailure { throwable ->
-            mutableStates.value = mutableStates.value +
-                (track.id to DownloadState.Failed(throwable.message ?: "下载失败"))
-            throw throwable
+            taskRecords[taskId]?.takeIf { it.status != DownloadTaskStatus.Paused }?.let {
+                updateTask(it.copy(status = DownloadTaskStatus.Failed, failureMessage = throwable.message ?: "下载失败"))
+            }
         }
+        activeTaskIds -= taskId
+        schedule()
+    }
+
+    override suspend fun pause(taskId: String) {
+        val task = taskRecords[taskId] ?: return
+        if (task.status !in setOf(DownloadTaskStatus.Downloading, DownloadTaskStatus.Queued)) return
+        output.pause(taskId)
+        activeTaskIds -= taskId
+        updateTask(task.copy(status = DownloadTaskStatus.Paused))
+        schedule()
+    }
+
+    override suspend fun resume(taskId: String) {
+        taskRecords[taskId]?.takeIf { it.status != DownloadTaskStatus.Completed }?.let { download(it.track) }
+    }
+
+    override suspend fun retry(taskId: String) = resume(taskId)
+
+    override suspend fun deleteTask(taskId: String, deleteFile: Boolean) {
+        val task = taskRecords.remove(taskId) ?: return
+        activeTaskIds -= taskId
+        output.deleteTemporary(taskId)
+        if (deleteFile) task.completedUri?.let(output::delete)
+        val records = readRecords().toMutableMap()
+        records.remove(taskId)
+        writeRecords(records)
+        writeTasks()
+        publish()
     }
 
     override suspend fun deleteDownloaded(track: MusicTrack) {
@@ -58,7 +143,9 @@ class IosDownloadRepository(
         val uri = records.remove(key) ?: track.localUri
         if (uri != null) output.delete(uri)
         writeRecords(records)
-        mutableStates.value = mutableStates.value - key
+        taskRecords.remove(key)
+        writeTasks()
+        publish()
     }
 
     private fun downloadFileName(track: MusicTrack, payload: PlaybackPayload): String {
@@ -91,8 +178,67 @@ class IosDownloadRepository(
         defaults.synchronize()
     }
 
+    private fun updateTask(task: DownloadTask) {
+        taskRecords[task.id] = task
+        writeTasks()
+        publish()
+    }
+
+    private fun readTasks(): List<DownloadTask> {
+        return defaults.stringForKey(KEY_DOWNLOAD_TASKS)
+            ?.lineSequence()
+            ?.mapNotNull { line ->
+                val values = line.split(TASK_FIELD_SEPARATOR)
+                if (values.size < 8) return@mapNotNull null
+                val status = runCatching { DownloadTaskStatus.valueOf(values[5]) }.getOrNull() ?: return@mapNotNull null
+                DownloadTask(
+                    id = values[0],
+                    track = MusicTrack(
+                        id = values[1], title = values[2], artists = values[3], album = values[4],
+                        source = values[6], sourceType = TrackSourceType.Provider,
+                    ),
+                    status = status,
+                    createdAt = values[7].toLongOrNull() ?: 0,
+                    completedUri = values.getOrNull(8)?.takeIf { it.isNotBlank() },
+                    failureMessage = values.getOrNull(9)?.takeIf { it.isNotBlank() },
+                )
+            }
+            ?.toList()
+            .orEmpty()
+    }
+
+    private fun writeTasks() {
+        defaults.setObject(
+            taskRecords.values.joinToString("\n") { task ->
+                listOf(
+                    task.id, task.track.id, task.track.title, task.track.artists, task.track.album,
+                    task.status.name, task.track.source, task.createdAt.toString(), task.completedUri.orEmpty(), task.failureMessage.orEmpty(),
+                ).joinToString(TASK_FIELD_SEPARATOR)
+            },
+            KEY_DOWNLOAD_TASKS,
+        )
+        defaults.synchronize()
+    }
+
+    private fun publish() {
+        mutableTasks.value = taskRecords.values.sortedWith(
+            compareBy<DownloadTask> { if (it.status == DownloadTaskStatus.Downloading) 0 else 1 }.thenByDescending { it.createdAt },
+        )
+        mutableStates.value = taskRecords.values.associate { task ->
+            task.id to when (task.status) {
+                DownloadTaskStatus.Queued -> DownloadState.Queued
+                DownloadTaskStatus.Downloading -> DownloadState.Downloading(0f)
+                DownloadTaskStatus.Paused -> DownloadState.Paused
+                DownloadTaskStatus.Failed -> DownloadState.Failed(task.failureMessage ?: "下载失败")
+                DownloadTaskStatus.Completed -> DownloadState.Downloaded(task.completedUri.orEmpty())
+            }
+        }
+    }
+
     private companion object {
         private const val KEY_DOWNLOAD_RECORDS = "ios_download_records"
+        private const val KEY_DOWNLOAD_TASKS = "ios_download_tasks"
         private const val RECORD_SEPARATOR = "\u001f"
+        private const val TASK_FIELD_SEPARATOR = "\u001e"
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSUserDefaults
+import platform.Foundation.NSDate
 import kotlin.coroutines.resume
 
 class IosDownloadRepository(
@@ -62,8 +63,8 @@ class IosDownloadRepository(
         val existing = taskRecords[track.id]
         if (existing?.status == DownloadTaskStatus.Downloading || existing?.status == DownloadTaskStatus.Queued) return
         updateTask(
-            (existing ?: DownloadTask(track.id, track, DownloadTaskStatus.Queued, System.currentTimeMillis()))
-                .copy(status = DownloadTaskStatus.Queued, failureMessage = null, updatedAt = System.currentTimeMillis()),
+            (existing ?: DownloadTask(track.id, track, DownloadTaskStatus.Queued, nowMillis()))
+                .copy(status = DownloadTaskStatus.Queued, failureMessage = null, updatedAt = nowMillis()),
         )
         payload?.let { taskPayloads[track.id] = it }
         schedule()
@@ -245,6 +246,8 @@ class IosDownloadRepository(
             }
         }
     }
+
+    private fun nowMillis(): Long = (NSDate().timeIntervalSince1970 * 1000.0).toLong()
 
     private companion object {
         private const val KEY_DOWNLOAD_RECORDS = "ios_download_records"

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosDownloadRepository.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSUserDefaults
-import platform.Foundation.NSDate
 import kotlin.coroutines.resume
 
 class IosDownloadRepository(
@@ -45,6 +44,7 @@ class IosDownloadRepository(
                 completedUri = uri,
             )
         }
+        logicalClock = taskRecords.values.maxOfOrNull { it.createdAt } ?: 0L
         writeTasks()
         publish()
     }
@@ -247,7 +247,12 @@ class IosDownloadRepository(
         }
     }
 
-    private fun nowMillis(): Long = (NSDate().timeIntervalSince1970 * 1000.0).toLong()
+    private var logicalClock = 0L
+
+    private fun nowMillis(): Long {
+        logicalClock += 1
+        return logicalClock
+    }
 
     private companion object {
         private const val KEY_DOWNLOAD_RECORDS = "ios_download_records"


### PR DESCRIPTION
## 内容

- 新增持久化下载队列、进度、暂停恢复、失败重试与删除策略。
- 设置页新增下载管理入口与并行下载数量配置。
- Android 接入前台下载服务；iOS 接入后台 URLSession 生命周期。

## 验证

- `ANDROID_HOME=/home/bruce/Android/Sdk ./gradlew :shared:testDebugUnitTest :androidApp:compileDebugKotlin --no-daemon`
- `git diff --check`

## 备注

- `:shared:lint` 受仓库既有 AndroidResourceCache.kt 的 Compose lint/Kotlin 分析 API 兼容性崩溃阻断。
