### PR TITLE
[feat] add first-launch setup guide

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -12,6 +12,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
     override suspend fun load(): AppSettings = withContext(Dispatchers.IO) {
         val rawHomeSection = preferences.getString(KEY_HOME_SECTION, null)
         AppSettings(
+            onboardingCompleted = preferences.getBoolean(KEY_ONBOARDING_COMPLETED, false),
             homeSection = homeSectionValue(rawHomeSection),
             mineSection = mineSectionValue(rawHomeSection),
             playlistFilter = enumValue(KEY_PLAYLIST_FILTER, PlaylistFilter.All),
@@ -72,6 +73,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
     override suspend fun save(settings: AppSettings) {
         withContext(Dispatchers.IO) {
             preferences.edit()
+                .putBoolean(KEY_ONBOARDING_COMPLETED, settings.onboardingCompleted)
                 .putString(KEY_HOME_SECTION, settings.homeSection.name)
                 .putString(KEY_MINE_SECTION, settings.mineSection.name)
                 .putString(KEY_PLAYLIST_FILTER, settings.playlistFilter.name)
@@ -219,6 +221,7 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
 
     private companion object {
         private const val PREFS_NAME = "fuo_settings"
+        private const val KEY_ONBOARDING_COMPLETED = "onboarding_completed"
         private const val KEY_HOME_SECTION = "home_section"
         private const val KEY_MINE_SECTION = "mine_section"
         private const val KEY_PLAYLIST_FILTER = "playlist_filter"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -51,9 +51,6 @@ class MainActivity : ComponentActivity() {
                     ?.getStringExtra(ProviderWebLoginActivity.EXTRA_PROVIDER_ID)
                     .orEmpty()
                 val providerId = returnedProviderId.ifBlank { pendingWebLoginProviderId.orEmpty() }
-                if (providerId.isNotBlank()) {
-                    controller.openSettings(providerId)
-                }
                 if (result.resultCode == RESULT_OK) {
                     val cookiesJson = result.data
                         ?.getStringExtra(ProviderWebLoginActivity.EXTRA_COOKIES_JSON)
@@ -96,7 +93,6 @@ class MainActivity : ComponentActivity() {
                 onOpenProviderWebLogin = { provider ->
                     if (provider.loginConfig != null) {
                         pendingWebLoginProviderId = provider.providerId
-                        controller.openSettings(provider.providerId)
                         webLoginLauncher.launch(ProviderWebLoginActivity.createIntent(this@MainActivity, provider))
                     }
                 },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -165,6 +165,19 @@ fun AppRoot(
         themeMode = controller.themeMode,
         themeColorScheme = controller.themeColorScheme,
     ) {
+        if (!controller.isSettingsLoaded) {
+            AppInitializationLoadingScreen()
+            return@FuoEvolveTheme
+        }
+        if (!controller.onboardingCompleted) {
+            OnboardingScreen(
+                controller = controller,
+                onOpenProviderWebLogin = onOpenProviderWebLogin,
+                onLogoutProvider = onLogoutProvider,
+                onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
+            )
+            return@FuoEvolveTheme
+        }
         val snackbarHostState = remember { SnackbarHostState() }
         val playlistOperationFeedback = controller.playlistOperationFeedback
         val downloadQueueFeedback = controller.downloadQueueFeedback

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -80,6 +80,7 @@ enum class PlaybackSpectrumStyle(
 }
 
 data class AppSettings(
+    val onboardingCompleted: Boolean = false,
     val homeSection: HomeSection = HomeSection.Recommend,
     val mineSection: MineSection = MineSection.Playlists,
     val playlistFilter: PlaylistFilter = PlaylistFilter.All,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -77,6 +77,10 @@ class FuoPlayerController(
     private val debugLogRepository: DebugLogRepository = NoOpDebugLogRepository,
     private val scope: CoroutineScope,
 ) {
+    var isSettingsLoaded by mutableStateOf(false)
+        private set
+    var onboardingCompleted by mutableStateOf(false)
+        private set
     var availableProviders by mutableStateOf<List<ProviderInfo>>(emptyList())
         private set
     var providers by mutableStateOf<List<ProviderInfo>>(emptyList())
@@ -336,6 +340,7 @@ class FuoPlayerController(
                 applySettings(it)
                 downloadRepository.updateParallelism(downloadParallelism)
             }
+            isSettingsLoaded = true
             runCatching { playbackQueueStore.load() }
                 .onSuccess { restorePlaybackQueue(it) }
             updateLocalMusicScanSettings()
@@ -760,6 +765,88 @@ class FuoPlayerController(
             }.onFailure {
                 setError(it)
             }
+            isLoading = false
+        }
+    }
+
+    suspend fun configureOnboardingProviders(
+        selectedProviderIds: Set<String>,
+        bilibiliReplacementOnly: Boolean,
+    ): Boolean {
+        val availableProviderIds = availableProviders.map { it.providerId }.toSet()
+        val selectedIds = selectedProviderIds.intersect(availableProviderIds)
+        if (selectedIds.isEmpty()) {
+            message = "请至少选择一个音源"
+            return false
+        }
+        if (bilibiliReplacementOnly && selectedIds == setOf("bilibili")) {
+            message = "Bilibili 仅作为替换音源时，请再选择一个常规音源"
+            return false
+        }
+
+        val previousSettings = currentSettings()
+        isLoading = true
+        message = "正在初始化音源"
+        return runCatching {
+            enabledProviderIds = selectedIds
+            if (bilibiliReplacementOnly && "bilibili" in selectedIds) {
+                val regularProviderIds = selectedIds - "bilibili"
+                searchProviderIds = regularProviderIds
+                recommendProviderIds = regularProviderIds
+                exploreProviderIds = regularProviderIds
+                mineProviderIds = regularProviderIds
+                smartReplacementProviderIds = setOf("bilibili")
+                unavailablePlaybackPolicy = UnavailablePlaybackPolicy.SmartReplace
+            } else {
+                searchProviderIds = emptySet()
+                recommendProviderIds = emptySet()
+                exploreProviderIds = emptySet()
+                mineProviderIds = emptySet()
+                smartReplacementProviderIds = emptySet()
+            }
+            providerRepository.updateEnabledProviders(enabledProviderIds)
+            clearProviderContent()
+            refreshProviderCatalog()
+            settingsStore.save(currentSettings())
+        }.fold(
+            onSuccess = {
+                message = "音源初始化完成"
+                refreshHomeContent(homeSection)
+                true
+            },
+            onFailure = { throwable ->
+                applySettings(previousSettings)
+                runCatching {
+                    providerRepository.updateEnabledProviders(enabledProviderIds)
+                    clearProviderContent()
+                    refreshProviderCatalog()
+                    settingsStore.save(previousSettings)
+                }
+                setError(throwable)
+                false
+            },
+        ).also {
+            isLoading = false
+        }
+    }
+
+    suspend fun completeOnboarding(): Boolean {
+        if (onboardingCompleted) return true
+        isLoading = true
+        message = "正在保存初始设置"
+        return runCatching {
+            settingsStore.save(currentSettings().copy(onboardingCompleted = true))
+        }.fold(
+            onSuccess = {
+                onboardingCompleted = true
+                message = "初始设置已完成"
+                true
+            },
+            onFailure = {
+                setError(it)
+                false
+            },
+        ).also {
             isLoading = false
         }
     }
@@ -3412,6 +3499,7 @@ class FuoPlayerController(
     }
 
     private fun applySettings(settings: AppSettings) {
+        onboardingCompleted = settings.onboardingCompleted
         homeSection = settings.homeSection
         mineSection = settings.mineSection
         playlistFilter = settings.playlistFilter
@@ -3447,7 +3535,15 @@ class FuoPlayerController(
     }
 
     private fun persistSettings() {
-        val settings = AppSettings(
+        val settings = currentSettings()
+        scope.launch {
+            settingsStore.save(settings)
+        }
+    }
+
+    private fun currentSettings(): AppSettings {
+        return AppSettings(
+            onboardingCompleted = onboardingCompleted,
             homeSection = homeSection,
             mineSection = mineSection,
             playlistFilter = playlistFilter,
@@ -3481,9 +3577,6 @@ class FuoPlayerController(
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
         )
-        scope.launch {
-            settingsStore.save(settings)
-        }
     }
 
     private suspend fun updateResourceCacheLimit() {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/OnboardingScreen.kt
@@ -1,0 +1,466 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+@Composable
+fun AppInitializationLoadingScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            CircularProgressIndicator()
+            Text(
+                text = "正在加载设置",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnboardingScreen(
+    controller: FuoPlayerController,
+    onOpenProviderWebLogin: (ProviderInfo) -> Unit,
+    onLogoutProvider: (ProviderInfo) -> Unit,
+    onImportYtmusicHeaderFile: (() -> Unit)? = null,
+) {
+    val scope = rememberCoroutineScope()
+    val availableProviders = controller.orderedAvailableProviders()
+    var selectedProviderIds by rememberSaveable {
+        mutableStateOf(controller.enabledProviderIds.toList())
+    }
+    var bilibiliReplacementOnly by rememberSaveable {
+        mutableStateOf(
+            "bilibili" in controller.enabledProviderIds &&
+                controller.smartReplacementProviderIds == setOf("bilibili") &&
+                ProviderDisplaySection.entries
+                    .filter { it != ProviderDisplaySection.Replace }
+                    .none { controller.isProviderShownIn("bilibili", it) },
+        )
+    }
+    val selectedProviders = availableProviders.filter { it.providerId in selectedProviderIds }
+    val pageCount = selectedProviders.size + 2
+    val pagerState = rememberPagerState(pageCount = { pageCount })
+    val isSourcePage = pagerState.currentPage == 0
+    val isQualityPage = pagerState.currentPage == pageCount - 1
+
+    LaunchedEffect(availableProviders) {
+        if (availableProviders.isEmpty()) return@LaunchedEffect
+        val availableIds = availableProviders.map { it.providerId }.toSet()
+        val normalizedSelection = selectedProviderIds.filter { it in availableIds }
+        selectedProviderIds = normalizedSelection.ifEmpty {
+            controller.enabledProviderIds.intersect(availableIds)
+                .ifEmpty { setOf(availableProviders.first().providerId) }
+                .toList()
+        }
+    }
+    LaunchedEffect(pageCount) {
+        if (pagerState.currentPage >= pageCount) {
+            pagerState.scrollToPage((pageCount - 1).coerceAtLeast(0))
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("初始设置") },
+                navigationIcon = {
+                    if (!isSourcePage) {
+                        IconButton(
+                            enabled = !controller.isLoading,
+                            onClick = {
+                                scope.launch {
+                                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                                }
+                            },
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "上一步")
+                        }
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            OnboardingFooter(
+                currentPage = pagerState.currentPage,
+                pageCount = pageCount,
+                isLoading = controller.isLoading,
+                actionLabel = when {
+                    isSourcePage -> "继续"
+                    isQualityPage -> "完成"
+                    controller.authStateFor(selectedProviders[pagerState.currentPage - 1]).isLoggedIn -> "继续"
+                    else -> "跳过"
+                },
+                onAction = {
+                    scope.launch {
+                        when {
+                            isSourcePage -> {
+                                val applied = controller.configureOnboardingProviders(
+                                    selectedProviderIds = selectedProviderIds.toSet(),
+                                    bilibiliReplacementOnly = bilibiliReplacementOnly,
+                                )
+                                if (applied) pagerState.animateScrollToPage(1)
+                            }
+                            isQualityPage -> controller.completeOnboarding()
+                            else -> pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                        }
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            userScrollEnabled = !controller.isLoading && !isSourcePage,
+            verticalAlignment = Alignment.Top,
+        ) { page ->
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopCenter,
+            ) {
+                when {
+                    page == 0 -> ProviderSelectionPage(
+                        providers = availableProviders,
+                        selectedProviderIds = selectedProviderIds.toSet(),
+                        bilibiliReplacementOnly = bilibiliReplacementOnly,
+                        enabled = !controller.isLoading,
+                        message = controller.message.takeIf { message ->
+                            (selectedProviderIds.isEmpty() && message.startsWith("请至少")) ||
+                                (bilibiliReplacementOnly && selectedProviderIds == listOf("bilibili") &&
+                                    message.startsWith("Bilibili"))
+                        }.orEmpty(),
+                        onProviderSelected = { providerId, selected ->
+                            selectedProviderIds = if (selected) {
+                                (selectedProviderIds + providerId).distinct()
+                            } else {
+                                selectedProviderIds - providerId
+                            }
+                            if (providerId == "bilibili" && !selected) {
+                                bilibiliReplacementOnly = false
+                            }
+                        },
+                        onBilibiliReplacementOnlyChange = { bilibiliReplacementOnly = it },
+                    )
+                    page == pageCount - 1 -> AudioQualityOnboardingPage(controller)
+                    else -> ProviderLoginOnboardingPage(
+                        controller = controller,
+                        provider = selectedProviders[page - 1],
+                        onOpenProviderWebLogin = onOpenProviderWebLogin,
+                        onLogoutProvider = onLogoutProvider,
+                        onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderSelectionPage(
+    providers: List<ProviderInfo>,
+    selectedProviderIds: Set<String>,
+    bilibiliReplacementOnly: Boolean,
+    enabled: Boolean,
+    message: String,
+    onProviderSelected: (String, Boolean) -> Unit,
+    onBilibiliReplacementOnlyChange: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = 720.dp)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.MusicNote,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "选择要启用的音源",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "至少选择一个音源，之后可以逐一登录；这些设置也可以稍后在设置中修改。",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (providers.isEmpty()) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    Text("音源正在初始化")
+                }
+            }
+        } else {
+            providers.forEach { provider ->
+                val selected = provider.providerId in selectedProviderIds
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(enabled = enabled) {
+                            onProviderSelected(provider.providerId, !selected)
+                        },
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = selected,
+                            enabled = enabled,
+                            onCheckedChange = { onProviderSelected(provider.providerId, it) },
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = provider.providerName,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                text = if (selected) "将启用此音源" else "不会加载此音源",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (selected) {
+                            Icon(
+                                imageVector = Icons.Filled.CheckCircle,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if ("bilibili" in selectedProviderIds) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .clickable(enabled = enabled) {
+                            onBilibiliReplacementOnlyChange(!bilibiliReplacementOnly)
+                        }
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = bilibiliReplacementOnly,
+                        enabled = enabled,
+                        onCheckedChange = onBilibiliReplacementOnlyChange,
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Bilibili 仅作为替换音源", fontWeight = FontWeight.SemiBold)
+                        Text(
+                            text = "不在搜索和首页展示，只在原音源资源不可用时参与智能替换。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
+            }
+        }
+        if (message.startsWith("请至少") || message.startsWith("Bilibili")) {
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProviderLoginOnboardingPage(
+    controller: FuoPlayerController,
+    provider: ProviderInfo,
+    onOpenProviderWebLogin: (ProviderInfo) -> Unit,
+    onLogoutProvider: (ProviderInfo) -> Unit,
+    onImportYtmusicHeaderFile: (() -> Unit)?,
+) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = 720.dp)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "登录 ${provider.providerName}",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "登录后可以使用个人歌单和推荐内容；也可以跳过，稍后再登录。",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        ProviderLoginPanel(
+            controller = controller,
+            provider = provider,
+            onOpenProviderWebLogin = onOpenProviderWebLogin,
+            onLogoutProvider = onLogoutProvider,
+            onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
+        )
+    }
+}
+
+@Composable
+private fun AudioQualityOnboardingPage(controller: FuoPlayerController) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = 720.dp)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "设置默认音质",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "分别为 Wi‑Fi 和蜂窝网络选择音质。音质越高，使用的流量和缓存空间越多。",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        AudioQualitySettingsPanel(controller)
+    }
+}
+
+@Composable
+private fun OnboardingFooter(
+    currentPage: Int,
+    pageCount: Int,
+    isLoading: Boolean,
+    actionLabel: String,
+    onAction: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 3.dp,
+        shadowElevation = 3.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                repeat(pageCount) { index ->
+                    Box(
+                        modifier = Modifier
+                            .size(if (index == currentPage) 10.dp else 8.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (index == currentPage) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.outlineVariant
+                                },
+                            ),
+                    )
+                }
+            }
+            Button(
+                modifier = Modifier.widthIn(min = 220.dp),
+                enabled = !isLoading,
+                onClick = onAction,
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(Modifier.size(8.dp))
+                }
+                Text(
+                    text = if (isLoading) "请稍候" else actionLabel,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FuoPlayerControllerTest {
@@ -134,6 +135,81 @@ class FuoPlayerControllerTest {
             assertNull(controller.selectedPlaylist)
             assertNull(controller.selectedMediaItem)
             assertEquals("无法识别分享链接", controller.message)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun onboardingConfiguresBilibiliAsReplacementOnlyAndPersistsCompletion() = runTest {
+        val settings = FakeSettingsStore(AppSettings())
+        val provider = FakeProviderRepository(emptyList())
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = settings,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertTrue(controller.isSettingsLoaded)
+            assertFalse(controller.onboardingCompleted)
+            assertTrue(
+                controller.configureOnboardingProviders(
+                    selectedProviderIds = setOf("netease", "bilibili"),
+                    bilibiliReplacementOnly = true,
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(setOf("netease", "bilibili"), controller.enabledProviderIds)
+            assertEquals(setOf("netease", "bilibili"), provider.lastEnabledProviderIds)
+            assertFalse(controller.isProviderShownIn("bilibili", ProviderDisplaySection.Search))
+            assertFalse(controller.isProviderShownIn("bilibili", ProviderDisplaySection.Recommend))
+            assertFalse(controller.isProviderShownIn("bilibili", ProviderDisplaySection.Explore))
+            assertFalse(controller.isProviderShownIn("bilibili", ProviderDisplaySection.Mine))
+            assertTrue(controller.isProviderShownIn("bilibili", ProviderDisplaySection.Replace))
+            assertEquals(setOf("bilibili"), settings.saved.smartReplacementProviderIds)
+            assertEquals(UnavailablePlaybackPolicy.SmartReplace, settings.saved.unavailablePlaybackPolicy)
+
+            assertTrue(controller.completeOnboarding())
+            assertTrue(controller.onboardingCompleted)
+            assertTrue(settings.saved.onboardingCompleted)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun onboardingRejectsBilibiliAsTheOnlyReplacementProvider() = runTest {
+        val settings = FakeSettingsStore(AppSettings())
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                settingsStore = settings,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+
+            assertFalse(
+                controller.configureOnboardingProviders(
+                    selectedProviderIds = setOf("bilibili"),
+                    bilibiliReplacementOnly = true,
+                ),
+            )
+            assertEquals("Bilibili 仅作为替换音源时，请再选择一个常规音源", controller.message)
+            assertEquals(DEFAULT_ENABLED_PROVIDER_IDS, controller.enabledProviderIds)
+            assertFalse(settings.saved.onboardingCompleted)
         } finally {
             controllerScope.cancel()
         }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -9,6 +9,7 @@ class IosAppSettingsStore : AppSettingsStore {
 
     override suspend fun load(): AppSettings = withContext(Dispatchers.Default) {
         AppSettings(
+            onboardingCompleted = boolValue(KEY_ONBOARDING_COMPLETED, false),
             homeSection = enumValue(KEY_HOME_SECTION, HomeSection.Recommend),
             mineSection = enumValue(KEY_MINE_SECTION, MineSection.Playlists),
             localMusicViewMode = enumValue(KEY_LOCAL_MUSIC_VIEW_MODE, LocalMusicViewMode.All),
@@ -35,6 +36,7 @@ class IosAppSettingsStore : AppSettingsStore {
             wifiAudioQualityPolicy = enumValue(KEY_WIFI_AUDIO_QUALITY_POLICY, DEFAULT_WIFI_AUDIO_QUALITY_POLICY),
             cellularAudioQualityPolicy = enumValue(KEY_CELLULAR_AUDIO_QUALITY_POLICY, DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY),
             unavailablePlaybackPolicy = enumValue(KEY_UNAVAILABLE_PLAYBACK_POLICY, DEFAULT_UNAVAILABLE_PLAYBACK_POLICY),
+            smartReplacementProviderIds = readStringSet(KEY_SMART_REPLACEMENT_PROVIDER_IDS),
             smartReplacementMinScore = doubleValue(
                 KEY_SMART_REPLACEMENT_MIN_SCORE,
                 DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
@@ -54,6 +56,7 @@ class IosAppSettingsStore : AppSettingsStore {
 
     override suspend fun save(settings: AppSettings) {
         withContext(Dispatchers.Default) {
+            defaults.setBool(settings.onboardingCompleted, KEY_ONBOARDING_COMPLETED)
             defaults.setObject(settings.homeSection.name, KEY_HOME_SECTION)
             defaults.setObject(settings.mineSection.name, KEY_MINE_SECTION)
             defaults.setObject(settings.localMusicViewMode.name, KEY_LOCAL_MUSIC_VIEW_MODE)
@@ -77,6 +80,10 @@ class IosAppSettingsStore : AppSettingsStore {
             defaults.setObject(settings.wifiAudioQualityPolicy.name, KEY_WIFI_AUDIO_QUALITY_POLICY)
             defaults.setObject(settings.cellularAudioQualityPolicy.name, KEY_CELLULAR_AUDIO_QUALITY_POLICY)
             defaults.setObject(settings.unavailablePlaybackPolicy.name, KEY_UNAVAILABLE_PLAYBACK_POLICY)
+            defaults.setObject(
+                settings.smartReplacementProviderIds.joinToString(LIST_SEPARATOR),
+                KEY_SMART_REPLACEMENT_PROVIDER_IDS,
+            )
             defaults.setDouble(settings.smartReplacementMinScore, KEY_SMART_REPLACEMENT_MIN_SCORE)
             defaults.setBool(settings.smartReplacementUseReplacementMetadata, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA)
             defaults.setBool(settings.smartReplacementUseReplacementLyrics, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS)
@@ -171,6 +178,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val LIST_SEPARATOR = "\u001f"
         private const val MAP_SEPARATOR = "\u001e"
         private const val HEADER_SEPARATOR = "\u001d"
+        private const val KEY_ONBOARDING_COMPLETED = "onboarding_completed"
         private const val KEY_HOME_SECTION = "home_section"
         private const val KEY_MINE_SECTION = "mine_section"
         private const val KEY_LOCAL_MUSIC_VIEW_MODE = "local_music_view_mode"
@@ -194,6 +202,7 @@ class IosAppSettingsStore : AppSettingsStore {
         private const val KEY_WIFI_AUDIO_QUALITY_POLICY = "wifi_audio_quality_policy"
         private const val KEY_CELLULAR_AUDIO_QUALITY_POLICY = "cellular_audio_quality_policy"
         private const val KEY_UNAVAILABLE_PLAYBACK_POLICY = "unavailable_playback_policy"
+        private const val KEY_SMART_REPLACEMENT_PROVIDER_IDS = "smart_replacement_provider_ids"
         private const val KEY_SMART_REPLACEMENT_MIN_SCORE = "smart_replacement_min_score"
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA = "smart_replacement_use_replacement_metadata"
         private const val KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS = "smart_replacement_use_replacement_lyrics"


### PR DESCRIPTION
## Summary

- add a shared horizontal first-launch setup flow for selecting and enabling music providers
- guide users through login or skip pages for each selected provider, including a Bilibili replacement-only shortcut
- add separate Wi-Fi and cellular audio quality setup before completing onboarding
- persist onboarding completion on Android and iOS, and persist smart-replacement provider IDs on iOS
- keep Android WebView login returns in their original navigation context

## User impact

New installs and existing users upgrading to this version see the setup guide once. The guide requires at least one regular provider when Bilibili is configured as replacement-only, and login remains optional.

## Validation

- `./gradlew :shared:allTests`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :androidApp:lintDebug :shared:lintDebug`
- `git diff --check`
- Pixel 9 emulator: validated first launch, provider validation, horizontal swiping, login skipping, audio quality setup, persisted Bilibili replacement-only configuration, completion, and relaunch

## Notes

iOS persistence is implemented, but native iOS compile/test tasks were skipped in the current Linux environment.