### PR TITLE
Feat: Support media position control

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -127,8 +127,12 @@ class AndroidNativeAudioEngine(
     }
 
     override fun seekTo(positionMs: Long) {
-        mediaController?.seekTo(positionMs)
-        mutableState.value = mutableState.value.copy(positionMs = positionMs)
+        val duration = mutableState.value.durationMs
+        val normalizedPosition = positionMs.coerceAtLeast(0).let { position ->
+            duration.takeIf { it > 0 }?.let(position::coerceAtMost) ?: position
+        }
+        mediaController?.seekTo(normalizedPosition)
+        mutableState.value = mutableState.value.copy(positionMs = normalizedPosition)
     }
 
     private fun connectController() {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -111,6 +111,14 @@ class FuoPlaybackService : MediaSessionService() {
                         publishPlaybackState()
                     }
 
+                    override fun onPositionDiscontinuity(
+                        oldPosition: Player.PositionInfo,
+                        newPosition: Player.PositionInfo,
+                        reason: Int,
+                    ) {
+                        publishPlaybackState()
+                    }
+
                     override fun onPlayerError(error: PlaybackException) {
                         val item = player.currentMediaItem
                         Log.e(
@@ -129,14 +137,15 @@ class FuoPlaybackService : MediaSessionService() {
                 })
             }
         player = exoPlayer
-        mediaSession = MediaSession.Builder(this, QueueCommandPlayer(exoPlayer))
+        val sessionPlayer = QueueCommandPlayer(exoPlayer)
+        mediaSession = MediaSession.Builder(this, sessionPlayer)
             .setCallback(object : MediaSession.Callback {
                 override fun onConnect(
                     session: MediaSession,
                     controller: MediaSession.ControllerInfo,
                 ): MediaSession.ConnectionResult {
                     return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-                        .setAvailablePlayerCommands(queuePlayerCommands(exoPlayer.getAvailableCommands()))
+                        .setAvailablePlayerCommands(sessionPlayer.getAvailableCommands())
                         .build()
                 }
 
@@ -629,7 +638,7 @@ class FuoPlaybackService : MediaSessionService() {
         }
 
         override fun isCommandAvailable(command: Int): Boolean {
-            return command in queueNavigationCommands || super.isCommandAvailable(command)
+            return command in forcedPlayerCommands || super.isCommandAvailable(command)
         }
 
         @Suppress("DEPRECATION")
@@ -669,6 +678,12 @@ class FuoPlaybackService : MediaSessionService() {
             Player.COMMAND_SEEK_TO_NEXT,
             Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
         )
+        private val seekCommands = setOf(
+            Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+            Player.COMMAND_SEEK_BACK,
+            Player.COMMAND_SEEK_FORWARD,
+        )
+        private val forcedPlayerCommands = queueNavigationCommands + seekCommands
 
         @Volatile
         var transportControls: TransportControls? = null
@@ -727,7 +742,7 @@ class FuoPlaybackService : MediaSessionService() {
         private fun queuePlayerCommands(commands: Player.Commands): Player.Commands {
             return Player.Commands.Builder()
                 .addAll(commands)
-                .addAll(*queueNavigationCommands.toIntArray())
+                .addAll(*forcedPlayerCommands.toIntArray())
                 .build()
         }
 

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -15,6 +15,7 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
     private var didReachEnd = false
     private var playbackError: String?
     private var endObserver: NSObjectProtocol?
+    private var periodicTimeObserver: Any?
     private let spectrumAnalyzer = AudioTapSpectrumAnalyzer()
 
     override init() {
@@ -28,12 +29,22 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         ) { [weak self] notification in
             guard let self, notification.object as? AVPlayerItem === self.player.currentItem else { return }
             self.didReachEnd = true
+            self.updateNowPlaying()
+        }
+        periodicTimeObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 1, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] _ in
+            self?.updateNowPlaying()
         }
     }
 
     deinit {
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
+        }
+        if let periodicTimeObserver {
+            player.removeTimeObserver(periodicTimeObserver)
         }
     }
 
