### PR TITLE
[feat] Modernize global state management

### DIFF
--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -69,6 +69,7 @@ jobs:
             -configuration Debug \
             -sdk iphonesimulator \
             -derivedDataPath build/ios-ci \
+            ARCHS=arm64 \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -58,7 +58,7 @@ val releaseAbiSplitsEnabled = providers.gradleProperty("fuo.releaseAbiSplits")
 
 android {
     namespace = "org.feeluown.mobile"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "org.feeluown.mobile"
@@ -182,6 +182,9 @@ dependencies {
     implementation(libs.androidx.media3.datasource)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)
+    implementation(libs.androidx.datastore)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.jellyfin.media3.ffmpeg.decoder)
     implementation(libs.kotlinx.coroutines.android)
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppSettingsStore.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
-class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
+internal class AndroidLegacySettingsLoader(context: Context) {
     private val preferences = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    override suspend fun load(): AppSettings = withContext(Dispatchers.IO) {
+    suspend fun load(): AppSettings = withContext(Dispatchers.IO) {
         val rawHomeSection = preferences.getString(KEY_HOME_SECTION, null)
         AppSettings(
             homeSection = homeSectionValue(rawHomeSection),
@@ -69,49 +69,6 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         )
     }
 
-    override suspend fun save(settings: AppSettings) {
-        withContext(Dispatchers.IO) {
-            preferences.edit()
-                .putString(KEY_HOME_SECTION, settings.homeSection.name)
-                .putString(KEY_MINE_SECTION, settings.mineSection.name)
-                .putString(KEY_PLAYLIST_FILTER, settings.playlistFilter.name)
-                .putString(KEY_LOCAL_MUSIC_VIEW_MODE, settings.localMusicViewMode.name)
-                .putStringSet(KEY_EXCLUDED_LOCAL_MUSIC_DIRECTORY_IDS, settings.excludedLocalMusicDirectoryIds)
-                .putInt(KEY_LOCAL_MUSIC_MIN_DURATION_SECONDS, settings.localMusicMinDurationSeconds)
-                .putString(KEY_SEARCH_SCOPE, settings.searchScope.name)
-                .putNullableString(KEY_SELECTED_SEARCH_PROVIDER_ID, settings.selectedSearchProviderId)
-                .putNullableString(KEY_SELECTED_SETTINGS_PROVIDER_ID, settings.selectedSettingsProviderId)
-                .putString(KEY_PROVIDER_LOGIN_MODE, settings.providerLoginMode.name)
-                .putString(KEY_PROVIDER_COOKIE_INPUTS, cookieInputsJson(settings.providerCookieInputs))
-                .putString(KEY_PROVIDER_HEADER_INPUTS, headerInputsJson(settings.providerHeaderInputs))
-                .putStringSet(KEY_ENABLED_PROVIDER_IDS, settings.enabledProviderIds)
-                .putString(KEY_PROVIDER_ORDER_IDS, stringListJson(settings.providerOrderIds))
-                .putStringSet(KEY_SEARCH_PROVIDER_IDS, settings.searchProviderIds)
-                .putStringSet(KEY_RECOMMEND_PROVIDER_IDS, settings.recommendProviderIds)
-                .putStringSet(KEY_EXPLORE_PROVIDER_IDS, settings.exploreProviderIds)
-                .putStringSet(KEY_MINE_PROVIDER_IDS, settings.mineProviderIds)
-                .putInt(KEY_AUDIO_CACHE_LIMIT_MB, settings.audioCacheLimitMb)
-                .putInt(KEY_IMAGE_CACHE_LIMIT_MB, settings.imageCacheLimitMb)
-                .putInt(KEY_DOWNLOAD_PARALLELISM, settings.downloadParallelism.coerceIn(1, 5))
-                .putString(KEY_WIFI_AUDIO_QUALITY_POLICY, settings.wifiAudioQualityPolicy.name)
-                .putString(KEY_CELLULAR_AUDIO_QUALITY_POLICY, settings.cellularAudioQualityPolicy.name)
-                .putString(KEY_UNAVAILABLE_PLAYBACK_POLICY, settings.unavailablePlaybackPolicy.name)
-                .putStringSet(KEY_SMART_REPLACEMENT_PROVIDER_IDS, settings.smartReplacementProviderIds)
-                .putFloat(KEY_SMART_REPLACEMENT_MIN_SCORE, settings.smartReplacementMinScore.toFloat())
-                .putBoolean(
-                    KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA,
-                    settings.smartReplacementUseReplacementMetadata,
-                )
-                .putBoolean(KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS, settings.smartReplacementUseReplacementLyrics)
-                .putString(KEY_LYRIC_FONT_SIZE, settings.lyricFontSize.name)
-                .remove(KEY_SHOW_PLAYBACK_SPECTRUM)
-                .putString(KEY_PLAYBACK_SPECTRUM_STYLE, settings.playbackSpectrumStyle.name)
-                .putString(KEY_THEME_MODE, settings.themeMode.name)
-                .putString(KEY_THEME_COLOR_SCHEME, settings.themeColorScheme.name)
-                .apply()
-        }
-    }
-
     private inline fun <reified T : Enum<T>> enumValue(key: String, fallback: T): T {
         val raw = preferences.getString(key, null) ?: return fallback
         return runCatching { enumValueOf<T>(raw) }.getOrDefault(fallback)
@@ -146,16 +103,6 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
     }
 
 
-    private fun cookieInputsJson(inputs: Map<String, String>): String {
-        val json = JSONObject()
-        inputs.forEach { (key, value) ->
-            if (key.isNotBlank() && value.isNotBlank()) {
-                json.put(key, value)
-            }
-        }
-        return json.toString()
-    }
-
     private fun readHeaderInputs(): Map<String, ProviderHeaderInput> {
         val raw = preferences.getString(KEY_PROVIDER_HEADER_INPUTS, null).orEmpty()
         if (raw.isBlank()) return emptyMap()
@@ -178,21 +125,6 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
         }.getOrDefault(emptyMap())
     }
 
-    private fun headerInputsJson(inputs: Map<String, ProviderHeaderInput>): String {
-        val json = JSONObject()
-        inputs.forEach { (providerId, input) ->
-            if (providerId.isNotBlank() && (input.authorization.isNotBlank() || input.cookie.isNotBlank())) {
-                json.put(
-                    providerId,
-                    JSONObject()
-                        .put("authorization", input.authorization)
-                        .put("cookie", input.cookie),
-                )
-            }
-        }
-        return json.toString()
-    }
-
     private fun readStringSet(key: String): Set<String> {
         return preferences.getStringSet(key, emptySet()).orEmpty().filter { it.isNotBlank() }.toSet()
     }
@@ -207,15 +139,6 @@ class AndroidAppSettingsStore(context: Context) : AppSettingsStore {
                 .distinct()
         }.getOrDefault(emptyList())
     }
