### PR TITLE
feat: add NetEase yrc lyrics with karaoke fill

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -380,10 +380,23 @@ class FuoPlaybackService : MediaSessionService() {
             title = if (parts.isEmpty()) payload.title.ifBlank { request.track.title } else request.track.title,
             artists = payload.artists.ifBlank { request.track.artists },
             album = payload.album.ifBlank { request.track.album },
-            source = payload.source.ifBlank { request.track.source },
+            source = if (payload.isSmartReplacement) {
+                payload.originalSource?.takeIf { it.isNotBlank() } ?: request.track.source
+            } else {
+                payload.source.ifBlank { request.track.source }
+            },
             coverUrl = payload.coverUrl ?: request.track.coverUrl,
             durationMs = if (parts.isEmpty()) payload.durationMs ?: request.track.durationMs else request.track.durationMs,
-            providerName = payload.providerName ?: request.track.providerName,
+            providerId = if (payload.isSmartReplacement) {
+                payload.originalId ?: request.track.providerId
+            } else {
+                request.track.providerId
+            },
+            providerName = if (payload.isSmartReplacement) {
+                payload.originalProviderName ?: request.track.providerName
+            } else {
+                payload.providerName ?: request.track.providerName
+            },
             isSmartReplacement = payload.isSmartReplacement,
             originalId = payload.originalId,
             originalTitle = payload.originalTitle,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -775,6 +775,7 @@ interface ProviderMusicRepository {
         smartReplacementUseOriginalMetadata: Boolean = true,
         smartReplacementUseOriginalLyrics: Boolean = true,
     ): PlaybackPayload
+    suspend fun lyrics(track: MusicTrack): String? = null
     suspend fun authState(providerId: String): ProviderAuthState
     suspend fun refreshAuthState(providerId: String): ProviderAuthState = authState(providerId)
     suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -3363,10 +3363,9 @@ class FuoPlayerController(
             PlayerStatus.Paused -> {
                 if (playbackState.currentTrack != null) playbackEngine.resume()
             }
-            PlayerStatus.Idle, PlayerStatus.Ended -> {
+            PlayerStatus.Idle, PlayerStatus.Ended, PlayerStatus.Loading, PlayerStatus.Error -> {
                 (currentQueueTrack() ?: playbackState.currentTrack)?.let(::startPlayback)
             }
-            else -> Unit
         }
     }
 
@@ -4015,10 +4014,23 @@ class FuoPlayerController(
                         title = if (isMultipartPlayback) playbackTrack.title else payload.title.ifBlank { playbackTrack.title },
                         artists = payload.artists.ifBlank { playbackTrack.artists },
                         album = payload.album.ifBlank { playbackTrack.album },
-                        source = payload.source.ifBlank { playbackTrack.source },
-                        coverUrl = payload.coverUrl ?: playbackTrack.coverUrl,
-                        durationMs = if (isMultipartPlayback) playbackTrack.durationMs else payload.durationMs ?: playbackTrack.durationMs,
-                        providerName = payload.providerName ?: playbackTrack.providerName,
+                    source = if (payload.isSmartReplacement) {
+                        payload.originalSource?.takeIf { it.isNotBlank() } ?: playbackTrack.source
+                    } else {
+                        payload.source.ifBlank { playbackTrack.source }
+                    },
+                    coverUrl = payload.coverUrl ?: playbackTrack.coverUrl,
+                    durationMs = if (isMultipartPlayback) playbackTrack.durationMs else payload.durationMs ?: playbackTrack.durationMs,
+                    providerName = if (payload.isSmartReplacement) {
+                        payload.originalProviderName ?: playbackTrack.providerName
+                    } else {
+                        payload.providerName ?: playbackTrack.providerName
+                    },
+                    providerId = if (payload.isSmartReplacement) {
+                        payload.originalId ?: playbackTrack.providerId
+                    } else {
+                        playbackTrack.providerId
+                    },
                         isSmartReplacement = payload.isSmartReplacement,
                         originalId = payload.originalId,
                         originalTitle = payload.originalTitle,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -89,6 +89,7 @@ enum class PlaylistTargetType {
 
 private const val DYNAMIC_QUEUE_PREFETCH_REMAINING = 2
 private const val LIST_PREFETCH_REMAINING = 8
+private const val PLAYBACK_PLAN_LOOKAHEAD = 8
 private const val PLAYLIST_BACKGROUND_PAGE_INTERVAL_MS = 3_000L
 private val DEFAULT_DEBUG_LOG_LEVEL_FILTERS = setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error)
 
@@ -3874,11 +3875,16 @@ class FuoPlayerController(
     }
 
     private fun mergedPlaybackLyrics(engineState: PlaybackState): String? {
-        engineState.lyrics?.takeIf { it.isNotBlank() }?.let { return it }
         val engineTrackId = engineState.currentTrack?.id
-        val currentId = currentQueueTrack()?.id ?: playbackState.currentTrack?.id
-        return playbackState.lyrics?.takeIf {
+        val currentId = currentQueueTrack()?.id
+            ?: engineTrackId
+            ?: playbackState.currentTrack?.id
+        engineState.lyrics?.takeIf {
             it.isNotBlank() && (engineTrackId == null || engineTrackId == currentId)
+        }?.let { return it }
+        val previousTrackId = playbackState.currentTrack?.id
+        return playbackState.lyrics?.takeIf {
+            it.isNotBlank() && previousTrackId != null && previousTrackId == currentId
         }
     }
 
@@ -4094,6 +4100,7 @@ class FuoPlayerController(
                     )
                     displayQueue()
                         .drop(1)
+                        .take(PLAYBACK_PLAN_LOOKAHEAD)
                         .forEach { queuedTrack ->
                             val nextTrack = queuedTrack.preferDownloaded()
                             add(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -393,6 +393,8 @@ class FuoPlayerController(
     private var autoAdvanceEligibleTrackId: String? = null
     private var lastRecoveredPlaybackErrorKey: String? = null
     private var playRequestSerial: Long = 0
+    private var lyricsLoadJob: Job? = null
+    private var lyricsLoadedForTrackId: String? = null
     private var localMusicRefreshSerial: Long = 0
     private var hasLocalMusicPermission: Boolean = false
     private var observedCompletedDownloadTaskIds = emptySet<String>()
@@ -513,7 +515,9 @@ class FuoPlayerController(
                     currentTrack = currentQueueTrack() ?: engineState.currentTrack,
                     playbackParts = engineState.playbackParts.ifEmpty { playbackParts },
                     currentPartIndex = engineState.currentPartIndex.takeIf { it >= 0 } ?: currentPartIndex,
+                    lyrics = mergedPlaybackLyrics(engineState),
                 )
+                maybeLoadLyrics(playbackState.currentTrack)
                 if (engineState.playbackParts.isNotEmpty()) {
                     playbackParts = engineState.playbackParts
                     currentPartIndex = engineState.currentPartIndex
@@ -1840,23 +1844,17 @@ class FuoPlayerController(
     }
 
     fun downloadLocalLyrics(track: MusicTrack, providerTrack: MusicTrack) {
-        val providerId = providerTrack.source.takeIf { it.isNotBlank() } ?: providerTrack.providerId
         scope.launch {
             isLoading = true
             message = "正在下载歌词"
             runCatching {
                 withTimeout(25_000) {
-                    providerRepository.resolve(
+                    providerRepository.lyrics(
                         providerTrack.copy(providerId = providerTrack.providerId ?: providerTrack.id),
-                        unavailablePlaybackPolicy,
-                        providerId?.let(::setOf).orEmpty(),
-                        smartReplacementMinScore,
-                        smartReplacementUseOriginalMetadata = true,
-                        smartReplacementUseOriginalLyrics = true,
                     )
                 }
-            }.onSuccess { payload ->
-                val lyrics = payload.lyrics?.takeIf { it.isNotBlank() }
+            }.onSuccess { lyricsText ->
+                val lyrics = lyricsText?.takeIf { it.isNotBlank() }
                 if (lyrics == null) {
                     message = "未获取到歌词"
                     localMetadataSearchMessage = "未获取到歌词"
@@ -3876,6 +3874,63 @@ class FuoPlayerController(
             ?: track.providerId?.substringBefore(":")?.takeIf { it.isNotBlank() }
     }
 
+    private fun mergedPlaybackLyrics(engineState: PlaybackState): String? {
+        engineState.lyrics?.takeIf { it.isNotBlank() }?.let { return it }
+        val engineTrackId = engineState.currentTrack?.id
+        val currentId = currentQueueTrack()?.id ?: playbackState.currentTrack?.id
+        return playbackState.lyrics?.takeIf {
+            it.isNotBlank() && (engineTrackId == null || engineTrackId == currentId)
+        }
+    }
+
+    private fun maybeLoadLyrics(track: MusicTrack?) {
+        if (track == null) return
+        if (!playbackState.lyrics.isNullOrBlank()) {
+            lyricsLoadedForTrackId = track.id
+            return
+        }
+        track.lyrics?.takeIf { it.isNotBlank() }?.let {
+            playbackState = playbackState.copy(lyrics = it)
+            lyricsLoadedForTrackId = track.id
+            return
+        }
+        if (lyricsLoadedForTrackId == track.id) return
+        lyricsLoadedForTrackId = track.id
+        val requestSerial = playRequestSerial
+        lyricsLoadJob?.cancel()
+        lyricsLoadJob = scope.launch {
+            val lyrics = runCatching {
+                providerRepository.lyrics(lyricSourceTrackForPlayback(track))
+            }.getOrNull()?.takeIf { it.isNotBlank() }
+            if (requestSerial != playRequestSerial) return@launch
+            val currentId = currentQueueTrack()?.id ?: playbackState.currentTrack?.id
+            if (currentId != track.id) return@launch
+            if (!lyrics.isNullOrBlank()) {
+                playbackState = playbackState.copy(lyrics = lyrics)
+            }
+        }
+    }
+
+    private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack {
+        if (!track.isSmartReplacement) return track
+        val originalId = track.originalId?.takeIf { it.isNotBlank() } ?: return track
+        val originalSource = track.originalSource?.takeIf { it.isNotBlank() }
+            ?: originalId.substringBefore(':').takeIf { it.isNotBlank() }
+            ?: track.source
+        return track.copy(
+            id = originalId,
+            providerId = originalId,
+            source = originalSource,
+            providerName = track.originalProviderName ?: track.providerName,
+            title = track.originalTitle ?: track.title,
+            artists = track.originalArtists ?: track.artists,
+            album = track.originalAlbum ?: track.album,
+            coverUrl = track.originalCoverUrl ?: track.coverUrl,
+            isSmartReplacement = false,
+            lyrics = null,
+        )
+    }
+
     private fun play(
         track: MusicTrack,
         sourceQueue: List<MusicTrack>,
@@ -3911,6 +3966,8 @@ class FuoPlayerController(
             currentPartIndex = -1
         }
         updateCurrentTrack(playbackTrack)
+        lyricsLoadJob?.cancel()
+        lyricsLoadedForTrackId = null
         playbackState = playbackState.copy(
             status = PlayerStatus.Loading,
             currentTrack = playbackTrack,
@@ -3919,6 +3976,7 @@ class FuoPlayerController(
             positionMs = 0,
             playbackParts = playbackParts,
             currentPartIndex = if (isPlaybackPartRequest) requestedPartIndex ?: -1 else -1,
+            lyrics = playbackTrack.lyrics,
             errorMessage = null,
         )
         persistPlaybackQueue()
@@ -3929,6 +3987,7 @@ class FuoPlayerController(
             ?.let { index -> playbackParts.getOrNull(index) }
             ?.toTrack(playbackTrack)
             ?: playbackTrack
+        maybeLoadLyrics(playbackTrack)
         if (!playbackEngine.resolvesResourcesInternally) {
             scope.launch playRequest@{
                 runCatching {
@@ -3986,11 +4045,12 @@ class FuoPlayerController(
                         currentTrack = playableTrack,
                         queue = displayQueue(),
                         queueIndex = displayQueueIndex(),
-                        lyrics = payload.lyrics,
+                        lyrics = payload.lyrics?.takeIf { it.isNotBlank() } ?: playbackState.lyrics,
                         audioQuality = payload.audioQuality,
                         playbackParts = playbackParts,
                         currentPartIndex = currentPartIndex,
                     )
+                    maybeLoadLyrics(playableTrack)
                     persistPlaybackQueue()
                     message = currentPlaybackPartLabel()?.let { "${playableTrack.title} · $it" }
                         ?: "${playableTrack.title} - ${playableTrack.artists}"

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -128,12 +128,6 @@ class KotlinProviderRepository : ProviderMusicRepository {
             error("media unavailable: ${track.id}")
         }
 
-        val originalLyrics = when {
-            !smartReplacementUseOriginalLyrics -> null
-            !track.lyrics.isNullOrBlank() -> track.lyrics
-            else -> runCatching { originalProvider?.lyrics(track) }.getOrNull()?.takeIf { it.isNotBlank() }
-        }
-
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
             .flatMap { provider -> provider.search("${track.title} ${track.artists}").tracks }
             .mapNotNull { candidate ->
@@ -163,11 +157,22 @@ class KotlinProviderRepository : ProviderMusicRepository {
                     artists = if (smartReplacementUseOriginalMetadata) track.artists else candidate.artists,
                     album = if (smartReplacementUseOriginalMetadata) track.album else candidate.album,
                     coverUrl = if (smartReplacementUseOriginalMetadata) track.coverUrl else candidate.coverUrl,
-                    lyrics = if (smartReplacementUseOriginalLyrics) originalLyrics ?: payload.lyrics else payload.lyrics,
+                    // Lyrics are loaded asynchronously after playback starts.
+                    lyrics = if (smartReplacementUseOriginalLyrics) track.lyrics else payload.lyrics,
                 )
             }
             .maxByOrNull { it.first }
         return candidates?.second ?: error("media unavailable and no smart replacement: ${track.id}")
+    }
+
+    override suspend fun lyrics(track: MusicTrack): String? {
+        initialize()
+        track.lyrics?.takeIf { it.isNotBlank() }?.let { return it }
+        val lyricTrack = lyricSourceTrack(track)
+        val providerId = lyricTrack.source.ifBlank {
+            splitResourceId(lyricTrack.providerId ?: lyricTrack.id).first
+        }
+        return providerMap[providerId]?.lyrics(lyricTrack)?.takeIf { it.isNotBlank() }
     }
 
     override suspend fun authState(providerId: String): ProviderAuthState = requireProvider(providerId).authState()
@@ -307,6 +312,25 @@ class KotlinProviderRepository : ProviderMusicRepository {
     private fun selectedProvidersForReplacement(providerIds: Set<String>, originalProviderId: String): List<KotlinMusicProvider> {
         val ids = if (providerIds.isEmpty()) enabledProviderIds else providerIds
         return ids.filter { it != originalProviderId }.mapNotNull { providerMap[it] }
+    }
+
+    private fun lyricSourceTrack(track: MusicTrack): MusicTrack {
+        if (!track.isSmartReplacement) return track
+        val originalId = track.originalId?.takeIf { it.isNotBlank() } ?: return track
+        val originalSource = track.originalSource?.takeIf { it.isNotBlank() }
+            ?: splitResourceId(originalId).first
+        return track.copy(
+            id = originalId,
+            providerId = originalId,
+            source = originalSource,
+            providerName = track.originalProviderName ?: track.providerName,
+            title = track.originalTitle ?: track.title,
+            artists = track.originalArtists ?: track.artists,
+            album = track.originalAlbum ?: track.album,
+            coverUrl = track.originalCoverUrl ?: track.coverUrl,
+            isSmartReplacement = false,
+            lyrics = null,
+        )
     }
 
     private fun requireProvider(providerId: String): KotlinMusicProvider =

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -115,60 +115,108 @@ class KotlinProviderRepository : ProviderMusicRepository {
         smartReplacementUseOriginalLyrics: Boolean,
     ): PlaybackPayload {
         initialize()
-        val originalProviderId = track.source.ifBlank { splitResourceId(track.providerId ?: track.id).first }
-        val originalProvider = providerMap[originalProviderId]
         val quality = if (isCellularConnection()) {
             cellularAudioQualityPolicy.policy
         } else {
             wifiAudioQualityPolicy.policy
         }
-        val direct = originalProvider?.resolve(track, quality)
+        // Persisted smart-replaced tracks keep original ids but may flip `source` to the
+        // replacement provider. Prefer the known replacement, then the original identity.
+        if (track.isSmartReplacement) {
+            resolveKnownReplacement(
+                track = track,
+                quality = quality,
+                useOriginalMetadata = smartReplacementUseOriginalMetadata,
+                useOriginalLyrics = smartReplacementUseOriginalLyrics,
+            )?.let { return it }
+        }
+        val mediaTrack = track.asOriginalMediaTrack()
+        val originalProviderId = mediaTrack.source.ifBlank {
+            splitResourceId(mediaTrack.providerId ?: mediaTrack.id).first
+        }
+        val originalProvider = providerMap[originalProviderId]
+        val direct = originalProvider?.resolve(mediaTrack, quality)
         if (direct != null) return direct
         if (unavailablePolicy == UnavailablePlaybackPolicy.Skip) {
-            error("media unavailable: ${track.id}")
+            error("media unavailable: ${mediaTrack.id}")
         }
 
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
-            .flatMap { provider -> provider.search("${track.title} ${track.artists}").tracks }
+            .flatMap { provider -> provider.search("${mediaTrack.title} ${mediaTrack.artists}").tracks }
             .mapNotNull { candidate ->
-                val score = replacementScore(track, candidate)
+                val score = replacementScore(mediaTrack, candidate)
                 if (score < smartReplacementMinScore) return@mapNotNull null
                 val provider = providerMap[candidate.source] ?: return@mapNotNull null
                 val payload = provider.resolve(candidate, quality) ?: return@mapNotNull null
-                score to payload.copy(
-                    isSmartReplacement = true,
-                    originalId = track.id,
-                    originalTitle = track.title,
-                    originalArtists = track.artists,
-                    originalAlbum = track.album,
-                    originalSource = track.source,
-                    originalProviderName = track.providerName,
-                    originalCoverUrl = track.coverUrl,
-                    replacementId = candidate.id,
-                    replacementTitle = candidate.title,
-                    replacementArtists = candidate.artists,
-                    replacementAlbum = candidate.album,
-                    replacementSource = candidate.source,
-                    replacementProviderName = candidate.providerName,
-                    replacementCoverUrl = candidate.coverUrl,
-                    replacementStrategy = "title_artist_duration",
-                    replacementScore = score,
-                    title = if (smartReplacementUseOriginalMetadata) track.title else candidate.title,
-                    artists = if (smartReplacementUseOriginalMetadata) track.artists else candidate.artists,
-                    album = if (smartReplacementUseOriginalMetadata) track.album else candidate.album,
-                    coverUrl = if (smartReplacementUseOriginalMetadata) track.coverUrl else candidate.coverUrl,
-                    // Lyrics are loaded asynchronously after playback starts.
-                    lyrics = if (smartReplacementUseOriginalLyrics) track.lyrics else payload.lyrics,
+                score to annotateSmartReplacement(
+                    payload = payload,
+                    original = mediaTrack,
+                    candidate = candidate,
+                    score = score,
+                    useOriginalMetadata = smartReplacementUseOriginalMetadata,
+                    useOriginalLyrics = smartReplacementUseOriginalLyrics,
                 )
             }
             .maxByOrNull { it.first }
-        return candidates?.second ?: error("media unavailable and no smart replacement: ${track.id}")
+        return candidates?.second ?: error("media unavailable and no smart replacement: ${mediaTrack.id}")
     }
+
+    private suspend fun resolveKnownReplacement(
+        track: MusicTrack,
+        quality: String,
+        useOriginalMetadata: Boolean,
+        useOriginalLyrics: Boolean,
+    ): PlaybackPayload? {
+        val replacementTrack = track.asReplacementMediaTrack() ?: return null
+        val provider = providerMap[replacementTrack.source] ?: return null
+        val payload = provider.resolve(replacementTrack, quality) ?: return null
+        val original = track.asOriginalMediaTrack()
+        return annotateSmartReplacement(
+            payload = payload,
+            original = original,
+            candidate = replacementTrack,
+            score = track.replacementScore ?: 1.0,
+            useOriginalMetadata = useOriginalMetadata,
+            useOriginalLyrics = useOriginalLyrics,
+        )
+    }
+
+    private fun annotateSmartReplacement(
+        payload: PlaybackPayload,
+        original: MusicTrack,
+        candidate: MusicTrack,
+        score: Double,
+        useOriginalMetadata: Boolean,
+        useOriginalLyrics: Boolean,
+    ): PlaybackPayload = payload.copy(
+        isSmartReplacement = true,
+        originalId = original.id,
+        originalTitle = original.title,
+        originalArtists = original.artists,
+        originalAlbum = original.album,
+        originalSource = original.source,
+        originalProviderName = original.providerName,
+        originalCoverUrl = original.coverUrl,
+        replacementId = candidate.id,
+        replacementTitle = candidate.title,
+        replacementArtists = candidate.artists,
+        replacementAlbum = candidate.album,
+        replacementSource = candidate.source,
+        replacementProviderName = candidate.providerName,
+        replacementCoverUrl = candidate.coverUrl,
+        replacementStrategy = "title_artist_duration",
+        replacementScore = score,
+        title = if (useOriginalMetadata) original.title else candidate.title,
+        artists = if (useOriginalMetadata) original.artists else candidate.artists,
+        album = if (useOriginalMetadata) original.album else candidate.album,
+        coverUrl = if (useOriginalMetadata) original.coverUrl else candidate.coverUrl,
+        lyrics = if (useOriginalLyrics) original.lyrics else payload.lyrics,
+    )
 
     override suspend fun lyrics(track: MusicTrack): String? {
         initialize()
         track.lyrics?.takeIf { it.isNotBlank() }?.let { return it }
-        val lyricTrack = lyricSourceTrack(track)
+        val lyricTrack = track.asOriginalMediaTrack()
         val providerId = lyricTrack.source.ifBlank {
             splitResourceId(lyricTrack.providerId ?: lyricTrack.id).first
         }
@@ -314,22 +362,72 @@ class KotlinProviderRepository : ProviderMusicRepository {
         return ids.filter { it != originalProviderId }.mapNotNull { providerMap[it] }
     }
 
-    private fun lyricSourceTrack(track: MusicTrack): MusicTrack {
-        if (!track.isSmartReplacement) return track
-        val originalId = track.originalId?.takeIf { it.isNotBlank() } ?: return track
-        val originalSource = track.originalSource?.takeIf { it.isNotBlank() }
-            ?: splitResourceId(originalId).first
-        return track.copy(
+    private fun MusicTrack.asOriginalMediaTrack(): MusicTrack {
+        if (!isSmartReplacement) return this
+        val originalId = originalId?.takeIf { it.isNotBlank() } ?: id
+        val originalSource = originalSource?.takeIf { it.isNotBlank() }
+            ?: splitResourceId(originalId).first.takeIf { it.isNotBlank() }
+            ?: source
+        return copy(
             id = originalId,
             providerId = originalId,
             source = originalSource,
-            providerName = track.originalProviderName ?: track.providerName,
-            title = track.originalTitle ?: track.title,
-            artists = track.originalArtists ?: track.artists,
-            album = track.originalAlbum ?: track.album,
-            coverUrl = track.originalCoverUrl ?: track.coverUrl,
+            providerName = originalProviderName ?: providerName,
+            title = originalTitle ?: title,
+            artists = originalArtists ?: artists,
+            album = originalAlbum ?: album,
+            coverUrl = originalCoverUrl ?: coverUrl,
             isSmartReplacement = false,
-            lyrics = null,
+            originalId = null,
+            originalTitle = null,
+            originalArtists = null,
+            originalAlbum = null,
+            originalSource = null,
+            originalProviderName = null,
+            originalCoverUrl = null,
+            replacementId = null,
+            replacementTitle = null,
+            replacementArtists = null,
+            replacementAlbum = null,
+            replacementSource = null,
+            replacementProviderName = null,
+            replacementCoverUrl = null,
+            replacementStrategy = null,
+            replacementScore = null,
+        )
+    }
+
+    private fun MusicTrack.asReplacementMediaTrack(): MusicTrack? {
+        val replacementId = replacementId?.takeIf { it.isNotBlank() } ?: return null
+        val replacementSource = replacementSource?.takeIf { it.isNotBlank() }
+            ?: splitResourceId(replacementId).first.takeIf { it.isNotBlank() }
+            ?: return null
+        return copy(
+            id = replacementId,
+            providerId = replacementId,
+            source = replacementSource,
+            providerName = replacementProviderName ?: providerName,
+            title = replacementTitle ?: title,
+            artists = replacementArtists ?: artists,
+            album = replacementAlbum ?: album,
+            coverUrl = replacementCoverUrl ?: coverUrl,
+            isSmartReplacement = false,
+            originalId = null,
+            originalTitle = null,
+            originalArtists = null,
+            originalAlbum = null,
+            originalSource = null,
+            originalProviderName = null,
+            originalCoverUrl = null,
+            replacementId = null,
+            replacementTitle = null,
+            replacementArtists = null,
+            replacementAlbum = null,
+            replacementSource = null,
+            replacementProviderName = null,
+            replacementCoverUrl = null,
+            replacementStrategy = null,
+            replacementScore = null,
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -128,6 +128,12 @@ class KotlinProviderRepository : ProviderMusicRepository {
             error("media unavailable: ${track.id}")
         }
 
+        val originalLyrics = when {
+            !smartReplacementUseOriginalLyrics -> null
+            !track.lyrics.isNullOrBlank() -> track.lyrics
+            else -> runCatching { originalProvider?.lyrics(track) }.getOrNull()?.takeIf { it.isNotBlank() }
+        }
+
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
             .flatMap { provider -> provider.search("${track.title} ${track.artists}").tracks }
             .mapNotNull { candidate ->
@@ -157,7 +163,7 @@ class KotlinProviderRepository : ProviderMusicRepository {
                     artists = if (smartReplacementUseOriginalMetadata) track.artists else candidate.artists,
                     album = if (smartReplacementUseOriginalMetadata) track.album else candidate.album,
                     coverUrl = if (smartReplacementUseOriginalMetadata) track.coverUrl else candidate.coverUrl,
-                    lyrics = if (smartReplacementUseOriginalLyrics) track.lyrics ?: payload.lyrics else payload.lyrics,
+                    lyrics = if (smartReplacementUseOriginalLyrics) originalLyrics ?: payload.lyrics else payload.lyrics,
                 )
             }
             .maxByOrNull { it.first }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -76,16 +76,24 @@ import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -188,7 +196,7 @@ private fun MiniPlayerProgress(state: PlaybackState, isLoadingAudio: Boolean) {
 
 @Composable
 private fun MiniPlayerLyricLine(state: PlaybackState) {
-    val lines = remember(state.lyrics) { parseLrc(state.lyrics) }
+    val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
     val currentIndex = currentLyricIndex(lines, state.positionMs)
     val currentLine = lines.getOrNull(currentIndex)?.text?.takeIf { it.isNotBlank() } ?: return
 
@@ -1246,9 +1254,10 @@ fun ProgressBlock(state: PlaybackState, onSeek: (Long) -> Unit) {
 
 @Composable
 fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifier) {
-    val lines = remember(state.lyrics) { parseLrc(state.lyrics) }
+    val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
     val listState = rememberLazyListState()
-    val currentIndex = currentLyricIndex(lines, state.positionMs)
+    val renderPositionMs = rememberKaraokePositionMs(state.positionMs, state.status == PlayerStatus.Playing)
+    val currentIndex = currentLyricIndex(lines, renderPositionMs)
     val activeStyle = when (fontSize) {
         LyricFontSize.Small -> MaterialTheme.typography.titleMedium
         LyricFontSize.Medium -> MaterialTheme.typography.titleLarge
@@ -1294,13 +1303,24 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         .padding(vertical = linePadding),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
-                    Text(
-                        text = line.text,
-                        style = if (active) activeStyle else inactiveStyle,
-                        color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    if (active && !line.words.isNullOrEmpty()) {
+                        KaraokeLyricText(
+                            words = line.words,
+                            positionMs = renderPositionMs,
+                            style = activeStyle,
+                            activeColor = MaterialTheme.colorScheme.primary,
+                            inactiveColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    } else {
+                        Text(
+                            text = line.text,
+                            style = if (active) activeStyle else inactiveStyle,
+                            color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     line.translation?.takeIf { it.isNotBlank() }?.let { translation ->
                         Text(
                             text = translation,
@@ -1314,6 +1334,67 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun rememberKaraokePositionMs(positionMs: Long, isPlaying: Boolean): Long {
+    var renderPositionMs by remember { mutableLongStateOf(positionMs) }
+    LaunchedEffect(positionMs, isPlaying) {
+        renderPositionMs = positionMs
+        if (!isPlaying) return@LaunchedEffect
+        val anchorPosition = positionMs
+        val anchorFrame = withFrameNanos { it }
+        while (true) {
+            withFrameNanos { frame ->
+                val elapsedMs = (frame - anchorFrame) / 1_000_000L
+                renderPositionMs = anchorPosition + elapsedMs
+            }
+        }
+    }
+    return renderPositionMs
+}
+
+@Composable
+private fun KaraokeLyricText(
+    words: List<LyricWord>,
+    positionMs: Long,
+    style: TextStyle,
+    activeColor: Color,
+    inactiveColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val text = remember(words) { words.joinToString("") { it.text } }
+    val textStyle = style.copy(fontWeight = FontWeight.SemiBold)
+    val textMeasurer = rememberTextMeasurer()
+    val wordWidths = remember(words, textStyle, textMeasurer) {
+        words.map { word ->
+            textMeasurer.measure(
+                text = word.text,
+                style = textStyle,
+                constraints = Constraints(),
+            ).size.width.toFloat()
+        }
+    }
+    val progress = karaokeFillProgress(words, positionMs, wordWidths)
+
+    Box(modifier = modifier) {
+        Text(
+            text = text,
+            style = textStyle,
+            color = inactiveColor,
+        )
+        Text(
+            text = text,
+            style = textStyle,
+            color = activeColor,
+            modifier = Modifier.drawWithContent {
+                val clipRight = size.width * progress
+                clipRect(left = 0f, top = 0f, right = clipRight, bottom = size.height) {
+                    this@drawWithContent.drawContent()
+                }
+            },
+        )
     }
 }
 
@@ -1585,10 +1666,17 @@ fun formatMs(value: Long): String {
     return "$minutes:${seconds.toString().padStart(2, '0')}"
 }
 
+data class LyricWord(
+    val startMs: Long,
+    val durationMs: Long,
+    val text: String,
+)
+
 data class LyricLine(
     val timeMs: Long,
     val text: String,
     val translation: String? = null,
+    val words: List<LyricWord>? = null,
 )
 
 private data class RawLyricLine(
@@ -1596,6 +1684,43 @@ private data class RawLyricLine(
     val text: String,
     val order: Int,
 )
+
+fun parseLyrics(raw: String?): List<LyricLine> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return if (raw.lineSequence().any { yrcLineHeaderRegex.containsMatchIn(it.trim()) }) {
+        parseYrc(raw)
+    } else {
+        parseLrc(raw)
+    }
+}
+
+fun parseYrc(raw: String?): List<LyricLine> {
+    if (raw.isNullOrBlank()) return emptyList()
+    val lines = mutableListOf<LyricLine>()
+    raw.lineSequence().forEach { rawLine ->
+        val trimmed = rawLine.trim()
+        if (trimmed.isEmpty() || trimmed.startsWith('{')) return@forEach
+        val headerMatch = yrcLineHeaderRegex.find(trimmed) ?: return@forEach
+        val startMs = headerMatch.groupValues[1].toLongOrNull() ?: return@forEach
+        val body = trimmed.substring(headerMatch.range.last + 1)
+        val words = yrcWordRegex.findAll(body).mapNotNull { match ->
+            val wordStart = match.groupValues[1].toLongOrNull() ?: return@mapNotNull null
+            val duration = match.groupValues[2].toLongOrNull() ?: return@mapNotNull null
+            val text = match.groupValues[3]
+            if (text.isEmpty()) null else LyricWord(wordStart, duration, text)
+        }.toList()
+        val text = words.joinToString("") { it.text }.ifBlank {
+            body.replace(yrcWordRegex, "").trim()
+        }
+        if (text.isBlank()) return@forEach
+        lines += LyricLine(
+            timeMs = startMs,
+            text = text,
+            words = words.takeIf { it.isNotEmpty() },
+        )
+    }
+    return lines.sortedBy { it.timeMs }
+}
 
 fun parseLrc(raw: String?): List<LyricLine> {
     if (raw.isNullOrBlank()) return emptyList()
@@ -1659,5 +1784,34 @@ fun currentLyricIndex(lines: List<LyricLine>, positionMs: Long): Int {
     return index.coerceAtLeast(0)
 }
 
+fun karaokeFillProgress(
+    words: List<LyricWord>,
+    positionMs: Long,
+    wordWidths: List<Float>,
+): Float {
+    if (words.isEmpty() || wordWidths.isEmpty()) return 0f
+    val totalWidth = wordWidths.sum()
+    if (totalWidth <= 0f) return 0f
+    var filledWidth = 0f
+    val count = minOf(words.size, wordWidths.size)
+    for (index in 0 until count) {
+        val word = words[index]
+        val width = wordWidths[index]
+        val durationMs = word.durationMs.coerceAtLeast(1L)
+        when {
+            positionMs < word.startMs -> return (filledWidth / totalWidth).coerceIn(0f, 1f)
+            positionMs >= word.startMs + durationMs -> filledWidth += width
+            else -> {
+                val fraction = ((positionMs - word.startMs).toFloat() / durationMs).coerceIn(0f, 1f)
+                filledWidth += width * fraction
+                return (filledWidth / totalWidth).coerceIn(0f, 1f)
+            }
+        }
+    }
+    return (filledWidth / totalWidth).coerceIn(0f, 1f)
+}
+
 val lrcTimeRegex = Regex("""\[(\d{1,3}:\d{1,2}(?:\.\d{1,3})?)]""")
 val lrcMetadataRegex = Regex("""^\[[A-Za-z]+:.*]$""")
+val yrcLineHeaderRegex = Regex("""^\[(\d+),(\d+)]""")
+val yrcWordRegex = Regex("""\((\d+),(\d+),\d+\)([^(]*)""")

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1256,8 +1256,7 @@ fun ProgressBlock(state: PlaybackState, onSeek: (Long) -> Unit) {
 fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifier) {
     val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
     val listState = rememberLazyListState()
-    val renderPositionMs = rememberKaraokePositionMs(state.positionMs, state.status == PlayerStatus.Playing)
-    val currentIndex = currentLyricIndex(lines, renderPositionMs)
+    val currentIndex = currentLyricIndex(lines, state.positionMs)
     val activeStyle = when (fontSize) {
         LyricFontSize.Small -> MaterialTheme.typography.titleMedium
         LyricFontSize.Medium -> MaterialTheme.typography.titleLarge
@@ -1306,7 +1305,8 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                     if (active && !line.words.isNullOrEmpty()) {
                         KaraokeLyricText(
                             words = line.words,
-                            positionMs = renderPositionMs,
+                            positionMs = state.positionMs,
+                            isPlaying = state.status == PlayerStatus.Playing,
                             style = activeStyle,
                             activeColor = MaterialTheme.colorScheme.primary,
                             inactiveColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1359,37 +1359,44 @@ private fun rememberKaraokePositionMs(positionMs: Long, isPlaying: Boolean): Lon
 private fun KaraokeLyricText(
     words: List<LyricWord>,
     positionMs: Long,
+    isPlaying: Boolean,
     style: TextStyle,
     activeColor: Color,
     inactiveColor: Color,
     modifier: Modifier = Modifier,
 ) {
+    val renderPositionMs = rememberKaraokePositionMs(positionMs, isPlaying)
     val text = remember(words) { words.joinToString("") { it.text } }
-    val textStyle = style.copy(fontWeight = FontWeight.SemiBold)
     val textMeasurer = rememberTextMeasurer()
-    val wordWidths = remember(words, textStyle, textMeasurer) {
+    val fontSize = style.fontSize
+    val wordWidths = remember(words, fontSize, textMeasurer) {
+        val measureStyle = style.copy(fontWeight = FontWeight.SemiBold)
         words.map { word ->
             textMeasurer.measure(
                 text = word.text,
-                style = textStyle,
+                style = measureStyle,
                 constraints = Constraints(),
             ).size.width.toFloat()
         }
     }
-    val progress = karaokeFillProgress(words, positionMs, wordWidths)
+    val progress = karaokeFillProgress(words, renderPositionMs, wordWidths)
+    val textStyle = style.copy(fontWeight = FontWeight.SemiBold)
 
     Box(modifier = modifier) {
         Text(
             text = text,
             style = textStyle,
             color = inactiveColor,
+            softWrap = true,
         )
         Text(
             text = text,
             style = textStyle,
             color = activeColor,
+            softWrap = true,
             modifier = Modifier.drawWithContent {
-                val clipRight = size.width * progress
+                val clipRight = size.width * progress.coerceIn(0f, 1f)
+                if (clipRight <= 0f || !clipRight.isFinite()) return@drawWithContent
                 clipRect(left = 0f, top = 0f, right = clipRight, bottom = size.height) {
                     this@drawWithContent.drawContent()
                 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -651,8 +651,7 @@ fun PlayerInfoTags(
 ) {
     var replacementInfoTrack by remember(track?.id) { mutableStateOf<MusicTrack?>(null) }
     var showAudioFormatInfo by remember(track?.id) { mutableStateOf(false) }
-    var showAudioDecoderInfo by remember(track?.id) { mutableStateOf(false) }
-    val canShowAudioFormatInfo = audioFormatInfo?.hasDisplayableValue() == true
+    val canShowAudioInfo = audioFormatInfo?.hasDisplayableValue() == true || audioDecoderInfo != null
     Row(
         modifier = Modifier.horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -670,13 +669,7 @@ fun PlayerInfoTags(
         audioQuality?.takeIf { it.isNotBlank() }?.let {
             InfoTag(
                 text = it.uppercase(),
-                onClick = if (canShowAudioFormatInfo) ({ showAudioFormatInfo = true }) else null,
-            )
-        }
-        audioDecoderInfo?.let { decoderInfo ->
-            InfoTag(
-                text = if (decoderInfo.type == AudioDecoderType.Software) "SW" else "HW",
-                onClick = { showAudioDecoderInfo = true },
+                onClick = if (canShowAudioInfo) ({ showAudioFormatInfo = true }) else null,
             )
         }
     }
@@ -692,32 +685,18 @@ fun PlayerInfoTags(
     if (showAudioFormatInfo) {
         AudioFormatInfoDialog(
             info = audioFormatInfo,
+            decoderInfo = audioDecoderInfo,
             onDismiss = { showAudioFormatInfo = false },
-        )
-    }
-    audioDecoderInfo?.let { decoderInfo ->
-        if (!showAudioDecoderInfo) return@let
-        AlertDialog(
-            onDismissRequest = { showAudioDecoderInfo = false },
-            title = { Text("音频解码") },
-            text = {
-                Text(
-                    text = "当前音频正在使用${
-                        if (decoderInfo.type == AudioDecoderType.Software) "软件解码" else "硬件解码"
-                    }\n解码器：${decoderInfo.name}",
-                )
-            },
-            confirmButton = {
-                TextButton(onClick = { showAudioDecoderInfo = false }) {
-                    Text("知道了")
-                }
-            },
         )
     }
 }
 
 @Composable
-fun AudioFormatInfoDialog(info: AudioFormatInfo?, onDismiss: () -> Unit) {
+fun AudioFormatInfoDialog(
+    info: AudioFormatInfo?,
+    decoderInfo: AudioDecoderInfo? = null,
+    onDismiss: () -> Unit,
+) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("音频信息") },
@@ -727,6 +706,15 @@ fun AudioFormatInfoDialog(info: AudioFormatInfo?, onDismiss: () -> Unit) {
                 info?.codec?.takeIf { it.isNotBlank() }?.let { ReplacementInfoLine("编码", it) }
                 formatAudioBitrate(info?.averageBitrate)?.let { ReplacementInfoLine("平均比特率", it) }
                 formatAudioBitrate(info?.peakBitrate)?.let { ReplacementInfoLine("峰值比特率", it) }
+                decoderInfo?.let { decoder ->
+                    ReplacementInfoLine(
+                        "解码方式",
+                        if (decoder.type == AudioDecoderType.Software) "软件解码" else "硬件解码",
+                    )
+                    decoder.name.takeIf { it.isNotBlank() }?.let {
+                        ReplacementInfoLine("解码器", it)
+                    }
+                }
             }
         },
         confirmButton = {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1685,12 +1685,42 @@ private data class RawLyricLine(
     val order: Int,
 )
 
+const val LYRIC_TRANSLATION_MARKER = "\n__FUO_LYRIC_TRANSLATION__\n"
+
+fun composeLyricsWithTranslation(main: String, translation: String?): String {
+    val trimmedMain = main.trimEnd()
+    val trimmedTranslation = translation?.trim()?.takeIf { it.isNotBlank() } ?: return trimmedMain
+    return trimmedMain + LYRIC_TRANSLATION_MARKER + trimmedTranslation
+}
+
 fun parseLyrics(raw: String?): List<LyricLine> {
     if (raw.isNullOrBlank()) return emptyList()
-    return if (raw.lineSequence().any { yrcLineHeaderRegex.containsMatchIn(it.trim()) }) {
-        parseYrc(raw)
+    val parts = raw.split(LYRIC_TRANSLATION_MARKER, limit = 2)
+    val main = parts[0]
+    val translationRaw = parts.getOrNull(1)
+    val lines = if (main.lineSequence().any { yrcLineHeaderRegex.containsMatchIn(it.trim()) }) {
+        parseYrc(main)
     } else {
-        parseLrc(raw)
+        parseLrc(main)
+    }
+    return attachLyricTranslations(lines, translationRaw)
+}
+
+fun attachLyricTranslations(lines: List<LyricLine>, translationRaw: String?): List<LyricLine> {
+    if (translationRaw.isNullOrBlank() || lines.isEmpty()) return lines
+    val translationLines = parseLrc(translationRaw).filter { it.timeMs != Long.MAX_VALUE }
+    if (translationLines.isEmpty()) return lines
+    val byTime = translationLines
+        .groupBy { it.timeMs }
+        .mapValues { (_, value) -> value.first().text }
+    return lines.map { line ->
+        if (line.timeMs == Long.MAX_VALUE || !line.translation.isNullOrBlank()) return@map line
+        val exact = byTime[line.timeMs]
+        val nearest = translationLines
+            .minByOrNull { kotlin.math.abs(it.timeMs - line.timeMs) }
+            ?.takeIf { kotlin.math.abs(it.timeMs - line.timeMs) <= 50 }
+            ?.text
+        line.copy(translation = exact ?: nearest)
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1309,14 +1309,19 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                             isPlaying = state.status == PlayerStatus.Playing,
                             style = activeStyle,
                             activeColor = MaterialTheme.colorScheme.primary,
-                            inactiveColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            // Keep the unsung portion clearly muted so primary fill pops.
+                            inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
                             modifier = Modifier.fillMaxWidth(),
                         )
                     } else {
                         Text(
                             text = line.text,
                             style = if (active) activeStyle else inactiveStyle,
-                            color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            color = if (active) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.46f)
+                            },
                             fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -1325,8 +1330,8 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         Text(
                             text = translation,
                             style = translationStyle,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = if (active) 0.88f else 0.72f,
+                            color = MaterialTheme.colorScheme.onSurface.copy(
+                                alpha = if (active) 0.52f else 0.38f,
                             ),
                             modifier = Modifier.fillMaxWidth(),
                         )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/core/ProviderSupport.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/core/ProviderSupport.kt
@@ -360,6 +360,8 @@ abstract class BaseKotlinProvider(
 
     override suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload? = null
 
+    override suspend fun lyrics(track: MusicTrack): String? = null
+
     override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = emptyList()
 
     override suspend fun playlistDetail(playlist: ProviderPlaylist, offset: Int, limit: Int): ProviderPlaylistDetail =
@@ -443,6 +445,7 @@ interface KotlinMusicProvider {
     suspend fun search(keyword: String): ProviderSearchResults
     suspend fun trackDetail(identifier: String): MusicTrack?
     suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload?
+    suspend fun lyrics(track: MusicTrack): String? = null
     suspend fun authState(): ProviderAuthState
     suspend fun loginWithCookies(cookiesJson: String): ProviderAuthState
     suspend fun loginWithHeaders(authorization: String, cookie: String): ProviderAuthState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -614,11 +614,18 @@ class NeteaseProvider(
                 ),
             ),
             neteaseAuthenticatedHeaders(),
-            cacheKey = "netease:lyric-yrc:$identifier",
+            cacheKey = "netease:lyric-yrc-tr:$identifier",
             cachePolicy = ProviderCachePolicies.lyric,
         ).value.let { parseNeteaseResponse(it) }
-        root.obj("yrc")?.stringOrNull("lyric")
-            ?: root.obj("lrc")?.stringOrNull("lyric")
+        val yrc = root.obj("yrc")?.stringOrNull("lyric")
+        val lrc = root.obj("lrc")?.stringOrNull("lyric")
+        val main = yrc ?: lrc ?: return@runCatching null
+        val translation = when {
+            yrc != null -> root.obj("ytlrc")?.stringOrNull("lyric")
+                ?: root.obj("tlyric")?.stringOrNull("lyric")
+            else -> root.obj("tlyric")?.stringOrNull("lyric")
+        }
+        org.feeluown.mobile.composeLyricsWithTranslation(main, translation)
     }.getOrNull()
 
     private suspend fun currentUserId(): String? = runCatching { requestCurrentUserId() }.getOrNull()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -599,20 +599,17 @@ class NeteaseProvider(
         val root = http.getText(
             ID,
             queryUrl(
-                "$BASE/api/song/lyric/v1",
+                "$BASE/api/song/lyric",
                 mapOf(
                     "id" to identifier,
                     "lv" to "-1",
                     "kv" to "-1",
                     "tv" to "-1",
-                    "rv" to "-1",
                     "yv" to "-1",
-                    "ytv" to "-1",
-                    "yrv" to "-1",
                 ),
             ),
             neteaseAuthenticatedHeaders(),
-            cacheKey = "netease:lyric-v1:$identifier",
+            cacheKey = "netease:lyric-yrc:$identifier",
             cachePolicy = ProviderCachePolicies.lyric,
         ).value.let { parseNeteaseResponse(it) }
         root.obj("yrc")?.stringOrNull("lyric")

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -93,6 +93,12 @@ class NeteaseProvider(
         )
     }
 
+    override suspend fun lyrics(track: org.feeluown.mobile.MusicTrack): String? {
+        val (_, identifier) = splitResourceId(track.providerId ?: track.id)
+        val id = identifier.ifBlank { track.id.substringAfterLast(':') }
+        return lyric(id)
+    }
+
     override suspend fun authState(): ProviderAuthState {
         val credentials = currentCredentials()
         if (credentials == null) return authState(null)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -598,12 +598,25 @@ class NeteaseProvider(
     private suspend fun lyric(identifier: String): String? = runCatching {
         val root = http.getText(
             ID,
-            queryUrl("$BASE/api/song/lyric", mapOf("id" to identifier, "lv" to "-1", "kv" to "1", "tv" to "-1")),
+            queryUrl(
+                "$BASE/api/song/lyric/v1",
+                mapOf(
+                    "id" to identifier,
+                    "lv" to "-1",
+                    "kv" to "-1",
+                    "tv" to "-1",
+                    "rv" to "-1",
+                    "yv" to "-1",
+                    "ytv" to "-1",
+                    "yrv" to "-1",
+                ),
+            ),
             neteaseAuthenticatedHeaders(),
-            cacheKey = "netease:lyric:$identifier",
+            cacheKey = "netease:lyric-v1:$identifier",
             cachePolicy = ProviderCachePolicies.lyric,
         ).value.let { parseNeteaseResponse(it) }
-        root.obj("lrc")?.stringOrNull("lyric")
+        root.obj("yrc")?.stringOrNull("lyric")
+            ?: root.obj("lrc")?.stringOrNull("lyric")
     }.getOrNull()
 
     private suspend fun currentUserId(): String? = runCatching { requestCurrentUserId() }.getOrNull()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -87,7 +87,6 @@ class NeteaseProvider(
             headers = mapOf("Referer" to "https://music.163.com/"),
             coverUrl = track.coverUrl,
             durationMs = data.long("time") ?: track.durationMs,
-            lyrics = lyric(id),
             audioQuality = data.stringOrNull("type") ?: qualityPolicy,
             providerName = NAME,
         )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -748,6 +748,12 @@ class QQMusicProvider(
             ?: root.array("songlist").firstOrNull()?.asObject()
     }
 
+    override suspend fun lyrics(track: org.feeluown.mobile.MusicTrack): String? {
+        val (_, identifier) = splitResourceId(track.providerId ?: track.id)
+        val id = identifier.ifBlank { track.id.substringAfterLast(':') }
+        return lyric(id)
+    }
+
     private suspend fun lyric(identifier: String): String? = runCatching {
         val root = http.getText(
             providerId = ID,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -88,7 +88,6 @@ class QQMusicProvider(
                 headers = mapOf("Referer" to "https://y.qq.com/"),
                 coverUrl = track.coverUrl,
                 durationMs = track.durationMs,
-                lyrics = lyric(songMid),
                 audioQuality = quality.label,
                 providerName = NAME,
             )

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -3569,9 +3569,7 @@ class FuoPlayerControllerTest {
         val providerTrack = providerTrack("provider:1", "Provider Title")
         val provider = FakeProviderRepository(
             tracks = listOf(providerTrack),
-            resolveHandler = { track, _, _, _, _, _ ->
-                payloadFor(track).copy(lyrics = "[00:01.00]Provider lyric")
-            },
+            lyricsHandler = { "[00:01.00]Provider lyric" },
         )
         val local = FakeLocalMusicRepository(tracks = listOf(localTrack))
         val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -3590,8 +3588,8 @@ class FuoPlayerControllerTest {
 
             assertEquals("[00:01.00]Provider lyric", local.lastSavedLyrics)
             assertEquals("[00:01.00]Provider lyric", controller.localTracks.first().lyrics)
-            assertEquals(1, provider.resolveCount)
-            assertEquals(setOf("netease"), provider.lastSmartReplacementProviderIds)
+            assertEquals(1, provider.lyricsCount)
+            assertEquals(0, provider.resolveCount)
         } finally {
             controllerScope.cancel()
         }
@@ -4153,6 +4151,7 @@ class FuoPlayerControllerTest {
         private val resolveHandler: (
             suspend (MusicTrack, UnavailablePlaybackPolicy, Set<String>, Double, Boolean, Boolean) -> PlaybackPayload
         )? = null,
+        private val lyricsHandler: (suspend (MusicTrack) -> String?)? = null,
         private val availableProviderInfos: List<ProviderInfo> = listOf(
             ProviderInfo(providerId = "netease", providerName = "网易云音乐"),
             ProviderInfo(providerId = "qqmusic", providerName = "QQ 音乐"),
@@ -4168,6 +4167,7 @@ class FuoPlayerControllerTest {
         private var isLoggedIn = initialIsLoggedIn
         private var enabledProviderIds = DEFAULT_ENABLED_PROVIDER_IDS
         var resolveCount = 0
+        var lyricsCount = 0
         var logoutCount = 0
         var authStateCount = 0
         var refreshAuthStateCount = 0
@@ -4238,6 +4238,11 @@ class FuoPlayerControllerTest {
                 album = track.album,
                 source = track.source,
             )
+        }
+
+        override suspend fun lyrics(track: MusicTrack): String? {
+            lyricsCount += 1
+            return lyricsHandler?.invoke(track) ?: track.lyrics
         }
 
         override suspend fun authState(providerId: String): ProviderAuthState {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LyricsParserTest {
     @Test
@@ -39,5 +40,55 @@ class LyricsParserTest {
         assertEquals("Hello", lines[0].text)
         assertNull(lines[0].translation)
         assertEquals(1_500, lines[1].timeMs)
+    }
+
+    @Test
+    fun parseYrcParsesWordTimingsAndSkipsJsonMetadata() {
+        val lines = parseYrc(
+            """
+            {"t":0,"c":[{"tx":"作词: "}]}
+            [1000,2000](1000,500,0)逐(1500,500,0)字
+            [3500,1800](3500,600,0)歌(4100,700,0)词
+            """.trimIndent(),
+        )
+
+        assertEquals(2, lines.size)
+        assertEquals(1_000, lines[0].timeMs)
+        assertEquals("逐字", lines[0].text)
+        assertEquals(
+            listOf(
+                LyricWord(1_000, 500, "逐"),
+                LyricWord(1_500, 500, "字"),
+            ),
+            lines[0].words,
+        )
+        assertEquals("歌词", lines[1].text)
+        assertEquals(2, lines[1].words?.size)
+    }
+
+    @Test
+    fun parseLyricsDetectsYrcVersusLrc() {
+        val yrc = parseLyrics("[1000,2000](1000,500,0)逐(1500,500,0)字")
+        val lrc = parseLyrics("[00:01.00]普通歌词")
+
+        assertEquals("逐字", yrc.single().text)
+        assertTrue(!yrc.single().words.isNullOrEmpty())
+        assertEquals("普通歌词", lrc.single().text)
+        assertNull(lrc.single().words)
+    }
+
+    @Test
+    fun karaokeFillProgressUsesWordWidthsAndTimeline() {
+        val words = listOf(
+            LyricWord(1_000, 1_000, "逐"),
+            LyricWord(2_000, 1_000, "字"),
+        )
+        val widths = listOf(10f, 30f)
+
+        assertEquals(0f, karaokeFillProgress(words, 500, widths), absoluteTolerance = 0.0001f)
+        assertEquals(0.125f, karaokeFillProgress(words, 1_500, widths), absoluteTolerance = 0.0001f)
+        assertEquals(0.25f, karaokeFillProgress(words, 2_000, widths), absoluteTolerance = 0.0001f)
+        assertEquals(0.625f, karaokeFillProgress(words, 2_500, widths), absoluteTolerance = 0.0001f)
+        assertEquals(1f, karaokeFillProgress(words, 3_000, widths), absoluteTolerance = 0.0001f)
     }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
@@ -78,6 +78,43 @@ class LyricsParserTest {
     }
 
     @Test
+    fun parseLyricsAttachesYtlrcTranslationToYrcLines() {
+        val raw = composeLyricsWithTranslation(
+            """
+            [11820,2220](11820,120,0)The (11940,420,0)club
+            [14040,1860](14040,180,0)So (14220,150,0)the
+            """.trimIndent(),
+            """
+            [00:11.820]这俱乐部
+            [00:14.040]所以我们
+            """.trimIndent(),
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals(2, lines.size)
+        assertEquals("The club", lines[0].text)
+        assertEquals("这俱乐部", lines[0].translation)
+        assertEquals(2, lines[0].words?.size)
+        assertEquals("So the", lines[1].text)
+        assertEquals("所以我们", lines[1].translation)
+    }
+
+    @Test
+    fun parseLyricsAttachesTlyricTranslationToLrcLines() {
+        val raw = composeLyricsWithTranslation(
+            "[00:11.82]The club isn't the best place",
+            "[00:11.82]这俱乐部不是个能找到安慰的地方",
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals("The club isn't the best place", lines.single().text)
+        assertEquals("这俱乐部不是个能找到安慰的地方", lines.single().translation)
+        assertNull(lines.single().words)
+    }
+
+    @Test
     fun karaokeFillProgressUsesWordWidthsAndTimeline() {
         val words = listOf(
             LyricWord(1_000, 1_000, "逐"),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
@@ -863,9 +863,6 @@ class ProviderPlaylistFeatureTest {
                 engine {
                     addHandler { request ->
                         when (request.url.encodedPath) {
-                            "/weapi/song/enhance/player/url" -> respond(
-                                """{"code":200,"data":[{"id":456,"url":"https://example.test/song.mp3","freeTrialInfo":null,"time":180000,"type":"mp3"}]}""",
-                            )
                             "/api/song/lyric" -> {
                                 assertEquals("-1", request.url.parameters["yv"])
                                 val id = request.url.parameters["id"]
@@ -895,16 +892,13 @@ class ProviderPlaylistFeatureTest {
         )
         val withoutYrc = withYrc.copy(id = "netease:789", providerId = "netease:789", title = "普通歌曲")
 
-        val yrcPayload = provider.resolve(withYrc, AudioQualityPolicy.High.policy)
-        val lrcPayload = provider.resolve(withoutYrc, AudioQualityPolicy.High.policy)
-
-        assertEquals("[1000,2000](1000,500,0)逐(1500,500,0)字", yrcPayload?.lyrics)
-        assertEquals("[00:02.00]回退", lrcPayload?.lyrics)
+        assertEquals("[1000,2000](1000,500,0)逐(1500,500,0)字", provider.lyrics(withYrc))
+        assertEquals("[00:02.00]回退", provider.lyrics(withoutYrc))
         client.close()
     }
 
     @Test
-    fun smartReplacementKeepsOriginalNeteaseLyricsWhenMediaUnavailable() = runTest {
+    fun smartReplacementDoesNotBlockOnOriginalLyricsFetch() = runTest {
         val lyricRequests = mutableListOf<String>()
         val client = ProviderHttpClient(
             HttpClient(MockEngine) {
@@ -963,8 +957,54 @@ class ProviderPlaylistFeatureTest {
         assertEquals(true, payload.isSmartReplacement)
         assertEquals("https://example.test/bilibili.m4s", payload.url)
         assertEquals("哔哩哔哩", payload.replacementProviderName)
-        assertEquals("[1000,2000](1000,500,0)原(1500,500,0)词", payload.lyrics)
+        assertEquals(null, payload.lyrics)
+        assertEquals(emptyList(), lyricRequests)
+
+        val replaced = track.copy(
+            isSmartReplacement = true,
+            originalId = payload.originalId,
+            originalSource = payload.originalSource,
+            originalProviderName = payload.originalProviderName,
+            source = payload.source,
+            providerName = payload.providerName,
+        )
+        assertEquals("[1000,2000](1000,500,0)原(1500,500,0)词", repository.lyrics(replaced))
         assertEquals(listOf("456"), lyricRequests)
+        client.close()
+    }
+
+    @Test
+    fun neteaseResolveDoesNotWaitForLyrics() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/weapi/song/enhance/player/url" -> respond(
+                                """{"code":200,"data":[{"id":456,"url":"https://example.test/song.mp3","freeTrialInfo":null,"time":180000,"type":"mp3"}]}""",
+                            )
+                            "/api/song/lyric" -> error("lyric must not block resolve")
+                            else -> error("unexpected NetEase request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "netease:456",
+            title = "可播放歌曲",
+            artists = "歌手",
+            album = "专辑",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:456",
+        )
+
+        val payload = provider.resolve(track, AudioQualityPolicy.High.policy)
+
+        assertEquals("https://example.test/song.mp3", payload?.url)
+        assertEquals(null, payload?.lyrics)
         client.close()
     }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
@@ -203,8 +203,9 @@ class ProviderPlaylistFeatureTest {
                                     """{"code":200,"data":[{"id":456,"url":"https://example.test/fm.mp3","br":320000,"type":"mp3","time":240000,"freeTrialInfo":null}]}""",
                                 )
                             }
-                            "/api/song/lyric" -> {
+                            "/api/song/lyric/v1" -> {
                                 assertEquals("-1", request.url.parameters["lv"])
+                                assertEquals("-1", request.url.parameters["yv"])
                                 respond("""{"code":200,"lrc":{"lyric":"[00:00.00]FM"}}""")
                             }
                             else -> error("unexpected NetEase request: ${request.url.encodedPath}")
@@ -852,6 +853,53 @@ class ProviderPlaylistFeatureTest {
 
         assertEquals("https://example.test/song.mp3", payload?.url)
         assertEquals(null, payload?.lyrics)
+        client.close()
+    }
+
+    @Test
+    fun neteasePrefersYrcLyricsAndFallsBackToLrc() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/weapi/song/enhance/player/url" -> respond(
+                                """{"code":200,"data":[{"id":456,"url":"https://example.test/song.mp3","freeTrialInfo":null,"time":180000,"type":"mp3"}]}""",
+                            )
+                            "/api/song/lyric/v1" -> {
+                                assertEquals("-1", request.url.parameters["yv"])
+                                val id = request.url.parameters["id"]
+                                if (id == "456") {
+                                    respond(
+                                        """{"code":200,"yrc":{"lyric":"[1000,2000](1000,500,0)逐(1500,500,0)字"},"lrc":{"lyric":"[00:01.00]普通"}}""",
+                                    )
+                                } else {
+                                    respond("""{"code":200,"lrc":{"lyric":"[00:02.00]回退"}}""")
+                                }
+                            }
+                            else -> error("unexpected NetEase request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val withYrc = MusicTrack(
+            id = "netease:456",
+            title = "逐字歌曲",
+            artists = "歌手",
+            album = "专辑",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:456",
+        )
+        val withoutYrc = withYrc.copy(id = "netease:789", providerId = "netease:789", title = "普通歌曲")
+
+        val yrcPayload = provider.resolve(withYrc, AudioQualityPolicy.High.policy)
+        val lrcPayload = provider.resolve(withoutYrc, AudioQualityPolicy.High.policy)
+
+        assertEquals("[1000,2000](1000,500,0)逐(1500,500,0)字", yrcPayload?.lyrics)
+        assertEquals("[00:02.00]回退", lrcPayload?.lyrics)
         client.close()
     }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
@@ -203,7 +203,7 @@ class ProviderPlaylistFeatureTest {
                                     """{"code":200,"data":[{"id":456,"url":"https://example.test/fm.mp3","br":320000,"type":"mp3","time":240000,"freeTrialInfo":null}]}""",
                                 )
                             }
-                            "/api/song/lyric/v1" -> {
+                            "/api/song/lyric" -> {
                                 assertEquals("-1", request.url.parameters["lv"])
                                 assertEquals("-1", request.url.parameters["yv"])
                                 respond("""{"code":200,"lrc":{"lyric":"[00:00.00]FM"}}""")
@@ -866,7 +866,7 @@ class ProviderPlaylistFeatureTest {
                             "/weapi/song/enhance/player/url" -> respond(
                                 """{"code":200,"data":[{"id":456,"url":"https://example.test/song.mp3","freeTrialInfo":null,"time":180000,"type":"mp3"}]}""",
                             )
-                            "/api/song/lyric/v1" -> {
+                            "/api/song/lyric" -> {
                                 assertEquals("-1", request.url.parameters["yv"])
                                 val id = request.url.parameters["id"]
                                 if (id == "456") {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
@@ -904,6 +904,71 @@ class ProviderPlaylistFeatureTest {
     }
 
     @Test
+    fun smartReplacementKeepsOriginalNeteaseLyricsWhenMediaUnavailable() = runTest {
+        val lyricRequests = mutableListOf<String>()
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/weapi/song/enhance/player/url" -> respond(
+                                """{"code":200,"data":[{"id":456,"url":null,"freeTrialInfo":{"start":0,"end":30},"time":180000,"type":"mp3"}]}""",
+                            )
+                            "/api/song/lyric" -> {
+                                lyricRequests += request.url.parameters["id"].orEmpty()
+                                respond(
+                                    """{"code":200,"yrc":{"lyric":"[1000,2000](1000,500,0)原(1500,500,0)词"},"lrc":{"lyric":"[00:01.00]原文"}}""",
+                                )
+                            }
+                            "/x/web-interface/search/type" -> respond(
+                                """{"code":0,"data":{"result":[{"bvid":"BVdemo","title":"人间芳菲","author":"音阙诗听","duration":"3:36","pic":"//example.test/cover.jpg"}]}}""",
+                            )
+                            "/x/web-interface/view" -> respond(
+                                """{"code":0,"data":{"bvid":"BVdemo","cid":123,"title":"人间芳菲","duration":216,"pages":[{"cid":123,"page":1,"part":"人间芳菲","duration":216}]}}""",
+                            )
+                            "/x/web-interface/nav" -> respond(
+                                """{"code":0,"data":{"wbi_img":{"img_url":"https://example.test/wbi/abcdefghijklmnopqrstuvwxyz.png","sub_url":"https://example.test/wbi/0123456789abcdefghijklmnopqrstuvwxyz.png"}}}""",
+                            )
+                            "/x/player/playurl" -> respond(
+                                """{"code":0,"data":{"dash":{"audio":[{"baseUrl":"https://example.test/bilibili.m4s","bandwidth":192000,"length":216000}]}}}""",
+                            )
+                            else -> error("unexpected request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val repository = KotlinProviderRepository(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "netease:456",
+            title = "人间芳菲",
+            artists = "音阙诗听",
+            album = "人间芳菲",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:456",
+            providerName = "网易云音乐",
+            durationMs = 216_000,
+        )
+
+        val payload = repository.resolve(
+            track = track,
+            unavailablePolicy = UnavailablePlaybackPolicy.SmartReplace,
+            smartReplacementProviderIds = setOf("bilibili"),
+            smartReplacementMinScore = 0.5,
+            smartReplacementUseOriginalMetadata = true,
+            smartReplacementUseOriginalLyrics = true,
+        )
+
+        assertEquals(true, payload.isSmartReplacement)
+        assertEquals("https://example.test/bilibili.m4s", payload.url)
+        assertEquals("哔哩哔哩", payload.replacementProviderName)
+        assertEquals("[1000,2000](1000,500,0)原(1500,500,0)词", payload.lyrics)
+        assertEquals(listOf("456"), lyricRequests)
+        client.close()
+    }
+
+    @Test
     fun qqmusicDoesNotUseTestFileAsPlayableMedia() = runTest {
         val requestedData = mutableListOf<String>()
         val client = ProviderHttpClient(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderPlaylistFeatureTest.kt
@@ -892,8 +892,85 @@ class ProviderPlaylistFeatureTest {
         )
         val withoutYrc = withYrc.copy(id = "netease:789", providerId = "netease:789", title = "普通歌曲")
 
-        assertEquals("[1000,2000](1000,500,0)逐(1500,500,0)字", provider.lyrics(withYrc))
+        assertEquals(
+            composeLyricsWithTranslation(
+                "[1000,2000](1000,500,0)逐(1500,500,0)字",
+                null,
+            ),
+            provider.lyrics(withYrc),
+        )
         assertEquals("[00:02.00]回退", provider.lyrics(withoutYrc))
+        client.close()
+    }
+
+    @Test
+    fun neteaseCombinesYrcWithYtlrcTranslation() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/api/song/lyric" -> respond(
+                                """{"code":200,"yrc":{"lyric":"[11820,2220](11820,120,0)The (11940,420,0)club"},"ytlrc":{"lyric":"[00:11.820]这俱乐部"},"tlyric":{"lyric":"[00:11.82]备用翻译"},"lrc":{"lyric":"[00:11.82]The club"}}""",
+                            )
+                            else -> error("unexpected NetEase request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "netease:452601986",
+            title = "Shape Of You",
+            artists = "Ed Sheeran",
+            album = "÷",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:452601986",
+        )
+
+        val lyrics = provider.lyrics(track)
+        val lines = parseLyrics(lyrics)
+
+        assertTrue(lyrics.orEmpty().contains(LYRIC_TRANSLATION_MARKER.trim()))
+        assertEquals("The club", lines.single().text)
+        assertEquals("这俱乐部", lines.single().translation)
+        assertEquals(2, lines.single().words?.size)
+        client.close()
+    }
+
+    @Test
+    fun neteaseCombinesLrcWithTlyricTranslation() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/api/song/lyric" -> respond(
+                                """{"code":200,"lrc":{"lyric":"[00:11.82]The club isn't the best place"},"tlyric":{"lyric":"[00:11.82]这俱乐部不是个能找到安慰的地方"}}""",
+                            )
+                            else -> error("unexpected NetEase request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "netease:451703096",
+            title = "Shape of You",
+            artists = "Ed Sheeran",
+            album = "÷",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:451703096",
+        )
+
+        val lines = parseLyrics(provider.lyrics(track))
+
+        assertEquals("The club isn't the best place", lines.single().text)
+        assertEquals("这俱乐部不是个能找到安慰的地方", lines.single().translation)
         client.close()
     }
 
@@ -970,6 +1047,72 @@ class ProviderPlaylistFeatureTest {
         )
         assertEquals("[1000,2000](1000,500,0)原(1500,500,0)词", repository.lyrics(replaced))
         assertEquals(listOf("456"), lyricRequests)
+        client.close()
+    }
+
+    @Test
+    fun smartReplacementReusesKnownReplacementWithoutResolvingWrongProvider() = runTest {
+        val requestedPaths = mutableListOf<String>()
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        requestedPaths += request.url.encodedPath
+                        when (request.url.encodedPath) {
+                            "/weapi/song/enhance/player/url" -> error("should not resolve original NetEase media first")
+                            "/x/web-interface/view" -> {
+                                assertEquals("BVdemo", request.url.parameters["bvid"])
+                                respond(
+                                    """{"code":0,"data":{"bvid":"BVdemo","cid":123,"title":"人间芳菲","duration":216,"pages":[{"cid":123,"page":1,"part":"人间芳菲","duration":216}]}}""",
+                                )
+                            }
+                            "/x/web-interface/nav" -> respond(
+                                """{"code":0,"data":{"wbi_img":{"img_url":"https://example.test/wbi/abcdefghijklmnopqrstuvwxyz.png","sub_url":"https://example.test/wbi/0123456789abcdefghijklmnopqrstuvwxyz.png"}}}""",
+                            )
+                            "/x/player/playurl" -> respond(
+                                """{"code":0,"data":{"dash":{"audio":[{"baseUrl":"https://example.test/bilibili.m4s","bandwidth":192000,"length":216000}]}}}""",
+                            )
+                            else -> error("unexpected request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val repository = KotlinProviderRepository(client, InMemoryProviderCredentialStore())
+        val persisted = MusicTrack(
+            id = "netease:456",
+            title = "人间芳菲",
+            artists = "音阙诗听",
+            album = "人间芳菲",
+            source = "bilibili",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:456",
+            providerName = "哔哩哔哩",
+            durationMs = 216_000,
+            isSmartReplacement = true,
+            originalId = "netease:456",
+            originalSource = "netease",
+            originalProviderName = "网易云音乐",
+            replacementId = "bilibili:BVdemo",
+            replacementSource = "bilibili",
+            replacementProviderName = "哔哩哔哩",
+            replacementTitle = "人间芳菲",
+        )
+
+        val payload = repository.resolve(
+            track = persisted,
+            unavailablePolicy = UnavailablePlaybackPolicy.SmartReplace,
+            smartReplacementProviderIds = setOf("bilibili"),
+            smartReplacementMinScore = 0.5,
+            smartReplacementUseOriginalMetadata = true,
+            smartReplacementUseOriginalLyrics = true,
+        )
+
+        assertEquals(true, payload.isSmartReplacement)
+        assertEquals("https://example.test/bilibili.m4s", payload.url)
+        assertEquals("netease", payload.originalSource)
+        assertEquals("bilibili:BVdemo", payload.replacementId)
+        assertTrue("/weapi/song/enhance/player/url" !in requestedPaths)
         client.close()
     }
 


### PR DESCRIPTION
## Summary
- 网易云歌词改为请求 `/api/song/lyric/v1`，优先使用 `yrc` 逐字歌词，缺失时回退 `lrc`
- 扩展歌词解析模型（`LyricWord` / `parseYrc` / `parseLyrics`），自动识别 yrc 与普通 LRC
- `LyricsPanel` 当前行按时间轴与字宽做平滑卡拉 OK 填色；迷你播放器仍显示整行

## Test plan
- [ ] `./gradlew :shared:testDebugUnitTest --tests 'org.feeluown.mobile.LyricsParserTest' --tests 'org.feeluown.mobile.ProviderPlaylistFeatureTest'`
- [ ] 播放有逐字歌词的网易云歌曲，确认当前行平滑填色
- [ ] 播放无 yrc 仅有 lrc 的歌曲，确认仍按行高亮
- [ ] 迷你播放器仍只显示当前整行文案


Made with [Cursor](https://cursor.com)