### PR TITLE
[feat] add Expressive cover-based theme colors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ serializationJson = "1.8.1"
 lifecycle = "2.10.0"
 navigation3 = "1.1.1"
 datastore = "1.2.1"
+materialKolor = "5.0.0-alpha07"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -25,6 +26,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
 compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.11.0-alpha07" }
+material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.animation)
             implementation(libs.compose.material3.expressive)
+            implementation(libs.material.kolor)
             implementation(compose.materialIconsExtended)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformCoverArt.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformCoverArt.android.kt
@@ -47,16 +47,7 @@ actual fun PlatformCoverArt(
     modifier: Modifier,
     placeholder: CoverPlaceholder,
 ) {
-    val context = LocalContext.current
-    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
-
-    LaunchedEffect(imageUrl) {
-        image = imageUrl?.takeIf { it.isNotBlank() }?.let {
-            runCatching { loadCover(context, it) }.getOrNull()
-        }
-    }
-
-    val bitmap = image
+    val bitmap = rememberPlatformCoverImage(imageUrl)
     if (bitmap != null) {
         Image(
             bitmap = bitmap,
@@ -67,6 +58,21 @@ actual fun PlatformCoverArt(
     } else {
         CoverFallback(placeholder = placeholder, modifier = modifier)
     }
+}
+
+@Composable
+internal actual fun rememberPlatformCoverImage(imageUrl: String?): ImageBitmap? {
+    val context = LocalContext.current
+    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
+
+    LaunchedEffect(imageUrl) {
+        image = imageUrl?.takeIf { it.isNotBlank() }?.let {
+            runCatching {
+                PlatformCoverImageCache.getOrLoad(it) { loadCover(context, it) }
+            }.getOrNull()
+        }
+    }
+    return image
 }
 
 private suspend fun loadCover(context: Context, imageUrl: String): ImageBitmap? = withContext(Dispatchers.IO) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -224,6 +224,8 @@ fun AppRoot(
     FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
+        dynamicCoverColorEnabled = controller.dynamicCoverColorEnabled,
+        coverImageUrl = controller.playbackState.currentTrack?.coverUrl,
     ) {
         if (!controller.isSettingsLoaded) {
             AppInitializationLoadingScreen()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -224,8 +224,6 @@ fun AppRoot(
     FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
-        dynamicCoverColorEnabled = controller.dynamicCoverColorEnabled,
-        coverImageUrl = controller.playbackState.currentTrack?.coverUrl,
     ) {
         if (!controller.isSettingsLoaded) {
             AppInitializationLoadingScreen()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -70,7 +70,7 @@ enum class RepeatMode(
 enum class ThemeColorScheme(
     val label: String,
 ) {
-    Dynamic("动态颜色"),
+    Dynamic("系统动态"),
     ExpressiveDefault("Expressive 默认"),
     FuoGreen("青绿"),
     OceanBlue("海蓝"),
@@ -111,6 +111,7 @@ data class AppSettings(
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
+    val dynamicCoverColorEnabled: Boolean = false,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -322,6 +322,8 @@ class FuoPlayerController(
         private set
     var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
         private set
+    var dynamicCoverColorEnabled by mutableStateOf(false)
+        private set
     var debugLogLines by mutableStateOf<List<String>>(emptyList())
         private set
     var debugLogLevelFilters by mutableStateOf(DEFAULT_DEBUG_LOG_LEVEL_FILTERS)
@@ -1377,6 +1379,11 @@ class FuoPlayerController(
 
     fun onThemeColorSchemeChange(value: ThemeColorScheme) {
         themeColorScheme = value
+        persistSettings()
+    }
+
+    fun onDynamicCoverColorEnabledChange(value: Boolean) {
+        dynamicCoverColorEnabled = value
         persistSettings()
     }
 
@@ -4338,6 +4345,7 @@ class FuoPlayerController(
         lyricFontSize = settings.lyricFontSize
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
+        dynamicCoverColorEnabled = settings.dynamicCoverColorEnabled
     }
 
     private fun persistSettings() {
@@ -4377,6 +4385,7 @@ class FuoPlayerController(
             lyricFontSize = lyricFontSize,
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
+            dynamicCoverColorEnabled = dynamicCoverColorEnabled,
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -7,22 +7,68 @@ import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.expressiveLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamicColorScheme
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.ktx.themeColorOrNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.math.pow
+
+private const val COVER_THEME_MAX_COLORS = 128
+private const val REQUIRED_CONTRAST_RATIO = 4.5
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FuoTheme(
     themeMode: ThemeMode,
     themeColorScheme: ThemeColorScheme,
+    dynamicCoverColorEnabled: Boolean = false,
+    coverImageUrl: String? = null,
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
+    val normalizedCoverUrl = coverImageUrl?.takeIf { it.isNotBlank() }
+    val coverImage = rememberPlatformCoverImage(
+        if (dynamicCoverColorEnabled) normalizedCoverUrl else null,
+    )
+    val coverColorScheme by produceState<ColorScheme?>(
+        initialValue = null,
+        dynamicCoverColorEnabled,
+        normalizedCoverUrl,
+        darkTheme,
+        coverImage,
+    ) {
+        value = null
+        if (!dynamicCoverColorEnabled || normalizedCoverUrl == null || coverImage == null) {
+            return@produceState
+        }
+
+        val cacheKey = "$normalizedCoverUrl|$darkTheme"
+        CoverThemeSchemeCache.get(cacheKey)?.let {
+            value = it
+            return@produceState
+        }
+
+        val scheme = withContext(Dispatchers.Default) {
+            coverImage.themeColorOrNull(maxColors = COVER_THEME_MAX_COLORS)
+                ?.let { seedColor -> expressiveColorScheme(seedColor, darkTheme) }
+        }?.takeIf(::hasAccessibleContrast)
+
+        if (scheme != null) {
+            CoverThemeSchemeCache.put(cacheKey, scheme)
+        }
+        value = scheme
+    }
+
     MaterialExpressiveTheme(
-        colorScheme = fuoColorScheme(themeColorScheme, darkTheme),
+        colorScheme = fuoColorScheme(themeColorScheme, darkTheme, coverColorScheme),
         motionScheme = MotionScheme.expressive(),
         shapes = FuoShapes,
         typography = FuoTypography,
@@ -42,9 +88,16 @@ internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boole
 }
 
 @Composable
-private fun fuoColorScheme(themeColorScheme: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
+private fun fuoColorScheme(
+    themeColorScheme: ThemeColorScheme,
+    darkTheme: Boolean,
+    coverColorScheme: ColorScheme?,
+): ColorScheme {
+    coverColorScheme?.takeIf(::hasAccessibleContrast)?.let { return it }
     if (themeColorScheme == ThemeColorScheme.Dynamic) {
-        platformDynamicColorScheme(darkTheme)?.let { return it }
+        platformDynamicColorScheme(darkTheme)
+            ?.takeIf(::hasAccessibleContrast)
+            ?.let { return it }
     }
     return presetColorScheme(
         preset = if (themeColorScheme == ThemeColorScheme.Dynamic) {
@@ -59,188 +112,101 @@ private fun fuoColorScheme(themeColorScheme: ThemeColorScheme, darkTheme: Boolea
 @Composable
 internal expect fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme?
 
+@Composable
 internal fun themePreviewColor(themeColorScheme: ThemeColorScheme, darkTheme: Boolean): Color {
     if (themeColorScheme == ThemeColorScheme.Dynamic) {
-        return if (darkTheme) Color(0xFFB8C8FF) else Color(0xFF3F5FDC)
+        return platformDynamicColorScheme(darkTheme)?.primary
+            ?: presetColorScheme(ThemeColorScheme.ExpressiveDefault, darkTheme).primary
     }
-    return when (themeColorScheme) {
-        ThemeColorScheme.Dynamic -> Color.Unspecified
-        ThemeColorScheme.ExpressiveDefault -> if (darkTheme) Color(0xFFD0BCFF) else Color(0xFF6750A4)
-        ThemeColorScheme.FuoGreen -> if (darkTheme) Color(0xFF93DDAA) else Color(0xFF246B43)
-        ThemeColorScheme.OceanBlue -> if (darkTheme) Color(0xFFA7C8FF) else Color(0xFF0066B3)
-        ThemeColorScheme.Violet -> if (darkTheme) Color(0xFFD7B8FF) else Color(0xFF7650B4)
-        ThemeColorScheme.Rose -> if (darkTheme) Color(0xFFFFB1C8) else Color(0xFFB13F66)
-        ThemeColorScheme.Amber -> if (darkTheme) Color(0xFFFFCF73) else Color(0xFF8A5A00)
-    }
+    return presetColorScheme(themeColorScheme, darkTheme).primary
 }
 
-private fun presetColorScheme(preset: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
+internal fun presetColorScheme(preset: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
+    return expressiveColorScheme(themeSeedColor(preset), darkTheme)
+}
+
+internal fun themeSeedColor(preset: ThemeColorScheme): Color {
     return when (preset) {
-        ThemeColorScheme.Dynamic,
-        ThemeColorScheme.ExpressiveDefault -> expressiveDefaultColorScheme(darkTheme)
-        ThemeColorScheme.FuoGreen -> if (darkTheme) {
-            darkColorScheme(
-                primary = Color(0xFF93DDAA),
-                onPrimary = Color(0xFF00391F),
-                primaryContainer = Color(0xFF0A5430),
-                onPrimaryContainer = Color(0xFFB0FAC5),
-                secondary = Color(0xFFAFCDB7),
-                onSecondary = Color(0xFF1B3524),
-                secondaryContainer = Color(0xFF314C39),
-                onSecondaryContainer = Color(0xFFCAE9D2),
-                tertiary = Color(0xFFA4D1DC),
-                onTertiary = Color(0xFF05363F),
-                tertiaryContainer = Color(0xFF224D57),
-                onTertiaryContainer = Color(0xFFC0EDF8),
-            )
-        } else {
-            lightColorScheme(
-                primary = Color(0xFF246B43),
-                onPrimary = Color.White,
-                primaryContainer = Color(0xFFA9F5C1),
-                onPrimaryContainer = Color(0xFF00210F),
-                secondary = Color(0xFF4D6353),
-                onSecondary = Color.White,
-                secondaryContainer = Color(0xFFD0E8D6),
-                onSecondaryContainer = Color(0xFF0A1F13),
-                tertiary = Color(0xFF3D6670),
-                onTertiary = Color.White,
-                tertiaryContainer = Color(0xFFC0ECF7),
-                onTertiaryContainer = Color(0xFF001F27),
-            )
-        }
-        ThemeColorScheme.OceanBlue -> if (darkTheme) {
-            darkColorScheme(
-                primary = Color(0xFFA7C8FF),
-                onPrimary = Color(0xFF00315F),
-                primaryContainer = Color(0xFF004786),
-                onPrimaryContainer = Color(0xFFD5E3FF),
-                secondary = Color(0xFFBBC7DB),
-                onSecondary = Color(0xFF253140),
-                secondaryContainer = Color(0xFF3B4858),
-                onSecondaryContainer = Color(0xFFD7E3F7),
-                tertiary = Color(0xFFD8BDE8),
-                onTertiary = Color(0xFF3B2948),
-                tertiaryContainer = Color(0xFF523F5F),
-                onTertiaryContainer = Color(0xFFF5D9FF),
-            )
-        } else {
-            lightColorScheme(
-                primary = Color(0xFF0066B3),
-                onPrimary = Color.White,
-                primaryContainer = Color(0xFFD5E3FF),
-                onPrimaryContainer = Color(0xFF001C39),
-                secondary = Color(0xFF53606F),
-                onSecondary = Color.White,
-                secondaryContainer = Color(0xFFD7E3F7),
-                onSecondaryContainer = Color(0xFF101C2B),
-                tertiary = Color(0xFF6A5778),
-                onTertiary = Color.White,
-                tertiaryContainer = Color(0xFFF2DAFF),
-                onTertiaryContainer = Color(0xFF241432),
-            )
-        }
-        ThemeColorScheme.Violet -> if (darkTheme) {
-            darkColorScheme(
-                primary = Color(0xFFD7B8FF),
-                onPrimary = Color(0xFF40206F),
-                primaryContainer = Color(0xFF583688),
-                onPrimaryContainer = Color(0xFFEEDBFF),
-                secondary = Color(0xFFCDC1D7),
-                onSecondary = Color(0xFF342D3E),
-                secondaryContainer = Color(0xFF4B4355),
-                onSecondaryContainer = Color(0xFFE9DDF3),
-                tertiary = Color(0xFFF0B8C8),
-                onTertiary = Color(0xFF4A2533),
-                tertiaryContainer = Color(0xFF643B49),
-                onTertiaryContainer = Color(0xFFFFD9E3),
-            )
-        } else {
-            lightColorScheme(
-                primary = Color(0xFF7650B4),
-                onPrimary = Color.White,
-                primaryContainer = Color(0xFFEEDBFF),
-                onPrimaryContainer = Color(0xFF2A0055),
-                secondary = Color(0xFF625A6B),
-                onSecondary = Color.White,
-                secondaryContainer = Color(0xFFE9DDF3),
-                onSecondaryContainer = Color(0xFF1E1726),
-                tertiary = Color(0xFF7E5260),
-                onTertiary = Color.White,
-                tertiaryContainer = Color(0xFFFFD9E3),
-                onTertiaryContainer = Color(0xFF31101D),
-            )
-        }
-        ThemeColorScheme.Rose -> if (darkTheme) {
-            darkColorScheme(
-                primary = Color(0xFFFFB1C8),
-                onPrimary = Color(0xFF651B3B),
-                primaryContainer = Color(0xFF8B2A52),
-                onPrimaryContainer = Color(0xFFFFD9E4),
-                secondary = Color(0xFFE3BDC7),
-                onSecondary = Color(0xFF422932),
-                secondaryContainer = Color(0xFF5A3F49),
-                onSecondaryContainer = Color(0xFFFFD9E4),
-                tertiary = Color(0xFFF4C09B),
-                onTertiary = Color(0xFF4A280D),
-                tertiaryContainer = Color(0xFF653E21),
-                onTertiaryContainer = Color(0xFFFFDCC5),
-            )
-        } else {
-            lightColorScheme(
-                primary = Color(0xFFB13F66),
-                onPrimary = Color.White,
-                primaryContainer = Color(0xFFFFD9E4),
-                onPrimaryContainer = Color(0xFF3F001F),
-                secondary = Color(0xFF735762),
-                onSecondary = Color.White,
-                secondaryContainer = Color(0xFFFFD9E4),
-                onSecondaryContainer = Color(0xFF2A151F),
-                tertiary = Color(0xFF805433),
-                onTertiary = Color.White,
-                tertiaryContainer = Color(0xFFFFDCC5),
-                onTertiaryContainer = Color(0xFF2E1500),
-            )
-        }
-        ThemeColorScheme.Amber -> if (darkTheme) {
-            darkColorScheme(
-                primary = Color(0xFFFFCF73),
-                onPrimary = Color(0xFF482900),
-                primaryContainer = Color(0xFF664000),
-                onPrimaryContainer = Color(0xFFFFDFA6),
-                secondary = Color(0xFFD9C3A4),
-                onSecondary = Color(0xFF3C2E1B),
-                secondaryContainer = Color(0xFF554430),
-                onSecondaryContainer = Color(0xFFF6DEBF),
-                tertiary = Color(0xFFBBD0A4),
-                onTertiary = Color(0xFF273619),
-                tertiaryContainer = Color(0xFF3D4D2E),
-                onTertiaryContainer = Color(0xFFD7ECC0),
-            )
-        } else {
-            lightColorScheme(
-                primary = Color(0xFF8A5A00),
-                onPrimary = Color.White,
-                primaryContainer = Color(0xFFFFDFA6),
-                onPrimaryContainer = Color(0xFF2B1700),
-                secondary = Color(0xFF6D5C43),
-                onSecondary = Color.White,
-                secondaryContainer = Color(0xFFF6DEBF),
-                onSecondaryContainer = Color(0xFF251A08),
-                tertiary = Color(0xFF54643D),
-                onTertiary = Color.White,
-                tertiaryContainer = Color(0xFFD7ECC0),
-                onTertiaryContainer = Color(0xFF121F04),
-            )
-        }
+        ThemeColorScheme.Dynamic -> themeSeedColor(ThemeColorScheme.ExpressiveDefault)
+        ThemeColorScheme.ExpressiveDefault -> Color(0xFF6750A4)
+        ThemeColorScheme.FuoGreen -> Color(0xFF246B43)
+        ThemeColorScheme.OceanBlue -> Color(0xFF0066B3)
+        ThemeColorScheme.Violet -> Color(0xFF7650B4)
+        ThemeColorScheme.Rose -> Color(0xFFB13F66)
+        ThemeColorScheme.Amber -> Color(0xFF8A5A00)
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-private fun expressiveDefaultColorScheme(darkTheme: Boolean): ColorScheme {
-    return if (darkTheme) {
-        darkColorScheme()
-    } else {
-        expressiveLightColorScheme()
+internal fun expressiveColorScheme(seedColor: Color, darkTheme: Boolean): ColorScheme {
+    return dynamicColorScheme(
+        seedColor = seedColor,
+        isDark = darkTheme,
+        style = PaletteStyle.Expressive,
+        specVersion = ColorSpec.SpecVersion.SPEC_2025,
+    )
+}
+
+internal fun hasAccessibleContrast(colorScheme: ColorScheme): Boolean {
+    return listOf(
+        colorScheme.primary to colorScheme.onPrimary,
+        colorScheme.primaryContainer to colorScheme.onPrimaryContainer,
+        colorScheme.secondary to colorScheme.onSecondary,
+        colorScheme.secondaryContainer to colorScheme.onSecondaryContainer,
+        colorScheme.tertiary to colorScheme.onTertiary,
+        colorScheme.tertiaryContainer to colorScheme.onTertiaryContainer,
+        colorScheme.error to colorScheme.onError,
+        colorScheme.errorContainer to colorScheme.onErrorContainer,
+        colorScheme.surface to colorScheme.onSurface,
+        colorScheme.surfaceVariant to colorScheme.onSurfaceVariant,
+        colorScheme.surfaceContainer to colorScheme.onSurface,
+        colorScheme.surfaceContainerHigh to colorScheme.onSurface,
+        colorScheme.surfaceContainerHighest to colorScheme.onSurface,
+        colorScheme.inverseSurface to colorScheme.inverseOnSurface,
+    ).all { (background, foreground) ->
+        colorContrastRatio(foreground, background) >= REQUIRED_CONTRAST_RATIO
+    }
+}
+
+internal fun colorContrastRatio(foreground: Color, background: Color): Double {
+    val foregroundLuminance = relativeLuminance(foreground)
+    val backgroundLuminance = relativeLuminance(background)
+    val lighter = maxOf(foregroundLuminance, backgroundLuminance)
+    val darker = minOf(foregroundLuminance, backgroundLuminance)
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private fun relativeLuminance(color: Color): Double {
+    fun linearize(component: Float): Double {
+        val value = component.toDouble()
+        return if (value <= 0.03928) {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).pow(2.4)
+        }
+    }
+
+    return linearize(color.red) * 0.2126 +
+        linearize(color.green) * 0.7152 +
+        linearize(color.blue) * 0.0722
+}
+
+private object CoverThemeSchemeCache {
+    private const val MAX_ENTRIES = 8
+    private val mutex = Mutex()
+    private val values = mutableMapOf<String, ColorScheme>()
+    private val order = mutableListOf<String>()
+
+    suspend fun get(key: String): ColorScheme? = mutex.withLock { values[key] }
+
+    suspend fun put(key: String, value: ColorScheme) {
+        mutex.withLock {
+            values.remove(key)
+            order.remove(key)
+            if (order.size >= MAX_ENTRIES) {
+                values.remove(order.removeAt(0))
+            }
+            values[key] = value
+            order += key
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
@@ -29,11 +30,56 @@ private const val REQUIRED_CONTRAST_RATIO = 4.5
 fun FuoTheme(
     themeMode: ThemeMode,
     themeColorScheme: ThemeColorScheme,
-    dynamicCoverColorEnabled: Boolean = false,
-    coverImageUrl: String? = null,
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
+    FuoExpressiveTheme(
+        colorScheme = fuoColorScheme(themeColorScheme, darkTheme),
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun PlayerDynamicColorTheme(
+    themeMode: ThemeMode,
+    dynamicCoverColorEnabled: Boolean,
+    coverImageUrl: String?,
+    content: @Composable () -> Unit,
+) {
+    val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
+    val coverColorScheme = rememberCoverColorScheme(
+        dynamicCoverColorEnabled = dynamicCoverColorEnabled,
+        coverImageUrl = coverImageUrl,
+        darkTheme = darkTheme,
+    )
+    FuoExpressiveTheme(
+        colorScheme = coverColorScheme ?: MaterialTheme.colorScheme,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun FuoExpressiveTheme(
+    colorScheme: ColorScheme,
+    content: @Composable () -> Unit,
+) {
+    MaterialExpressiveTheme(
+        colorScheme = colorScheme,
+        motionScheme = MotionScheme.expressive(),
+        shapes = FuoShapes,
+        typography = FuoTypography,
+        content = content,
+    )
+}
+
+@Composable
+private fun rememberCoverColorScheme(
+    dynamicCoverColorEnabled: Boolean,
+    coverImageUrl: String?,
+    darkTheme: Boolean,
+): ColorScheme? {
     val normalizedCoverUrl = coverImageUrl?.takeIf { it.isNotBlank() }
     val coverImage = rememberPlatformCoverImage(
         if (dynamicCoverColorEnabled) normalizedCoverUrl else null,
@@ -66,14 +112,7 @@ fun FuoTheme(
         }
         value = scheme
     }
-
-    MaterialExpressiveTheme(
-        colorScheme = fuoColorScheme(themeColorScheme, darkTheme, coverColorScheme),
-        motionScheme = MotionScheme.expressive(),
-        shapes = FuoShapes,
-        typography = FuoTypography,
-        content = content,
-    )
+    return coverColorScheme
 }
 
 private val FuoShapes = Shapes()
@@ -91,9 +130,7 @@ internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boole
 private fun fuoColorScheme(
     themeColorScheme: ThemeColorScheme,
     darkTheme: Boolean,
-    coverColorScheme: ColorScheme?,
 ): ColorScheme {
-    coverColorScheme?.takeIf(::hasAccessibleContrast)?.let { return it }
     if (themeColorScheme == ThemeColorScheme.Dynamic) {
         platformDynamicColorScheme(darkTheme)
             ?.takeIf(::hasAccessibleContrast)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlatformCoverArt.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlatformCoverArt.kt
@@ -2,6 +2,10 @@ package org.feeluown.mobile
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 enum class CoverPlaceholder {
     Song,
@@ -18,3 +22,58 @@ expect fun PlatformCoverArt(
     modifier: Modifier,
     placeholder: CoverPlaceholder,
 )
+
+@Composable
+internal expect fun rememberPlatformCoverImage(imageUrl: String?): ImageBitmap?
+
+private const val PLATFORM_COVER_IMAGE_CACHE_ENTRIES = 4
+
+internal object PlatformCoverImageCache {
+    private val mutex = Mutex()
+    private val images = mutableMapOf<String, ImageBitmap>()
+    private val imageOrder = mutableListOf<String>()
+    private val inFlight = mutableMapOf<String, CompletableDeferred<ImageBitmap?>>()
+
+    suspend fun getOrLoad(key: String, loader: suspend () -> ImageBitmap?): ImageBitmap? {
+        var cached: ImageBitmap? = null
+        var pending: CompletableDeferred<ImageBitmap?>? = null
+        var ownsLoad = false
+        mutex.withLock {
+            cached = images[key]
+            if (cached == null) {
+                pending = inFlight[key]
+                if (pending == null) {
+                    pending = CompletableDeferred()
+                    inFlight[key] = requireNotNull(pending)
+                    ownsLoad = true
+                }
+            }
+        }
+        if (cached != null) return cached
+
+        val deferred = requireNotNull(pending)
+        if (ownsLoad) {
+            try {
+                val image = loader()
+                mutex.withLock {
+                    inFlight.remove(key)
+                    if (image != null) {
+                        images.remove(key)
+                        imageOrder.remove(key)
+                        if (imageOrder.size >= PLATFORM_COVER_IMAGE_CACHE_ENTRIES) {
+                            images.remove(imageOrder.removeAt(0))
+                        }
+                        images[key] = image
+                        imageOrder += key
+                    }
+                }
+                deferred.complete(image)
+            } catch (throwable: Throwable) {
+                mutex.withLock { inFlight.remove(key) }
+                deferred.completeExceptionally(throwable)
+                throw throwable
+            }
+        }
+        return deferred.await()
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -89,6 +89,18 @@ import kotlin.math.roundToInt
 @Composable
 @OptIn(ExperimentalSharedTransitionApi::class)
 fun MiniPlayer(controller: FuoPlayerController) {
+    PlayerDynamicColorTheme(
+        themeMode = controller.themeMode,
+        dynamicCoverColorEnabled = controller.dynamicCoverColorEnabled,
+        coverImageUrl = controller.playbackState.currentTrack?.coverUrl,
+    ) {
+        MiniPlayerContent(controller)
+    }
+}
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+private fun MiniPlayerContent(controller: FuoPlayerController) {
     val state = controller.playbackState
     val isLoadingAudio = state.status == PlayerStatus.Loading
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
@@ -194,8 +206,19 @@ private fun PlayingProgressIndicator(
 }
 
 @Composable
-@OptIn(ExperimentalSharedTransitionApi::class)
 fun FullPlayer(controller: FuoPlayerController) {
+    PlayerDynamicColorTheme(
+        themeMode = controller.themeMode,
+        dynamicCoverColorEnabled = controller.dynamicCoverColorEnabled,
+        coverImageUrl = controller.playbackState.currentTrack?.coverUrl,
+    ) {
+        FullPlayerContent(controller)
+    }
+}
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+private fun FullPlayerContent(controller: FuoPlayerController) {
     val state = controller.playbackState
     val currentTrack = state.currentTrack
     val pagerState = rememberPagerState(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -928,6 +928,22 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
+            FuoSettingRow(
+                modifier = Modifier.fillMaxWidth(),
+                title = "封面动态取色",
+                supportingText = "根据当前播放封面生成主题色；无封面或加载失败时沿用所选配色",
+                enabled = !controller.isLoading,
+                onClick = {
+                    controller.onDynamicCoverColorEnabledChange(!controller.dynamicCoverColorEnabled)
+                },
+                trailingContent = {
+                    Switch(
+                        checked = controller.dynamicCoverColorEnabled,
+                        enabled = !controller.isLoading,
+                        onCheckedChange = controller::onDynamicCoverColorEnabledChange,
+                    )
+                },
+            )
         }
     }
 }
@@ -1465,14 +1481,16 @@ private fun debugLogLevelLabel(level: DebugLogLevel): String = when (level) {
 @Composable
 private fun debugLogLevelContainerColor(level: DebugLogLevel?) = when (level) {
     DebugLogLevel.Debug -> MaterialTheme.colorScheme.surfaceContainerHigh
-    DebugLogLevel.Info -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.20f)
-    DebugLogLevel.Warning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f)
-    DebugLogLevel.Error -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f)
+    DebugLogLevel.Info -> MaterialTheme.colorScheme.secondaryContainer
+    DebugLogLevel.Warning -> MaterialTheme.colorScheme.tertiaryContainer
+    DebugLogLevel.Error -> MaterialTheme.colorScheme.errorContainer
     null -> MaterialTheme.colorScheme.surface
 }
 
 @Composable
 private fun debugLogLevelContentColor(level: DebugLogLevel?) = when (level) {
+    DebugLogLevel.Info -> MaterialTheme.colorScheme.onSecondaryContainer
+    DebugLogLevel.Warning -> MaterialTheme.colorScheme.onTertiaryContainer
     DebugLogLevel.Error -> MaterialTheme.colorScheme.onErrorContainer
     else -> MaterialTheme.colorScheme.onSurface
 }
@@ -1510,6 +1528,7 @@ fun PermissionPanel(onRequestAudioPermission: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
         shape = MaterialTheme.shapes.medium,
     ) {
         Row(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AppSettingsRepositoryTest {
@@ -92,6 +93,25 @@ class AppSettingsRepositoryTest {
         repository.update { it.copy(themeMode = ThemeMode.Dark) }
 
         assertEquals(ThemeMode.Dark, repository.state.value.settings.themeMode)
+    }
+
+    @Test
+    fun missingDynamicCoverSettingUsesDisabledDefault() = runTest {
+        val dataStore = FakePreferencesDataStore(
+            mutablePreferencesOf(
+                stringPreferencesKey("app_settings_json_v1") to "{\"onboardingCompleted\":true}",
+            ),
+        )
+        val repository = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+
+        val settings = repository.awaitSettings()
+
+        assertTrue(settings.onboardingCompleted)
+        assertFalse(settings.dynamicCoverColorEnabled)
     }
 
     private class FakePreferencesDataStore(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -2463,6 +2463,7 @@ class FuoPlayerControllerTest {
                 lyricFontSize = LyricFontSize.Large,
                 themeMode = ThemeMode.Dark,
                 themeColorScheme = ThemeColorScheme.OceanBlue,
+                dynamicCoverColorEnabled = true,
             ),
         )
         val provider = FakeProviderRepository(emptyList())
@@ -2510,6 +2511,7 @@ class FuoPlayerControllerTest {
             assertEquals(LyricFontSize.Large, controller.lyricFontSize)
             assertEquals(ThemeMode.Dark, controller.themeMode)
             assertEquals(ThemeColorScheme.OceanBlue, controller.themeColorScheme)
+            assertTrue(controller.dynamicCoverColorEnabled)
             assertEquals(AudioQualityPolicy.Highest, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Low, provider.lastCellularAudioQualityPolicy)
 
@@ -2529,6 +2531,7 @@ class FuoPlayerControllerTest {
             controller.onLyricFontSizeChange(LyricFontSize.Medium)
             controller.onThemeModeChange(ThemeMode.Light)
             controller.onThemeColorSchemeChange(ThemeColorScheme.FuoGreen)
+            controller.onDynamicCoverColorEnabledChange(false)
             advanceUntilIdle()
 
             assertEquals(ProviderLoginMode.WebView, store.saved.providerLoginMode)
@@ -2550,6 +2553,7 @@ class FuoPlayerControllerTest {
             assertEquals(LyricFontSize.Medium, store.saved.lyricFontSize)
             assertEquals(ThemeMode.Light, store.saved.themeMode)
             assertEquals(ThemeColorScheme.FuoGreen, store.saved.themeColorScheme)
+            assertFalse(store.saved.dynamicCoverColorEnabled)
             assertEquals(AudioQualityPolicy.High, provider.lastWifiAudioQualityPolicy)
             assertEquals(AudioQualityPolicy.Standard, provider.lastCellularAudioQualityPolicy)
         } finally {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
@@ -1,0 +1,53 @@
+package org.feeluown.mobile
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FuoThemeTest {
+    @Test
+    fun fixedPresetsGenerateAccessibleLightAndDarkSchemes() {
+        ThemeColorScheme.entries
+            .filter { it != ThemeColorScheme.Dynamic }
+            .forEach { preset ->
+                assertTrue(
+                    hasAccessibleContrast(presetColorScheme(preset, darkTheme = false)),
+                    "light scheme for $preset",
+                )
+                assertTrue(
+                    hasAccessibleContrast(presetColorScheme(preset, darkTheme = true)),
+                    "dark scheme for $preset",
+                )
+            }
+    }
+
+    @Test
+    fun coverSeedsGenerateAccessibleSchemesInBothModes() {
+        listOf(
+            Color(0xFFFF2020),
+            Color(0xFF102040),
+            Color(0xFF22AA77),
+            Color(0xFF8060D0),
+        ).forEach { seed ->
+            assertTrue(hasAccessibleContrast(expressiveColorScheme(seed, darkTheme = false)))
+            assertTrue(hasAccessibleContrast(expressiveColorScheme(seed, darkTheme = true)))
+        }
+    }
+
+    @Test
+    fun namedPresetsKeepTheirConfiguredSeedColors() {
+        assertEquals(Color(0xFF6750A4), themeSeedColor(ThemeColorScheme.ExpressiveDefault))
+        assertEquals(Color(0xFF246B43), themeSeedColor(ThemeColorScheme.FuoGreen))
+        assertEquals(Color(0xFF0066B3), themeSeedColor(ThemeColorScheme.OceanBlue))
+        assertEquals(Color(0xFF7650B4), themeSeedColor(ThemeColorScheme.Violet))
+        assertEquals(Color(0xFFB13F66), themeSeedColor(ThemeColorScheme.Rose))
+        assertEquals(Color(0xFF8A5A00), themeSeedColor(ThemeColorScheme.Amber))
+    }
+
+    @Test
+    fun contrastRatioUsesForegroundAndBackgroundLuminance() {
+        assertEquals(21.0, colorContrastRatio(Color.White, Color.Black), absoluteTolerance = 0.01)
+        assertTrue(colorContrastRatio(Color.Black, Color.White) >= 21.0 - 0.01)
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformCoverArt.ios.kt
@@ -29,7 +29,13 @@ import kotlinx.cinterop.readBytes
 import kotlinx.cinterop.reinterpret
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.Data
 import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Pixmap
+import org.jetbrains.skia.SamplingMode
+import org.jetbrains.skia.impl.use
 import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
@@ -38,6 +44,8 @@ import platform.Foundation.dataTaskWithURL
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+private const val MAX_COVER_SIZE_PX = 768
+
 @Composable
 actual fun PlatformCoverArt(
     title: String,
@@ -45,11 +53,7 @@ actual fun PlatformCoverArt(
     modifier: Modifier,
     placeholder: CoverPlaceholder,
 ) {
-    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
-    LaunchedEffect(imageUrl) {
-        image = imageUrl?.takeIf { it.isNotBlank() }?.let { loadImage(it) }
-    }
-    val bitmap = image
+    val bitmap = rememberPlatformCoverImage(imageUrl)
     if (bitmap != null) {
         Image(bitmap, title, modifier, contentScale = ContentScale.Crop)
     } else {
@@ -73,6 +77,17 @@ actual fun PlatformCoverArt(
     }
 }
 
+@Composable
+internal actual fun rememberPlatformCoverImage(imageUrl: String?): ImageBitmap? {
+    var image by remember(imageUrl) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(imageUrl) {
+        image = imageUrl?.takeIf { it.isNotBlank() }?.let {
+            runCatching { PlatformCoverImageCache.getOrLoad(it) { loadImage(it) } }.getOrNull()
+        }
+    }
+    return image
+}
+
 @OptIn(ExperimentalForeignApi::class)
 private suspend fun loadImage(imageUrl: String): ImageBitmap? = withContext(Dispatchers.Default) {
     val resolvedUrl = when {
@@ -92,7 +107,36 @@ private suspend fun loadImage(imageUrl: String): ImageBitmap? = withContext(Disp
         fetchData(url)
     } ?: return@withContext null
     val bytes = data.bytes?.reinterpret<ByteVar>()?.readBytes(data.length.toInt()) ?: return@withContext null
-    runCatching { Image.makeFromEncoded(bytes).toComposeImageBitmap() }.getOrNull()
+    runCatching {
+        Image.makeFromEncoded(bytes).toCoverImageBitmap()
+    }.getOrNull()
+}
+
+private fun Image.toCoverImageBitmap(): ImageBitmap {
+    if (width <= MAX_COVER_SIZE_PX && height <= MAX_COVER_SIZE_PX) {
+        return toComposeImageBitmap()
+    }
+
+    val scale = minOf(
+        MAX_COVER_SIZE_PX.toFloat() / width,
+        MAX_COVER_SIZE_PX.toFloat() / height,
+    )
+    val targetWidth = (width * scale).toInt().coerceAtLeast(1)
+    val targetHeight = (height * scale).toInt().coerceAtLeast(1)
+    val imageInfo = ImageInfo.makeN32(targetWidth, targetHeight, ColorAlphaType.PREMUL)
+    val data = Data.makeUninitialized(imageInfo.computeMinByteSize())
+    return data.use { pixelData ->
+        Pixmap().use { pixmap ->
+            pixmap.reset(
+                info = imageInfo,
+                addr = pixelData.writableData(),
+                rowBytes = imageInfo.minRowBytes,
+                underlyingMemoryOwner = pixelData,
+            )
+            check(scalePixels(pixmap, SamplingMode.MITCHELL, cache = false))
+            Image.makeFromPixmap(pixmap).toComposeImageBitmap()
+        }
+    }
 }
 
 private suspend fun fetchData(url: NSURL): NSData? = suspendCoroutine { continuation ->


### PR DESCRIPTION
## Summary

- Add Material 3 Expressive theme generation with fixed presets and contrast validation.
- Add an opt-in, default-off setting for deriving theme colors from the current cover.
- Cache and downsample cover images on Android/iOS, with fallback to the selected scheme when the cover is missing or cannot be loaded.
- Align debug and permission surfaces with semantic Material 3 color roles.

## Validation

- `./gradlew :shared:allTests --console=plain`
- `./gradlew :shared:compileKotlinIosSimulatorArm64 --console=plain`
- `./gradlew :androidApp:assembleDebug :androidApp:lint :shared:lint --console=plain`
- `git diff --check`

## Notes

- Android build, shared tests, iOS compilation, and lint all pass.
- No Android device or emulator is available in the current environment, so runtime interaction and screenshot verification remain pending.