-
-    private fun stringListJson(values: List<String>): String {
-        val array = JSONArray()
-        values.filter { it.isNotBlank() }.distinct().forEach { array.put(it) }
-        return array.toString()
-    }
-
-    private fun android.content.SharedPreferences.Editor.putNullableString(key: String, value: String?) =
-        if (value == null) remove(key) else putString(key, value)
 
     private companion object {
         private const val PREFS_NAME = "fuo_settings"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidSettingsRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidSettingsRepository.kt
@@ -1,0 +1,30 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import androidx.datastore.core.okio.OkioStorage
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferencesSerializer
+import kotlinx.coroutines.CoroutineScope
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+fun createAndroidAppSettingsRepository(
+    context: Context,
+    scope: CoroutineScope,
+): AppSettingsRepository {
+    val applicationContext = context.applicationContext
+    val dataStore = createSettingsDataStore(
+        storage = OkioStorage<Preferences>(
+            fileSystem = FileSystem.SYSTEM,
+            serializer = PreferencesSerializer,
+            producePath = {
+                applicationContext.filesDir.resolve(APP_SETTINGS_FILE_NAME).absolutePath.toPath()
+            },
+        ),
+    )
+    return DataStoreAppSettingsRepository(
+        dataStore = dataStore,
+        legacyLoader = LegacyAppSettingsLoader { AndroidLegacySettingsLoader(applicationContext).load() },
+        scope = scope,
+    )
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -28,9 +28,15 @@ class FuoEvolveApplication : PyApplication() {
         AndroidNativeAudioEngine(applicationContext, appScope)
     }
 
-    private val settingsStore: AndroidAppSettingsStore by lazy {
-        AndroidAppSettingsStore(applicationContext)
+    private val settingsRepository: AppSettingsRepository by lazy {
+        createAndroidAppSettingsRepository(applicationContext, appScope)
     }
+
+    private val providerSessionRepository: ProviderSessionRepository by lazy {
+        DefaultProviderSessionRepository(providerRepository)
+    }
+
+    private val navigator by lazy { AppNavigator() }
 
     private val playbackQueueStore: AndroidPlaybackQueueStore by lazy {
         AndroidPlaybackQueueStore(applicationContext)
@@ -50,7 +56,9 @@ class FuoEvolveApplication : PyApplication() {
             localRepository = localRepository,
             downloadRepository = downloadRepository,
             playbackEngine = playbackEngine,
-            settingsStore = settingsStore,
+            settingsRepository = settingsRepository,
+            providerSessionRepository = providerSessionRepository,
+            navigator = navigator,
             playbackQueueStore = playbackQueueStore,
             resourceCacheRepository = resourceCacheRepository,
             debugLogRepository = debugLogRepository,
@@ -82,6 +90,15 @@ class FuoEvolveApplication : PyApplication() {
                 }
             }
         }
+    }
+
+    val appViewModel: FuoAppViewModel by lazy {
+        FuoAppViewModel(
+            controller = controller,
+            settingsRepository = settingsRepository,
+            providerSessionRepository = providerSessionRepository,
+            navigator = navigator,
+        )
     }
 
     override fun onTerminate() {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,10 +37,12 @@ class MainActivity : ComponentActivity() {
             ) {
                 hasAudioPermission = hasAudioPermission()
             }
-            val controller = fuoApplication.controller
+            val appViewModel = fuoApplication.appViewModel
+            val controller = appViewModel.controller
+            val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
             val systemDark = LocalConfiguration.current.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
                 Configuration.UI_MODE_NIGHT_YES
-            val darkTheme = resolveDarkTheme(controller.themeMode, systemDark)
+            val darkTheme = resolveDarkTheme(appUiState.settings.settings.themeMode, systemDark)
             SideEffect {
                 configureSystemBars(darkTheme)
             }
@@ -87,7 +90,7 @@ class MainActivity : ComponentActivity() {
             }
 
             AppRoot(
-                controller = controller,
+                appViewModel = appViewModel,
                 hasAudioPermission = hasAudioPermission,
                 appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
                 onRequestAudioPermission = {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.chaquopy) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
-# Compose 1.9 lint requires a newer Lint version than AGP 8.7.3 bundles.
-android.experimental.lint.version=8.8.2
 kotlin.native.ignoreDisabledTargets=true
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,16 @@
 [versions]
-agp = "8.7.3"
+agp = "8.13.2"
 chaquopy = "17.0.0"
-compose = "1.9.3"
-kotlin = "2.1.20"
+compose = "1.11.1"
+kotlin = "2.3.20"
 media3 = "1.5.1"
 activityCompose = "1.10.1"
 coreKtx = "1.15.0"
-coroutines = "1.10.1"
+coroutines = "1.10.2"
 serializationJson = "1.8.1"
+lifecycle = "2.10.0"
+navigation3 = "1.1.1"
+datastore = "1.2.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -21,7 +24,13 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
-compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0-alpha04" }
+compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.11.0-alpha07" }
+androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycle" }
+androidx-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -31,3 +40,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.android.library)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
@@ -13,7 +14,6 @@ kotlin {
     }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach { target ->
@@ -32,6 +32,12 @@ kotlin {
             implementation(compose.materialIconsExtended)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.androidx.lifecycle.runtime.compose)
+            implementation(libs.androidx.lifecycle.viewmodel.compose)
+            implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+            implementation(libs.androidx.navigation3.ui)
+            implementation(libs.androidx.datastore)
+            implementation(libs.androidx.datastore.preferences)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
@@ -47,7 +53,7 @@ kotlin {
 
 android {
     namespace = "org.feeluown.mobile.shared"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -1,20 +1,15 @@
 package org.feeluown.mobile
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
@@ -133,6 +128,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
@@ -152,7 +150,7 @@ data class AppLayoutInfo(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun AppRoot(
-    controller: FuoPlayerController,
+    appViewModel: FuoAppViewModel,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
@@ -161,9 +159,11 @@ fun AppRoot(
     onShareText: (String) -> Unit = {},
     appVersionInfo: String? = null,
 ) {
+    val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
+    val controller = appViewModel.controller
     FuoEvolveTheme(
-        themeMode = controller.themeMode,
-        themeColorScheme = controller.themeColorScheme,
+        themeMode = appUiState.settings.settings.themeMode,
+        themeColorScheme = appUiState.settings.settings.themeColorScheme,
     ) {
         val snackbarHostState = remember { SnackbarHostState() }
         val playlistOperationFeedback = controller.playlistOperationFeedback
@@ -193,7 +193,6 @@ fun AppRoot(
                 )
             }
 
-            val destination = appDestination(controller)
             val currentFeature = controller.selectedFeature
             val currentTrack = controller.selectedTrack
             val currentVideo = controller.selectedVideo
@@ -238,42 +237,37 @@ fun AppRoot(
                 SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
                     CompositionLocalProvider(LocalPlayerSharedTransitionScope provides this) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            AnimatedContent(
-                                targetState = destination,
+                            NavDisplay(
+                                backStack = appUiState.backStack,
                                 modifier = Modifier.fillMaxSize(),
-                                transitionSpec = {
-                                    val direction = if (targetState.ordinal >= initialState.ordinal) 1 else -1
-                                    (slideInHorizontally(animationSpec = tween(220)) { it / 5 * direction } + fadeIn(tween(180)))
-                                        .togetherWith(
-                                            slideOutHorizontally(animationSpec = tween(180)) { -it / 6 * direction } +
-                                                fadeOut(tween(160)),
-                                        )
-                                        .using(SizeTransform(clip = false))
+                                onBack = { appViewModel.dispatch(AppIntent.NavigateBack) },
+                                entryProvider = { route ->
+                                    NavEntry(route) {
+                                        when (route) {
+                                            AppRoute.Home -> HomeScreen(
+                                                controller = controller,
+                                                hasAudioPermission = hasAudioPermission,
+                                                onRequestAudioPermission = onRequestAudioPermission,
+                                            )
+                                            AppRoute.DebugLogs -> DebugLogScreen(controller)
+                                            AppRoute.DownloadManager -> DownloadManagerScreen(controller)
+                                            AppRoute.Settings -> SettingsScreen(
+                                                controller,
+                                                onOpenProviderWebLogin,
+                                                onLogoutProvider,
+                                                onImportYtmusicHeaderFile,
+                                                appVersionInfo,
+                                            )
+                                            AppRoute.Search -> SearchScreen(controller)
+                                            AppRoute.Feature -> ProviderFeatureScreen(controller, currentFeature ?: lastFeature)
+                                            AppRoute.Track -> ProviderTrackScreen(controller, currentTrack ?: lastTrack)
+                                            AppRoute.Video -> ProviderVideoScreen(controller, currentVideo ?: lastVideo)
+                                            AppRoute.Playlist -> ProviderPlaylistScreen(controller, currentPlaylist ?: lastPlaylist)
+                                            AppRoute.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
+                                        }
+                                    }
                                 },
-                            ) { target ->
-                                when (target) {
-                                    AppDestination.Home -> HomeScreen(
-                                        controller = controller,
-                                        hasAudioPermission = hasAudioPermission,
-                                        onRequestAudioPermission = onRequestAudioPermission,
-                                    )
-                                    AppDestination.DebugLogs -> DebugLogScreen(controller)
-                                    AppDestination.DownloadManager -> DownloadManagerScreen(controller)
-                                    AppDestination.Settings -> SettingsScreen(
-                                        controller,
-                                        onOpenProviderWebLogin,
-                                        onLogoutProvider,
-                                        onImportYtmusicHeaderFile,
-                                        appVersionInfo,
-                                    )
-                                    AppDestination.Search -> SearchScreen(controller)
-                                    AppDestination.Feature -> ProviderFeatureScreen(controller, currentFeature ?: lastFeature)
-                                    AppDestination.Track -> ProviderTrackScreen(controller, currentTrack ?: lastTrack)
-                                    AppDestination.Video -> ProviderVideoScreen(controller, currentVideo ?: lastVideo)
-                                    AppDestination.Playlist -> ProviderPlaylistScreen(controller, currentPlaylist ?: lastPlaylist)
-                                    AppDestination.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
-                                }
-                            }
+                            )
                             AnimatedVisibility(
                                 visible = controller.isFullPlayerOpen,
                                 modifier = Modifier.fillMaxSize(),
@@ -380,31 +374,4 @@ fun ProviderPlaylistTargetDialog(controller: FuoPlayerController, track: MusicTr
             }
         },
     )
-}
-private enum class AppDestination {
-    Home,
-    Feature,
-    Track,
-    Video,
-    Playlist,
-    Search,
-    Settings,
-    DebugLogs,
-    DownloadManager,
-    MediaItem,
-}
-
-private fun appDestination(controller: FuoPlayerController): AppDestination {
-    return when {
-        controller.isDebugLogOpen -> AppDestination.DebugLogs
-        controller.isDownloadManagerOpen -> AppDestination.DownloadManager
-        controller.isSettingsOpen -> AppDestination.Settings
-        controller.selectedVideo != null -> AppDestination.Video
-        controller.selectedTrack != null -> AppDestination.Track
-        controller.selectedMediaItem != null -> AppDestination.MediaItem
-        controller.selectedPlaylist != null -> AppDestination.Playlist
-        controller.selectedFeature != null -> AppDestination.Feature
-        controller.isSearchOpen -> AppDestination.Search
-        else -> AppDestination.Home
-    }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppSettingsRepository.kt
@@ -1,0 +1,114 @@
+package org.feeluown.mobile
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Storage
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+
+const val APP_SETTINGS_FILE_NAME = "app_settings.preferences_pb"
+
+fun createSettingsDataStore(storage: Storage<Preferences>): DataStore<Preferences> =
+    DataStoreFactory.create(storage = storage)
+
+fun interface LegacyAppSettingsLoader {
+    suspend fun load(): AppSettings
+}
+
+class DataStoreAppSettingsRepository(
+    private val dataStore: DataStore<Preferences>,
+    private val legacyLoader: LegacyAppSettingsLoader?,
+    private val scope: CoroutineScope,
+) : AppSettingsRepository {
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+    private val updateMutex = Mutex()
+    private val ready = CompletableDeferred<AppSettings>()
+    private val mutableState = MutableStateFlow(SettingsState())
+
+    override val state: StateFlow<SettingsState> = mutableState.asStateFlow()
+
+    init {
+        scope.launchSettingsInitialization()
+    }
+
+    override suspend fun awaitSettings(): AppSettings = ready.await()
+
+    override suspend fun update(transform: (AppSettings) -> AppSettings) {
+        ready.await()
+        updateMutex.withLock {
+            var updated = mutableState.value.settings
+            dataStore.edit { preferences ->
+                val current = preferences[SETTINGS_JSON_KEY]
+                    ?.let { raw -> runCatching { decodeSettings(raw) }.getOrNull() }
+                    ?: mutableState.value.settings
+                updated = transform(current).withoutProviderCredentials()
+                preferences[SETTINGS_JSON_KEY] = json.encodeToString(updated)
+            }
+            mutableState.value = SettingsState(isLoaded = true, settings = updated)
+        }
+    }
+
+    private fun CoroutineScope.launchSettingsInitialization() = launch {
+        runCatching { loadOrMigrate() }
+            .onSuccess { settings ->
+                mutableState.value = SettingsState(isLoaded = true, settings = settings)
+                ready.complete(settings)
+            }
+            .onFailure { throwable ->
+                val fallback = AppSettings()
+                mutableState.value = SettingsState(
+                    isLoaded = true,
+                    settings = fallback,
+                    errorMessage = throwable.message ?: throwable::class.simpleName,
+                )
+                ready.complete(fallback)
+            }
+    }
+
+    private suspend fun loadOrMigrate(): AppSettings {
+        val stored = dataStore.data.first()[SETTINGS_JSON_KEY]
+        if (!stored.isNullOrBlank()) {
+            return runCatching { decodeSettings(stored) }.getOrElse {
+                AppSettings().also { fallback ->
+                    dataStore.edit { preferences ->
+                        preferences[SETTINGS_JSON_KEY] = json.encodeToString(fallback)
+                    }
+                }
+            }
+        }
+
+        val migrated = legacyLoader
+            ?.load()
+            ?.withoutProviderCredentials()
+            ?: AppSettings()
+        dataStore.edit { preferences ->
+            preferences[SETTINGS_JSON_KEY] = json.encodeToString(migrated)
+        }
+        return migrated
+    }
+
+    private fun decodeSettings(raw: String): AppSettings = json.decodeFromString(raw)
+
+    private fun AppSettings.withoutProviderCredentials(): AppSettings = copy(
+        providerCookieInputs = emptyMap(),
+        providerHeaderInputs = emptyMap(),
+    )
+
+    private companion object {
+        val SETTINGS_JSON_KEY = stringPreferencesKey("app_settings_json_v1")
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
@@ -1,0 +1,130 @@
+package org.feeluown.mobile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface AppRoute : NavKey {
+    @Serializable
+    data object Home : AppRoute
+
+    @Serializable
+    data object Search : AppRoute
+
+    @Serializable
+    data object Feature : AppRoute
+
+    @Serializable
+    data object Track : AppRoute
+
+    @Serializable
+    data object Video : AppRoute
+
+    @Serializable
+    data object Playlist : AppRoute
+
+    @Serializable
+    data object MediaItem : AppRoute
+
+    @Serializable
+    data object Settings : AppRoute
+
+    @Serializable
+    data object DebugLogs : AppRoute
+
+    @Serializable
+    data object DownloadManager : AppRoute
+}
+
+class AppNavigator {
+    private val mutableBackStack = MutableStateFlow<List<AppRoute>>(listOf(AppRoute.Home))
+
+    val backStack: StateFlow<List<AppRoute>> = mutableBackStack
+
+    val currentRoute: AppRoute
+        get() = mutableBackStack.value.last()
+
+    fun contains(route: AppRoute): Boolean = route in mutableBackStack.value
+
+    fun navigate(route: AppRoute) {
+        if (route == AppRoute.Home) {
+            mutableBackStack.value = listOf(AppRoute.Home)
+            return
+        }
+        if (currentRoute != route) {
+            mutableBackStack.value = mutableBackStack.value + route
+        }
+    }
+
+    fun pop(route: AppRoute): Boolean {
+        val stack = mutableBackStack.value
+        val index = stack.indexOfLast { it == route }
+        if (index <= 0) return false
+        mutableBackStack.value = stack.take(index).ifEmpty { listOf(AppRoute.Home) }
+        return true
+    }
+
+    fun pop(): Boolean {
+        val stack = mutableBackStack.value
+        if (stack.size <= 1) return false
+        mutableBackStack.value = stack.dropLast(1)
+        return true
+    }
+
+    fun remove(routes: Set<AppRoute>) {
+        val filtered = mutableBackStack.value.filterNot { it != AppRoute.Home && it in routes }
+        mutableBackStack.value = filtered.ifEmpty { listOf(AppRoute.Home) }
+    }
+}
+
+data class AppUiState(
+    val settings: SettingsState = SettingsState(),
+    val providerSessions: ProviderSessionState = ProviderSessionState(),
+    val backStack: List<AppRoute> = listOf(AppRoute.Home),
+)
+
+sealed interface AppIntent {
+    data object NavigateBack : AppIntent
+    data class UpdateSettings(val transform: (AppSettings) -> AppSettings) : AppIntent
+}
+
+/** 应用壳层 ViewModel：组合设置、登录会话和导航三个全局单一事实源。 */
+class FuoAppViewModel(
+    val controller: FuoPlayerController,
+    private val settingsRepository: AppSettingsRepository,
+    providerSessionRepository: ProviderSessionRepository,
+    private val navigator: AppNavigator,
+) : ViewModel() {
+    val uiState: StateFlow<AppUiState> = combine(
+        settingsRepository.state,
+        providerSessionRepository.state,
+        navigator.backStack,
+    ) { settings, sessions, backStack ->
+        AppUiState(settings, sessions, backStack)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = AppUiState(
+            settings = settingsRepository.state.value,
+            providerSessions = providerSessionRepository.state.value,
+            backStack = navigator.backStack.value,
+        ),
+    )
+
+    fun dispatch(intent: AppIntent) {
+        when (intent) {
+            AppIntent.NavigateBack -> controller.navigateBack()
+            is AppIntent.UpdateSettings -> viewModelScope.launch {
+                settingsRepository.update(intent.transform)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -4,19 +4,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class TrackSourceType {
     Provider,
     LocalMediaStore,
     Downloaded,
 }
 
+@Serializable
 enum class ProviderLoginMode {
     WebView,
     Cookie,
     Headers,
 }
 
+@Serializable
 enum class AudioQualityPolicy(
     val label: String,
     val policy: String,
@@ -27,6 +31,7 @@ enum class AudioQualityPolicy(
     Low("低流量", "lq<>"),
 }
 
+@Serializable
 enum class UnavailablePlaybackPolicy(
     val label: String,
 ) {
@@ -34,6 +39,7 @@ enum class UnavailablePlaybackPolicy(
     Skip("跳过"),
 }
 
+@Serializable
 enum class LyricFontSize(
     val label: String,
 ) {
@@ -42,6 +48,7 @@ enum class LyricFontSize(
     Large("大"),
 }
 
+@Serializable
 enum class ThemeMode(
     val label: String,
 ) {
@@ -50,6 +57,7 @@ enum class ThemeMode(
     Dark("暗色"),
 }
 
+@Serializable
 enum class RepeatMode(
     val label: String,
 ) {
@@ -58,6 +66,7 @@ enum class RepeatMode(
     SINGLE("单曲循环"),
 }
 
+@Serializable
 enum class ThemeColorScheme(
     val label: String,
 ) {
@@ -70,6 +79,7 @@ enum class ThemeColorScheme(
     Amber("琥珀"),
 }
 
+@Serializable
 enum class PlaybackSpectrumStyle(
     val label: String,
 ) {
@@ -79,6 +89,7 @@ enum class PlaybackSpectrumStyle(
     Wave("波形"),
 }
 
+@Serializable
 data class AppSettings(
     val homeSection: HomeSection = HomeSection.Recommend,
     val mineSection: MineSection = MineSection.Playlists,
@@ -114,6 +125,7 @@ data class AppSettings(
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
 )
 
+@Serializable
 data class ProviderHeaderInput(
     val authorization: String = "",
     val cookie: String = "",
@@ -814,15 +826,32 @@ interface PlaybackEngine {
     fun seekTo(positionMs: Long)
 }
 
-interface AppSettingsStore {
-    suspend fun load(): AppSettings
-    suspend fun save(settings: AppSettings)
+data class SettingsState(
+    val isLoaded: Boolean = false,
+    val settings: AppSettings = AppSettings(),
+    val errorMessage: String? = null,
+)
+
+interface AppSettingsRepository {
+    val state: StateFlow<SettingsState>
+    suspend fun awaitSettings(): AppSettings
+    suspend fun update(transform: (AppSettings) -> AppSettings)
 }
 
-object NoOpAppSettingsStore : AppSettingsStore {
-    override suspend fun load(): AppSettings = AppSettings()
+class InMemoryAppSettingsRepository(
+    initialSettings: AppSettings = AppSettings(),
+) : AppSettingsRepository {
+    private val mutableState = MutableStateFlow(SettingsState(isLoaded = true, settings = initialSettings))
+    override val state: StateFlow<SettingsState> = mutableState
 
-    override suspend fun save(settings: AppSettings) = Unit
+    override suspend fun awaitSettings(): AppSettings = mutableState.value.settings
+
+    override suspend fun update(transform: (AppSettings) -> AppSettings) {
+        mutableState.value = SettingsState(
+            isLoaded = true,
+            settings = transform(mutableState.value.settings),
+        )
+    }
 }
 
 data class CacheUsage(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -618,47 +618,49 @@ class FuoPlayerController(
                 toggleVideoFullscreen()
                 true
             }
-            isDebugLogOpen -> {
-                closeDebugLogs()
-                true
+            else -> when (navigator.currentRoute) {
+                AppRoute.DebugLogs -> {
+                    closeDebugLogs()
+                    true
+                }
+                AppRoute.DownloadManager -> {
+                    closeDownloadManager()
+                    true
+                }
+                AppRoute.Settings -> {
+                    if (settingsLoginProviderId != null) {
+                        closeSettingsProviderLogin()
+                    } else {
+                        closeSettings()
+                    }
+                    true
+                }
+                AppRoute.Video -> {
+                    closeVideo()
+                    true
+                }
+                AppRoute.Track -> {
+                    closeTrack()
+                    true
+                }
+                AppRoute.MediaItem -> {
+                    closeMediaItem()
+                    true
+                }
+                AppRoute.Playlist -> {
+                    closePlaylist()
+                    true
+                }
+                AppRoute.Feature -> {
+                    closeFeature()
+                    true
+                }
+                AppRoute.Search -> {
+                    closeSearch()
+                    true
+                }
+                AppRoute.Home -> false
             }
-            isDownloadManagerOpen -> {
-                closeDownloadManager()
-                true
-            }
-            isSettingsOpen && settingsLoginProviderId != null -> {
-                closeSettingsProviderLogin()
-                true
-            }
-            isSettingsOpen -> {
-                closeSettings()
-                true
-            }
-            selectedVideo != null -> {
-                closeVideo()
-                true
-            }
-            selectedTrack != null -> {
-                closeTrack()
-                true
-            }
-            selectedMediaItem != null -> {
-                closeMediaItem()
-                true
-            }
-            selectedPlaylist != null -> {
-                closePlaylist()
-                true
-            }
-            selectedFeature != null -> {
-                closeFeature()
-                true
-            }
-            isSearchOpen -> {
-                closeSearch()
-                true
-            }
-            else -> false
         }
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -12,13 +13,16 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class SearchScope {
     Local,
     Provider,
     All,
 }
 
+@Serializable
 enum class ProviderSearchTab {
     Songs,
     Artists,
@@ -27,12 +31,14 @@ enum class ProviderSearchTab {
     Videos,
 }
 
+@Serializable
 enum class HomeSection {
     Recommend,
     Music,
     Mine,
 }
 
+@Serializable
 enum class ProviderDisplaySection(val label: String) {
     Search("搜索"),
     Recommend("推荐"),
@@ -41,6 +47,7 @@ enum class ProviderDisplaySection(val label: String) {
     Replace("替换"),
 }
 
+@Serializable
 enum class MineSection {
     Playlists,
     Songs,
@@ -49,12 +56,14 @@ enum class MineSection {
     LocalMusic,
 }
 
+@Serializable
 enum class PlaylistFilter {
     All,
     UserPlaylists,
     FavoritePlaylists,
 }
 
+@Serializable
 enum class LocalMusicViewMode {
     All,
     Artist,
@@ -71,7 +80,10 @@ class FuoPlayerController(
     private val localRepository: LocalMusicRepository,
     private val downloadRepository: DownloadRepository,
     private val playbackEngine: PlaybackEngine,
-    private val settingsStore: AppSettingsStore = NoOpAppSettingsStore,
+    private val settingsRepository: AppSettingsRepository = InMemoryAppSettingsRepository(),
+    private val providerSessionRepository: ProviderSessionRepository =
+        DefaultProviderSessionRepository(providerRepository),
+    private val navigator: AppNavigator = AppNavigator(),
     private val playbackQueueStore: PlaybackQueueStore = NoOpPlaybackQueueStore,
     private val resourceCacheRepository: ResourceCacheRepository = NoOpResourceCacheRepository,
     private val debugLogRepository: DebugLogRepository = NoOpDebugLogRepository,
@@ -205,18 +217,18 @@ class FuoPlayerController(
         private set
     var localMusicMinDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
         private set
-    var isSearchOpen by mutableStateOf(false)
-        private set
+    val isSearchOpen: Boolean
+        get() = navigator.contains(AppRoute.Search)
     var isFullPlayerOpen by mutableStateOf(false)
         private set
     var isVideoFullscreen by mutableStateOf(false)
         private set
-    var isSettingsOpen by mutableStateOf(false)
-        private set
-    var isDebugLogOpen by mutableStateOf(false)
-        private set
-    var isDownloadManagerOpen by mutableStateOf(false)
-        private set
+    val isSettingsOpen: Boolean
+        get() = navigator.contains(AppRoute.Settings)
+    val isDebugLogOpen: Boolean
+        get() = navigator.contains(AppRoute.DebugLogs)
+    val isDownloadManagerOpen: Boolean
+        get() = navigator.contains(AppRoute.DownloadManager)
     var isQueueOpen by mutableStateOf(false)
         private set
     var isLoading by mutableStateOf(false)
@@ -286,15 +298,7 @@ class FuoPlayerController(
     val displayUpNextCount: Int
         get() = upNextQueue.size
     val canNavigateBack: Boolean
-        get() = isFullPlayerOpen ||
-            isDebugLogOpen ||
-            isSettingsOpen ||
-            isSearchOpen ||
-            selectedFeature != null ||
-            selectedTrack != null ||
-            selectedVideo != null ||
-            selectedMediaItem != null ||
-            selectedPlaylist != null
+        get() = isFullPlayerOpen || navigator.backStack.value.size > 1
 
     private var mainQueue: List<MusicTrack> = emptyList()
     private var originalMainQueue: List<MusicTrack> = emptyList()
@@ -328,10 +332,17 @@ class FuoPlayerController(
     private var pendingLocalMusicMediaRefresh: Job? = null
     private var playbackParts: List<PlaybackPart> = emptyList()
     private var currentPartIndex: Int = -1
+    private val settingsUpdates = Channel<AppSettings>(capacity = Channel.UNLIMITED)
 
     init {
         scope.launch {
-            val loadedSettings = runCatching { settingsStore.load() }
+            for (settings in settingsUpdates) {
+                runCatching { settingsRepository.update { settings } }
+                    .onFailure { setError(it) }
+            }
+        }
+        scope.launch {
+            val loadedSettings = runCatching { settingsRepository.awaitSettings() }
             loadedSettings.getOrNull()?.let {
                 applySettings(it)
                 downloadRepository.updateParallelism(downloadParallelism)
@@ -356,6 +367,18 @@ class FuoPlayerController(
                 refreshHomeContent(homeSection, refreshCatalog = false)
             }.onFailure {
                 setError(it)
+            }
+        }
+        scope.launch {
+            providerSessionRepository.state.collect { sessionState ->
+                providerAuthStates = sessionState.authStates
+            }
+        }
+        scope.launch {
+            settingsRepository.state.collect { settingsState ->
+                if (settingsState.isLoaded) {
+                    applySettings(settingsState.settings)
+                }
             }
         }
         scope.launch {
@@ -443,12 +466,18 @@ class FuoPlayerController(
     }
 
     fun authStateFor(provider: ProviderInfo): ProviderAuthState {
-        return providerAuthStates[provider.providerId] ?: ProviderAuthState(
+        return providerSessionRepository.state.value.authStates[provider.providerId] ?: ProviderAuthState(
             providerId = provider.providerId,
             providerName = provider.providerName,
             isLoggedIn = false,
         )
     }
+
+    fun isProviderAuthBusy(providerId: String): Boolean =
+        providerId in providerSessionRepository.state.value.operations
+
+    fun providerAuthError(providerId: String): String? =
+        providerSessionRepository.state.value.errors[providerId]
 
     fun cookieInputFor(providerId: String): String = providerCookieInputs[providerId].orEmpty()
 
@@ -563,11 +592,11 @@ class FuoPlayerController(
     }
 
     fun openSearch() {
-        isSearchOpen = true
+        navigator.navigate(AppRoute.Search)
     }
 
     fun closeSearch() {
-        isSearchOpen = false
+        navigator.pop(AppRoute.Search)
     }
 
     fun navigateBack(): Boolean {
@@ -631,16 +660,14 @@ class FuoPlayerController(
     fun openSettings(providerId: String? = null) {
         providerId?.takeIf { it.isNotBlank() }?.let { selectedSettingsProviderId = it }
         providerId?.takeIf { it.isNotBlank() }?.let { settingsLoginProviderId = it }
-        isSettingsOpen = true
+        navigator.navigate(AppRoute.Settings)
         refreshAllProviderAuthStates(refreshUserInfo = true)
         refreshResourceCacheUsage()
         refreshLocalMusicDirectories()
     }
 
     fun closeSettings() {
-        isSettingsOpen = false
-        isDebugLogOpen = false
-        isDownloadManagerOpen = false
+        navigator.pop(AppRoute.Settings)
         settingsLoginProviderId = null
     }
 
@@ -656,20 +683,20 @@ class FuoPlayerController(
 
     fun openDebugLogs() {
         if (!debugLogRepository.isAvailable) return
-        isDebugLogOpen = true
+        navigator.navigate(AppRoute.DebugLogs)
         refreshDebugLogs()
     }
 
     fun closeDebugLogs() {
-        isDebugLogOpen = false
+        navigator.pop(AppRoute.DebugLogs)
     }
 
     fun openDownloadManager() {
-        isDownloadManagerOpen = true
+        navigator.navigate(AppRoute.DownloadManager)
     }
 
     fun closeDownloadManager() {
-        isDownloadManagerOpen = false
+        navigator.pop(AppRoute.DownloadManager)
     }
 
     fun dismissDownloadQueueFeedback(feedback: String) {
@@ -715,19 +742,16 @@ class FuoPlayerController(
 
     fun onProviderCookiesChange(providerId: String, value: String) {
         providerCookieInputs = providerCookieInputs + (providerId to value)
-        persistSettings()
     }
 
     fun onProviderHeaderAuthorizationChange(providerId: String, value: String) {
         val input = providerHeaderInputFor(providerId).copy(authorization = value)
         providerHeaderInputs = providerHeaderInputs + (providerId to input)
-        persistSettings()
     }
 
     fun onProviderHeaderCookieChange(providerId: String, value: String) {
         val input = providerHeaderInputFor(providerId).copy(cookie = value)
         providerHeaderInputs = providerHeaderInputs + (providerId to input)
-        persistSettings()
     }
 
     fun onSettingsProviderChange(providerId: String) {
@@ -868,11 +892,9 @@ class FuoPlayerController(
             return
         }
         scope.launch {
-            isLoading = true
             message = "正在登录 $providerName"
-            runCatching { providerRepository.loginWithCookies(providerId, cookies) }
+            runCatching { providerSessionRepository.loginWithCookies(providerId, cookies) }
                 .onSuccess {
-                    providerAuthStates = providerAuthStates + (providerId to it)
                     providerCookieInputs = providerCookieInputs - providerId
                     persistSettings()
                     message = if (it.isLoggedIn) {
@@ -887,7 +909,6 @@ class FuoPlayerController(
                     }
                 }
                 .onFailure { setError(it) }
-            isLoading = false
         }
     }
 
@@ -901,11 +922,9 @@ class FuoPlayerController(
             return
         }
         scope.launch {
-            isLoading = true
             message = "正在登录 $providerName"
-            runCatching { providerRepository.loginWithHeaders(providerId, authorization, cookie) }
+            runCatching { providerSessionRepository.loginWithHeaders(providerId, authorization, cookie) }
                 .onSuccess {
-                    providerAuthStates = providerAuthStates + (providerId to it)
                     persistSettings()
                     message = if (it.isLoggedIn) {
                         "${it.providerName} 已登录：${it.userName.orEmpty()}"
@@ -919,7 +938,6 @@ class FuoPlayerController(
                     }
                 }
                 .onFailure { setError(it) }
-            isLoading = false
         }
     }
 
@@ -930,11 +948,9 @@ class FuoPlayerController(
         }
         val providerName = providerName("ytmusic")
         scope.launch {
-            isLoading = true
             message = "正在登录 $providerName"
-            runCatching { providerRepository.loginWithYtmusicHeaderFile(headerFileJson) }
+            runCatching { providerSessionRepository.loginWithYtmusicHeaderFile(headerFileJson) }
                 .onSuccess {
-                    providerAuthStates = providerAuthStates + ("ytmusic" to it)
                     message = if (it.isLoggedIn) {
                         "${it.providerName} 已登录：${it.userName.orEmpty()}"
                     } else {
@@ -947,18 +963,15 @@ class FuoPlayerController(
                     }
                 }
                 .onFailure { setError(it) }
-            isLoading = false
         }
     }
 
     fun logoutProvider(providerId: String) {
         val providerName = providerName(providerId)
         scope.launch {
-            isLoading = true
             message = "正在退出 $providerName"
-            runCatching { providerRepository.logout(providerId) }
+            runCatching { providerSessionRepository.logout(providerId) }
                 .onSuccess {
-                    providerAuthStates = providerAuthStates + (providerId to it)
                     providerCookieInputs = providerCookieInputs - providerId
                     providerHeaderInputs = providerHeaderInputs - providerId
                     persistSettings()
@@ -970,7 +983,6 @@ class FuoPlayerController(
                     }
                 }
                 .onFailure { setError(it) }
-            isLoading = false
         }
     }
 
@@ -1315,7 +1327,7 @@ class FuoPlayerController(
             searchScope = SearchScope.Provider
             selectedSearchProviderId = providerId
         }
-        isSearchOpen = true
+        navigator.navigate(AppRoute.Search)
         search()
     }
 
@@ -1463,6 +1475,7 @@ class FuoPlayerController(
     }
 
     fun openFeature(feature: ProviderFeature) {
+        navigator.navigate(AppRoute.Feature)
         selectedFeature = feature
         selectedFeatureContent = null
         selectedFeatureTracks = emptyList()
@@ -1509,6 +1522,7 @@ class FuoPlayerController(
     }
 
     fun closeFeature() {
+        navigator.pop(AppRoute.Feature)
         selectedFeature = null
         selectedFeatureContent = null
         selectedFeatureTracks = emptyList()
@@ -1520,6 +1534,7 @@ class FuoPlayerController(
 
     fun openTrackDetail(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
+        navigator.navigate(AppRoute.Track)
         selectedTrack = track
         selectedTrackError = null
         selectedTrackSimilar = emptyList()
@@ -1569,6 +1584,7 @@ class FuoPlayerController(
     }
 
     private suspend fun openSharedTrack(resource: ShareResourceRef) {
+        navigator.navigate(AppRoute.Track)
         val placeholder = MusicTrack(
             id = resource.toProviderTrackId(),
             title = resource.title,
@@ -1597,6 +1613,7 @@ class FuoPlayerController(
     }
 
     fun closeTrack() {
+        navigator.pop(AppRoute.Track)
         selectedTrack = null
         selectedTrackError = null
         selectedTrackSimilar = emptyList()
@@ -1634,6 +1651,7 @@ class FuoPlayerController(
     }
 
     fun openVideo(video: ProviderVideo) {
+        navigator.navigate(AppRoute.Video)
         selectedVideo = video
         selectedVideoPayload = null
         selectedVideoError = null
@@ -1665,6 +1683,7 @@ class FuoPlayerController(
     }
 
     fun closeVideo() {
+        navigator.pop(AppRoute.Video)
         isVideoFullscreen = false
         selectedVideo = null
         selectedVideoPayload = null
@@ -1878,6 +1897,7 @@ class FuoPlayerController(
     }
 
     fun openPlaylist(playlist: ProviderPlaylist, category: ProviderFeatureCategory? = null) {
+        navigator.navigate(AppRoute.Playlist)
         selectedPlaylistBackgroundLoadJob?.cancel()
         selectedPlaylist = playlist
         selectedPlaylistCategory = category
@@ -1922,6 +1942,7 @@ class FuoPlayerController(
     }
 
     fun closePlaylist() {
+        navigator.pop(AppRoute.Playlist)
         selectedPlaylistBackgroundLoadJob?.cancel()
         selectedPlaylist = null
         selectedPlaylistCategory = null
@@ -1934,6 +1955,7 @@ class FuoPlayerController(
     }
 
     fun openMediaItem(item: ProviderMediaItem) {
+        navigator.navigate(AppRoute.MediaItem)
         selectedMediaItem = item
         selectedMediaItemTracks = emptyList()
         selectedMediaItemTracksNextOffset = 0
@@ -1984,6 +2006,7 @@ class FuoPlayerController(
     }
 
     fun closeMediaItem() {
+        navigator.pop(AppRoute.MediaItem)
         selectedMediaItem = null
         selectedMediaItemTracks = emptyList()
         selectedMediaItemTracksNextOffset = 0
@@ -2681,13 +2704,7 @@ class FuoPlayerController(
                 searchScope = SearchScope.All
             }
         }
-        providerAuthStates = loadedProviders.associate { provider ->
-            provider.providerId to (providerAuthStates[provider.providerId] ?: ProviderAuthState(
-                providerId = provider.providerId,
-                providerName = provider.providerName,
-                isLoggedIn = false,
-            ))
-        }
+        providerSessionRepository.updateProviders(loadedProviders)
         providerCapabilities = providerRepository.providerCapabilities()
             .associateBy { it.providerId }
         providerFeatures = providerRepository.features().sortedFeaturesByOrder()
@@ -2705,6 +2722,15 @@ class FuoPlayerController(
     }
 
     private fun clearProviderContent() {
+        navigator.remove(
+            setOf(
+                AppRoute.Feature,
+                AppRoute.Track,
+                AppRoute.Video,
+                AppRoute.Playlist,
+                AppRoute.MediaItem,
+            ),
+        )
         selectedPlaylistBackgroundLoadJob?.cancel()
         recommendSections = emptyList()
         musicSections = emptyList()
@@ -2756,17 +2782,17 @@ class FuoPlayerController(
         providers.forEach { provider ->
             runCatching {
                 if (refreshUserInfo) {
-                    providerRepository.refreshAuthState(provider.providerId)
+                    providerSessionRepository.refresh(provider.providerId, refreshUserInfo = true)
                 } else {
-                    providerRepository.authState(provider.providerId)
+                    providerSessionRepository.refresh(provider.providerId)
                 }
             }
-                .onSuccess { providerAuthStates = providerAuthStates + (provider.providerId to it) }
+                .onFailure { setError(it) }
         }
     }
 
     private fun isProviderLoggedIn(providerId: String): Boolean {
-        return providerAuthStates[providerId]?.isLoggedIn == true
+        return providerSessionRepository.state.value.authStates[providerId]?.isLoggedIn == true
     }
 
     private fun trackProviderId(track: MusicTrack): String? {
@@ -3422,8 +3448,6 @@ class FuoPlayerController(
         selectedSearchProviderId = settings.selectedSearchProviderId
         selectedSettingsProviderId = settings.selectedSettingsProviderId
         providerLoginMode = settings.providerLoginMode
-        providerCookieInputs = settings.providerCookieInputs
-        providerHeaderInputs = settings.providerHeaderInputs
         enabledProviderIds = settings.enabledProviderIds.ifEmpty { DEFAULT_ENABLED_PROVIDER_IDS }
         providerOrderIds = settings.providerOrderIds.ifEmpty { DEFAULT_PROVIDER_ORDER_IDS }
         searchProviderIds = settings.searchProviderIds
@@ -3458,8 +3482,6 @@ class FuoPlayerController(
             selectedSearchProviderId = selectedSearchProviderId,
             selectedSettingsProviderId = selectedSettingsProviderId,
             providerLoginMode = providerLoginMode,
-            providerCookieInputs = providerCookieInputs,
-            providerHeaderInputs = providerHeaderInputs,
             enabledProviderIds = enabledProviderIds,
             providerOrderIds = providerOrderIds,
             searchProviderIds = searchProviderIds,
@@ -3481,9 +3503,7 @@ class FuoPlayerController(
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
         )
-        scope.launch {
-            settingsStore.save(settings)
-        }
+        settingsUpdates.trySend(settings)
     }
 
     private suspend fun updateResourceCacheLimit() {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderSessionRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderSessionRepository.kt
@@ -1,0 +1,126 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+enum class ProviderSessionOperation {
+    Refresh,
+    Login,
+    Logout,
+}
+
+data class ProviderSessionState(
+    val authStates: Map<String, ProviderAuthState> = emptyMap(),
+    val operations: Map<String, ProviderSessionOperation> = emptyMap(),
+    val errors: Map<String, String> = emptyMap(),
+)
+
+interface ProviderSessionRepository {
+    val state: StateFlow<ProviderSessionState>
+
+    suspend fun updateProviders(providers: List<ProviderInfo>)
+    suspend fun refresh(providerId: String, refreshUserInfo: Boolean = false): ProviderAuthState
+    suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState
+    suspend fun loginWithHeaders(providerId: String, authorization: String, cookie: String): ProviderAuthState
+    suspend fun loginWithYtmusicHeaderFile(headerFileJson: String): ProviderAuthState
+    suspend fun logout(providerId: String): ProviderAuthState
+}
+
+/**
+ * 音源登录态的唯一写入入口。
+ *
+ * 所有刷新、登录和退出操作都通过同一把互斥锁提交，避免慢刷新覆盖刚完成的登录结果，
+ * 也避免登录与退出并发时界面最终显示旧状态。
+ */
+class DefaultProviderSessionRepository(
+    private val providerRepository: ProviderMusicRepository,
+) : ProviderSessionRepository {
+    private val operationMutex = Mutex()
+    private val mutableState = MutableStateFlow(ProviderSessionState())
+
+    override val state: StateFlow<ProviderSessionState> = mutableState.asStateFlow()
+
+    override suspend fun updateProviders(providers: List<ProviderInfo>) {
+        operationMutex.withLock {
+            val providerIds = providers.mapTo(mutableSetOf()) { it.providerId }
+            val current = mutableState.value
+            mutableState.value = current.copy(
+                authStates = providers.associate { provider ->
+                    provider.providerId to (current.authStates[provider.providerId] ?: ProviderAuthState(
+                        providerId = provider.providerId,
+                        providerName = provider.providerName,
+                        isLoggedIn = false,
+                    ))
+                },
+                operations = current.operations.filterKeys(providerIds::contains),
+                errors = current.errors.filterKeys(providerIds::contains),
+            )
+        }
+    }
+
+    override suspend fun refresh(providerId: String, refreshUserInfo: Boolean): ProviderAuthState =
+        mutate(providerId, ProviderSessionOperation.Refresh) {
+            if (refreshUserInfo) {
+                providerRepository.refreshAuthState(providerId)
+            } else {
+                providerRepository.authState(providerId)
+            }
+        }
+
+    override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState =
+        mutate(providerId, ProviderSessionOperation.Login) {
+            providerRepository.loginWithCookies(providerId, cookiesJson)
+        }
+
+    override suspend fun loginWithHeaders(
+        providerId: String,
+        authorization: String,
+        cookie: String,
+    ): ProviderAuthState = mutate(providerId, ProviderSessionOperation.Login) {
+        providerRepository.loginWithHeaders(providerId, authorization, cookie)
+    }
+
+    override suspend fun loginWithYtmusicHeaderFile(headerFileJson: String): ProviderAuthState =
+        mutate("ytmusic", ProviderSessionOperation.Login) {
+            providerRepository.loginWithYtmusicHeaderFile(headerFileJson)
+        }
+
+    override suspend fun logout(providerId: String): ProviderAuthState =
+        mutate(providerId, ProviderSessionOperation.Logout) {
+            providerRepository.logout(providerId)
+        }
+
+    private suspend fun mutate(
+        providerId: String,
+        operation: ProviderSessionOperation,
+        block: suspend () -> ProviderAuthState,
+    ): ProviderAuthState = operationMutex.withLock {
+        val before = mutableState.value
+        mutableState.value = before.copy(
+            operations = before.operations + (providerId to operation),
+            errors = before.errors - providerId,
+        )
+        try {
+            val authState = block()
+            val current = mutableState.value
+            mutableState.value = current.copy(
+                authStates = current.authStates + (providerId to authState),
+                operations = current.operations - providerId,
+                errors = current.errors - providerId,
+            )
+            authState
+        } catch (throwable: Throwable) {
+            val current = mutableState.value
+            mutableState.value = current.copy(
+                operations = current.operations - providerId,
+                errors = current.errors + (
+                    providerId to (throwable.message ?: throwable::class.simpleName.orEmpty())
+                ),
+            )
+            throw throwable
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -485,6 +485,8 @@ fun ProviderLoginPanel(
     onImportYtmusicHeaderFile: (() -> Unit)? = null,
 ) {
     val authState = controller.authStateFor(provider)
+    val isAuthBusy = controller.isProviderAuthBusy(provider.providerId)
+    val authError = controller.providerAuthError(provider.providerId)
     val supportedLoginModes = listOf(
         ProviderLoginMode.WebView,
         ProviderLoginMode.Cookie,
@@ -532,12 +534,19 @@ fun ProviderLoginPanel(
                     },
                 )
             }
+            authError?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
             if (authState.isLoggedIn) {
                 Button(
-                    enabled = !controller.isLoading,
+                    enabled = !isAuthBusy,
                     onClick = { onLogoutProvider(provider) },
                 ) {
-                    Text(if (controller.isLoading) "退出中" else "退出登录")
+                    Text(if (isAuthBusy) "退出中" else "退出登录")
                 }
                 return@Column
             }
@@ -558,12 +567,12 @@ fun ProviderLoginPanel(
             when (activeLoginMode) {
                 ProviderLoginMode.WebView -> {
                     Button(
-                        enabled = !controller.isLoading && provider.loginConfig != null,
+                        enabled = !isAuthBusy && provider.loginConfig != null,
                         onClick = { onOpenProviderWebLogin(provider) },
                     ) {
                         Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
                         Spacer(Modifier.size(8.dp))
-                        Text(if (controller.isLoading) "登录中" else "WebView 登录")
+                        Text(if (isAuthBusy) "登录中" else "WebView 登录")
                     }
                 }
                 ProviderLoginMode.Cookie -> {
@@ -578,7 +587,7 @@ fun ProviderLoginPanel(
                         maxLines = 8,
                     )
                     Button(
-                        enabled = !controller.isLoading,
+                        enabled = !isAuthBusy,
                         onClick = {
                             controller.loginProviderWithCookies(
                                 provider.providerId,
@@ -588,14 +597,14 @@ fun ProviderLoginPanel(
                     ) {
                         Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
                         Spacer(Modifier.size(8.dp))
-                        Text(if (controller.isLoading) "登录中" else "登录")
+                        Text(if (isAuthBusy) "登录中" else "登录")
                     }
                 }
                 ProviderLoginMode.Headers -> {
                     val headerInput = controller.providerHeaderInputFor(provider.providerId)
                     if (provider.providerId == "ytmusic" && onImportYtmusicHeaderFile != null) {
                         Button(
-                            enabled = !controller.isLoading,
+                            enabled = !isAuthBusy,
                             onClick = onImportYtmusicHeaderFile,
                         ) {
                             Text("导入 ytmusic_header.json")
@@ -619,12 +628,12 @@ fun ProviderLoginPanel(
                         maxLines = 8,
                     )
                     Button(
-                        enabled = !controller.isLoading,
+                        enabled = !isAuthBusy,
                         onClick = { controller.loginProviderWithHeaders(provider.providerId) },
                     ) {
                         Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
                         Spacer(Modifier.size(8.dp))
-                        Text(if (controller.isLoading) "登录中" else "登录")
+                        Text(if (isAuthBusy) "登录中" else "登录")
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -891,7 +891,7 @@ fun ThemeColorSchemeOption(
             .clip(shape)
             .background(
                 if (selected) {
-                    MaterialTheme.colorScheme.primaryContainer
+                    MaterialTheme.colorScheme.primary
                 } else {
                     MaterialTheme.colorScheme.surface
                 },
@@ -912,7 +912,7 @@ fun ThemeColorSchemeOption(
             text = scheme.label,
             style = MaterialTheme.typography.labelMedium,
             color = if (selected) {
-                MaterialTheme.colorScheme.onPrimaryContainer
+                MaterialTheme.colorScheme.onPrimary
             } else {
                 MaterialTheme.colorScheme.onSurface
             },
@@ -1111,6 +1111,7 @@ fun DownloadSettingsPanel(controller: FuoPlayerController) {
                         selected = controller.downloadParallelism == value,
                         onClick = { controller.onDownloadParallelismChange(value) },
                         shape = SegmentedButtonDefaults.itemShape(index = value - 1, count = 5),
+                        colors = settingsSegmentedButtonColors(),
                     ) { Text(value.toString()) }
                 }
             }
@@ -1265,6 +1266,7 @@ fun DebugLogScreen(controller: FuoPlayerController) {
                             )
                         },
                         label = { Text(debugLogLevelLabel(level)) },
+                        colors = settingsFilterChipColors(),
                     )
                 }
             }
@@ -1448,6 +1450,7 @@ fun CacheLimitRow(
                     selected = selected == value,
                     onClick = { onSelect(value) },
                     label = { Text(formatCacheLimit(value)) },
+                    colors = settingsFilterChipColors(),
                 )
             }
         }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppNavigatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppNavigatorTest.kt
@@ -1,0 +1,34 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppNavigatorTest {
+    @Test
+    fun navigationOwnsAnOrderedBackStack() {
+        val navigator = AppNavigator()
+
+        navigator.navigate(AppRoute.Search)
+        navigator.navigate(AppRoute.Track)
+
+        assertEquals(listOf(AppRoute.Home, AppRoute.Search, AppRoute.Track), navigator.backStack.value)
+        assertTrue(navigator.pop(AppRoute.Track))
+        assertEquals(AppRoute.Search, navigator.currentRoute)
+        assertTrue(navigator.pop())
+        assertEquals(listOf(AppRoute.Home), navigator.backStack.value)
+        assertFalse(navigator.pop())
+    }
+
+    @Test
+    fun poppingAParentAlsoRemovesItsChildRoutes() {
+        val navigator = AppNavigator()
+        navigator.navigate(AppRoute.Settings)
+        navigator.navigate(AppRoute.DebugLogs)
+
+        navigator.pop(AppRoute.Settings)
+
+        assertEquals(listOf(AppRoute.Home), navigator.backStack.value)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -1,0 +1,110 @@
+package org.feeluown.mobile
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppSettingsRepositoryTest {
+    @Test
+    fun legacySettingsMigrateOnceAndDiscardLoginDrafts() = runTest {
+        val dataStore = FakePreferencesDataStore()
+        var migrationCount = 0
+        val legacy = AppSettings(
+            localMusicMinDurationSeconds = 42,
+            providerCookieInputs = mapOf("netease" to "secret"),
+            providerHeaderInputs = mapOf("qqmusic" to ProviderHeaderInput(cookie = "secret")),
+        )
+        val first = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = LegacyAppSettingsLoader {
+                migrationCount += 1
+                legacy
+            },
+            scope = backgroundScope,
+        )
+
+        val migrated = first.awaitSettings()
+
+        assertEquals(42, migrated.localMusicMinDurationSeconds)
+        assertTrue(migrated.providerCookieInputs.isEmpty())
+        assertTrue(migrated.providerHeaderInputs.isEmpty())
+
+        val second = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = LegacyAppSettingsLoader {
+                migrationCount += 1
+                AppSettings(localMusicMinDurationSeconds = 99)
+            },
+            scope = backgroundScope,
+        )
+
+        assertEquals(42, second.awaitSettings().localMusicMinDurationSeconds)
+        assertEquals(1, migrationCount)
+    }
+
+    @Test
+    fun concurrentTransformsDoNotLoseUpdates() = runTest {
+        val repository = DataStoreAppSettingsRepository(
+            dataStore = FakePreferencesDataStore(),
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+        repository.awaitSettings()
+
+        List(20) {
+            async {
+                repository.update { settings ->
+                    settings.copy(localMusicMinDurationSeconds = settings.localMusicMinDurationSeconds + 1)
+                }
+            }
+        }.awaitAll()
+
+        assertEquals(
+            DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS + 20,
+            repository.state.value.settings.localMusicMinDurationSeconds,
+        )
+    }
+
+    @Test
+    fun corruptedPayloadRecoversAndAcceptsFutureUpdates() = runTest {
+        val dataStore = FakePreferencesDataStore(
+            mutablePreferencesOf(stringPreferencesKey("app_settings_json_v1") to "not-json"),
+        )
+        val repository = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+
+        assertEquals(AppSettings(), repository.awaitSettings())
+        repository.update { it.copy(themeMode = ThemeMode.Dark) }
+
+        assertEquals(ThemeMode.Dark, repository.state.value.settings.themeMode)
+    }
+
+    private class FakePreferencesDataStore(
+        initial: Preferences = emptyPreferences(),
+    ) : DataStore<Preferences> {
+        private val mutex = Mutex()
+        private val mutableData = MutableStateFlow(initial)
+
+        override val data: Flow<Preferences> = mutableData
+
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences =
+            mutex.withLock {
+                transform(mutableData.value).also { mutableData.value = it }
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -97,7 +97,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = settings,
+                settingsRepository = settings,
                 scope = controllerScope,
             )
 
@@ -205,7 +205,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = downloads,
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(
                         enabledProviderIds = setOf("netease", "qqmusic", "bilibili"),
                         smartReplacementProviderIds = setOf("qqmusic"),
@@ -398,7 +398,7 @@ class FuoPlayerControllerTest {
                     localRepository = FakeLocalMusicRepository(),
                     downloadRepository = FakeDownloadRepository(emptyMap()),
                     playbackEngine = FakePlaybackEngine(),
-                    settingsStore = FakeSettingsStore(AppSettings(homeSection = section)),
+                    settingsRepository = FakeSettingsStore(AppSettings(homeSection = section)),
                     scope = controllerScope,
                 )
 
@@ -469,7 +469,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(
                         enabledProviderIds = setOf("netease", "qqmusic", "bilibili"),
                         smartReplacementProviderIds = setOf("qqmusic", "bilibili"),
@@ -502,7 +502,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(smartReplacementMinScore = 0.75),
                 ),
                 scope = controllerScope,
@@ -532,7 +532,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(
                         smartReplacementUseReplacementMetadata = true,
                         smartReplacementUseReplacementLyrics = true,
@@ -567,7 +567,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(
                         enabledProviderIds = setOf("netease", "qqmusic", "bilibili"),
                         unavailablePlaybackPolicy = UnavailablePlaybackPolicy.SmartReplace,
@@ -886,7 +886,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(unavailablePlaybackPolicy = UnavailablePlaybackPolicy.Skip),
                 ),
                 scope = controllerScope,
@@ -922,7 +922,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = engine,
-                settingsStore = FakeSettingsStore(
+                settingsRepository = FakeSettingsStore(
                     AppSettings(unavailablePlaybackPolicy = UnavailablePlaybackPolicy.Skip),
                 ),
                 scope = controllerScope,
@@ -2080,7 +2080,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = downloads,
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = FakeSettingsStore(AppSettings(downloadParallelism = 4)),
+                settingsRepository = FakeSettingsStore(AppSettings(downloadParallelism = 4)),
                 scope = controllerScope,
             )
 
@@ -2138,7 +2138,7 @@ class FuoPlayerControllerTest {
                 localRepository = local,
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = store,
+                settingsRepository = store,
                 resourceCacheRepository = cache,
                 scope = controllerScope,
             )
@@ -2155,11 +2155,11 @@ class FuoPlayerControllerTest {
             assertEquals(30, controller.localMusicMinDurationSeconds)
             assertEquals(LocalMusicScanSettings(setOf("Podcasts/"), 30), local.lastSettings)
             assertEquals(ProviderLoginMode.Cookie, controller.providerLoginMode)
-            assertEquals("""{"MUSIC_U":"saved"}""", controller.cookieInputFor("netease"))
+            assertEquals("", controller.cookieInputFor("netease"))
             assertEquals(setOf("netease", "ytmusic"), controller.enabledProviderIds)
             assertEquals(listOf("ytmusic", "netease"), controller.providers.map { it.providerId })
             assertEquals(
-                ProviderHeaderInput("SAPISIDHASH saved", "SID=saved"),
+                ProviderHeaderInput(),
                 controller.providerHeaderInputFor("ytmusic"),
             )
             assertEquals(256, controller.audioCacheLimitMb)
@@ -2199,11 +2199,8 @@ class FuoPlayerControllerTest {
             advanceUntilIdle()
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
-            assertEquals("""{"MUSIC_U":"draft"}""", store.saved.providerCookieInputs["netease"])
-            assertEquals(
-                ProviderHeaderInput("SAPISIDHASH draft", "SID=draft"),
-                store.saved.providerHeaderInputs["ytmusic"],
-            )
+            assertEquals(null, store.saved.providerCookieInputs["netease"])
+            assertEquals(null, store.saved.providerHeaderInputs["ytmusic"])
             assertEquals(setOf("netease", "ytmusic"), store.saved.enabledProviderIds)
             assertEquals(listOf("ytmusic", "netease", "qqmusic", "bilibili"), store.saved.providerOrderIds)
             assertEquals(MineSection.Artists, store.saved.mineSection)
@@ -2436,7 +2433,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = store,
+                settingsRepository = store,
                 scope = controllerScope,
             )
 
@@ -2523,7 +2520,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = store,
+                settingsRepository = store,
                 scope = controllerScope,
             )
 
@@ -2551,7 +2548,7 @@ class FuoPlayerControllerTest {
                 localRepository = FakeLocalMusicRepository(),
                 downloadRepository = FakeDownloadRepository(emptyMap()),
                 playbackEngine = FakePlaybackEngine(),
-                settingsStore = store,
+                settingsRepository = store,
                 scope = controllerScope,
             )
 
@@ -3718,14 +3715,17 @@ class FuoPlayerControllerTest {
         override fun seekTo(positionMs: Long) = Unit
     }
 
-    private class FakeSettingsStore(initial: AppSettings = AppSettings()) : AppSettingsStore {
+    private class FakeSettingsStore(initial: AppSettings = AppSettings()) : AppSettingsRepository {
+        private val mutableState = MutableStateFlow(SettingsState(isLoaded = true, settings = initial))
+        override val state = mutableState
         var saved = initial
             private set
 
-        override suspend fun load(): AppSettings = saved
+        override suspend fun awaitSettings(): AppSettings = saved
 
-        override suspend fun save(settings: AppSettings) {
-            saved = settings
+        override suspend fun update(transform: (AppSettings) -> AppSettings) {
+            saved = transform(saved)
+            mutableState.value = SettingsState(isLoaded = true, settings = saved)
         }
     }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1782,6 +1782,37 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun navigateBackClosesSearchAboveTrackWithoutDiscardingTrack() = runTest {
+        val track = providerTrack("provider:1", "First")
+        val navigator = AppNavigator()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                navigator = navigator,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.openTrackDetail(track)
+            controller.openTrackArtist(track)
+            advanceUntilIdle()
+
+            assertEquals(AppRoute.Search, navigator.currentRoute)
+            assertEquals(track.id, controller.selectedTrack?.id)
+
+            assertTrue(controller.navigateBack())
+            assertEquals(AppRoute.Track, navigator.currentRoute)
+            assertEquals(track.id, controller.selectedTrack?.id)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun navigateBackClosesPlaylistBeforeFeature() = runTest {
         val feature = ProviderFeature(
             id = "netease_daily_songs",

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderSessionRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderSessionRepositoryTest.kt
@@ -1,0 +1,108 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProviderSessionRepositoryTest {
+    @Test
+    fun slowRefreshCannotOverwriteNewLogin() = runTest {
+        val provider = RacingProviderRepository()
+        val repository = DefaultProviderSessionRepository(provider)
+        repository.updateProviders(listOf(PROVIDER))
+
+        val refresh = async { repository.refresh(PROVIDER.providerId, refreshUserInfo = true) }
+        provider.refreshStarted.await()
+        val login = async { repository.loginWithCookies(PROVIDER.providerId, "{}") }
+        provider.allowRefreshToFinish.complete(Unit)
+
+        refresh.await()
+        login.await()
+
+        assertTrue(repository.state.value.authStates.getValue(PROVIDER.providerId).isLoggedIn)
+        assertTrue(repository.state.value.operations.isEmpty())
+    }
+
+    @Test
+    fun logoutPublishesTheFinalSessionState() = runTest {
+        val provider = RacingProviderRepository()
+        provider.allowRefreshToFinish.complete(Unit)
+        val repository = DefaultProviderSessionRepository(provider)
+        repository.updateProviders(listOf(PROVIDER))
+
+        repository.loginWithCookies(PROVIDER.providerId, "{}")
+        repository.logout(PROVIDER.providerId)
+
+        assertFalse(repository.state.value.authStates.getValue(PROVIDER.providerId).isLoggedIn)
+        assertEquals(ProviderSessionState().errors, repository.state.value.errors)
+    }
+
+    private class RacingProviderRepository : ProviderMusicRepository {
+        var isLoggedIn = false
+        val refreshStarted = CompletableDeferred<Unit>()
+        val allowRefreshToFinish = CompletableDeferred<Unit>()
+
+        override suspend fun initialize() = Unit
+        override suspend fun providers(): List<ProviderInfo> = listOf(PROVIDER)
+        override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> = emptyList()
+        override suspend fun resolve(
+            track: MusicTrack,
+            unavailablePolicy: UnavailablePlaybackPolicy,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+        ): PlaybackPayload = PlaybackPayload(
+            url = "",
+            title = track.title,
+            artists = track.artists,
+            album = track.album,
+            source = track.source,
+        )
+
+        override suspend fun authState(providerId: String): ProviderAuthState = state(isLoggedIn)
+
+        override suspend fun refreshAuthState(providerId: String): ProviderAuthState {
+            val captured = isLoggedIn
+            refreshStarted.complete(Unit)
+            allowRefreshToFinish.await()
+            return state(captured)
+        }
+
+        override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState {
+            isLoggedIn = true
+            return state(true)
+        }
+
+        override suspend fun logout(providerId: String): ProviderAuthState {
+            isLoggedIn = false
+            return state(false)
+        }
+
+        override suspend fun updateAudioQualityPolicies(
+            wifiPolicy: AudioQualityPolicy,
+            cellularPolicy: AudioQualityPolicy,
+        ) = Unit
+
+        override suspend fun features(): List<ProviderFeature> = emptyList()
+        override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+            ProviderContentSection(feature)
+
+        override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = emptyList()
+        override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> = emptyList()
+
+        private fun state(loggedIn: Boolean) = ProviderAuthState(
+            providerId = PROVIDER.providerId,
+            providerName = PROVIDER.providerName,
+            isLoggedIn = loggedIn,
+        )
+    }
+
+    private companion object {
+        val PROVIDER = ProviderInfo("netease", "网易云音乐")
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -53,7 +53,7 @@ private fun IosApp(
         )
     }
     AppRoot(
-        controller = container.controller,
+        appViewModel = container.appViewModel,
         hasAudioPermission = container.hasAudioPermission,
         onRequestAudioPermission = container::requestAudioPermission,
         onOpenProviderWebLogin = container::openProviderWebLogin,
@@ -75,7 +75,9 @@ private class IosAppContainer(
     private val localRepository = IosLocalMusicRepository(mediaLibraryOutput)
     private val downloadRepository = IosDownloadRepository(providerRepository, downloadOutput)
     private val playbackEngine = IosNativeAudioEngine(scope, audioOutput)
-    private val settingsStore = IosAppSettingsStore()
+    private val settingsRepository = createIosAppSettingsRepository(scope)
+    private val providerSessionRepository = DefaultProviderSessionRepository(providerRepository)
+    private val navigator = AppNavigator()
     private val playbackQueueStore = IosPlaybackQueueStore()
     private val resourceCacheRepository = IosResourceCacheRepository()
 
@@ -84,10 +86,19 @@ private class IosAppContainer(
         localRepository = localRepository,
         downloadRepository = downloadRepository,
         playbackEngine = playbackEngine,
-        settingsStore = settingsStore,
+        settingsRepository = settingsRepository,
+        providerSessionRepository = providerSessionRepository,
+        navigator = navigator,
         playbackQueueStore = playbackQueueStore,
         resourceCacheRepository = resourceCacheRepository,
         scope = scope,
+    )
+
+    val appViewModel = FuoAppViewModel(
+        controller = controller,
+        settingsRepository = settingsRepository,
+        providerSessionRepository = providerSessionRepository,
+        navigator = navigator,
     )
 
     val hasAudioPermission: Boolean

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppSettingsStore.kt
@@ -4,10 +4,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import platform.Foundation.NSUserDefaults
 
-class IosAppSettingsStore : AppSettingsStore {
+internal class IosLegacySettingsLoader {
     private val defaults = NSUserDefaults.standardUserDefaults
 
-    override suspend fun load(): AppSettings = withContext(Dispatchers.Default) {
+    suspend fun load(): AppSettings = withContext(Dispatchers.Default) {
         AppSettings(
             homeSection = enumValue(KEY_HOME_SECTION, HomeSection.Recommend),
             mineSection = enumValue(KEY_MINE_SECTION, MineSection.Playlists),
@@ -50,43 +50,6 @@ class IosAppSettingsStore : AppSettingsStore {
             themeMode = enumValue(KEY_THEME_MODE, ThemeMode.System),
             themeColorScheme = enumValue(KEY_THEME_COLOR_SCHEME, ThemeColorScheme.Dynamic),
         )
-    }
-
-    override suspend fun save(settings: AppSettings) {
-        withContext(Dispatchers.Default) {
-            defaults.setObject(settings.homeSection.name, KEY_HOME_SECTION)
-            defaults.setObject(settings.mineSection.name, KEY_MINE_SECTION)
-            defaults.setObject(settings.localMusicViewMode.name, KEY_LOCAL_MUSIC_VIEW_MODE)
-            defaults.setObject(settings.excludedLocalMusicDirectoryIds.joinToString(LIST_SEPARATOR), KEY_EXCLUDED_LOCAL_MUSIC_DIRECTORY_IDS)
-            defaults.setInteger(settings.localMusicMinDurationSeconds.toLong(), KEY_LOCAL_MUSIC_MIN_DURATION_SECONDS)
-            defaults.setObject(settings.searchScope.name, KEY_SEARCH_SCOPE)
-            defaults.setNullableString(settings.selectedSearchProviderId, KEY_SELECTED_SEARCH_PROVIDER_ID)
-            defaults.setNullableString(settings.selectedSettingsProviderId, KEY_SELECTED_SETTINGS_PROVIDER_ID)
-            defaults.setObject(settings.providerLoginMode.name, KEY_PROVIDER_LOGIN_MODE)
-            defaults.setObject(stringMapValue(settings.providerCookieInputs), KEY_PROVIDER_COOKIE_INPUTS)
-            defaults.setObject(headerInputsValue(settings.providerHeaderInputs), KEY_PROVIDER_HEADER_INPUTS)
-            defaults.setObject(settings.enabledProviderIds.joinToString(LIST_SEPARATOR), KEY_ENABLED_PROVIDER_IDS)
-            defaults.setObject(settings.providerOrderIds.joinToString(LIST_SEPARATOR), KEY_PROVIDER_ORDER_IDS)
-            defaults.setObject(settings.searchProviderIds.joinToString(LIST_SEPARATOR), KEY_SEARCH_PROVIDER_IDS)
-            defaults.setObject(settings.recommendProviderIds.joinToString(LIST_SEPARATOR), KEY_RECOMMEND_PROVIDER_IDS)
-            defaults.setObject(settings.exploreProviderIds.joinToString(LIST_SEPARATOR), KEY_EXPLORE_PROVIDER_IDS)
-            defaults.setObject(settings.mineProviderIds.joinToString(LIST_SEPARATOR), KEY_MINE_PROVIDER_IDS)
-            defaults.setInteger(settings.audioCacheLimitMb.toLong(), KEY_AUDIO_CACHE_LIMIT_MB)
-            defaults.setInteger(settings.imageCacheLimitMb.toLong(), KEY_IMAGE_CACHE_LIMIT_MB)
-            defaults.setInteger(settings.downloadParallelism.coerceIn(1, 5).toLong(), KEY_DOWNLOAD_PARALLELISM)
-            defaults.setObject(settings.wifiAudioQualityPolicy.name, KEY_WIFI_AUDIO_QUALITY_POLICY)
-            defaults.setObject(settings.cellularAudioQualityPolicy.name, KEY_CELLULAR_AUDIO_QUALITY_POLICY)
-            defaults.setObject(settings.unavailablePlaybackPolicy.name, KEY_UNAVAILABLE_PLAYBACK_POLICY)
-            defaults.setDouble(settings.smartReplacementMinScore, KEY_SMART_REPLACEMENT_MIN_SCORE)
-            defaults.setBool(settings.smartReplacementUseReplacementMetadata, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_METADATA)
-            defaults.setBool(settings.smartReplacementUseReplacementLyrics, KEY_SMART_REPLACEMENT_USE_REPLACEMENT_LYRICS)
-            defaults.setObject(settings.lyricFontSize.name, KEY_LYRIC_FONT_SIZE)
-            defaults.removeObjectForKey(KEY_SHOW_PLAYBACK_SPECTRUM)
-            defaults.setObject(settings.playbackSpectrumStyle.name, KEY_PLAYBACK_SPECTRUM_STYLE)
-            defaults.setObject(settings.themeMode.name, KEY_THEME_MODE)
-            defaults.setObject(settings.themeColorScheme.name, KEY_THEME_COLOR_SCHEME)
-            defaults.synchronize()
-        }
     }
 
     private inline fun <reified T : Enum<T>> enumValue(key: String, fallback: T): T {
@@ -144,26 +107,6 @@ class IosAppSettingsStore : AppSettingsStore {
                 authorization = parts.getOrElse(0) { "" },
                 cookie = parts.getOrElse(1) { "" },
             )
-        }
-    }
-
-    private fun stringMapValue(values: Map<String, String>): String {
-        return values.entries
-            .filter { it.key.isNotBlank() && it.value.isNotBlank() }
-            .joinToString("\n") { "${it.key}$MAP_SEPARATOR${it.value}" }
-    }
-
-    private fun headerInputsValue(values: Map<String, ProviderHeaderInput>): String {
-        return stringMapValue(values.mapValues { (_, input) ->
-            "${input.authorization}$HEADER_SEPARATOR${input.cookie}"
-        })
-    }
-
-    private fun NSUserDefaults.setNullableString(value: String?, key: String) {
-        if (value == null) {
-            removeObjectForKey(key)
-        } else {
-            setObject(value, key)
         }
     }
 

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosSettingsRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosSettingsRepository.kt
@@ -1,0 +1,37 @@
+package org.feeluown.mobile
+
+import androidx.datastore.core.okio.OkioStorage
+import androidx.datastore.preferences.core.PreferencesSerializer
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
+
+@OptIn(ExperimentalForeignApi::class)
+fun createIosAppSettingsRepository(scope: CoroutineScope): AppSettingsRepository {
+    val dataStore = createSettingsDataStore(
+        storage = OkioStorage<Preferences>(
+            fileSystem = FileSystem.SYSTEM,
+            serializer = PreferencesSerializer,
+            producePath = {
+                val documentDirectory = NSFileManager.defaultManager.URLForDirectory(
+                    directory = NSDocumentDirectory,
+                    inDomain = NSUserDomainMask,
+                    appropriateForURL = null,
+                    create = false,
+                    error = null,
+                )
+                (requireNotNull(documentDirectory?.path) + "/$APP_SETTINGS_FILE_NAME").toPath()
+            },
+        ),
+    )
+    return DataStoreAppSettingsRepository(
+        dataStore = dataStore,
+        legacyLoader = LegacyAppSettingsLoader { IosLegacySettingsLoader().load() },
+        scope = scope,
+    )
+}


### PR DESCRIPTION
## What changed

- add a KMP `ViewModel` and `StateFlow`-based app state combining settings, provider sessions, and navigation
- migrate persisted settings to DataStore with one-time SharedPreferences/NSUserDefaults migration and corrupted-data recovery
- add a serialized provider-session repository so refresh, login, and logout cannot overwrite each other out of order
- migrate top-level navigation to Navigation 3 and a single route back stack
- keep provider credential drafts in memory instead of persisting them
- update the compatible Kotlin, Compose, Lifecycle, Navigation 3, DataStore, AGP, and Gradle toolchain; remove the obsolete `iosX64` target
- add coverage for settings migration/concurrency/recovery, provider login races, and navigation behavior

## Why

Settings, UI state, provider data, and authentication were previously maintained by multiple mutable state owners. Asynchronous persistence and provider refreshes could finish out of order, leaving the screen inconsistent with stored settings or the actual login session.

The new repositories make settings and provider sessions single sources of truth, while the application ViewModel exposes lifecycle-aware state to Compose.

## Impact

- settings now stay synchronized across UI and persistence
- slow provider refreshes no longer overwrite newer login/logout results
- top-level back navigation is represented by one ordered stack
- existing platform settings are migrated automatically on first launch

## Validation

- `./gradlew :shared:testDebugUnitTest` (84 tests, 0 failures)
- `./gradlew :shared:compileKotlinIosSimulatorArm64`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :shared:lintDebug :androidApp:lintDebug`
- `git diff --check`