@@ -51,8 +62,8 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         }
         let asset = AVURLAsset(url: url, options: assetOptions)
         player.replaceCurrentItem(with: playerItem(asset: asset))
-        updateNowPlaying(payload: payload)
         player.play()
+        updateNowPlaying(payload: payload, playbackRate: 1)
     }
 
     func play(url: String, headers: [String: String], title: String, artists: String, album: String) {
@@ -61,10 +72,12 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
 
     func pause() {
         player.pause()
+        updateNowPlaying()
     }
 
     func resume() {
         player.play()
+        updateNowPlaying(playbackRate: 1)
     }
 
     func stop() {
@@ -72,12 +85,19 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
         player.replaceCurrentItem(with: nil)
         didReachEnd = false
         playbackError = nil
+        currentPayload = nil
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         spectrumAnalyzer.clear()
     }
 
     func seekTo(positionMs: Int64) {
         didReachEnd = false
-        player.seek(to: CMTime(value: positionMs, timescale: 1000))
+        let duration = durationMs()
+        let nonNegativePosition = max(positionMs, 0)
+        let normalizedPosition = duration > 0 ? min(nonNegativePosition, duration) : nonNegativePosition
+        player.seek(to: CMTime(value: normalizedPosition, timescale: 1000)) { [weak self] _ in
+            self?.updateNowPlaying()
+        }
     }
 
     func playbackStatus() -> String {
@@ -249,14 +269,37 @@ final class IOSNativeAudioEngine: NSObject, NativeAudioEngine, IosAudioOutput {
             self?.pause()
             return .success
         }
+        center.changePlaybackPositionCommand.isEnabled = true
+        center.changePlaybackPositionCommand.addTarget { [weak self] event in
+            guard
+                let self,
+                self.player.currentItem != nil,
+                let event = event as? MPChangePlaybackPositionCommandEvent
+            else {
+                return .commandFailed
+            }
+            self.seekTo(positionMs: Int64((event.positionTime * 1000).rounded()))
+            return .success
+        }
     }
 
-    private func updateNowPlaying(payload: PlaybackPayload) {
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
-            MPMediaItemPropertyTitle: payload.title,
-            MPMediaItemPropertyArtist: payload.artists,
-            MPMediaItemPropertyAlbumTitle: payload.album,
+    private func updateNowPlaying(payload: PlaybackPayload? = nil, playbackRate: Float? = nil) {
+        guard let activePayload = payload ?? currentPayload else { return }
+        var nowPlayingInfo: [String: Any] = [
+            MPMediaItemPropertyTitle: activePayload.title,
+            MPMediaItemPropertyArtist: activePayload.artists,
+            MPMediaItemPropertyAlbumTitle: activePayload.album,
         ]
+        let duration = durationMs()
+        if duration > 0 {
+            nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = Double(duration) / 1000
+        }
+        let elapsed = max(0, CMTimeGetSeconds(player.currentTime()))
+        if elapsed.isFinite {
+            nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsed
+        }
+        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate ?? (didReachEnd ? 0 : player.rate)
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
 }
 

--- a/iosApp/FuoEvolve/Info.plist
+++ b/iosApp/FuoEvolve/Info.plist
@@ -33,6 +33,10 @@
         <key>NSAllowsArbitraryLoads</key>
         <true/>
     </dict>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>audio</string>
+    </array>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UISupportedInterfaceOrientations</key>

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -2766,7 +2766,10 @@ class FuoPlayerController(
     }
 
     fun seekTo(positionMs: Long) {
-        playbackEngine.seekTo(positionMs)
+        val normalizedPosition = positionMs.coerceAtLeast(0).let { position ->
+            playbackState.durationMs.takeIf { it > 0 }?.let(position::coerceAtMost) ?: position
+        }
+        playbackEngine.seekTo(normalizedPosition)
     }
 
     fun openFullPlayer() {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1132,14 +1132,20 @@ fun PlayPauseButton(
 @Composable
 fun ProgressBlock(state: PlaybackState, onSeek: (Long) -> Unit) {
     val duration = state.durationMs.takeIf { it > 0 } ?: 1L
+    val canSeek = state.currentTrack != null &&
+        state.durationMs > 0 &&
+        state.status != PlayerStatus.Idle &&
+        state.status != PlayerStatus.Loading &&
+        state.status != PlayerStatus.Error
     var isSeeking by remember(state.currentTrack?.id) { mutableStateOf(false) }
     var seekPosition by remember(state.currentTrack?.id) {
         mutableStateOf(state.positionMs.coerceIn(0, duration).toFloat())
     }
 
-    LaunchedEffect(state.positionMs, duration, isSeeking) {
-        if (!isSeeking) {
+    LaunchedEffect(state.positionMs, duration, isSeeking, canSeek) {
+        if (!isSeeking || !canSeek) {
             seekPosition = state.positionMs.coerceIn(0, duration).toFloat()
+            if (!canSeek) isSeeking = false
         }
     }
 
@@ -1150,18 +1156,22 @@ fun ProgressBlock(state: PlaybackState, onSeek: (Long) -> Unit) {
             seekPosition = it
         },
         onValueChangeFinished = {
-            if (isSeeking) {
-                onSeek(seekPosition.toLong())
+            if (isSeeking && canSeek) {
+                onSeek(seekPosition.toLong().coerceIn(0, duration))
                 isSeeking = false
             }
         },
+        enabled = canSeek,
         valueRange = 0f..duration.toFloat(),
     )
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Text(formatMs(state.positionMs), style = MaterialTheme.typography.labelMedium)
+        Text(
+            formatMs(if (isSeeking) seekPosition.toLong() else state.positionMs),
+            style = MaterialTheme.typography.labelMedium,
+        )
         Text(formatMs(state.durationMs), style = MaterialTheme.typography.labelMedium)
     }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -248,6 +248,39 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun seekToClampsToCurrentTrackDuration() = runTest {
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            val track = providerTrack("provider:seek", "Seek").copy(durationMs = 100_000)
+            engine.emitState(
+                PlaybackState(
+                    status = PlayerStatus.Paused,
+                    currentTrack = track,
+                    durationMs = 100_000,
+                ),
+            )
+            advanceUntilIdle()
+
+            controller.seekTo(-1_000)
+            controller.seekTo(120_000)
+
+            assertEquals(listOf(0L, 100_000L), engine.seekPositions)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun downloadImmediatelyPublishesQueueFeedback() = runTest {
         val track = providerTrack("netease:1", "Queue Song")
         val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -4254,6 +4287,7 @@ class FuoPlayerControllerTest {
         var lastTrack: MusicTrack? = null
         var lastPayload: PlaybackPayload? = null
         var resumeCount = 0
+        val seekPositions = mutableListOf<Long>()
 
         override fun prepareLoading(track: MusicTrack) {
             mutableState.value = PlaybackState(
@@ -4291,6 +4325,10 @@ class FuoPlayerControllerTest {
             )
         }
 
+        fun emitState(state: PlaybackState) {
+            mutableState.value = state
+        }
+
         override fun pause() {
             mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
         }
@@ -4305,6 +4343,7 @@ class FuoPlayerControllerTest {
         }
 
         override fun seekTo(positionMs: Long) {
+            seekPositions += positionMs
             mutableState.value = mutableState.value.copy(positionMs = positionMs)
         }
     }


### PR DESCRIPTION
## Summary

- Clamp seek positions to valid track bounds on Android and iOS.
- Enable seek commands and publish updated playback positions on Android.
- Add iOS Now Playing progress updates, position seeking, and background audio support.
- Disable progress seeking when playback is unavailable.
- Add controller coverage for seek position clamping.

## Testing

- Added shared unit coverage for negative and out-of-range seek positions.
- Not run (not requested).