### PR TITLE
fix: restore local music playback on Android 10

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.media.MediaCodecList
@@ -462,6 +463,8 @@ class FuoPlaybackService : MediaSessionService() {
             CacheDataSource.Factory()
                 .setCache(AndroidResourceCache.audioCache(this))
                 .setUpstreamDataSourceFactory(upstreamFactory)
+        } else if (mediaItem.localConfiguration?.uri?.scheme == ContentResolver.SCHEME_CONTENT) {
+            MediaStoreDataSource.Factory(contentResolver)
         } else {
             upstreamFactory
         }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MediaStoreDataSource.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MediaStoreDataSource.kt
@@ -1,0 +1,110 @@
+package org.feeluown.mobile
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import androidx.media3.common.C
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DataSourceException
+import java.io.EOFException
+import java.io.FileInputStream
+import java.io.IOException
+
+/**
+ * Reads MediaStore content through a file descriptor rather than an asset file descriptor.
+ *
+ * Some Android 10 MediaProvider implementations return an asset descriptor which never
+ * becomes readable. A regular parcel file descriptor is supported by those providers and
+ * avoids leaving ExoPlayer in STATE_BUFFERING indefinitely.
+ */
+@UnstableApi
+internal class MediaStoreDataSource(
+    private val contentResolver: ContentResolver,
+) : BaseDataSource(false) {
+    private var inputStream: FileInputStream? = null
+    private var parcelFileDescriptor: ParcelFileDescriptor? = null
+    private var openedUri: Uri? = null
+    private var bytesRemaining = 0L
+    private var opened = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        transferInitializing(dataSpec)
+        openedUri = dataSpec.uri
+        try {
+            val descriptor = contentResolver.openFileDescriptor(dataSpec.uri, "r")
+                ?: throw IOException("Unable to open MediaStore item: ${dataSpec.uri}")
+            parcelFileDescriptor = descriptor
+            val stream = FileInputStream(descriptor.fileDescriptor)
+            inputStream = stream
+
+            val skipped = stream.channel.position(dataSpec.position).position()
+            if (skipped != dataSpec.position) throw EOFException()
+
+            val availableLength = descriptor.statSize.takeIf { it >= 0L }
+                ?.minus(dataSpec.position)
+                ?.coerceAtLeast(0L)
+                ?: C.LENGTH_UNSET.toLong()
+            bytesRemaining = if (dataSpec.length != C.LENGTH_UNSET.toLong()) {
+                dataSpec.length
+            } else {
+                availableLength
+            }
+        } catch (exception: IOException) {
+            closeQuietly()
+            throw DataSourceException(
+                exception,
+                PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
+            )
+        }
+        opened = true
+        transferStarted(dataSpec)
+        return bytesRemaining
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        if (length == 0) return 0
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+        val requested = if (bytesRemaining == C.LENGTH_UNSET.toLong()) {
+            length
+        } else {
+            minOf(length.toLong(), bytesRemaining).toInt()
+        }
+        return try {
+            inputStream?.read(buffer, offset, requested)?.also { read ->
+                if (read > 0 && bytesRemaining != C.LENGTH_UNSET.toLong()) bytesRemaining -= read
+                if (read > 0) bytesTransferred(read)
+            } ?: C.RESULT_END_OF_INPUT
+        } catch (exception: IOException) {
+            throw DataSourceException(exception, PlaybackException.ERROR_CODE_IO_UNSPECIFIED)
+        }
+    }
+
+    override fun getUri(): Uri? = openedUri
+
+    override fun close() {
+        openedUri = null
+        try {
+            closeQuietly()
+        } finally {
+            if (opened) {
+                opened = false
+                transferEnded()
+            }
+        }
+    }
+
+    private fun closeQuietly() {
+        runCatching { inputStream?.close() }
+        inputStream = null
+        runCatching { parcelFileDescriptor?.close() }
+        parcelFileDescriptor = null
+    }
+
+    class Factory(private val contentResolver: ContentResolver) : DataSource.Factory {
+        override fun createDataSource(): DataSource = MediaStoreDataSource(contentResolver)
+    }
+}


### PR DESCRIPTION
### Motivation

- 修复在部分 Android 10 / Magic UI 设备上本地音乐一直显示“正在加载音频”的问题，该问题由 MediaStore 返回的 asset descriptor 在某些厂商实现中不可读导致播放器停在缓冲状态。 

### Description

- 新增 `MediaStoreDataSource`（`androidApp/src/main/kotlin/org/feeluown/mobile/MediaStoreDataSource.kt`），通过 `ParcelFileDescriptor` + 可寻址的 `FileInputStream` 读取 `content://` 媒体条目以避免 asset-descriptor 阻塞。 
- 在播放服务中将本地 `content://` URL 路由到新的数据源工厂（`FuoPlaybackService.createMediaSource`），同时保留对远程 URL 的缓存路径与普通文件播放逻辑不变。 
- 在数据源实现中实现对请求范围、EOF 的正确处理并在打开失败或关闭时同时释放 `FileInputStream` 与 `ParcelFileDescriptor`，以避免资源泄漏和异常场景下的挂起。 
- 添加必要的导入并把分支判定 `ContentResolver.SCHEME_CONTENT` 与新的 `MediaStoreDataSource.Factory` 连接起来，兼容 ExoPlayer 的 `ProgressiveMediaSource` 用法。 

### Testing

- 运行 `git diff --check` 检查修改无冲突或格式警告，结果正常。 
- 检查工作区状态使用 `git status --short --branch`，变更已记录且工作区整洁。 
- 尝试使用 `./gradlew :androidApp:compileDebugKotlin` 进行 Kotlin 编译验证时失败，原因是运行环境中未配置 Android SDK（缺少 `sdk.dir` / `ANDROID_HOME`），因此完整 Android 编译无法在此环境执行。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6867a7af7083219b8c489fc7666616)