### PR TITLE
[feat] Align UI with Material 3 Expressive

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -186,6 +186,8 @@ dependencies {
     implementation(project(":shared"))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.compose.material3.expressive)
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.androidx.media3.datasource)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -27,6 +28,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val fuoApplication = application as FuoEvolveApplication
         val launchSharedText = sharedTextFromIntent(intent)
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderWebLoginActivity.kt
@@ -1,45 +1,57 @@
 package org.feeluown.mobile
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
-import android.graphics.Color
-import android.graphics.Typeface
-import android.graphics.drawable.GradientDrawable
-import android.os.Build
 import android.os.Bundle
-import android.text.TextUtils
-import android.view.Gravity
-import android.view.View
-import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
 import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.LinearLayout
-import android.widget.TextView
 import android.widget.Toast
-import androidx.annotation.RequiresApi
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import org.json.JSONArray
 import org.json.JSONObject
 
-class ProviderWebLoginActivity : Activity() {
+@OptIn(ExperimentalMaterial3Api::class)
+class ProviderWebLoginActivity : ComponentActivity() {
     private lateinit var providerId: String
     private lateinit var providerName: String
     private lateinit var loginUrl: String
     private lateinit var cookieKeyGroups: List<List<String>>
-    private lateinit var statusView: TextView
     private lateinit var webView: WebView
+    private var statusMessage by mutableStateOf("")
 
     @SuppressLint("SetJavaScriptEnabled") // 提供方登录页完成认证需要 JavaScript。
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         providerId = intent.getStringExtra(EXTRA_PROVIDER_ID).orEmpty()
         providerName = intent.getStringExtra(EXTRA_PROVIDER_NAME).orEmpty().ifBlank { providerId }
         loginUrl = intent.getStringExtra(EXTRA_LOGIN_URL).orEmpty()
@@ -49,21 +61,11 @@ class ProviderWebLoginActivity : Activity() {
             finish()
             return
         }
+        statusMessage = getString(R.string.provider_login_cookie_hint)
 
         cookieManager().setAcceptCookie(true)
         val userAgent = loginUserAgent()
         val useMobileViewport = providerId == "bilibili"
-        val darkTheme = webLoginDarkTheme()
-        val colors = webLoginColors(darkTheme)
-        configureSystemBars(darkTheme)
-
-        statusView = TextView(this).apply {
-            text = getString(R.string.provider_login_cookie_hint)
-            textSize = 13f
-            setTextColor(colors.onSurfaceVariant)
-            setPadding(dp(20), dp(10), dp(20), dp(10))
-            setBackgroundColor(colors.surfaceVariant)
-        }
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
@@ -82,57 +84,57 @@ class ProviderWebLoginActivity : Activity() {
             }
         }
 
-        val titleView = TextView(this).apply {
-            text = getString(R.string.provider_browser_login_title, providerName)
-            textSize = 18f
-            typeface = Typeface.DEFAULT_BOLD
-            setTextColor(colors.onSurface)
-            gravity = Gravity.CENTER_VERTICAL
-            ellipsize = TextUtils.TruncateAt.END
-            maxLines = 1
-            setPadding(0, 0, dp(12), 0)
-            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        setContent {
+            FuoTheme(
+                themeMode = webLoginThemeMode(),
+                themeColorScheme = webLoginThemeColorScheme(),
+            ) {
+                Scaffold(
+                    topBar = {
+                        CenterAlignedTopAppBar(
+                            title = { Text(getString(R.string.provider_browser_login_title, providerName)) },
+                            navigationIcon = {
+                                IconButton(
+                                    onClick = {
+                                        setResult(RESULT_CANCELED)
+                                        finish()
+                                    },
+                                ) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = getString(R.string.close))
+                                }
+                            },
+                            actions = {
+                                TextButton(onClick = { finishWithCookies(webView.url, auto = false) }) {
+                                    Text(getString(R.string.done))
+                                }
+                            },
+                        )
+                    },
+                ) { paddingValues ->
+                    Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                        Surface(
+                            color = MaterialTheme.colorScheme.surfaceContainer,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ) {
+                            Text(
+                                text = statusMessage,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                        AndroidView(
+                            factory = { webView },
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                        )
+                    }
+                }
+            }
         }
-        val closeButton = toolbarButton(text = getString(R.string.close), filled = false, colors = colors) {
-            setResult(RESULT_CANCELED)
-            finish()
-        }
-        val doneButton = toolbarButton(text = getString(R.string.done), filled = true, colors = colors) {
-            finishWithCookies(webView.url, auto = false)
-        }
-        val toolbarDivider = View(this).apply {
-            setBackgroundColor(colors.outline)
-        }
-        val toolbarContent = LinearLayout(this).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-            setPadding(dp(20), dp(8), dp(16), dp(8))
-            minimumHeight = dp(56)
-            setBackgroundColor(colors.surface)
-            addView(titleView)
-            addView(closeButton)
-            addView(doneButton)
-        }
-        val toolbar = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(colors.surface)
-            addView(toolbarContent, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
-            addView(toolbarDivider, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(1)))
-        }
-        val root = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(colors.background)
-            addView(toolbar, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
-            addView(statusView, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
-            addView(webView, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
-        }
-        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(0, systemBars.top, 0, systemBars.bottom)
-            insets
-        }
-        setContentView(root)
-        ViewCompat.requestApplyInsets(root)
+        configureSystemBars(webLoginThemeMode())
         webView.loadUrl(loginUrl, mapOf("User-Agent" to userAgent))
     }
 
@@ -140,115 +142,30 @@ class ProviderWebLoginActivity : Activity() {
         return if (providerId == "bilibili") MOBILE_USER_AGENT else DESKTOP_USER_AGENT
     }
 
