### PR TITLE
Feat: Local music display by directories

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
@@ -768,10 +768,7 @@ private fun File.runCatchingReadText(): String? {
 }
 
 private fun Set<String>.normalizedDirectoryIds(): Set<String> {
-    return flatMap { id ->
-        val trimmed = id.trim('/')
-        if (trimmed.isBlank()) listOf(id) else listOf(id, trimmed)
-    }.toSet()
+    return flatMap(::localMusicDirectoryIdAliases).toSet()
 }
 
 private fun sanitizeFileName(value: String): String {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalMusicRepository.kt
@@ -7,6 +7,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.net.Uri
 import android.os.Build
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
@@ -65,7 +66,8 @@ class AndroidLocalMusicRepository(
 
     override suspend fun isDatabaseStale(): Boolean = withContext(Dispatchers.IO) {
         val stored = database.readableDatabase.getMeta(KEY_MEDIA_FINGERPRINT)
-        stored == null || stored != queryMediaFingerprint()
+        val layout = database.readableDatabase.getMeta(KEY_SCAN_LAYOUT_VERSION)
+        stored == null || layout != SCAN_LAYOUT_VERSION || stored != queryMediaFingerprint()
     }
 
     override suspend fun directories(): List<LocalMusicDirectory> = withContext(Dispatchers.IO) {
@@ -73,9 +75,9 @@ class AndroidLocalMusicRepository(
         val result = mutableListOf<LocalMusicDirectory>()
         db.rawQuery(
             """
-            SELECT directory_id, directory_name, COUNT(*)
+            SELECT directory_id, directory_name, directory_cover_url, COUNT(*)
             FROM tracks
-            GROUP BY directory_id, directory_name
+            GROUP BY directory_id, directory_name, directory_cover_url
             ORDER BY directory_name
             """.trimIndent(),
             null,
@@ -84,7 +86,8 @@ class AndroidLocalMusicRepository(
                 result += LocalMusicDirectory(
                     id = cursor.getString(0).orEmpty(),
                     name = cursor.getString(1).orEmpty(),
-                    trackCount = cursor.getInt(2),
+                    trackCount = cursor.getInt(3),
+                    coverUrl = cursor.getString(2)?.takeIf { it.isNotBlank() },
                 )
             }
         }
@@ -97,12 +100,26 @@ class AndroidLocalMusicRepository(
 
     override suspend fun refreshDatabase(): List<MusicTrack> = withContext(Dispatchers.IO) {
         val rows = queryAudioRows()
+        val imageCovers = queryImageCovers()
+        val fallbackCovers = rows
+            .groupBy { it.directory.id }
+            .mapValues { (_, directoryRows) ->
+                directoryRows
+                    .sortedWith(
+                        compareBy<AudioRow> { it.displayName.lowercase(Locale.ROOT) }
+                            .thenBy { it.mediaId },
+                    )
+                    .firstOrNull()
+                    ?.let { localCoverUri(it.uri, it.albumId) }
+            }
         val metadataOverrides = metadataOverrides()
         val folderLyrics = queryLyrics()
         val appLyrics = queryAppLyrics()
         val records = rows.map { row ->
-            val directory = directoryInfo(row.relativePath)
-            val sourceType = if (row.relativePath.contains(FEELUOWN_FOLDER)) {
+            val directory = row.directory.copy(
+                coverUrl = imageCovers[row.directory.id] ?: fallbackCovers[row.directory.id],
+            )
+            val sourceType = if (row.directory.id == FEELUOWN_DIRECTORY_ID) {
                 TrackSourceType.Downloaded
             } else {
                 TrackSourceType.LocalMediaStore
@@ -123,6 +140,7 @@ class AndroidLocalMusicRepository(
                     coverUrl = localCoverUri(row.uri, row.albumId),
                     durationMs = row.durationMs.takeIf { it > 0 },
                     localUri = row.uri.toString(),
+                    localDirectoryId = directory.id,
                     lyrics = row.lyrics(folderLyrics, appLyrics),
                 ),
                 directory = directory,
@@ -224,6 +242,17 @@ class AndroidLocalMusicRepository(
             }
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idColumn)
+                val relativePath = if (relativePathColumn >= 0) {
+                    cursor.getString(relativePathColumn).orEmpty()
+                } else {
+                    ""
+                }
+                val filePath = if (dataColumn >= 0) {
+                    cursor.getString(dataColumn).orEmpty()
+                } else {
+                    ""
+                }
+                val directory = directoryInfo(relativePath, filePath) ?: continue
                 rows += AudioRow(
                     uri = ContentUris.withAppendedId(collection, id),
                     title = cursor.getString(titleColumn).orEmpty(),
@@ -232,16 +261,9 @@ class AndroidLocalMusicRepository(
                     albumId = cursor.getLong(albumIdColumn),
                     durationMs = cursor.getLong(durationColumn),
                     displayName = cursor.getString(displayNameColumn).orEmpty(),
-                    relativePath = if (relativePathColumn >= 0) {
-                        cursor.getString(relativePathColumn).orEmpty()
-                    } else {
-                        ""
-                    },
-                    filePath = if (dataColumn >= 0) {
-                        cursor.getString(dataColumn).orEmpty()
-                    } else {
-                        ""
-                    },
+                    relativePath = relativePath,
+                    filePath = filePath,
+                    directory = directory,
                     mediaId = id,
                     dateAdded = cursor.getLong(dateAddedColumn),
                     dateModified = cursor.getLong(dateModifiedColumn),
@@ -252,6 +274,68 @@ class AndroidLocalMusicRepository(
     }
 
     private fun queryMediaFingerprint(): String = mediaFingerprint(queryAudioRows())
+
+    private fun queryImageCovers(): Map<String, String> {
+        val collection = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+        val projection = mutableListOf(
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.DISPLAY_NAME,
+        ).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                add(MediaStore.Images.Media.RELATIVE_PATH)
+            } else {
+                @Suppress("DEPRECATION")
+                add(MediaStore.Images.Media.DATA)
+            }
+        }.toTypedArray()
+        val rows = mutableListOf<ImageRow>()
+        try {
+            appContext.contentResolver.query(collection, projection, null, null, null)
+        } catch (_: SecurityException) {
+            null
+        }?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            val displayNameColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME)
+            val relativePathColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                cursor.getColumnIndex(MediaStore.Images.Media.RELATIVE_PATH)
+            } else {
+                -1
+            }
+            val dataColumn = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                @Suppress("DEPRECATION")
+                cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+            } else {
+                -1
+            }
+            while (cursor.moveToNext()) {
+                val relativePath = if (relativePathColumn >= 0) {
+                    cursor.getString(relativePathColumn).orEmpty()
+                } else {
+                    ""
+                }
+                val filePath = if (dataColumn >= 0) {
+                    cursor.getString(dataColumn).orEmpty()
+                } else {
+                    ""
+                }
+                val directory = directoryInfo(relativePath, filePath) ?: continue
+                val id = cursor.getLong(idColumn)
+                rows += ImageRow(
+                    directoryId = directory.id,
+                    displayName = cursor.getString(displayNameColumn).orEmpty(),
+                    uri = ContentUris.withAppendedId(collection, id),
+                )
+            }
+        }
+        return rows
+            .sortedWith(
+                compareBy<ImageRow> { it.directoryId }
+                    .thenBy { it.displayName.lowercase(Locale.ROOT) }
+                    .thenBy { it.displayName },
+            )
+            .distinctBy { it.directoryId }
+            .associate { it.directoryId to it.uri.toString() }
+    }
 
     private fun queryLyrics(): Map<String, String> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return emptyMap()
@@ -386,23 +470,12 @@ class AndroidLocalMusicRepository(
         return track.title
     }
 
-    private fun directoryInfo(relativePath: String): LocalMusicDirectory {
-        val normalized = relativePath.trim('/').ifBlank { OTHER_DIRECTORY_ID }
-        val name = if (normalized == OTHER_DIRECTORY_ID) "其他媒体库" else normalized
-        return LocalMusicDirectory(
-            id = normalized,
-            name = name,
-            trackCount = 0,
-        )
-    }
-
     private companion object {
-        private const val FEELUOWN_FOLDER = "FeelUOwn"
         private const val LYRICS_FOLDER = "lyrics"
         private const val METADATA_OVERRIDE_FILE = "local_music_metadata.json"
-        private const val OTHER_DIRECTORY_ID = "__other__"
         private const val KEY_INITIALIZED = "initialized"
         private const val KEY_MEDIA_FINGERPRINT = "media_fingerprint"
+        private const val KEY_SCAN_LAYOUT_VERSION = "scan_layout_version"
         private const val KEY_LAST_REFRESH_AT = "last_refresh_at"
     }
 }
@@ -424,6 +497,7 @@ private class LocalMusicDatabase(context: Context) : SQLiteOpenHelper(context, D
                 lyrics TEXT,
                 directory_id TEXT NOT NULL,
                 directory_name TEXT NOT NULL,
+                directory_cover_url TEXT,
                 display_name TEXT NOT NULL,
                 media_id INTEGER NOT NULL,
                 date_added INTEGER NOT NULL,
@@ -444,7 +518,7 @@ private class LocalMusicDatabase(context: Context) : SQLiteOpenHelper(context, D
 
     private companion object {
         private const val DATABASE_NAME = "local_music.db"
-        private const val DATABASE_VERSION = 1
+        private const val DATABASE_VERSION = 2
     }
 }
 
@@ -467,9 +541,16 @@ private data class AudioRow(
     val displayName: String,
     val relativePath: String,
     val filePath: String,
+    val directory: LocalMusicDirectory,
     val mediaId: Long,
     val dateAdded: Long,
     val dateModified: Long,
+)
+
+private data class ImageRow(
+    val directoryId: String,
+    val displayName: String,
+    val uri: Uri,
 )
 
 private fun SQLiteDatabase.replaceTracks(records: List<LocalTrackRecord>, fingerprint: String) {
@@ -481,6 +562,7 @@ private fun SQLiteDatabase.replaceTracks(records: List<LocalTrackRecord>, finger
         }
         putMeta("initialized", "1")
         putMeta("media_fingerprint", fingerprint)
+        putMeta("scan_layout_version", SCAN_LAYOUT_VERSION)
         putMeta("last_refresh_at", System.currentTimeMillis().toString())
         setTransactionSuccessful()
     } finally {
@@ -519,6 +601,7 @@ private fun SQLiteDatabase.readTracks(settings: LocalMusicScanSettings): List<Mu
                 coverUrl = cursor.getString(6)?.takeIf { it.isNotBlank() },
                 durationMs = durationMs,
                 localUri = cursor.getString(8).orEmpty(),
+                localDirectoryId = directoryId,
                 lyrics = cursor.getString(9)?.takeIf { it.isNotBlank() },
             )
         }
@@ -579,10 +662,63 @@ private fun LocalTrackRecord.toContentValues(): ContentValues {
         put("lyrics", track.lyrics)
         put("directory_id", directory.id)
         put("directory_name", directory.name)
+        put("directory_cover_url", directory.coverUrl)
         put("display_name", displayName)
         put("media_id", mediaId)
         put("date_added", dateAdded)
         put("date_modified", dateModified)
+    }
+}
+
+private const val MUSIC_DIRECTORY_NAME = "Music"
+private const val MUSIC_ROOT_DIRECTORY_ID = "Music/"
+private const val FEELUOWN_DIRECTORY_ID = "Music/FeelUOwn/"
+private const val SCAN_LAYOUT_VERSION = "music-first-level-v1"
+
+private fun directoryInfo(relativePath: String, filePath: String): LocalMusicDirectory? {
+    val firstLevelName = if (relativePath.isNotBlank()) {
+        val segments = relativePath
+            .replace('\\', '/')
+            .split('/')
+            .filter { it.isNotBlank() }
+        if (segments.firstOrNull()?.equals(MUSIC_DIRECTORY_NAME, ignoreCase = true) != true) {
+            return null
+        }
+        segments.getOrNull(1)
+    } else {
+        val musicRoot = Environment
+            .getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC)
+            .path
+            .replace('\\', '/')
+            .trimEnd('/')
+        val normalizedFilePath = filePath.replace('\\', '/').trimEnd('/')
+        val normalizedDirectoryPath = normalizedFilePath.substringBeforeLast('/', "")
+        if (normalizedDirectoryPath != musicRoot &&
+            !normalizedDirectoryPath.startsWith("$musicRoot/")
+        ) {
+            return null
+        }
+        if (normalizedDirectoryPath == musicRoot) {
+            null
+        } else {
+            normalizedDirectoryPath
+                .removePrefix("$musicRoot/")
+                .substringBefore('/')
+                .takeIf { it.isNotBlank() }
+        }
+    }
+    return if (firstLevelName.isNullOrBlank()) {
+        LocalMusicDirectory(
+            id = MUSIC_ROOT_DIRECTORY_ID,
+            name = "歌曲",
+            trackCount = 0,
+        )
+    } else {
+        LocalMusicDirectory(
+            id = "$MUSIC_DIRECTORY_NAME/$firstLevelName/",
+            name = firstLevelName,
+            trackCount = 0,
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -149,6 +149,7 @@ class MainActivity : ComponentActivity() {
                 enabled = controller.isFullPlayerOpen ||
                     controller.isVideoFullscreen ||
                     controller.settingsLoginProviderId != null ||
+                    controller.selectedLocalMusicCollection != null ||
                     controller.selectedLocalMusicDirectoryId != null,
             ) {
                 controller.navigateBack()

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -53,11 +53,13 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             var hasAudioPermission by remember { mutableStateOf(hasAudioPermission()) }
+            var hasImagePermission by remember { mutableStateOf(hasImagePermission()) }
             var hasMicrophonePermission by remember { mutableStateOf(hasMicrophonePermission()) }
             val permissionLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestMultiplePermissions(),
             ) {
                 hasAudioPermission = hasAudioPermission()
+                hasImagePermission = hasImagePermission()
             }
             val microphonePermissionLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestPermission(),
@@ -146,7 +148,8 @@ class MainActivity : ComponentActivity() {
             BackHandler(
                 enabled = controller.isFullPlayerOpen ||
                     controller.isVideoFullscreen ||
-                    controller.settingsLoginProviderId != null,
+                    controller.settingsLoginProviderId != null ||
+                    controller.selectedLocalMusicDirectoryId != null,
             ) {
                 controller.navigateBack()
             }
@@ -159,9 +162,13 @@ class MainActivity : ComponentActivity() {
             AppRoot(
                 appViewModel = appViewModel,
                 hasAudioPermission = hasAudioPermission,
+                hasImagePermission = hasImagePermission,
                 appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
                 onRequestAudioPermission = {
-                    permissionLauncher.launch(audioPermissions())
+                    permissionLauncher.launch(mediaPermissions())
+                },
+                onRequestImagePermission = {
+                    permissionLauncher.launch(imagePermissions())
                 },
                 hasMicrophonePermission = hasMicrophonePermission,
                 onRequestMicrophonePermission = {
@@ -217,6 +224,22 @@ class MainActivity : ComponentActivity() {
     private fun hasAudioPermission(): Boolean {
         return audioPermissions().all {
             ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun hasImagePermission(): Boolean {
+        return imagePermissions().all {
+            ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    private fun mediaPermissions(): Array<String> = (audioPermissions().toList() + imagePermissions()).distinct().toTypedArray()
+
+    private fun imagePermissions(): Array<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.READ_MEDIA_IMAGES)
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
     }
 

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -413,7 +413,13 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
         let directory = cacheDirectory.appendingPathComponent("local-music-artwork", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let target = directory.appendingPathComponent("\(item.persistentID).jpg")
-        if !FileManager.default.fileExists(atPath: target.path) {
+        let shouldWrite: Bool
+        if let cachedData = try? Data(contentsOf: target) {
+            shouldWrite = cachedData != data
+        } else {
+            shouldWrite = true
+        }
+        if shouldWrite {
             try? data.write(to: target, options: .atomic)
         }
         return FileManager.default.fileExists(atPath: target.path) ? target : nil

--- a/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
+++ b/iosApp/FuoEvolve/IOSNativeAudioEngine.swift
@@ -379,7 +379,7 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
     func tracksJson() -> String {
         let tracks: [[String: Any]] = (MPMediaQuery.songs().items ?? []).compactMap { item in
             guard let assetURL = item.assetURL else { return nil }
-            return [
+            var track: [String: Any] = [
                 "id": String(item.persistentID),
                 "title": item.title ?? "",
                 "artists": item.artist ?? "",
@@ -387,6 +387,10 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
                 "duration_ms": Int64(item.playbackDuration * 1000),
                 "local_uri": assetURL.absoluteString,
             ]
+            if let artworkURL = cachedArtworkURL(for: item) {
+                track["artwork_url"] = artworkURL.absoluteString
+            }
+            return track
         }
         guard
             let data = try? JSONSerialization.data(withJSONObject: ["tracks": tracks]),
@@ -395,6 +399,24 @@ final class IOSMediaLibraryOutput: NSObject, IosMediaLibraryOutput {
             return #"{"tracks":[]}"#
         }
         return json
+    }
+
+    private func cachedArtworkURL(for item: MPMediaItem) -> URL? {
+        guard
+            let artwork = item.artwork,
+            let image = artwork.image(at: CGSize(width: 512, height: 512)),
+            let data = image.jpegData(compressionQuality: 0.9),
+            let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        else {
+            return nil
+        }
+        let directory = cacheDirectory.appendingPathComponent("local-music-artwork", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let target = directory.appendingPathComponent("\(item.persistentID).jpg")
+        if !FileManager.default.fileExists(atPath: target.path) {
+            try? data.write(to: target, options: .atomic)
+        }
+        return FileManager.default.fileExists(atPath: target.path) ? target : nil
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -363,6 +363,7 @@ fun AppRoot(
                                                 controller,
                                                 currentLocalPlaylist ?: lastLocalPlaylist,
                                             )
+                                            AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen(controller)
                                             AppRoute.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
                                         }
                                     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -216,6 +216,8 @@ fun AppRoot(
     onShareLocalPlaylistFile: ((String, String) -> Unit)? = null,
     onShareText: (String) -> Unit = {},
     appVersionInfo: String? = null,
+    hasImagePermission: Boolean = true,
+    onRequestImagePermission: () -> Unit = {},
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
     val controller = appViewModel.controller
@@ -331,6 +333,8 @@ fun AppRoot(
                                                 controller = controller,
                                                 hasAudioPermission = hasAudioPermission,
                                                 onRequestAudioPermission = onRequestAudioPermission,
+                                                hasImagePermission = hasImagePermission,
+                                                onRequestImagePermission = onRequestImagePermission,
                                                 onOpenRecognition = controller::openRecognition,
                                             )
                                             AppRoute.DebugLogs -> DebugLogScreen(controller)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
@@ -38,6 +38,9 @@ sealed interface AppRoute : NavKey {
     data object LocalPlaylist : AppRoute
 
     @Serializable
+    data object LocalMusicCollection : AppRoute
+
+    @Serializable
     data object MediaItem : AppRoute
 
     @Serializable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -142,6 +142,7 @@ data class LocalMusicDirectory(
     val id: String,
     val name: String,
     val trackCount: Int,
+    val coverUrl: String? = null,
 )
 
 data class LocalTrackMetadata(
@@ -160,6 +161,7 @@ data class MusicTrack(
     val coverUrl: String? = null,
     val durationMs: Long? = null,
     val localUri: String? = null,
+    val localDirectoryId: String? = null,
     val lyrics: String? = null,
     val providerId: String? = null,
     val providerName: String? = null,
@@ -403,6 +405,7 @@ object PlaybackQueueCodec {
         track.replacementCoverUrl.orEmpty(),
         track.replacementStrategy.orEmpty(),
         track.replacementScore?.toString().orEmpty(),
+        track.localDirectoryId.orEmpty(),
     ).map(::escape)
 
     private fun decodeTrack(fields: List<String>): MusicTrack? {
@@ -432,6 +435,7 @@ object PlaybackQueueCodec {
                 replacementCoverUrl = fields.unescapedOrNull(23),
                 replacementStrategy = fields.unescapedOrNull(24),
                 replacementScore = fields.unescapedOrNull(25)?.toDoubleOrNull(),
+                localDirectoryId = fields.unescapedOrNull(26),
                 isUnavailable = unescape(fields[15]).toBooleanStrictOrNull() ?: false,
                 artistItemId = unescape(fields[16]).ifBlank { null },
                 albumItemId = unescape(fields[17]).ifBlank { null },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -145,6 +145,21 @@ data class LocalMusicDirectory(
     val coverUrl: String? = null,
 )
 
+fun canonicalLocalMusicDirectoryId(id: String): String? {
+    return id.trim('/').takeIf { it.isNotBlank() }?.let { "$it/" }
+}
+
+fun localMusicDirectoryIdAliases(id: String): Set<String> {
+    val canonical = canonicalLocalMusicDirectoryId(id) ?: return setOf(id)
+    return setOf(id, canonical, canonical.removeSuffix("/"))
+}
+
+fun isLocalMusicDirectoryExcluded(directoryId: String, excludedDirectoryIds: Set<String>): Boolean {
+    return excludedDirectoryIds.any { excludedId ->
+        directoryId in localMusicDirectoryIdAliases(excludedId)
+    }
+}
+
 data class LocalTrackMetadata(
     val title: String,
     val artists: String,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -251,6 +251,8 @@ class FuoPlayerController(
         private set
     var localMusicDirectories by mutableStateOf<List<LocalMusicDirectory>>(emptyList())
         private set
+    var selectedLocalMusicDirectoryId by mutableStateOf<String?>(null)
+        private set
     var excludedLocalMusicDirectoryIds by mutableStateOf<Set<String>>(emptySet())
         private set
     var localMusicMinDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
@@ -342,7 +344,9 @@ class FuoPlayerController(
     val displayUpNextCount: Int
         get() = upNextQueue.size
     val canNavigateBack: Boolean
-        get() = isFullPlayerOpen || navigator.backStack.value.size > 1
+        get() = isFullPlayerOpen ||
+            selectedLocalMusicDirectoryId != null ||
+            navigator.backStack.value.size > 1
 
     private var mainQueue: List<MusicTrack> = emptyList()
     private var originalMainQueue: List<MusicTrack> = emptyList()
@@ -596,15 +600,20 @@ class FuoPlayerController(
                 } else {
                     localRepository.tracks()
                 }
-                localMusicDirectories = localRepository.directories()
-                tracks
+                tracks to localRepository.directories()
             }
             if (refreshSerial == localMusicRefreshSerial) {
                 result
-                    .onSuccess {
-                        localTracks = it
+                    .onSuccess { (tracks, directories) ->
+                        localTracks = tracks
+                        localMusicDirectories = directories
+                        if (selectedLocalMusicDirectoryId != null &&
+                            directories.none { it.id == selectedLocalMusicDirectoryId }
+                        ) {
+                            selectedLocalMusicDirectoryId = null
+                        }
                         if (showLoading) {
-                            message = if (it.isEmpty()) "未发现本地音乐" else "本地音乐 ${it.size} 首"
+                            message = if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首"
                         }
                     }
                     .onFailure {
@@ -626,14 +635,19 @@ class FuoPlayerController(
             val result = runCatching {
                 updateLocalMusicScanSettings()
                 val tracks = localRepository.tracks()
-                localMusicDirectories = localRepository.directories()
-                tracks
+                tracks to localRepository.directories()
             }
             if (refreshSerial == localMusicRefreshSerial) {
                 result
-                    .onSuccess {
-                        localTracks = it
-                        message = if (it.isEmpty()) "未发现本地音乐" else "本地音乐 ${it.size} 首"
+                    .onSuccess { (tracks, directories) ->
+                        localTracks = tracks
+                        localMusicDirectories = directories
+                        if (selectedLocalMusicDirectoryId != null &&
+                            directories.none { it.id == selectedLocalMusicDirectoryId }
+                        ) {
+                            selectedLocalMusicDirectoryId = null
+                        }
+                        message = if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首"
                     }
                     .onFailure { setError(it) }
             }
@@ -834,6 +848,10 @@ class FuoPlayerController(
             }
             isVideoFullscreen -> {
                 toggleVideoFullscreen()
+                true
+            }
+            selectedLocalMusicDirectoryId != null && navigator.currentRoute == AppRoute.Home -> {
+                closeLocalMusicDirectory()
                 true
             }
             else -> when (navigator.currentRoute) {
@@ -1389,6 +1407,7 @@ class FuoPlayerController(
 
     fun onHomeSectionChange(value: HomeSection) {
         homeSection = value
+        if (value != HomeSection.Mine) closeLocalMusicDirectory()
         persistSettings()
         if (value == HomeSection.Mine) {
             refreshActiveMineSectionIfNeeded()
@@ -1399,6 +1418,7 @@ class FuoPlayerController(
 
     fun onMineSectionChange(value: MineSection) {
         mineSection = value
+        if (value != MineSection.LocalMusic) closeLocalMusicDirectory()
         persistSettings()
         when (value) {
             MineSection.Playlists -> {
@@ -1450,7 +1470,18 @@ class FuoPlayerController(
 
     fun onLocalMusicViewModeChange(value: LocalMusicViewMode) {
         localMusicViewMode = value
+        closeLocalMusicDirectory()
         persistSettings()
+    }
+
+    fun openLocalMusicDirectory(directoryId: String) {
+        if (directoryId in excludedLocalMusicDirectoryIds) return
+        if (localMusicDirectories.none { it.id == directoryId }) return
+        selectedLocalMusicDirectoryId = directoryId
+    }
+
+    fun closeLocalMusicDirectory() {
+        selectedLocalMusicDirectoryId = null
     }
 
     fun onLocalMusicDirectoryEnabledChange(directoryId: String, enabled: Boolean) {
@@ -1458,6 +1489,9 @@ class FuoPlayerController(
             excludedLocalMusicDirectoryIds - directoryId
         } else {
             excludedLocalMusicDirectoryIds + directoryId
+        }
+        if (!enabled && selectedLocalMusicDirectoryId == directoryId) {
+            closeLocalMusicDirectory()
         }
         persistSettings()
         reloadLocalMusic()
@@ -4288,6 +4322,11 @@ class FuoPlayerController(
                 localRepository.directories()
             }.onSuccess {
                 localMusicDirectories = it
+                if (selectedLocalMusicDirectoryId != null &&
+                    it.none { directory -> directory.id == selectedLocalMusicDirectoryId }
+                ) {
+                    selectedLocalMusicDirectoryId = null
+                }
             }.onFailure {
                 setError(it)
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -72,6 +72,11 @@ enum class LocalMusicViewMode {
     Album,
 }
 
+data class LocalMusicCollectionSelection(
+    val mode: LocalMusicViewMode,
+    val key: String,
+)
+
 data class TrackArtistTarget(
     val name: String,
     val mediaItem: ProviderMediaItem? = null,
@@ -253,6 +258,8 @@ class FuoPlayerController(
         private set
     var selectedLocalMusicDirectoryId by mutableStateOf<String?>(null)
         private set
+    var selectedLocalMusicCollection by mutableStateOf<LocalMusicCollectionSelection?>(null)
+        private set
     var excludedLocalMusicDirectoryIds by mutableStateOf<Set<String>>(emptySet())
         private set
     var localMusicMinDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
@@ -345,6 +352,7 @@ class FuoPlayerController(
         get() = upNextQueue.size
     val canNavigateBack: Boolean
         get() = isFullPlayerOpen ||
+            selectedLocalMusicCollection != null ||
             selectedLocalMusicDirectoryId != null ||
             navigator.backStack.value.size > 1
 
@@ -610,7 +618,7 @@ class FuoPlayerController(
                         if (selectedLocalMusicDirectoryId != null &&
                             directories.none { it.id == selectedLocalMusicDirectoryId }
                         ) {
-                            selectedLocalMusicDirectoryId = null
+                            closeLocalMusicCollection()
                         }
                         if (showLoading) {
                             message = if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首"
@@ -645,7 +653,7 @@ class FuoPlayerController(
                         if (selectedLocalMusicDirectoryId != null &&
                             directories.none { it.id == selectedLocalMusicDirectoryId }
                         ) {
-                            selectedLocalMusicDirectoryId = null
+                            closeLocalMusicCollection()
                         }
                         message = if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首"
                     }
@@ -850,8 +858,9 @@ class FuoPlayerController(
                 toggleVideoFullscreen()
                 true
             }
-            selectedLocalMusicDirectoryId != null && navigator.currentRoute == AppRoute.Home -> {
-                closeLocalMusicDirectory()
+            (selectedLocalMusicCollection != null || selectedLocalMusicDirectoryId != null) &&
+                navigator.currentRoute == AppRoute.Home -> {
+                closeLocalMusicCollection()
                 true
             }
             else -> when (navigator.currentRoute) {
@@ -1470,28 +1479,48 @@ class FuoPlayerController(
 
     fun onLocalMusicViewModeChange(value: LocalMusicViewMode) {
         localMusicViewMode = value
-        closeLocalMusicDirectory()
+        closeLocalMusicCollection()
         persistSettings()
     }
 
     fun openLocalMusicDirectory(directoryId: String) {
-        if (directoryId in excludedLocalMusicDirectoryIds) return
+        if (isLocalMusicDirectoryExcluded(directoryId, excludedLocalMusicDirectoryIds)) return
         if (localMusicDirectories.none { it.id == directoryId }) return
+        selectedLocalMusicCollection = LocalMusicCollectionSelection(LocalMusicViewMode.All, directoryId)
         selectedLocalMusicDirectoryId = directoryId
     }
 
-    fun closeLocalMusicDirectory() {
+    fun openLocalMusicCollection(mode: LocalMusicViewMode, key: String) {
+        if (key.isBlank()) return
+        if (mode == LocalMusicViewMode.All) {
+            openLocalMusicDirectory(key)
+            return
+        }
         selectedLocalMusicDirectoryId = null
+        selectedLocalMusicCollection = LocalMusicCollectionSelection(mode, key)
+    }
+
+    fun closeLocalMusicCollection() {
+        selectedLocalMusicDirectoryId = null
+        selectedLocalMusicCollection = null
+    }
+
+    fun closeLocalMusicDirectory() {
+        closeLocalMusicCollection()
     }
 
     fun onLocalMusicDirectoryEnabledChange(directoryId: String, enabled: Boolean) {
+        val canonicalDirectoryId = canonicalLocalMusicDirectoryId(directoryId) ?: directoryId
+        val normalizedExcludedIds = excludedLocalMusicDirectoryIds.mapNotNull {
+            canonicalLocalMusicDirectoryId(it)
+        }.toSet()
         excludedLocalMusicDirectoryIds = if (enabled) {
-            excludedLocalMusicDirectoryIds - directoryId
+            normalizedExcludedIds - canonicalDirectoryId
         } else {
-            excludedLocalMusicDirectoryIds + directoryId
+            normalizedExcludedIds + canonicalDirectoryId
         }
         if (!enabled && selectedLocalMusicDirectoryId == directoryId) {
-            closeLocalMusicDirectory()
+            closeLocalMusicCollection()
         }
         persistSettings()
         reloadLocalMusic()
@@ -4196,6 +4225,8 @@ class FuoPlayerController(
         playlistFilter = settings.playlistFilter
         localMusicViewMode = settings.localMusicViewMode
         excludedLocalMusicDirectoryIds = settings.excludedLocalMusicDirectoryIds
+            .mapNotNull(::canonicalLocalMusicDirectoryId)
+            .toSet()
         localMusicMinDurationSeconds = settings.localMusicMinDurationSeconds
         searchScope = settings.searchScope
         selectedSearchProviderId = settings.selectedSearchProviderId
@@ -4234,7 +4265,9 @@ class FuoPlayerController(
             mineSection = mineSection,
             playlistFilter = playlistFilter,
             localMusicViewMode = localMusicViewMode,
-            excludedLocalMusicDirectoryIds = excludedLocalMusicDirectoryIds,
+            excludedLocalMusicDirectoryIds = excludedLocalMusicDirectoryIds
+                .mapNotNull(::canonicalLocalMusicDirectoryId)
+                .toSet(),
             localMusicMinDurationSeconds = localMusicMinDurationSeconds,
             searchScope = searchScope,
             selectedSearchProviderId = selectedSearchProviderId,
@@ -4325,7 +4358,7 @@ class FuoPlayerController(
                 if (selectedLocalMusicDirectoryId != null &&
                     it.none { directory -> directory.id == selectedLocalMusicDirectoryId }
                 ) {
-                    selectedLocalMusicDirectoryId = null
+                    closeLocalMusicCollection()
                 }
             }.onFailure {
                 setError(it)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -900,6 +900,10 @@ class FuoPlayerController(
                     closeLocalPlaylist()
                     true
                 }
+                AppRoute.LocalMusicCollection -> {
+                    closeLocalMusicCollection()
+                    true
+                }
                 AppRoute.Feature -> {
                     closeFeature()
                     true
@@ -1486,6 +1490,7 @@ class FuoPlayerController(
     fun openLocalMusicDirectory(directoryId: String) {
         if (isLocalMusicDirectoryExcluded(directoryId, excludedLocalMusicDirectoryIds)) return
         if (localMusicDirectories.none { it.id == directoryId }) return
+        navigator.navigate(AppRoute.LocalMusicCollection)
         selectedLocalMusicCollection = LocalMusicCollectionSelection(LocalMusicViewMode.All, directoryId)
         selectedLocalMusicDirectoryId = directoryId
     }
@@ -1496,11 +1501,13 @@ class FuoPlayerController(
             openLocalMusicDirectory(key)
             return
         }
+        navigator.navigate(AppRoute.LocalMusicCollection)
         selectedLocalMusicDirectoryId = null
         selectedLocalMusicCollection = LocalMusicCollectionSelection(mode, key)
     }
 
     fun closeLocalMusicCollection() {
+        navigator.pop(AppRoute.LocalMusicCollection)
         selectedLocalMusicDirectoryId = null
         selectedLocalMusicCollection = null
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/HomeScreen.kt
@@ -67,6 +67,8 @@ fun HomeScreen(
     controller: FuoPlayerController,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
     onOpenRecognition: () -> Unit,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
@@ -114,6 +116,8 @@ fun HomeScreen(
                 controller = controller,
                 hasAudioPermission = hasAudioPermission,
                 onRequestAudioPermission = onRequestAudioPermission,
+                hasImagePermission = hasImagePermission,
+                onRequestImagePermission = onRequestImagePermission,
                 onOpenRecognition = onOpenRecognition,
                 modifier = Modifier.weight(1f),
                 contentHorizontalPadding = if (layoutInfo.useWideLayout) 8.dp else 16.dp,
@@ -127,6 +131,8 @@ fun HomeSectionPager(
     controller: FuoPlayerController,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
     onOpenRecognition: () -> Unit,
     modifier: Modifier,
     contentHorizontalPadding: Dp,
@@ -202,6 +208,8 @@ fun HomeSectionPager(
                         controller = controller,
                         hasAudioPermission = hasAudioPermission,
                         onRequestAudioPermission = onRequestAudioPermission,
+                        hasImagePermission = hasImagePermission,
+                        onRequestImagePermission = onRequestImagePermission,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
@@ -248,6 +256,8 @@ fun HomeSectionPager(
                     controller = controller,
                     hasAudioPermission = hasAudioPermission,
                     onRequestAudioPermission = onRequestAudioPermission,
+                    hasImagePermission = hasImagePermission,
+                    onRequestImagePermission = onRequestImagePermission,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,12 +24,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -90,19 +93,6 @@ fun LocalMusicSection(
             excludedDirectoryIds = controller.excludedLocalMusicDirectoryIds,
         )
     }
-    val selection = controller.selectedLocalMusicCollection
-    val selectedCollection = selection
-        ?.takeIf { it.mode == viewMode }
-        ?.let { current -> collections.firstOrNull { it.key == current.key } }
-    LaunchedEffect(selection, viewMode, collections, controller.isLoading) {
-        if (selection != null && (
-                selection.mode != viewMode ||
-                    !controller.isLoading && collections.none { it.key == selection.key }
-            )
-        ) {
-            controller.closeLocalMusicCollection()
-        }
-    }
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     Column(
         modifier = modifier,
@@ -120,50 +110,88 @@ fun LocalMusicSection(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (selectedCollection != null) {
-                Row(
-                    modifier = Modifier.weight(1f),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = controller::closeLocalMusicCollection) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                    }
-                    Text(
-                        text = selectedCollection.title,
-                        style = MaterialTheme.typography.titleMedium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                if (showModeFilter) {
-                    LocalMusicViewModeTabs(controller)
-                }
-            } else if (showModeFilter) {
+            if (showModeFilter) {
                 LocalMusicViewModeTabs(controller)
             } else {
                 Spacer(Modifier)
             }
         }
-        if (selectedCollection == null) {
-            LocalMusicCollectionOverview(
-                mode = viewMode,
-                collections = collections,
-                onClick = { controller.openLocalMusicCollection(viewMode, it.key) },
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-            )
-            return@Column
-        }
-        LocalMusicCollectionDetail(
-            controller = controller,
-            collection = selectedCollection,
+        LocalMusicCollectionOverview(
             mode = viewMode,
+            collections = collections,
+            onClick = { controller.openLocalMusicCollection(viewMode, it.key) },
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
-            isWideLayout = isWideLayout,
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocalMusicCollectionScreen(controller: FuoPlayerController) {
+    val selection = controller.selectedLocalMusicCollection ?: return
+    val collections = remember(
+        controller.localTracks,
+        controller.localMusicDirectories,
+        controller.excludedLocalMusicDirectoryIds,
+        selection.mode,
+    ) {
+        buildLocalMusicCollections(
+            mode = selection.mode,
+            tracks = controller.localTracks,
+            directories = controller.localMusicDirectories,
+            excludedDirectoryIds = controller.excludedLocalMusicDirectoryIds,
+        )
+    }
+    val selectedCollection = collections.firstOrNull { it.key == selection.key }
+    LaunchedEffect(selection, selectedCollection, controller.isLoading) {
+        if (!controller.isLoading && selectedCollection == null) {
+            controller.closeLocalMusicCollection()
+        }
+    }
+    val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = selectedCollection?.title ?: selection.key,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = controller::closeLocalMusicCollection) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "返回",
+                        )
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            if (controller.playbackState.currentTrack != null) {
+                MiniPlayer(controller)
+            }
+        },
+    ) { paddingValues ->
+        selectedCollection?.let { collection ->
+            LocalMusicCollectionDetail(
+                controller = controller,
+                collection = collection,
+                mode = selection.mode,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(
+                        horizontal = if (isWideLayout) 20.dp else 16.dp,
+                        vertical = if (isWideLayout) 12.dp else 0.dp,
+                    ),
+                isWideLayout = isWideLayout,
+            )
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
@@ -1,6 +1,7 @@
 package org.feeluown.mobile
 
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
@@ -25,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -38,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -47,28 +51,46 @@ fun LocalMusicSection(
     controller: FuoPlayerController,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
     showModeFilter: Boolean,
     modifier: Modifier,
 ) {
-    LaunchedEffect(hasAudioPermission) {
+    var previousImagePermission by remember { mutableStateOf(hasImagePermission) }
+    LaunchedEffect(hasAudioPermission, hasImagePermission) {
         controller.onLocalMusicPermissionChange(hasAudioPermission)
         if (hasAudioPermission) {
-            controller.ensureLocalMusic()
+            if (!hasImagePermission || !previousImagePermission && hasImagePermission) {
+                controller.refreshLocalMusic()
+            } else {
+                controller.ensureLocalMusic()
+            }
         }
+        previousImagePermission = hasImagePermission
     }
-    val displayTracks = remember(controller.localTracks, controller.localMusicViewMode) {
+    val selectedDirectory = controller.localMusicDirectories.firstOrNull {
+        it.id == controller.selectedLocalMusicDirectoryId
+    }
+    val displayTracks = remember(
+        controller.localTracks,
+        controller.localMusicViewMode,
+        controller.selectedLocalMusicDirectoryId,
+    ) {
+        val tracksInDirectory = controller.selectedLocalMusicDirectoryId?.let { directoryId ->
+            controller.localTracks.filter { it.localDirectoryId == directoryId }
+        } ?: controller.localTracks
         when (controller.localMusicViewMode) {
-            LocalMusicViewMode.All -> controller.localTracks.sortedWith(
+            LocalMusicViewMode.All -> tracksInDirectory.sortedWith(
                 compareBy<MusicTrack> { localTitleSectionOrder(localTitleSection(it.title)) }
                     .thenBy { it.title.lowercase() }
                     .thenBy { it.artists.lowercase() },
             )
-            LocalMusicViewMode.Artist -> controller.localTracks.sortedWith(
+            LocalMusicViewMode.Artist -> tracksInDirectory.sortedWith(
                 compareBy<MusicTrack> { normalizedGroupName(it.artists, "未知歌手").lowercase() }
                     .thenBy { it.album.lowercase() }
                     .thenBy { it.title.lowercase() },
             )
-            LocalMusicViewMode.Album -> controller.localTracks.sortedWith(
+            LocalMusicViewMode.Album -> tracksInDirectory.sortedWith(
                 compareBy<MusicTrack> { normalizedGroupName(it.album, "未知专辑").lowercase() }
                     .thenBy { it.artists.lowercase() }
                     .thenBy { it.title.lowercase() },
@@ -84,19 +106,89 @@ fun LocalMusicSection(
             PermissionPanel(onRequestAudioPermission)
             return@Column
         }
+        if (!hasImagePermission) {
+            LocalMusicImagePermissionPanel(onRequestImagePermission)
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (showModeFilter) {
+            if (selectedDirectory != null) {
+                Row(
+                    modifier = Modifier.weight(1f),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(onClick = controller::closeLocalMusicDirectory) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回文件夹")
+                    }
+                    Text(
+                        text = selectedDirectory.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (showModeFilter) {
+                    LocalMusicViewModeTabs(controller)
+                }
+            } else if (showModeFilter) {
                 LocalMusicViewModeTabs(controller)
             } else {
                 Spacer(Modifier)
             }
-            if (displayTracks.isNotEmpty()) {
+            if (selectedDirectory != null && displayTracks.isNotEmpty()) {
                 PlayAllButton(onClick = { controller.playAllLocalTracks(displayTracks) })
             }
+        }
+        val isDirectoryOverview = controller.localMusicViewMode == LocalMusicViewMode.All &&
+            selectedDirectory == null
+        if (isDirectoryOverview) {
+            val directories = controller.localMusicDirectories.filter {
+                it.id !in controller.excludedLocalMusicDirectoryIds
+            }
+            if (isWideLayout) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    if (directories.isEmpty()) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            EmptyLocalMusicHint()
+                        }
+                    } else {
+                        items(directories, key = { it.id }) { directory ->
+                            LocalMusicDirectoryCard(
+                                directory = directory,
+                                onClick = { controller.openLocalMusicDirectory(directory.id) },
+                            )
+                        }
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    if (directories.isEmpty()) {
+                        item { EmptyLocalMusicHint() }
+                    } else {
+                        itemsIndexed(directories, key = { _, item -> item.id }) { _, directory ->
+                            LocalMusicDirectoryCard(
+                                directory = directory,
+                                onClick = { controller.openLocalMusicDirectory(directory.id) },
+                            )
+                        }
+                    }
+                }
+            }
+            return@Column
         }
         val groups = remember(displayTracks, controller.localMusicViewMode) {
             when (controller.localMusicViewMode) {
@@ -170,6 +262,70 @@ fun LocalMusicSection(
                         HorizontalDivider()
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalMusicDirectoryCard(
+    directory: LocalMusicDirectory,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onClick),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PlatformCoverArt(
+                title = directory.name,
+                imageUrl = directory.coverUrl,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .size(132.dp),
+                placeholder = CoverPlaceholder.Album,
+            )
+            Text(
+                text = directory.name,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = "${directory.trackCount} 首",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocalMusicImagePermissionPanel(onRequestImagePermission: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = "允许读取图片以显示文件夹封面",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            TextButton(onClick = onRequestImagePermission) {
+                Text("授权图片")
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicSection.kt
@@ -1,15 +1,16 @@
 package org.feeluown.mobile
 
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -20,7 +21,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,10 +41,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+
+internal data class LocalMusicCollection(
+    val key: String,
+    val title: String,
+    val coverUrl: String?,
+    val tracks: List<MusicTrack>,
+) {
+    val trackCount: Int get() = tracks.size
+}
 
 @Composable
 fun LocalMusicSection(
@@ -56,11 +64,11 @@ fun LocalMusicSection(
     showModeFilter: Boolean,
     modifier: Modifier,
 ) {
-    var previousImagePermission by remember { mutableStateOf(hasImagePermission) }
+    var previousImagePermission by remember { mutableStateOf<Boolean?>(null) }
     LaunchedEffect(hasAudioPermission, hasImagePermission) {
         controller.onLocalMusicPermissionChange(hasAudioPermission)
         if (hasAudioPermission) {
-            if (!hasImagePermission || !previousImagePermission && hasImagePermission) {
+            if (previousImagePermission == false && hasImagePermission) {
                 controller.refreshLocalMusic()
             } else {
                 controller.ensureLocalMusic()
@@ -68,33 +76,31 @@ fun LocalMusicSection(
         }
         previousImagePermission = hasImagePermission
     }
-    val selectedDirectory = controller.localMusicDirectories.firstOrNull {
-        it.id == controller.selectedLocalMusicDirectoryId
-    }
-    val displayTracks = remember(
+    val viewMode = controller.localMusicViewMode
+    val collections = remember(
         controller.localTracks,
-        controller.localMusicViewMode,
-        controller.selectedLocalMusicDirectoryId,
+        controller.localMusicDirectories,
+        controller.excludedLocalMusicDirectoryIds,
+        viewMode,
     ) {
-        val tracksInDirectory = controller.selectedLocalMusicDirectoryId?.let { directoryId ->
-            controller.localTracks.filter { it.localDirectoryId == directoryId }
-        } ?: controller.localTracks
-        when (controller.localMusicViewMode) {
-            LocalMusicViewMode.All -> tracksInDirectory.sortedWith(
-                compareBy<MusicTrack> { localTitleSectionOrder(localTitleSection(it.title)) }
-                    .thenBy { it.title.lowercase() }
-                    .thenBy { it.artists.lowercase() },
+        buildLocalMusicCollections(
+            mode = viewMode,
+            tracks = controller.localTracks,
+            directories = controller.localMusicDirectories,
+            excludedDirectoryIds = controller.excludedLocalMusicDirectoryIds,
+        )
+    }
+    val selection = controller.selectedLocalMusicCollection
+    val selectedCollection = selection
+        ?.takeIf { it.mode == viewMode }
+        ?.let { current -> collections.firstOrNull { it.key == current.key } }
+    LaunchedEffect(selection, viewMode, collections, controller.isLoading) {
+        if (selection != null && (
+                selection.mode != viewMode ||
+                    !controller.isLoading && collections.none { it.key == selection.key }
             )
-            LocalMusicViewMode.Artist -> tracksInDirectory.sortedWith(
-                compareBy<MusicTrack> { normalizedGroupName(it.artists, "未知歌手").lowercase() }
-                    .thenBy { it.album.lowercase() }
-                    .thenBy { it.title.lowercase() },
-            )
-            LocalMusicViewMode.Album -> tracksInDirectory.sortedWith(
-                compareBy<MusicTrack> { normalizedGroupName(it.album, "未知专辑").lowercase() }
-                    .thenBy { it.artists.lowercase() }
-                    .thenBy { it.title.lowercase() },
-            )
+        ) {
+            controller.closeLocalMusicCollection()
         }
     }
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
@@ -114,16 +120,16 @@ fun LocalMusicSection(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (selectedDirectory != null) {
+            if (selectedCollection != null) {
                 Row(
                     modifier = Modifier.weight(1f),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    IconButton(onClick = controller::closeLocalMusicDirectory) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回文件夹")
+                    IconButton(onClick = controller::closeLocalMusicCollection) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                     }
                     Text(
-                        text = selectedDirectory.name,
+                        text = selectedCollection.title,
                         style = MaterialTheme.typography.titleMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -137,130 +143,82 @@ fun LocalMusicSection(
             } else {
                 Spacer(Modifier)
             }
-            if (selectedDirectory != null && displayTracks.isNotEmpty()) {
-                PlayAllButton(onClick = { controller.playAllLocalTracks(displayTracks) })
-            }
         }
-        val isDirectoryOverview = controller.localMusicViewMode == LocalMusicViewMode.All &&
-            selectedDirectory == null
-        if (isDirectoryOverview) {
-            val directories = controller.localMusicDirectories.filter {
-                it.id !in controller.excludedLocalMusicDirectoryIds
-            }
-            if (isWideLayout) {
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(2),
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    if (directories.isEmpty()) {
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            EmptyLocalMusicHint()
-                        }
-                    } else {
-                        items(directories, key = { it.id }) { directory ->
-                            LocalMusicDirectoryCard(
-                                directory = directory,
-                                onClick = { controller.openLocalMusicDirectory(directory.id) },
-                            )
-                        }
-                    }
-                }
-            } else {
-                LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    if (directories.isEmpty()) {
-                        item { EmptyLocalMusicHint() }
-                    } else {
-                        itemsIndexed(directories, key = { _, item -> item.id }) { _, directory ->
-                            LocalMusicDirectoryCard(
-                                directory = directory,
-                                onClick = { controller.openLocalMusicDirectory(directory.id) },
-                            )
-                        }
-                    }
-                }
-            }
-            return@Column
-        }
-        val groups = remember(displayTracks, controller.localMusicViewMode) {
-            when (controller.localMusicViewMode) {
-                LocalMusicViewMode.All -> displayTracks.groupBy { localTitleSection(it.title) }
-                LocalMusicViewMode.Artist -> displayTracks.groupBy { normalizedGroupName(it.artists, "未知歌手") }
-                LocalMusicViewMode.Album -> displayTracks.groupBy { normalizedGroupName(it.album, "未知专辑") }
-            }
-        }
-        if (isWideLayout) {
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
+        if (selectedCollection == null) {
+            LocalMusicCollectionOverview(
+                mode = viewMode,
+                collections = collections,
+                onClick = { controller.openLocalMusicCollection(viewMode, it.key) },
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                if (displayTracks.isEmpty()) {
-                    item(span = { GridItemSpan(maxLineSpan) }) {
-                        EmptyLocalMusicHint()
-                    }
-                } else {
-                    groups.forEach { (section, tracks) ->
-                        item(key = "section:$section", span = { GridItemSpan(maxLineSpan) }) {
-                            LocalMusicSectionHeader(title = section, count = tracks.size)
-                        }
-                        items(tracks, key = { it.id }) { track ->
-                            TrackRow(
-                                track = track,
-                                downloadState = controller.downloadStates[track.id],
-                                onClick = { controller.playLocalTrack(track, displayTracks) },
-                                onAddToUpNext = { controller.addToUpNext(track) },
-                                onDownload = { controller.download(track) },
-                                onDeleteDownload = { controller.deleteDownload(track) },
-                                onOpenArtist = { controller.openTrackArtist(track) },
-                                onOpenAlbum = { controller.openTrackAlbum(track) },
-                                onEditLocalMetadata = { controller.openLocalMetadataEditor(track) },
-                            )
-                        }
-                    }
-                }
-            }
+            )
             return@Column
         }
-        LazyColumn(
+        LocalMusicCollectionDetail(
+            controller = controller,
+            collection = selectedCollection,
+            mode = viewMode,
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
-        ) {
-            if (displayTracks.isEmpty()) {
-                item {
-                    EmptyLocalMusicHint()
-                }
-            } else {
-                groups.forEach { (section, tracks) ->
-                    item(key = "section:$section") {
-                        LocalMusicSectionHeader(title = section, count = tracks.size)
-                    }
-                    itemsIndexed(tracks, key = { _, item -> item.id }) { _, track ->
-                        TrackRow(
-                            track = track,
-                            downloadState = controller.downloadStates[track.id],
-                            onClick = { controller.playLocalTrack(track, displayTracks) },
-                            onAddToUpNext = { controller.addToUpNext(track) },
-                            onDownload = { controller.download(track) },
-                            onDeleteDownload = { controller.deleteDownload(track) },
-                            onOpenArtist = { controller.openTrackArtist(track) },
-                            onOpenAlbum = { controller.openTrackAlbum(track) },
-                            onEditLocalMetadata = { controller.openLocalMetadataEditor(track) },
-                        )
-                        HorizontalDivider()
-                    }
+            isWideLayout = isWideLayout,
+        )
+    }
+}
+
+@Composable
+private fun LocalMusicCollectionOverview(
+    mode: LocalMusicViewMode,
+    collections: List<LocalMusicCollection>,
+    onClick: (LocalMusicCollection) -> Unit,
+    modifier: Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(if (LocalAppLayoutInfo.current.useWideLayout) 8.dp else 12.dp),
+    ) {
+        if (collections.isEmpty()) {
+            item { EmptyLocalMusicHint() }
+        } else {
+            item(key = "local-music-collections") {
+                when (mode) {
+                    LocalMusicViewMode.All -> ProviderPlaylistGrid(
+                        playlists = collections.map { collection ->
+                            ProviderPlaylist(
+                                id = collection.key,
+                                title = collection.title,
+                                providerId = "local",
+                                providerName = "本地 · ${collection.trackCount} 首",
+                                coverUrl = collection.coverUrl,
+                                trackCount = collection.trackCount,
+                            )
+                        },
+                        onClick = { playlist ->
+                            collections.firstOrNull { it.key == playlist.id }?.let(onClick)
+                        },
+                    )
+                    LocalMusicViewMode.Artist,
+                    LocalMusicViewMode.Album -> ProviderMediaItemGrid(
+                        items = collections.map { collection ->
+                            ProviderMediaItem(
+                                id = collection.key,
+                                title = collection.title,
+                                providerId = "local",
+                                providerName = "本地",
+                                type = if (mode == LocalMusicViewMode.Artist) {
+                                    ProviderMediaItemType.Artist
+                                } else {
+                                    ProviderMediaItemType.Album
+                                },
+                                coverUrl = collection.coverUrl,
+                                trackCount = collection.trackCount,
+                            )
+                        },
+                        onClick = { item ->
+                            collections.firstOrNull { it.key == item.id }?.let(onClick)
+                        },
+                    )
                 }
             }
         }
@@ -268,42 +226,230 @@ fun LocalMusicSection(
 }
 
 @Composable
-private fun LocalMusicDirectoryCard(
-    directory: LocalMusicDirectory,
-    onClick: () -> Unit,
+private fun LocalMusicCollectionDetail(
+    controller: FuoPlayerController,
+    collection: LocalMusicCollection,
+    mode: LocalMusicViewMode,
+    modifier: Modifier,
+    isWideLayout: Boolean,
 ) {
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .fuoInteractive()
-            .clickable(role = Role.Button, onClick = onClick),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = MaterialTheme.shapes.medium,
-    ) {
-        Column(
-            modifier = Modifier.padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+    val displayTrack = collection.toDisplayTrack(mode)
+    val placeholder = mode.localMusicCollectionPlaceholder()
+    val subtitle = mode.localMusicCollectionSubtitle(collection.trackCount)
+    if (isWideLayout) {
+        Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            PlatformCoverArt(
-                title = directory.name,
-                imageUrl = directory.coverUrl,
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .size(132.dp),
-                placeholder = CoverPlaceholder.Album,
-            )
-            Text(
-                text = directory.name,
-                style = MaterialTheme.typography.titleMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = "${directory.trackCount} 首",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    .weight(0.36f)
+                    .widthIn(min = 240.dp, max = 360.dp)
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                CoverBox(
+                    track = displayTrack,
+                    modifier = Modifier.size(168.dp),
+                    placeholder = placeholder,
+                )
+                Text(
+                    text = collection.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (collection.tracks.isNotEmpty()) {
+                    PlayAllButton(onClick = { controller.playAllLocalTracks(collection.tracks) })
+                }
+            }
+            LocalMusicTrackList(
+                controller = controller,
+                tracks = collection.tracks,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                isWideLayout = true,
             )
         }
+    } else {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            ProviderDetailHeader(
+                track = displayTrack,
+                title = collection.title,
+                subtitle = subtitle,
+                description = "",
+                placeholder = placeholder,
+                action = {
+                    PlayAllButton(
+                        onClick = { controller.playAllLocalTracks(collection.tracks) },
+                        enabled = collection.tracks.isNotEmpty(),
+                    )
+                },
+            )
+            LocalMusicTrackList(
+                controller = controller,
+                tracks = collection.tracks,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                isWideLayout = false,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocalMusicTrackList(
+    controller: FuoPlayerController,
+    tracks: List<MusicTrack>,
+    modifier: Modifier,
+    isWideLayout: Boolean,
+) {
+    if (isWideLayout) {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            if (tracks.isEmpty()) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    ProviderContentMessage("暂无歌曲")
+                }
+            } else {
+                items(tracks, key = { it.id }) { track ->
+                    LocalMusicTrackRow(controller, track, tracks)
+                }
+            }
+        }
+    } else {
+        LazyColumn(modifier = modifier) {
+            if (tracks.isEmpty()) {
+                item { ProviderContentMessage("暂无歌曲") }
+            } else {
+                itemsIndexed(tracks, key = { _, item -> item.id }) { _, track ->
+                    LocalMusicTrackRow(controller, track, tracks)
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocalMusicTrackRow(
+    controller: FuoPlayerController,
+    track: MusicTrack,
+    queue: List<MusicTrack>,
+) {
+    TrackRow(
+        track = track,
+        downloadState = controller.downloadStates[track.id],
+        onClick = { controller.playLocalTrack(track, queue) },
+        onAddToUpNext = { controller.addToUpNext(track) },
+        onDownload = { controller.download(track) },
+        onDeleteDownload = { controller.deleteDownload(track) },
+        onOpenArtist = { controller.openTrackArtist(track) },
+        onOpenAlbum = { controller.openTrackAlbum(track) },
+        onEditLocalMetadata = { controller.openLocalMetadataEditor(track) },
+    )
+}
+
+internal fun buildLocalMusicCollections(
+    mode: LocalMusicViewMode,
+    tracks: List<MusicTrack>,
+    directories: List<LocalMusicDirectory>,
+    excludedDirectoryIds: Set<String>,
+): List<LocalMusicCollection> {
+    val sortedTracks = when (mode) {
+        LocalMusicViewMode.All -> tracks.sortedWith(
+            compareBy<MusicTrack> { localTitleSectionOrder(localTitleSection(it.title)) }
+                .thenBy { it.title.lowercase() }
+                .thenBy { it.artists.lowercase() },
+        )
+        LocalMusicViewMode.Artist -> tracks.sortedWith(
+            compareBy<MusicTrack> { normalizedGroupName(it.artists, "未知歌手").lowercase() }
+                .thenBy { it.album.lowercase() }
+                .thenBy { it.title.lowercase() },
+        )
+        LocalMusicViewMode.Album -> tracks.sortedWith(
+            compareBy<MusicTrack> { normalizedGroupName(it.album, "未知专辑").lowercase() }
+                .thenBy { it.artists.lowercase() }
+                .thenBy { it.title.lowercase() },
+        )
+    }
+    return when (mode) {
+        LocalMusicViewMode.All -> directories
+            .filter { directory -> !isLocalMusicDirectoryExcluded(directory.id, excludedDirectoryIds) }
+            .map { directory ->
+                LocalMusicCollection(
+                    key = directory.id,
+                    title = directory.name,
+                    coverUrl = directory.coverUrl,
+                    tracks = sortedTracks.filter { it.localDirectoryId == directory.id },
+                )
+            }
+        LocalMusicViewMode.Artist -> sortedTracks
+            .groupBy { normalizedGroupName(it.artists, "未知歌手") }
+            .entries
+            .map { (name, group) ->
+                LocalMusicCollection(
+                    key = name,
+                    title = name,
+                    coverUrl = group.firstNotNullOfOrNull { it.coverUrl },
+                    tracks = group,
+                )
+            }
+        LocalMusicViewMode.Album -> sortedTracks
+            .groupBy { normalizedGroupName(it.album, "未知专辑") }
+            .entries
+            .map { (name, group) ->
+                LocalMusicCollection(
+                    key = name,
+                    title = name,
+                    coverUrl = group.firstNotNullOfOrNull { it.coverUrl },
+                    tracks = group,
+                )
+            }
+    }
+}
+
+private fun LocalMusicCollection.toDisplayTrack(mode: LocalMusicViewMode): MusicTrack {
+    return MusicTrack(
+        id = "local-collection:${mode.name}:$key",
+        title = title,
+        artists = if (mode == LocalMusicViewMode.Artist) title else "本地",
+        album = if (mode == LocalMusicViewMode.Album) title else "",
+        source = "local",
+        sourceType = TrackSourceType.LocalMediaStore,
+        coverUrl = coverUrl,
+    )
+}
+
+private fun LocalMusicViewMode.localMusicCollectionPlaceholder(): CoverPlaceholder {
+    return when (this) {
+        LocalMusicViewMode.All -> CoverPlaceholder.Playlist
+        LocalMusicViewMode.Artist -> CoverPlaceholder.Artist
+        LocalMusicViewMode.Album -> CoverPlaceholder.Album
+    }
+}
+
+private fun LocalMusicViewMode.localMusicCollectionSubtitle(trackCount: Int): String {
+    return when (this) {
+        LocalMusicViewMode.All -> "本地文件夹 · $trackCount 首"
+        LocalMusicViewMode.Artist -> "本地 · 歌手 · $trackCount 首"
+        LocalMusicViewMode.Album -> "本地 · 专辑 · $trackCount 首"
     }
 }
 
@@ -321,7 +467,7 @@ private fun LocalMusicImagePermissionPanel(onRequestImagePermission: () -> Unit)
         ) {
             Text(
                 modifier = Modifier.weight(1f),
-                text = "允许读取图片以显示文件夹封面",
+                text = "允许读取图片以显示封面",
                 style = MaterialTheme.typography.bodySmall,
             )
             TextButton(onClick = onRequestImagePermission) {
@@ -512,31 +658,6 @@ fun LocalMusicViewModeTabs(controller: FuoPlayerController) {
                 label = label,
             )
         }
-    }
-}
-
-@Composable
-fun LocalMusicSectionHeader(title: String, count: Int) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 10.dp, bottom = 6.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.primary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-            text = "$count 首",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -37,6 +37,8 @@ fun MineHomeSection(
     controller: FuoPlayerController,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
     modifier: Modifier,
 ) {
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
@@ -93,6 +95,8 @@ fun MineHomeSection(
                     controller = controller,
                     hasAudioPermission = hasAudioPermission,
                     onRequestAudioPermission = onRequestAudioPermission,
+                    hasImagePermission = hasImagePermission,
+                    onRequestImagePermission = onRequestImagePermission,
                     showModeFilter = !isWideLayout,
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1338,7 +1338,7 @@ fun sourceLabel(track: MusicTrack, downloadState: DownloadState?): String {
         when (track.sourceType) {
             TrackSourceType.Provider -> track.providerName ?: track.source.ifBlank { "音源" }
             TrackSourceType.LocalMediaStore -> "本地"
-            TrackSourceType.Downloaded -> track.providerName ?: "FeelUOwn"
+            TrackSourceType.Downloaded -> "本地"
         },
         "智能替换".takeIf { track.isSmartReplacement },
         "不可用".takeIf { track.isUnavailable },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -1108,14 +1108,20 @@ fun LocalMusicScanSettingsPanel(controller: FuoPlayerController) {
                             .clickable(role = Role.Button) {
                                 controller.onLocalMusicDirectoryEnabledChange(
                                     directory.id,
-                                    directory.id in controller.excludedLocalMusicDirectoryIds,
+                                    isLocalMusicDirectoryExcluded(
+                                        directory.id,
+                                        controller.excludedLocalMusicDirectoryIds,
+                                    ),
                                 )
                             },
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Checkbox(
-                            checked = directory.id !in controller.excludedLocalMusicDirectoryIds,
+                            checked = !isLocalMusicDirectoryExcluded(
+                                directory.id,
+                                controller.excludedLocalMusicDirectoryIds,
+                            ),
                             onCheckedChange = {
                                 controller.onLocalMusicDirectoryEnabledChange(directory.id, it)
                             },

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppNavigatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppNavigatorTest.kt
@@ -31,4 +31,15 @@ class AppNavigatorTest {
 
         assertEquals(listOf(AppRoute.Home), navigator.backStack.value)
     }
+
+    @Test
+    fun localMusicCollectionUsesAnIndependentRoute() {
+        val navigator = AppNavigator()
+
+        navigator.navigate(AppRoute.LocalMusicCollection)
+
+        assertEquals(listOf(AppRoute.Home, AppRoute.LocalMusicCollection), navigator.backStack.value)
+        assertTrue(navigator.pop(AppRoute.LocalMusicCollection))
+        assertEquals(listOf(AppRoute.Home), navigator.backStack.value)
+    }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -2621,6 +2621,51 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun localMusicDirectorySelectionUsesDirectoryTracksAndSystemBack() = runTest {
+        val directoryA = LocalMusicDirectory("Music/A/", "A", 2)
+        val directoryB = LocalMusicDirectory("Music/B/", "B", 1)
+        val local = FakeLocalMusicRepository(
+            directories = listOf(directoryA, directoryB),
+            tracks = listOf(
+                localTrack("local:1", "A song").copy(localDirectoryId = directoryA.id),
+                localTrack("local:2", "B song").copy(localDirectoryId = directoryB.id),
+            ),
+        )
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(emptyList()),
+                localRepository = local,
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = FakePlaybackEngine(),
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.onLocalMusicPermissionChange(true)
+            controller.onMineSectionChange(MineSection.LocalMusic)
+            advanceUntilIdle()
+
+            controller.openLocalMusicDirectory(directoryA.id)
+
+            assertEquals(directoryA.id, controller.selectedLocalMusicDirectoryId)
+            assertEquals(
+                listOf("A song"),
+                controller.localTracks.filter { it.localDirectoryId == controller.selectedLocalMusicDirectoryId }
+                    .map { it.title },
+            )
+            assertTrue(controller.navigateBack())
+            assertNull(controller.selectedLocalMusicDirectoryId)
+
+            controller.openLocalMusicDirectory(directoryA.id)
+            controller.onLocalMusicViewModeChange(LocalMusicViewMode.Artist)
+            assertNull(controller.selectedLocalMusicDirectoryId)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun readyLocalMusicDatabaseReadsTracksWithoutRefresh() = runTest {
         val local = FakeLocalMusicRepository(
             tracks = listOf(localTrack("local:content://music/1", "Cached")),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -2402,7 +2402,7 @@ class FuoPlayerControllerTest {
                 mineSection = MineSection.LocalMusic,
                 playlistFilter = PlaylistFilter.FavoritePlaylists,
                 localMusicViewMode = LocalMusicViewMode.Album,
-                excludedLocalMusicDirectoryIds = setOf("Podcasts/"),
+                excludedLocalMusicDirectoryIds = setOf("Podcasts"),
                 localMusicMinDurationSeconds = 30,
                 providerLoginMode = ProviderLoginMode.Cookie,
                 providerCookieInputs = mapOf("netease" to """{"MUSIC_U":"saved"}"""),
@@ -2660,6 +2660,14 @@ class FuoPlayerControllerTest {
             controller.openLocalMusicDirectory(directoryA.id)
             controller.onLocalMusicViewModeChange(LocalMusicViewMode.Artist)
             assertNull(controller.selectedLocalMusicDirectoryId)
+
+            controller.openLocalMusicCollection(LocalMusicViewMode.Artist, "歌手 A")
+            assertEquals(
+                LocalMusicCollectionSelection(LocalMusicViewMode.Artist, "歌手 A"),
+                controller.selectedLocalMusicCollection,
+            )
+            assertTrue(controller.navigateBack())
+            assertNull(controller.selectedLocalMusicCollection)
         } finally {
             controllerScope.cancel()
         }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicPresentationTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicPresentationTest.kt
@@ -1,0 +1,48 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalMusicPresentationTest {
+    @Test
+    fun localSourcesUseLocalLabel() {
+        assertEquals("本地", sourceLabel(localTrack(TrackSourceType.LocalMediaStore), null))
+        assertEquals("本地", sourceLabel(localTrack(TrackSourceType.Downloaded), null))
+        assertEquals("网易云音乐", sourceLabel(providerTrack(), null))
+    }
+
+    @Test
+    fun playbackQueueKeepsDirectoryIdAndReadsOlderTracks() {
+        val track = localTrack(TrackSourceType.LocalMediaStore).copy(localDirectoryId = "Music/A/")
+        val snapshot = PlaybackQueueSnapshot(mainQueue = listOf(track))
+
+        val decoded = PlaybackQueueCodec.decode(PlaybackQueueCodec.encode(snapshot)).mainQueue.single()
+
+        assertEquals("Music/A/", decoded.localDirectoryId)
+
+        val legacy = PlaybackQueueCodec.encode(snapshot).lineSequence().joinToString("\n") { line ->
+            if (line.startsWith("track\t")) line.substringBeforeLast('\t') else line
+        }
+        assertNull(PlaybackQueueCodec.decode(legacy).mainQueue.single().localDirectoryId)
+    }
+
+    private fun localTrack(sourceType: TrackSourceType) = MusicTrack(
+        id = "local:track",
+        title = "本地歌曲",
+        artists = "歌手",
+        album = "专辑",
+        source = "local",
+        sourceType = sourceType,
+    )
+
+    private fun providerTrack() = MusicTrack(
+        id = "netease:track",
+        title = "在线歌曲",
+        artists = "歌手",
+        album = "专辑",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+        providerName = "网易云音乐",
+    )
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicPresentationTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicPresentationTest.kt
@@ -3,8 +3,54 @@ package org.feeluown.mobile
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LocalMusicPresentationTest {
+    @Test
+    fun directoryExclusionsAcceptLegacyAndCanonicalIds() {
+        assertEquals("Music/Foo/", canonicalLocalMusicDirectoryId("Music/Foo"))
+        assertTrue(isLocalMusicDirectoryExcluded("Music/Foo/", setOf("Music/Foo")))
+        assertTrue(isLocalMusicDirectoryExcluded("Music/Foo", setOf("Music/Foo/")))
+    }
+
+    @Test
+    fun artistAndAlbumModesCreateSecondLevelCollections() {
+        val tracks = listOf(
+            localTrack(TrackSourceType.LocalMediaStore).copy(
+                id = "local:two",
+                title = "第二首",
+                artists = "歌手 B",
+                album = "专辑 2",
+                coverUrl = "cover-2",
+            ),
+            localTrack(TrackSourceType.LocalMediaStore).copy(
+                id = "local:one",
+                title = "第一首",
+                artists = "歌手 A",
+                album = "专辑 1",
+                coverUrl = "cover-1",
+            ),
+        )
+
+        val artists = buildLocalMusicCollections(
+            mode = LocalMusicViewMode.Artist,
+            tracks = tracks,
+            directories = emptyList(),
+            excludedDirectoryIds = emptySet(),
+        )
+        val albums = buildLocalMusicCollections(
+            mode = LocalMusicViewMode.Album,
+            tracks = tracks,
+            directories = emptyList(),
+            excludedDirectoryIds = emptySet(),
+        )
+
+        assertEquals(listOf("歌手 A", "歌手 B"), artists.map { it.title })
+        assertEquals(listOf("专辑 1", "专辑 2"), albums.map { it.title })
+        assertEquals(listOf("第一首"), artists.first().tracks.map { it.title })
+        assertEquals("cover-1", albums.first().coverUrl)
+    }
+
     @Test
     fun localSourcesUseLocalLabel() {
         assertEquals("本地", sourceLabel(localTrack(TrackSourceType.LocalMediaStore), null))

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosLocalMusicRepository.kt
@@ -36,7 +36,14 @@ class IosLocalMusicRepository(
 
     override suspend fun directories(): List<LocalMusicDirectory> {
         if (cachedTracks.isEmpty()) return emptyList()
-        return listOf(LocalMusicDirectory(LIBRARY_DIRECTORY_ID, "媒体资料库", cachedTracks.size))
+        return listOf(
+            LocalMusicDirectory(
+                id = LIBRARY_DIRECTORY_ID,
+                name = "歌曲",
+                trackCount = cachedTracks.size,
+                coverUrl = cachedTracks.firstNotNullOfOrNull { it.coverUrl },
+            ),
+        )
     }
 
     override suspend fun tracks(): List<MusicTrack> = if (libraryTracks.isEmpty()) refreshDatabase() else cachedTracks
@@ -54,8 +61,10 @@ class IosLocalMusicRepository(
                 album = item["album"]?.jsonPrimitive?.contentOrNull.orEmpty(),
                 source = "本地音乐",
                 sourceType = TrackSourceType.LocalMediaStore,
+                coverUrl = item["artwork_url"]?.jsonPrimitive?.contentOrNull,
                 durationMs = item["duration_ms"]?.jsonPrimitive?.longOrNull,
                 localUri = item["local_uri"]?.jsonPrimitive?.contentOrNull,
+                localDirectoryId = LIBRARY_DIRECTORY_ID,
             ))
         }
         cachedTracks = filterTracks(libraryTracks)

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.skia.Image
 import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLSession
 import platform.Foundation.dataTaskWithURL
@@ -85,7 +86,11 @@ private suspend fun loadImage(imageUrl: String): ImageBitmap? = withContext(Disp
         else -> imageUrl
     } ?: return@withContext null
     val url = NSURL.URLWithString(resolvedUrl) ?: return@withContext null
-    val data = fetchData(url) ?: return@withContext null
+    val data = if (url.scheme == "file") {
+        url.path?.let { NSFileManager.defaultManager.contentsAtPath(it) }
+    } else {
+        fetchData(url)
+    } ?: return@withContext null
     val bytes = data.bytes?.reinterpret<ByteVar>()?.readBytes(data.length.toInt()) ?: return@withContext null
     runCatching { Image.makeFromEncoded(bytes).toComposeImageBitmap() }.getOrNull()
 }

--- a/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlatformRepositoriesTest.kt
+++ b/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlatformRepositoriesTest.kt
@@ -74,6 +74,11 @@ class IosPlatformRepositoriesTest {
 
         repository.updateScanSettings(LocalMusicScanSettings())
         assertEquals(listOf("Short track", "Long track"), repository.tracks().map { it.title })
+        val directory = repository.directories().single()
+        assertEquals("歌曲", directory.name)
+        assertEquals(2, directory.trackCount)
+        assertEquals("file:///tmp/short.jpg", directory.coverUrl)
+        assertEquals("ios-media-library", repository.tracks().first().localDirectoryId)
         assertEquals(1, mediaLibrary.trackRequests)
     }
 
@@ -166,7 +171,8 @@ class IosPlatformRepositoriesTest {
                       "artists": "Artist",
                       "album": "Album",
                       "duration_ms": 30000,
-                      "local_uri": "ipod-library://short"
+                      "local_uri": "ipod-library://short",
+                      "artwork_url": "file:///tmp/short.jpg"
                     },
                     {
                       "id": "long",
@@ -174,7 +180,8 @@ class IosPlatformRepositoriesTest {
                       "artists": "Artist",
                       "album": "Album",
                       "duration_ms": 120000,
-                      "local_uri": "ipod-library://long"
+                      "local_uri": "ipod-library://long",
+                      "artwork_url": "file:///tmp/long.jpg"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary

- Add local music directory discovery and repository implementations for Android and iOS
- Integrate local music into Home, Mine, player controls, and playback state flows
- Add platform-specific permissions, cover art handling, and native audio integration
- Add unit coverage for player control, local music presentation, and iOS repositories

## Testing

- Added shared and iOS unit tests
- Not run (not requested)