-    private fun toolbarButton(
-        text: String,
-        filled: Boolean,
-        colors: WebLoginColors,
-        onClick: () -> Unit,
-    ): TextView {
-        return TextView(this).apply {
-            this.text = text
-            textSize = 14f
-            typeface = Typeface.DEFAULT_BOLD
-            gravity = Gravity.CENTER
-            isClickable = true
-            isFocusable = true
-            minWidth = dp(64)
-            minHeight = dp(40)
-            setPadding(dp(14), 0, dp(14), 0)
-            setTextColor(if (filled) colors.onPrimary else colors.onSurfaceVariant)
-            background = roundedBackground(
-                color = if (filled) colors.primary else Color.TRANSPARENT,
-                strokeColor = if (filled) Color.TRANSPARENT else colors.outline,
-            )
-            layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                dp(40),
-            ).apply {
-                marginStart = dp(8)
-            }
-            setOnClickListener { onClick() }
-        }
-    }
-
-    private fun webLoginColors(darkTheme: Boolean): WebLoginColors {
+    private fun webLoginThemeMode(): ThemeMode {
         val preferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val scheme = enumValue(
-            preferences.getString(KEY_THEME_COLOR_SCHEME, null),
-            ThemeColorScheme.Dynamic,
-        )
-        if (scheme == ThemeColorScheme.Dynamic && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            return dynamicWebLoginColors(darkTheme)
-        }
-        val primary = presetPrimaryColor(
-            if (scheme == ThemeColorScheme.Dynamic) ThemeColorScheme.ExpressiveDefault else scheme,
-            darkTheme,
-        )
-        return WebLoginColors(
-            background = if (darkTheme) Color.parseColor("#111411") else Color.WHITE,
-            surface = if (darkTheme) Color.parseColor("#191C19") else Color.WHITE,
-            surfaceVariant = if (darkTheme) Color.parseColor("#424940") else Color.parseColor("#EDF2EC"),
-            outline = if (darkTheme) Color.parseColor("#8C9389") else Color.parseColor("#D6DED5"),
-            primary = primary,
-            onPrimary = if (darkTheme) Color.parseColor("#1C1B1F") else Color.WHITE,
-            onSurface = if (darkTheme) Color.parseColor("#E3E3DE") else Color.parseColor("#1B1D1A"),
-            onSurfaceVariant = if (darkTheme) Color.parseColor("#C3C8BF") else Color.parseColor("#555F55"),
-        )
-    }
-
-    @RequiresApi(Build.VERSION_CODES.S)
-    private fun dynamicWebLoginColors(darkTheme: Boolean): WebLoginColors {
-        val primary = if (darkTheme) {
-            getColor(android.R.color.system_accent1_200)
-        } else {
-            getColor(android.R.color.system_accent1_600)
-        }
-        return WebLoginColors(
-            background = if (darkTheme) Color.parseColor("#111411") else Color.WHITE,
-            surface = if (darkTheme) Color.parseColor("#191C19") else Color.WHITE,
-            surfaceVariant = if (darkTheme) Color.parseColor("#424940") else Color.parseColor("#EDF2EC"),
-            outline = if (darkTheme) Color.parseColor("#8C9389") else Color.parseColor("#D6DED5"),
-            primary = primary,
-            onPrimary = if (darkTheme) Color.parseColor("#1C1B1F") else Color.WHITE,
-            onSurface = if (darkTheme) Color.parseColor("#E3E3DE") else Color.parseColor("#1B1D1A"),
-            onSurfaceVariant = if (darkTheme) Color.parseColor("#C3C8BF") else Color.parseColor("#555F55"),
-        )
-    }
-
-    private fun presetPrimaryColor(scheme: ThemeColorScheme, darkTheme: Boolean): Int {
-        val raw = when (scheme) {
-            ThemeColorScheme.Dynamic,
-            ThemeColorScheme.ExpressiveDefault -> if (darkTheme) "#D0BCFF" else "#6750A4"
-            ThemeColorScheme.FuoGreen -> if (darkTheme) "#93DDAA" else "#246B43"
-            ThemeColorScheme.OceanBlue -> if (darkTheme) "#A7C8FF" else "#0066B3"
-            ThemeColorScheme.Violet -> if (darkTheme) "#D7B8FF" else "#7650B4"
-            ThemeColorScheme.Rose -> if (darkTheme) "#FFB1C8" else "#B13F66"
-            ThemeColorScheme.Amber -> if (darkTheme) "#FFCF73" else "#8A5A00"
-        }
-        return Color.parseColor(raw)
-    }
-
-    private fun resolvedDarkTheme(themeMode: ThemeMode): Boolean {
-        return when (themeMode) {
-            ThemeMode.System -> {
-                val uiMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-                uiMode == Configuration.UI_MODE_NIGHT_YES
-            }
-            ThemeMode.Light -> false
-            ThemeMode.Dark -> true
-        }
-    }
-
-    private fun webLoginDarkTheme(): Boolean {
-        val preferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val themeMode = enumValue(
+        return enumValue(
             preferences.getString(KEY_THEME_MODE, null),
             ThemeMode.System,
         )
-        return resolvedDarkTheme(themeMode)
     }
 
-    private fun configureSystemBars(darkTheme: Boolean) {
+    private fun webLoginThemeColorScheme(): ThemeColorScheme {
+        val preferences = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return enumValue(
+            preferences.getString(KEY_THEME_COLOR_SCHEME, null),
+            ThemeColorScheme.Dynamic,
+        )
+    }
+
+    private fun configureSystemBars(themeMode: ThemeMode) {
+        val systemDark = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+            Configuration.UI_MODE_NIGHT_YES
+        val darkTheme = when (themeMode) {
+            ThemeMode.System -> systemDark
+            ThemeMode.Light -> false
+            ThemeMode.Dark -> true
+        }
         WindowCompat.getInsetsController(window, window.decorView).apply {
             isAppearanceLightStatusBars = !darkTheme
             isAppearanceLightNavigationBars = !darkTheme
@@ -258,17 +175,6 @@ class ProviderWebLoginActivity : Activity() {
     private inline fun <reified T : Enum<T>> enumValue(raw: String?, fallback: T): T {
         return runCatching { enumValueOf<T>(raw.orEmpty()) }.getOrDefault(fallback)
     }
-
-    private fun roundedBackground(color: Int, strokeColor: Int): GradientDrawable {
-        return GradientDrawable().apply {
-            shape = GradientDrawable.RECTANGLE
-            cornerRadius = dp(8).toFloat()
-            setColor(color)
-            setStroke(dp(1), strokeColor)
-        }
-    }
-
-    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
 
     override fun onDestroy() {
         cookieManager().flush()
@@ -313,7 +219,7 @@ class ProviderWebLoginActivity : Activity() {
                     }
                 }
         }
-        statusView.text = if (result.isEmpty()) {
+        statusMessage = if (result.isEmpty()) {
             "等待登录 Cookie"
         } else {
             "已获取 ${result.size} 个 Cookie"
@@ -433,14 +339,4 @@ class ProviderWebLoginActivity : Activity() {
         }
     }
 
-    private data class WebLoginColors(
-        val background: Int,
-        val surface: Int,
-        val surfaceVariant: Int,
-        val outline: Int,
-        val primary: Int,
-        val onPrimary: Int,
-        val onSurface: Int,
-        val onSurfaceVariant: Int,
-    )
 }

--- a/androidApp/src/main/res/values/styles.xml
+++ b/androidApp/src/main/res/values/styles.xml
@@ -1,5 +1,4 @@
 <resources>
     <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
-        <item name="android:colorAccent">#1DB954</item>
     </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
 compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.11.0-alpha07" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycle" }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -49,7 +49,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -125,11 +124,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -151,8 +152,21 @@ data class AppLayoutInfo(
     val gridColumns: Int = 3,
 )
 
-private const val PAGE_TRANSITION_DURATION_MILLIS = 320
-private const val PAGE_FADE_DURATION_MILLIS = 180
+internal fun appLayoutInfoFor(maxWidth: Dp, maxHeight: Dp): AppLayoutInfo {
+    val isLandscape = maxWidth > maxHeight
+    return AppLayoutInfo(
+        isLandscape = isLandscape,
+        useWideLayout = isLandscape && maxWidth >= 640.dp,
+        gridColumns = when {
+            maxWidth >= 980.dp -> 6
+            maxWidth >= 760.dp -> 5
+            maxWidth >= 640.dp -> 4
+            else -> 3
+        },
+    )
+}
+
+private const val PAGE_TRANSITION_DURATION_MILLIS = FuoMotion.pageTransitionMillis
 
 private fun pageTransition(
     initialOffsetX: (Int) -> Int,
@@ -161,12 +175,12 @@ private fun pageTransition(
     slideInHorizontally(
         initialOffsetX = initialOffsetX,
         animationSpec = tween(PAGE_TRANSITION_DURATION_MILLIS),
-    ) + fadeIn(animationSpec = tween(PAGE_FADE_DURATION_MILLIS))
+    ) + fadeIn(animationSpec = tween(FuoMotion.pageFadeMillis))
     ) togetherWith (
     slideOutHorizontally(
         targetOffsetX = targetOffsetX,
         animationSpec = tween(PAGE_TRANSITION_DURATION_MILLIS),
-    ) + fadeOut(animationSpec = tween(PAGE_FADE_DURATION_MILLIS))
+    ) + fadeOut(animationSpec = tween(FuoMotion.pageFadeMillis))
     )
 
 private fun forwardPageTransition(): ContentTransform =
@@ -202,13 +216,13 @@ fun AppRoot(
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
     val controller = appViewModel.controller
-    FuoEvolveTheme(
+    FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
     ) {
         if (!controller.isSettingsLoaded) {
             AppInitializationLoadingScreen()
-            return@FuoEvolveTheme
+            return@FuoTheme
         }
         if (!controller.onboardingCompleted) {
             OnboardingScreen(
@@ -217,7 +231,7 @@ fun AppRoot(
                 onLogoutProvider = onLogoutProvider,
                 onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
             )
-            return@FuoEvolveTheme
+            return@FuoTheme
         }
         val snackbarHostState = remember { SnackbarHostState() }
         val playlistOperationFeedback = controller.playlistOperationFeedback
@@ -234,17 +248,7 @@ fun AppRoot(
         }
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) {
-                val isLandscape = maxWidth > maxHeight
-                AppLayoutInfo(
-                    isLandscape = isLandscape,
-                    useWideLayout = isLandscape && maxWidth >= 640.dp,
-                    gridColumns = when {
-                        maxWidth >= 980.dp -> 6
-                        maxWidth >= 760.dp -> 5
-                        maxWidth >= 640.dp -> 4
-                        else -> 3
-                    },
-                )
+                appLayoutInfoFor(maxWidth, maxHeight)
             }
 
             val currentFeature = controller.selectedFeature
@@ -344,8 +348,10 @@ fun AppRoot(
                             AnimatedVisibility(
                                 visible = controller.isFullPlayerOpen,
                                 modifier = Modifier.fillMaxSize(),
-                                enter = slideInVertically(animationSpec = tween(260)) { it / 2 } + fadeIn(tween(180)),
-                                exit = slideOutVertically(animationSpec = tween(220)) { it / 2 } + fadeOut(tween(160)),
+                                enter = slideInVertically(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it / 2 } +
+                                    fadeIn(tween(FuoMotion.overlayFadeMillis)),
+                                exit = slideOutVertically(animationSpec = tween(FuoMotion.overlayExitMillis)) { it / 2 } +
+                                    fadeOut(tween(FuoMotion.overlayFadeMillis)),
                             ) {
                                 FullPlayer(controller)
                             }
@@ -394,8 +400,9 @@ fun TrackArtistTargetDialog(controller: FuoPlayerController, track: MusicTrack) 
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .clickable { controller.openArtistTarget(target) }
+                            .clip(MaterialTheme.shapes.medium)
+                            .fuoInteractive()
+                            .clickable(role = Role.Button) { controller.openArtistTarget(target) }
                             .padding(horizontal = 8.dp, vertical = 12.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -459,15 +466,16 @@ fun ProviderPlaylistTargetDialog(controller: FuoPlayerController, track: MusicTr
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .clickable { controller.addTrackToProviderPlaylist(playlist) }
+                            .clip(MaterialTheme.shapes.medium)
+                            .fuoInteractive()
+                            .clickable(role = Role.Button) { controller.addTrackToProviderPlaylist(playlist) }
                             .padding(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         CoverBox(
                             track = playlist.toDisplayTrack(),
-                            modifier = Modifier.size(40.dp),
+                            modifier = Modifier.size(48.dp),
                             placeholder = CoverPlaceholder.Playlist,
                         )
                         Column(modifier = Modifier.weight(1f)) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AudioRecognitionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AudioRecognitionScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Mic
@@ -254,11 +253,11 @@ private fun RecognizedSongCard(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainer,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Row(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadManagerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadManagerScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
@@ -80,7 +79,12 @@ fun DownloadManagerScreen(controller: FuoPlayerController) {
             }
             item { DownloadSectionTitle("已完成") }
             if (completed.isEmpty()) {
-                item { Text("暂无已完成下载", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                item {
+                    FuoEmptyState(
+                        modifier = Modifier.fillMaxWidth(),
+                        title = "暂无已完成下载",
+                    )
+                }
             } else {
                 items(completed.take(completedLimit), key = { it.id }) { task ->
                     DownloadTaskCard(
@@ -140,9 +144,12 @@ private fun DownloadTaskCard(
     onRetry: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    Surface(color = MaterialTheme.colorScheme.surfaceVariant, shape = RoundedCornerShape(10.dp)) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            modifier = Modifier.fillMaxWidth().padding(FuoSpacing.lg),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
@@ -1,0 +1,303 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+internal object FuoSpacing {
+    val xs = 4.dp
+    val sm = 8.dp
+    val md = 12.dp
+    val lg = 16.dp
+    val xl = 24.dp
+    val xxl = 32.dp
+}
+
+internal object FuoMotion {
+    const val pageTransitionMillis = 300
+    const val pageFadeMillis = 180
+    const val overlayEnterMillis = 240
+    const val overlayExitMillis = 200
+    const val overlayFadeMillis = 160
+}
+
+internal object FuoMediaOverlay {
+    val background = Color.Black
+    val scrim = Color.Black.copy(alpha = 0.6f)
+}
+
+internal val FuoMinimumTouchTarget = 48.dp
+
+internal fun Modifier.fuoInteractive(): Modifier = sizeIn(
+    minWidth = FuoMinimumTouchTarget,
+    minHeight = FuoMinimumTouchTarget,
+)
+
+@Composable
+internal fun FuoSectionCard(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val interactiveModifier = if (onClick == null) {
+        modifier
+    } else {
+        modifier
+            .fuoInteractive()
+            .clickable(
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+    }
+    Surface(
+        modifier = interactiveModifier,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
+            content = content,
+        )
+    }
+}
+
+@Composable
+internal fun FuoListItem(
+    headlineContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    supportingContent: (@Composable () -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    enabled: Boolean = true,
+    selected: Boolean = false,
+    onClick: (() -> Unit)? = null,
+) {
+    val itemModifier = if (onClick == null) {
+        modifier
+    } else {
+        modifier.clickable(
+            enabled = enabled,
+            role = Role.Button,
+            onClick = onClick,
+        )
+    }
+    ListItem(
+        headlineContent = headlineContent,
+        modifier = if (onClick == null) itemModifier else itemModifier.fuoInteractive(),
+        supportingContent = supportingContent,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+        colors = if (selected) {
+            ListItemDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                headlineColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                supportingColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        } else {
+            ListItemDefaults.colors()
+        },
+    )
+}
+
+@Composable
+internal fun FuoSettingRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    FuoListItem(
+        modifier = modifier,
+        enabled = enabled,
+        onClick = onClick,
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+        headlineContent = { Text(title) },
+        supportingContent = supportingText?.let { text ->
+            { Text(text, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+        },
+    )
+}
+
+@Composable
+internal fun FuoMetadataChip(
+    label: String,
+    modifier: Modifier = Modifier,
+    leadingIcon: ImageVector? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    if (onClick != null) {
+        AssistChip(
+            modifier = modifier.fuoInteractive(),
+            onClick = onClick,
+            label = { Text(label, maxLines = 1) },
+            leadingIcon = leadingIcon?.let { icon ->
+                { Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp)) }
+            },
+        )
+    } else {
+        Surface(
+            modifier = modifier,
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            shape = MaterialTheme.shapes.extraLarge,
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                leadingIcon?.let { Icon(it, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                Text(label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun FuoEmptyState(
+    title: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    icon: ImageVector? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(FuoSpacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+        ) {
+            icon?.let {
+                Icon(
+                    imageVector = it,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+            )
+            supportingText?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            if (actionLabel != null && onAction != null) {
+                Button(onClick = onAction) { Text(actionLabel) }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun FuoIconButton(
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .fuoInteractive()
+            .semantics {
+                this.contentDescription = contentDescription
+                role = Role.Button
+            },
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FuoSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    placeholder: String = "歌曲、歌手或专辑",
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    SearchBar(
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = query,
+                onQueryChange = onQueryChange,
+                onSearch = { onSearch() },
+                expanded = false,
+                onExpandedChange = {},
+                enabled = enabled,
+                placeholder = { androidx.compose.material3.Text(placeholder) },
+                leadingIcon = {
+                    androidx.compose.material3.Icon(Icons.Filled.Search, contentDescription = null)
+                },
+                trailingIcon = trailingContent,
+            )
+        },
+        expanded = false,
+        onExpandedChange = {},
+        modifier = modifier,
+        content = {},
+    )
+}
+
+internal fun standardContentPadding(): PaddingValues = PaddingValues(
+    horizontal = FuoSpacing.lg,
+    vertical = FuoSpacing.md,
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
@@ -45,6 +45,8 @@ internal object FuoSpacing {
     val xxl = 32.dp
 }
 
+internal val FuoBottomNavigationBarHeight = 64.dp
+
 internal object FuoMotion {
     const val pageTransitionMillis = 300
     const val pageFadeMillis = 180

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoDesignSystem.kt
@@ -45,8 +45,6 @@ internal object FuoSpacing {
     val xxl = 32.dp
 }
 
-internal val FuoBottomNavigationBarHeight = 64.dp
-
 internal object FuoMotion {
     const val pageTransitionMillis = 300
     const val pageFadeMillis = 180

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MotionScheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.expressiveLightColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -12,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-internal fun FuoEvolveTheme(
+fun FuoTheme(
     themeMode: ThemeMode,
     themeColorScheme: ThemeColorScheme,
     content: @Composable () -> Unit,
@@ -20,9 +23,15 @@ internal fun FuoEvolveTheme(
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
     MaterialExpressiveTheme(
         colorScheme = fuoColorScheme(themeColorScheme, darkTheme),
+        motionScheme = MotionScheme.expressive(),
+        shapes = FuoShapes,
+        typography = FuoTypography,
         content = content,
     )
 }
+
+private val FuoShapes = Shapes()
+private val FuoTypography = Typography()
 
 internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boolean {
     return when (themeMode) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
@@ -1,7 +1,6 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,14 +8,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Mic
@@ -30,11 +24,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRowDefaults
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -44,14 +39,10 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlin.math.absoluteValue
 
 @Composable
 fun LoadingIndicator(visible: Boolean) {
@@ -204,18 +195,8 @@ fun HomeSectionPager(
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
     ) {
-        HomeSectionTabs(
-            sections = sections,
-            selectedIndex = pagerState.currentPage.coerceIn(0, sections.lastIndex),
-            indicatorOffsetFraction = pagerState.currentPageOffsetFraction,
-            onClick = { index, section ->
-                if (section != controller.homeSection || index != pagerState.currentPage) {
-                    scope.launch { pagerState.animateScrollToPage(index) }
-                }
-            },
-        )
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
@@ -242,6 +223,23 @@ fun HomeSectionPager(
                 )
             }
         }
+        NavigationBar(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            sections.forEachIndexed { index, (section, label) ->
+                NavigationBarItem(
+                    selected = index == pagerState.currentPage,
+                    onClick = {
+                        if (section != controller.homeSection || index != pagerState.currentPage) {
+                            scope.launch { pagerState.animateScrollToPage(index) }
+                        }
+                    },
+                    icon = { Icon(homeSectionIcon(section), contentDescription = label) },
+                    label = { Text(label) },
+                    alwaysShowLabel = true,
+                )
+            }
+        }
     }
 }
 
@@ -254,60 +252,29 @@ fun HomeSectionRail(
     onRecognition: () -> Unit,
     onClick: (Int, HomeSection) -> Unit,
 ) {
-    Surface(
-        modifier = Modifier
-            .width(64.dp)
-            .fillMaxHeight(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxHeight()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+    NavigationRail(
+        modifier = Modifier.fillMaxHeight(),
+        header = {
             IconButton(onClick = onSettings) {
                 Icon(Icons.Filled.Settings, contentDescription = "设置")
             }
-            Spacer(Modifier.weight(1f))
-            sections.forEachIndexed { index, (section, label) ->
-                val selected = index == selectedIndex
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onClick(index, section) }
-                        .padding(vertical = 4.dp),
-                    color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
-                    contentColor = if (selected) {
-                        MaterialTheme.colorScheme.onSecondaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                    shape = RoundedCornerShape(8.dp),
-                ) {
-                    Column(
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 8.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Icon(homeSectionIcon(section), contentDescription = label)
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-            }
-            Spacer(Modifier.weight(1f))
-            IconButton(onClick = onRecognition) {
-                Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
-            }
-            IconButton(onClick = onSearch) {
-                Icon(Icons.Filled.Search, contentDescription = "搜索")
-            }
+        },
+    ) {
+        sections.forEachIndexed { index, (section, label) ->
+            NavigationRailItem(
+                selected = index == selectedIndex,
+                onClick = { onClick(index, section) },
+                icon = { Icon(homeSectionIcon(section), contentDescription = label) },
+                label = { Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                alwaysShowLabel = true,
+            )
+        }
+        Spacer(Modifier.weight(1f))
+        IconButton(onClick = onRecognition) {
+            Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
+        }
+        IconButton(onClick = onSearch) {
+            Icon(Icons.Filled.Search, contentDescription = "搜索")
         }
     }
 }
@@ -317,67 +284,6 @@ fun homeSectionIcon(section: HomeSection): ImageVector {
         HomeSection.Recommend -> Icons.Filled.PlayArrow
         HomeSection.Music -> Icons.Filled.Album
         HomeSection.Mine -> Icons.Filled.Person
-    }
-}
-
-@Composable
-@Suppress("DEPRECATION")
-fun HomeSectionTabs(
-    sections: List<Pair<HomeSection, String>>,
-    selectedIndex: Int,
-    indicatorOffsetFraction: Float,
-    onClick: (Int, HomeSection) -> Unit,
-) {
-    TabRow(
-        selectedTabIndex = selectedIndex,
-        modifier = Modifier.fillMaxWidth(),
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.primary,
-        indicator = { tabPositions ->
-            val current = tabPositions.getOrNull(selectedIndex) ?: return@TabRow
-            val targetIndex = when {
-                indicatorOffsetFraction > 0f -> (selectedIndex + 1).coerceAtMost(tabPositions.lastIndex)
-                indicatorOffsetFraction < 0f -> (selectedIndex - 1).coerceAtLeast(0)
-                else -> selectedIndex
-            }
-            val target = tabPositions[targetIndex]
-            val progress = indicatorOffsetFraction.absoluteValue.coerceIn(0f, 1f)
-            val indicatorLeft = lerp(current.left, target.left, progress)
-            val indicatorWidth = lerp(current.width, target.width, progress)
-            TabRowDefaults.SecondaryIndicator(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentSize(Alignment.BottomStart)
-                    .offset { IntOffset(indicatorLeft.roundToPx(), 0) }
-                    .width(indicatorWidth),
-            )
-        },
-    ) {
-        sections.forEachIndexed { index, (section, label) ->
-            Tab(
-                selected = index == selectedIndex,
-                onClick = { onClick(index, section) },
-                text = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = homeSectionIcon(section),
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = if (index == selectedIndex) FontWeight.SemiBold else FontWeight.Normal,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                },
-            )
-        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
@@ -1,6 +1,7 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,11 +9,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Mic
@@ -26,12 +30,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationRail
-import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -41,11 +44,16 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlin.math.absoluteValue
 
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
@@ -206,6 +214,17 @@ fun HomeSectionPager(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
     ) {
+        HomeSectionTabs(
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            sections = sections,
+            selectedIndex = pagerState.currentPage.coerceIn(0, sections.lastIndex),
+            indicatorOffsetFraction = pagerState.currentPageOffsetFraction,
+            onClick = { index, section ->
+                if (section != controller.homeSection || index != pagerState.currentPage) {
+                    scope.launch { pagerState.animateScrollToPage(index) }
+                }
+            },
+        )
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
@@ -233,26 +252,6 @@ fun HomeSectionPager(
                 )
             }
         }
-        NavigationBar(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(FuoBottomNavigationBarHeight),
-            windowInsets = WindowInsets(0, 0, 0, 0),
-        ) {
-            sections.forEachIndexed { index, (section, label) ->
-                NavigationBarItem(
-                    selected = index == pagerState.currentPage,
-                    onClick = {
-                        if (section != controller.homeSection || index != pagerState.currentPage) {
-                            scope.launch { pagerState.animateScrollToPage(index) }
-                        }
-                    },
-                    icon = { Icon(homeSectionIcon(section), contentDescription = label) },
-                    label = { Text(label) },
-                    alwaysShowLabel = true,
-                )
-            }
-        }
     }
 }
 
@@ -265,29 +264,127 @@ fun HomeSectionRail(
     onRecognition: () -> Unit,
     onClick: (Int, HomeSection) -> Unit,
 ) {
-    NavigationRail(
-        modifier = Modifier.fillMaxHeight(),
-        header = {
+    Surface(
+        modifier = Modifier
+            .width(64.dp)
+            .fillMaxHeight(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
             IconButton(onClick = onSettings) {
                 Icon(Icons.Filled.Settings, contentDescription = "设置")
             }
+            Spacer(Modifier.weight(1f))
+            sections.forEachIndexed { index, (section, label) ->
+                val selected = index == selectedIndex
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fuoInteractive()
+                        .clickable(role = Role.Tab) { onClick(index, section) }
+                        .padding(vertical = 4.dp),
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+                    contentColor = if (selected) {
+                        MaterialTheme.colorScheme.onSecondaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    shape = RoundedCornerShape(8.dp),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 8.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Icon(homeSectionIcon(section), contentDescription = label)
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.weight(1f))
+            IconButton(onClick = onRecognition) {
+                Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
+            }
+            IconButton(onClick = onSearch) {
+                Icon(Icons.Filled.Search, contentDescription = "搜索")
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("DEPRECATION")
+fun HomeSectionTabs(
+    sections: List<Pair<HomeSection, String>>,
+    selectedIndex: Int,
+    indicatorOffsetFraction: Float,
+    onClick: (Int, HomeSection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TabRow(
+        selectedTabIndex = selectedIndex,
+        modifier = modifier.fillMaxWidth(),
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.primary,
+        indicator = { tabPositions ->
+            val current = tabPositions.getOrNull(selectedIndex) ?: return@TabRow
+            val targetIndex = when {
+                indicatorOffsetFraction > 0f -> (selectedIndex + 1).coerceAtMost(tabPositions.lastIndex)
+                indicatorOffsetFraction < 0f -> (selectedIndex - 1).coerceAtLeast(0)
+                else -> selectedIndex
+            }
+            val target = tabPositions[targetIndex]
+            val progress = indicatorOffsetFraction.absoluteValue.coerceIn(0f, 1f)
+            val indicatorLeft = lerp(current.left, target.left, progress)
+            val indicatorWidth = lerp(current.width, target.width, progress)
+            TabRowDefaults.SecondaryIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentSize(Alignment.BottomStart)
+                    .offset { IntOffset(indicatorLeft.roundToPx(), 0) }
+                    .width(indicatorWidth),
+            )
         },
     ) {
         sections.forEachIndexed { index, (section, label) ->
-            NavigationRailItem(
+            Tab(
                 selected = index == selectedIndex,
                 onClick = { onClick(index, section) },
-                icon = { Icon(homeSectionIcon(section), contentDescription = label) },
-                label = { Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                alwaysShowLabel = true,
+                text = {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = homeSectionIcon(section),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = if (index == selectedIndex) FontWeight.SemiBold else FontWeight.Normal,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                },
             )
-        }
-        Spacer(Modifier.weight(1f))
-        IconButton(onClick = onRecognition) {
-            Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
-        }
-        IconButton(onClick = onSearch) {
-            Icon(Icons.Filled.Search, contentDescription = "搜索")
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -40,14 +42,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 @Composable
-fun LoadingIndicator(visible: Boolean) {
+fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
     AnimatedVisibility(visible = visible) {
-        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        LinearProgressIndicator(modifier = modifier.fillMaxWidth())
     }
 }
 @OptIn(ExperimentalMaterial3Api::class)
@@ -92,17 +95,20 @@ fun HomeScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-                .padding(horizontal = if (layoutInfo.useWideLayout) 8.dp else 16.dp),
+                .padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(if (layoutInfo.useWideLayout) 6.dp else 12.dp),
         ) {
-            LoadingIndicator(controller.isLoading)
+            LoadingIndicator(
+                visible = controller.isLoading,
+                modifier = Modifier.padding(horizontal = if (layoutInfo.useWideLayout) 8.dp else 16.dp),
+            )
             HomeSectionPager(
                 controller = controller,
                 hasAudioPermission = hasAudioPermission,
                 onRequestAudioPermission = onRequestAudioPermission,
                 onOpenRecognition = onOpenRecognition,
                 modifier = Modifier.weight(1f),
+                contentHorizontalPadding = if (layoutInfo.useWideLayout) 8.dp else 16.dp,
             )
         }
     }
@@ -115,6 +121,7 @@ fun HomeSectionPager(
     onRequestAudioPermission: () -> Unit,
     onOpenRecognition: () -> Unit,
     modifier: Modifier,
+    contentHorizontalPadding: Dp,
 ) {
     val sections = listOf(
         HomeSection.Recommend to "推荐",
@@ -148,7 +155,9 @@ fun HomeSectionPager(
 
     if (LocalAppLayoutInfo.current.useWideLayout) {
         Row(
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = contentHorizontalPadding),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             HomeSectionRail(
@@ -201,7 +210,8 @@ fun HomeSectionPager(
             state = pagerState,
             modifier = Modifier
                 .weight(1f)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .padding(horizontal = contentHorizontalPadding),
             pageSpacing = 16.dp,
         ) { page ->
             when (sections[page].first) {
@@ -224,7 +234,10 @@ fun HomeSectionPager(
             }
         }
         NavigationBar(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(FuoBottomNavigationBarHeight),
+            windowInsets = WindowInsets(0, 0, 0, 0),
         ) {
             sections.forEachIndexed { index, (section, label) ->
                 NavigationBarItem(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Search
@@ -313,7 +312,7 @@ fun LocalMetadataSearchResultRow(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            CoverBox(track, modifier = Modifier.size(40.dp))
+            CoverBox(track, modifier = Modifier.size(48.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = track.title.ifBlank { "未知歌曲" },
@@ -387,18 +386,10 @@ fun LocalMusicSectionHeader(title: String, count: Int) {
 
 @Composable
 fun EmptyLocalMusicHint() {
-    Surface(
+    FuoEmptyState(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 24.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
-    ) {
-        Text(
-            modifier = Modifier.padding(16.dp),
-            text = "未发现本地音乐",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
+        title = "未发现本地音乐",
+    )
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/OnboardingScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -45,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -58,7 +58,7 @@ fun AppInitializationLoadingScreen() {
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
         ) {
             CircularProgressIndicator()
             Text(
@@ -247,12 +247,12 @@ private fun ProviderSelectionPage(
         if (providers.isEmpty()) {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shape = MaterialTheme.shapes.medium,
             ) {
                 Row(
-                    modifier = Modifier.padding(16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.padding(FuoSpacing.lg),
+                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.md),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     CircularProgressIndicator(modifier = Modifier.size(24.dp))
@@ -265,20 +265,21 @@ private fun ProviderSelectionPage(
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(12.dp))
-                        .clickable(enabled = enabled) {
+                        .clip(MaterialTheme.shapes.medium)
+                        .fuoInteractive()
+                        .clickable(enabled = enabled, role = Role.Checkbox) {
                             onProviderSelected(provider.providerId, !selected)
                         },
                     color = if (selected) {
                         MaterialTheme.colorScheme.primaryContainer
                     } else {
-                        MaterialTheme.colorScheme.surfaceVariant
+                        MaterialTheme.colorScheme.surfaceContainer
                     },
-                    shape = RoundedCornerShape(12.dp),
+                    shape = MaterialTheme.shapes.medium,
                 ) {
                     Row(
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.padding(horizontal = FuoSpacing.lg, vertical = FuoSpacing.md),
+                        horizontalArrangement = Arrangement.spacedBy(FuoSpacing.md),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Checkbox(
@@ -313,15 +314,16 @@ private fun ProviderSelectionPage(
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.secondaryContainer,
-                shape = RoundedCornerShape(12.dp),
+                shape = MaterialTheme.shapes.medium,
             ) {
                 Row(
                     modifier = Modifier
-                        .clickable(enabled = enabled) {
+                        .fuoInteractive()
+                        .clickable(enabled = enabled, role = Role.Checkbox) {
                             onBilibiliReplacementOnlyChange(!bilibiliReplacementOnly)
                         }
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        .padding(FuoSpacing.lg),
+                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.md),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Checkbox(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Delete
@@ -52,12 +51,17 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -75,6 +79,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -91,9 +96,10 @@ fun MiniPlayer(controller: FuoPlayerController) {
         modifier = Modifier
             .fillMaxWidth()
             .animateContentSize(animationSpec = tween(220))
-            .clickable(onClick = controller::openFullPlayer),
-        shape = RoundedCornerShape(if (isWideLayout) 12.dp else 18.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = controller::openFullPlayer),
+        shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 3.dp,
     ) {
         Column {
@@ -622,20 +628,7 @@ fun formatAudioBitrate(value: Long?): String? {
 
 @Composable
 fun InfoTag(text: String, onClick: (() -> Unit)? = null) {
-    Surface(
-        modifier = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier,
-        color = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        shape = RoundedCornerShape(50),
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-            style = MaterialTheme.typography.labelMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
+    FuoMetadataChip(label = text, onClick = onClick)
 }
 
 @Composable
@@ -681,9 +674,21 @@ fun ReplacementInfoLine(label: String, value: String) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QueueBottomSheet(controller: FuoPlayerController) {
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    if (!isWideLayout) {
+        if (controller.isQueueOpen) {
+            ModalBottomSheet(
+                onDismissRequest = controller::toggleQueue,
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ) {
+                QueueBottomSheetContent(controller, sidePanel = false, embedded = true)
+            }
+        }
+        return
+    }
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = if (isWideLayout) Alignment.CenterEnd else Alignment.BottomCenter,
@@ -698,30 +703,34 @@ fun QueueBottomSheet(controller: FuoPlayerController) {
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
-                    .clickable(onClick = controller::toggleQueue),
+                    .clickable(role = Role.Button, onClick = controller::toggleQueue),
             )
         }
         AnimatedVisibility(
             visible = controller.isQueueOpen,
             modifier = Modifier.align(if (isWideLayout) Alignment.CenterEnd else Alignment.BottomCenter),
             enter = if (isWideLayout) {
-                slideInHorizontally(animationSpec = tween(220)) { it } + fadeIn(tween(160))
+                slideInHorizontally(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it } + fadeIn(tween(FuoMotion.overlayFadeMillis))
             } else {
-                slideInVertically(animationSpec = tween(220)) { it } + fadeIn(tween(160))
+                slideInVertically(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it } + fadeIn(tween(FuoMotion.overlayFadeMillis))
             },
             exit = if (isWideLayout) {
-                slideOutHorizontally(animationSpec = tween(180)) { it } + fadeOut(tween(140))
+                slideOutHorizontally(animationSpec = tween(FuoMotion.overlayExitMillis)) { it } + fadeOut(tween(FuoMotion.overlayFadeMillis))
             } else {
-                slideOutVertically(animationSpec = tween(180)) { it } + fadeOut(tween(140))
+                slideOutVertically(animationSpec = tween(FuoMotion.overlayExitMillis)) { it } + fadeOut(tween(FuoMotion.overlayFadeMillis))
             },
         ) {
-            QueueBottomSheetContent(controller, sidePanel = isWideLayout)
+            QueueBottomSheetContent(controller, sidePanel = true)
         }
     }
 }
 
 @Composable
-fun QueueBottomSheetContent(controller: FuoPlayerController, sidePanel: Boolean = false) {
+fun QueueBottomSheetContent(
+    controller: FuoPlayerController,
+    sidePanel: Boolean = false,
+    embedded: Boolean = false,
+) {
     var showClearConfirmDialog by remember { mutableStateOf(false) }
     val queueSize = controller.playbackState.queue.size
 
@@ -737,15 +746,14 @@ fun QueueBottomSheetContent(controller: FuoPlayerController, sidePanel: Boolean 
             Modifier
                 .fillMaxWidth()
                 .heightIn(max = 460.dp)
-                .navigationBarsPadding()
-                .clickable { }
+                .then(if (embedded) Modifier else Modifier.navigationBarsPadding())
         },
-        color = MaterialTheme.colorScheme.surface,
+        color = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = 8.dp,
         shape = if (sidePanel) {
-            RoundedCornerShape(topStart = 18.dp, bottomStart = 18.dp)
+            MaterialTheme.shapes.large
         } else {
-            RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp)
+            MaterialTheme.shapes.large
         },
     ) {
         Column(
@@ -858,7 +866,7 @@ fun FmModeBadge() {
         color = MaterialTheme.colorScheme.primary,
         contentColor = MaterialTheme.colorScheme.onPrimary,
         tonalElevation = 1.dp,
-        shape = RoundedCornerShape(50),
+        shape = MaterialTheme.shapes.extraLarge,
     ) {
         Text(
             text = "FM",
@@ -879,38 +887,18 @@ fun RepeatModeTextButton(
         RepeatMode.QUEUE -> Icons.Filled.Repeat
         RepeatMode.SINGLE -> Icons.Filled.RepeatOne
     }
-    Surface(
-        modifier = Modifier.clickable(onClick = onRepeat),
-        color = if (repeatMode == RepeatMode.OFF) {
-            MaterialTheme.colorScheme.surfaceVariant
-        } else {
-            MaterialTheme.colorScheme.primary
-        },
-        contentColor = if (repeatMode == RepeatMode.OFF) {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        } else {
-            MaterialTheme.colorScheme.onPrimary
-        },
-        tonalElevation = 1.dp,
-        shape = RoundedCornerShape(50),
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+    FilterChip(
+        selected = repeatMode != RepeatMode.OFF,
+        onClick = onRepeat,
+        label = { Text(repeatMode.label, maxLines = 1) },
+        leadingIcon = {
             Icon(
                 imageVector = repeatIcon,
                 contentDescription = null,
                 modifier = Modifier.size(18.dp),
             )
-            Text(
-                text = repeatMode.label,
-                style = MaterialTheme.typography.labelMedium,
-                maxLines = 1,
-            )
-        }
-    }
+        },
+    )
 }
 
 fun emptyDisplayTrack() = MusicTrack(
@@ -947,7 +935,7 @@ fun PlayerControls(
                 imageVector = Icons.Filled.Shuffle,
                 contentDescription = if (shuffleAvailable) "随机播放" else "私人 FM 使用顺序播放",
                 onClick = onShuffle,
-                size = 44.dp,
+                size = 48.dp,
                 iconSize = 24.dp,
                 selected = shuffleEnabled,
                 enabled = shuffleAvailable,
@@ -957,7 +945,7 @@ fun PlayerControls(
             imageVector = Icons.Filled.SkipPrevious,
             contentDescription = "上一首",
             onClick = onPrevious,
-            size = if (compact) 44.dp else 48.dp,
+            size = 48.dp,
             iconSize = if (compact) 24.dp else 26.dp,
         )
         PlayPauseButton(
@@ -972,7 +960,7 @@ fun PlayerControls(
             imageVector = Icons.Filled.SkipNext,
             contentDescription = "下一首",
             onClick = onNext,
-            size = if (compact) 44.dp else 48.dp,
+            size = 48.dp,
             iconSize = if (compact) 24.dp else 26.dp,
         )
         when {
@@ -996,23 +984,26 @@ fun RoundControlButton(
     selected: Boolean = false,
     enabled: Boolean = true,
 ) {
-    Surface(
-        modifier = Modifier
-            .size(size)
-            .clickable(enabled = enabled, onClick = onClick),
-        color = when {
-            prominent || selected -> MaterialTheme.colorScheme.primary
-            else -> MaterialTheme.colorScheme.surfaceVariant
-        },
-        contentColor = when {
-            prominent || selected -> MaterialTheme.colorScheme.onPrimary
-            enabled -> MaterialTheme.colorScheme.onSurfaceVariant
-            else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
-        },
-        tonalElevation = if (prominent) 3.dp else 1.dp,
-        shape = RoundedCornerShape(50),
-    ) {
-        Box(contentAlignment = Alignment.Center) {
+    val buttonSize = if (size < 48.dp) 48.dp else size
+    val buttonModifier = Modifier.size(buttonSize)
+    if (prominent || selected) {
+        FilledIconButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+        ) {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(iconSize),
+            )
+        }
+    } else {
+        FilledTonalIconButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = buttonModifier,
+        ) {
             Icon(
                 imageVector = imageVector,
                 contentDescription = contentDescription,
@@ -1033,11 +1024,11 @@ fun PlayPauseButton(
 ) {
     if (isLoading) {
         Surface(
-            modifier = Modifier.size(size),
-            color = if (prominent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier.size(if (size < 48.dp) 48.dp else size),
+            color = if (prominent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainer,
             contentColor = if (prominent) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
             tonalElevation = if (prominent) 3.dp else 1.dp,
-            shape = RoundedCornerShape(50),
+            shape = MaterialTheme.shapes.extraLarge,
         ) {
             Box(contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(
@@ -1142,12 +1133,12 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
 
     Surface(
         modifier = modifier,
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         LazyColumn(
             state = listState,
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
         ) {
             val displayLines = lines.takeIf { it.isNotEmpty() } ?: listOf(LyricLine(0, "暂无歌词"))
             itemsIndexed(displayLines) { index, line ->
@@ -1211,12 +1202,16 @@ fun QueueList(controller: FuoPlayerController, modifier: Modifier) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(enabled = !isUnavailable) { controller.playQueueIndex(index) }
+                    .fuoInteractive()
+                    .clickable(
+                        enabled = !isUnavailable,
+                        role = Role.Button,
+                    ) { controller.playQueueIndex(index) }
                     .padding(vertical = 10.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                CoverBox(track, modifier = Modifier.size(44.dp))
+                CoverBox(track, modifier = Modifier.size(48.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "${index + 1}. ${track.title.ifBlank { "未知歌曲" }}",
@@ -1281,7 +1276,8 @@ fun PlaybackPartList(
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onPartClick(index) },
+                    .fuoInteractive()
+                    .clickable(role = Role.Button) { onPartClick(index) },
                 color = if (selected) {
                     MaterialTheme.colorScheme.primaryContainer
                 } else {
@@ -1292,7 +1288,7 @@ fun PlaybackPartList(
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
-                shape = RoundedCornerShape(6.dp),
+                shape = MaterialTheme.shapes.small,
             ) {
                 Row(
                     modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailScreens.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
@@ -96,7 +96,8 @@ fun ProviderFeatureScreen(controller: FuoPlayerController, feature: ProviderFeat
             ) {
                 Column(
                     modifier = Modifier
-                        .width(280.dp)
+                        .weight(0.36f)
+                        .widthIn(min = 240.dp, max = 360.dp)
                         .fillMaxHeight()
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -488,7 +489,7 @@ fun ProviderVideoScreen(controller: FuoPlayerController, video: ProviderVideo?) 
             modifier = if (isFullscreen) {
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black)
+                    .background(FuoMediaOverlay.background)
             } else {
                 Modifier
                     .fillMaxSize()
@@ -516,7 +517,7 @@ fun ProviderVideoScreen(controller: FuoPlayerController, video: ProviderVideo?) 
                         .align(Alignment.TopEnd)
                         .padding(8.dp),
                     shape = CircleShape,
-                    color = Color.Black.copy(alpha = 0.6f),
+                    color = FuoMediaOverlay.scrim,
                 ) {
                     IconButton(onClick = controller::toggleVideoFullscreen) {
                         Icon(
@@ -608,7 +609,8 @@ fun ProviderPlaylistScreen(controller: FuoPlayerController, playlist: ProviderPl
             ) {
                 Column(
                     modifier = Modifier
-                        .width(300.dp)
+                        .weight(0.36f)
+                        .widthIn(min = 240.dp, max = 360.dp)
                         .fillMaxHeight()
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -833,7 +835,8 @@ fun ProviderMediaItemScreen(controller: FuoPlayerController, item: ProviderMedia
             ) {
                 Column(
                     modifier = Modifier
-                        .width(300.dp)
+                        .weight(0.36f)
+                        .widthIn(min = 240.dp, max = 360.dp)
                         .fillMaxHeight()
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.PlayArrow
@@ -33,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -206,7 +206,8 @@ fun ProviderVideoList(videos: List<ProviderVideo>, onClick: (ProviderVideo) -> U
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onClick(video) }
+                    .fuoInteractive()
+                    .clickable(role = Role.Button) { onClick(video) }
                     .padding(vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -329,7 +330,8 @@ fun ProviderFeatureCoverCard(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     Column(
         modifier = modifier
-            .clickable(onClick = onClick)
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
     ) {
         CoverBox(
@@ -404,7 +406,8 @@ fun PrivateFmButton(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     RecommendationButton(
         modifier = modifier
-            .clickable(enabled = enabled, onClick = onClick)
+            .fuoInteractive()
+            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
         title = "私人 FM",
         providerName = section.feature.providerName,
@@ -427,7 +430,8 @@ fun DailyRecommendationButton(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     RecommendationButton(
         modifier = modifier
-            .clickable(enabled = enabled, onClick = onClick)
+            .fuoInteractive()
+            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
         title = feature.title.ifBlank { "每日推荐" },
         providerName = feature.providerName,
@@ -450,7 +454,8 @@ fun RecommendationEntryButton(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     RecommendationButton(
         modifier = modifier
-            .clickable(enabled = enabled, onClick = onClick)
+            .fuoInteractive()
+            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
         title = feature.title.ifBlank { "推荐视频" },
         providerName = feature.providerName,
@@ -478,7 +483,7 @@ fun RecommendationButton(
                 .aspectRatio(1f),
             color = MaterialTheme.colorScheme.secondaryContainer,
             contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-            shape = RoundedCornerShape(8.dp),
+            shape = MaterialTheme.shapes.medium,
         ) {
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -545,7 +550,8 @@ fun ProviderPlaylistCard(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     Column(
         modifier = modifier
-            .clickable(onClick = onClick)
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
     ) {
         CoverBox(
@@ -623,7 +629,8 @@ fun ProviderMediaItemCard(
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     Column(
         modifier = modifier
-            .clickable(onClick = onClick)
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
     ) {
         CoverBox(
@@ -858,13 +865,8 @@ fun ProviderLockedSummary(providers: List<ProviderFeature>, onClick: (ProviderFe
 
 @Composable
 fun ProviderContentMessage(message: String) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
-    ) {
+    FuoSectionCard(modifier = Modifier.fillMaxWidth()) {
         Text(
-            modifier = Modifier.padding(16.dp),
             text = message,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SearchScreen.kt
@@ -1,6 +1,5 @@
 package org.feeluown.mobile
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,19 +12,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -36,11 +31,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -54,37 +47,39 @@ fun SearchScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(horizontal = 20.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                    .padding(horizontal = FuoSpacing.xl, vertical = FuoSpacing.md),
+                horizontalArrangement = Arrangement.spacedBy(FuoSpacing.xl),
             ) {
                 Box(
                     modifier = Modifier
-                        .width(320.dp)
+                        .weight(0.34f)
+                        .widthIn(min = 280.dp, max = 360.dp)
                         .fillMaxHeight(),
                 ) {
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 48.dp)
+                            .padding(bottom = FuoSpacing.xxl)
                             .verticalScroll(rememberScrollState()),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
                     ) {
-                        TextField(
+                        FuoSearchField(
                             modifier = Modifier.fillMaxWidth(),
-                            value = controller.query,
-                            onValueChange = controller::onQueryChange,
-                            singleLine = true,
-                            placeholder = { Text("歌曲、歌手或专辑") },
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                            keyboardActions = KeyboardActions(onSearch = { controller.search() }),
-                        )
-                        Button(
-                            modifier = Modifier.fillMaxWidth(),
+                            query = controller.query,
+                            onQueryChange = controller::onQueryChange,
+                            onSearch = controller::search,
                             enabled = !controller.isLoading,
-                            onClick = controller::search,
-                        ) {
-                            Icon(Icons.Filled.Search, contentDescription = "搜索")
-                        }
+                            placeholder = "歌曲、歌手或专辑",
+                            trailingContent = {
+                                FuoIconButton(
+                                    contentDescription = "搜索",
+                                    enabled = !controller.isLoading,
+                                    onClick = controller::search,
+                                ) {
+                                    Icon(Icons.Filled.Search, contentDescription = null)
+                                }
+                            },
+                        )
                         OutlinedButton(
                             modifier = Modifier.fillMaxWidth(),
                             onClick = onOpenRecognition,
@@ -117,7 +112,7 @@ fun SearchScreen(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxHeight(),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
                 ) {
                     LoadingIndicator(controller.isLoading)
                     ProviderSearchTabs(controller)
@@ -154,24 +149,31 @@ fun SearchScreen(
                         IconButton(onClick = controller::closeSearch) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                         }
-                        TextField(
+                        FuoSearchField(
                             modifier = Modifier.weight(1f),
-                            value = controller.query,
-                            onValueChange = controller::onQueryChange,
-                            singleLine = true,
-                            placeholder = { Text("歌曲、歌手或专辑") },
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                            keyboardActions = KeyboardActions(onSearch = { controller.search() }),
-                        )
-                        IconButton(onClick = onOpenRecognition) {
-                            Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
-                        }
-                        IconButton(
+                            query = controller.query,
+                            onQueryChange = controller::onQueryChange,
+                            onSearch = controller::search,
                             enabled = !controller.isLoading,
-                            onClick = controller::search,
-                        ) {
-                            Icon(Icons.Filled.Search, contentDescription = "搜索")
-                        }
+                            placeholder = "歌曲、歌手或专辑",
+                            trailingContent = {
+                                Row {
+                                    FuoIconButton(
+                                        contentDescription = "听歌识曲",
+                                        onClick = onOpenRecognition,
+                                    ) {
+                                        Icon(Icons.Filled.Mic, contentDescription = null)
+                                    }
+                                    FuoIconButton(
+                                        contentDescription = "搜索",
+                                        enabled = !controller.isLoading,
+                                        onClick = controller::search,
+                                    ) {
+                                        Icon(Icons.Filled.Search, contentDescription = null)
+                                    }
+                                }
+                            },
+                        )
                     }
                     Row(
                         modifier = Modifier
@@ -193,8 +195,8 @@ fun SearchScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .padding(horizontal = FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
         ) {
             LoadingIndicator(controller.isLoading)
             ProviderSearchTabs(controller)
@@ -346,41 +348,38 @@ private fun ProviderSearchRow(
     placeholder: CoverPlaceholder = CoverPlaceholder.Song,
     onClick: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        CoverBox(
-            track = MusicTrack(
-                id = title,
-                title = title,
-                artists = "",
-                album = "",
-                source = "",
-                sourceType = TrackSourceType.Provider,
-                coverUrl = coverUrl,
-            ),
-            modifier = Modifier.size(48.dp),
-            placeholder = placeholder,
-        )
-        Column(modifier = Modifier.weight(1f)) {
+    FuoListItem(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick,
+        leadingContent = {
+            CoverBox(
+                track = MusicTrack(
+                    id = title,
+                    title = title,
+                    artists = "",
+                    album = "",
+                    source = "",
+                    sourceType = TrackSourceType.Provider,
+                    coverUrl = coverUrl,
+                ),
+                modifier = Modifier.size(48.dp),
+                placeholder = placeholder,
+            )
+        },
+        headlineContent = {
             Text(
                 text = title.ifBlank { "未命名" },
-                style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
             )
+        },
+        supportingContent = {
             Text(
                 text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
             )
-        }
-    }
+        },
+    )
 }
 
 private fun ProviderSearchTab.label(controller: FuoPlayerController): String = when (this) {
@@ -393,20 +392,12 @@ private fun ProviderSearchTab.label(controller: FuoPlayerController): String = w
 
 @Composable
 fun EmptySearchHint(query: String, compactTop: Boolean = false) {
-    Surface(
+    FuoEmptyState(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = if (compactTop) 0.dp else 24.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
-    ) {
-        Text(
-            modifier = Modifier.padding(16.dp),
-            text = if (query.isBlank()) "输入关键词查找音乐" else "没有结果",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
+        title = if (query.isBlank()) "输入关键词查找音乐" else "没有结果",
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +27,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Login
@@ -59,6 +59,7 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
@@ -76,6 +77,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LookaheadScope
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontFamily
@@ -120,7 +122,7 @@ fun SettingsScreen(
                         },
                     ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                        }
+                    }
                 },
             )
         },
@@ -131,8 +133,8 @@ fun SettingsScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                    .padding(FuoSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
             ) {
                 ProviderLoginPanel(
                     controller = controller,
@@ -143,19 +145,19 @@ fun SettingsScreen(
                 )
             }
         } else if (layoutInfo.useWideLayout) {
+            val wideScrollState = rememberScrollState()
             Row(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    .padding(FuoSpacing.lg)
+                    .verticalScroll(wideScrollState),
+                horizontalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
             ) {
                 Column(
                     modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                        .weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
                 ) {
                     ProviderSwitchPanel(
                         controller = controller,
@@ -166,10 +168,8 @@ fun SettingsScreen(
                 }
                 Column(
                     modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                        .weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
                 ) {
                     PlayerDisplaySettingsPanel(controller)
                     LocalMusicScanSettingsPanel(controller)
@@ -187,8 +187,8 @@ fun SettingsScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                    .padding(FuoSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
             ) {
                 ProviderSwitchPanel(
                     controller = controller,
@@ -214,11 +214,11 @@ fun AppInfoPanel(appVersionInfo: String?) {
     Surface(
         modifier = Modifier
             .fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -295,11 +295,11 @@ fun ProviderSwitchPanel(
     var dragDistance by remember { mutableStateOf(0f) }
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -329,9 +329,9 @@ fun ProviderSwitchPanel(
                                 color = if (isDragging) {
                                     MaterialTheme.colorScheme.secondaryContainer
                                 } else {
-                                    MaterialTheme.colorScheme.surfaceVariant
+                                    MaterialTheme.colorScheme.surfaceContainerHigh
                                 },
-                                shape = RoundedCornerShape(8.dp),
+                                shape = MaterialTheme.shapes.medium,
                                 shadowElevation = if (isDragging) 8.dp else 0.dp,
                             ) {
                                 Row(
@@ -368,7 +368,9 @@ fun ProviderSwitchPanel(
                                             )
                                         }
                                         Icon(
-                                            modifier = Modifier.pointerInput(provider.providerId, controller.isLoading) {
+                                            modifier = Modifier
+                                                .fuoInteractive()
+                                                .pointerInput(provider.providerId, controller.isLoading) {
                                                 detectDragGesturesAfterLongPress(
                                                     onDragStart = {
                                                         draggingProviderId = provider.providerId
@@ -400,7 +402,7 @@ fun ProviderSwitchPanel(
                                             contentDescription = "长按拖动排序${provider.providerName}",
                                         )
                                     }
-                                    Checkbox(
+                                    Switch(
                                         checked = isEnabled,
                                         enabled = !controller.isLoading &&
                                             (isEnabled && controller.enabledProviderIds.size > 1 || !isEnabled),
@@ -498,11 +500,11 @@ fun ProviderLoginPanel(
         ?: ProviderLoginMode.Cookie
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -669,11 +671,11 @@ fun settingsFilterChipColors() = FilterChipDefaults.filterChipColors(
 fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -743,7 +745,7 @@ fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
                         text = "使用替换信息",
                         style = MaterialTheme.typography.bodyMedium,
                     )
-                    Checkbox(
+                    Switch(
                         checked = controller.smartReplacementUseReplacementMetadata,
                         enabled = !controller.isLoading,
                         onCheckedChange = controller::onSmartReplacementUseReplacementMetadataChange,
@@ -759,7 +761,7 @@ fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
                         text = "使用替换歌词",
                         style = MaterialTheme.typography.bodyMedium,
                     )
-                    Checkbox(
+                    Switch(
                         checked = controller.smartReplacementUseReplacementLyrics,
                         enabled = !controller.isLoading,
                         onCheckedChange = controller::onSmartReplacementUseReplacementLyricsChange,
@@ -775,11 +777,11 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
     val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -876,8 +878,13 @@ fun ThemeColorSchemeOption(
                     MaterialTheme.colorScheme.surface
                 },
             )
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .fuoInteractive()
+            .selectable(
+                selected = selected,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
+            .padding(horizontal = FuoSpacing.md, vertical = FuoSpacing.md),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -906,11 +913,11 @@ fun ThemeColorSchemeOption(
 fun AudioQualitySettingsPanel(controller: FuoPlayerController) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -964,11 +971,11 @@ fun AudioQualityRow(
 fun LocalMusicScanSettingsPanel(controller: FuoPlayerController) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -992,7 +999,8 @@ fun LocalMusicScanSettingsPanel(controller: FuoPlayerController) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable {
+                            .fuoInteractive()
+                            .clickable(role = Role.Button) {
                                 controller.onLocalMusicDirectoryEnabledChange(
                                     directory.id,
                                     directory.id in controller.excludedLocalMusicDirectoryIds,
@@ -1062,28 +1070,20 @@ fun LocalMusicDurationFilterRow(
 fun DownloadSettingsPanel(controller: FuoPlayerController) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth().clickable(onClick = controller::openDownloadManager),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(Icons.Filled.Download, contentDescription = null)
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("下载管理", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        text = "${controller.downloadTasks.count { it.status == DownloadTaskStatus.Downloading }} 个下载中",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            FuoSettingRow(
+                modifier = Modifier.fillMaxWidth(),
+                title = "下载管理",
+                supportingText = "${controller.downloadTasks.count { it.status == DownloadTaskStatus.Downloading }} 个下载中",
+                onClick = controller::openDownloadManager,
+                leadingContent = { Icon(Icons.Filled.Download, contentDescription = null) },
+            )
             Text("并行下载数量", style = MaterialTheme.typography.bodyMedium)
             SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                 (1..5).forEach { value ->
@@ -1103,11 +1103,11 @@ fun DownloadSettingsPanel(controller: FuoPlayerController) {
 fun CacheSettingsPanel(controller: FuoPlayerController) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
@@ -1154,26 +1154,15 @@ fun CacheSettingsPanel(controller: FuoPlayerController) {
 @Composable
 fun DebugSettingsPanel(controller: FuoPlayerController) {
     Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = controller::openDebugLogs),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(Icons.Filled.BugReport, contentDescription = null)
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "应用日志",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
-        }
+        FuoSettingRow(
+            title = "应用日志",
+            onClick = controller::openDebugLogs,
+            leadingContent = { Icon(Icons.Filled.BugReport, contentDescription = null) },
+        )
     }
 }
 
@@ -1331,7 +1320,7 @@ fun DebugLogScreen(controller: FuoPlayerController) {
                                     },
                                 ),
                             color = debugLogLevelContainerColor(level),
-                            shape = RoundedCornerShape(8.dp),
+                            shape = MaterialTheme.shapes.medium,
                         ) {
                             Row(
                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
@@ -1359,7 +1348,7 @@ fun DebugLogScreen(controller: FuoPlayerController) {
                                     color = debugLogLevelContentColor(level),
                                 )
                                 IconButton(
-                                    modifier = Modifier.size(40.dp),
+                                    modifier = Modifier.fuoInteractive().size(48.dp),
                                     onClick = { clipboardManager.setText(AnnotatedString(line)) },
                                 ) {
                                     Icon(Icons.Filled.ContentCopy, contentDescription = "复制")
@@ -1396,7 +1385,7 @@ private fun debugLogLevelLabel(level: DebugLogLevel): String = when (level) {
 
 @Composable
 private fun debugLogLevelContainerColor(level: DebugLogLevel?) = when (level) {
-    DebugLogLevel.Debug -> MaterialTheme.colorScheme.surfaceVariant
+    DebugLogLevel.Debug -> MaterialTheme.colorScheme.surfaceContainerHigh
     DebugLogLevel.Info -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.20f)
     DebugLogLevel.Warning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f)
     DebugLogLevel.Error -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f)
@@ -1442,7 +1431,7 @@ fun PermissionPanel(onRequestAudioPermission: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.secondaryContainer,
-        shape = RoundedCornerShape(8.dp),
+        shape = MaterialTheme.shapes.medium,
     ) {
         Row(
             modifier = Modifier.padding(12.dp),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -60,7 +61,8 @@ fun TrackRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -149,7 +151,7 @@ fun TrackAction(
                 imageVector = Icons.Filled.MoreVert,
                 contentDescription = "更多操作",
                 onClick = { expanded = true },
-                size = 44.dp,
+                size = 48.dp,
                 iconSize = 24.dp,
             )
         } else {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoDesignSystemTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoDesignSystemTest.kt
@@ -1,0 +1,46 @@
+package org.feeluown.mobile
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FuoDesignSystemTest {
+    @Test
+    fun spacingScaleUsesTheSharedFourPointGrid() {
+        assertEquals(4.dp, FuoSpacing.xs)
+        assertEquals(8.dp, FuoSpacing.sm)
+        assertEquals(12.dp, FuoSpacing.md)
+        assertEquals(16.dp, FuoSpacing.lg)
+        assertEquals(24.dp, FuoSpacing.xl)
+        assertEquals(32.dp, FuoSpacing.xxl)
+        assertEquals(48.dp, FuoMinimumTouchTarget)
+    }
+
+    @Test
+    fun layoutBreakpointsSeparateCompactLandscapeAndWideModes() {
+        val compact = appLayoutInfoFor(maxWidth = 360.dp, maxHeight = 800.dp)
+        val landscapePhone = appLayoutInfoFor(maxWidth = 600.dp, maxHeight = 360.dp)
+        val wide = appLayoutInfoFor(maxWidth = 840.dp, maxHeight = 600.dp)
+        val desktop = appLayoutInfoFor(maxWidth = 1200.dp, maxHeight = 800.dp)
+
+        assertFalse(compact.isLandscape)
+        assertFalse(compact.useWideLayout)
+        assertEquals(3, compact.gridColumns)
+        assertTrue(landscapePhone.isLandscape)
+        assertFalse(landscapePhone.useWideLayout)
+        assertEquals(3, landscapePhone.gridColumns)
+        assertTrue(wide.useWideLayout)
+        assertEquals(5, wide.gridColumns)
+        assertEquals(6, desktop.gridColumns)
+    }
+
+    @Test
+    fun themeModeResolutionHonorsExplicitModesAndSystemMode() {
+        assertFalse(resolvedDarkTheme(ThemeMode.System, systemDark = false))
+        assertTrue(resolvedDarkTheme(ThemeMode.System, systemDark = true))
+        assertFalse(resolvedDarkTheme(ThemeMode.Light, systemDark = true))
+        assertTrue(resolvedDarkTheme(ThemeMode.Dark, systemDark = false))
+    }
+}


### PR DESCRIPTION
## 变更内容

- 统一共享 Compose 主题 token、间距、动效、Shapes/Typography 和 48dp 触控语义。
- 将首页导航、搜索、设置、播放器队列/控制以及页面族迁移到 Material 3 组件。
- 将 Android Web 登录壳接入共享 `FuoTheme`，移除旧绿色 `colorAccent`。
- 增加主题、断点和设计 token 测试。

## 影响范围

- 保留播放器状态、导航业务、Provider 接口、下载协议和持久化逻辑。
- iOS 继续使用共享 Compose 入口。
- 紧凑屏队列使用 Material 3 `ModalBottomSheet`，宽屏保留侧边队列面板。

## 验证

- `./gradlew :shared:allTests`
- `./gradlew :androidApp:lint :shared:lint`
- `./gradlew :androidApp:assembleDebug`
- `git diff --check`

## 设备验证限制

当前环境没有 Android 设备/模拟器和 iOS Simulator，因此截图基线、TalkBack/VoiceOver、RTL、大字体和真实设备回归仍需在 CI 或本地设备上补充验证。
