### PR TITLE
fix: refresh lyrics and restore playback queue

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -154,15 +154,17 @@ class AndroidNativeAudioEngine(
     private fun updatePosition() {
         val controller = mediaController ?: return
         if (controller.playbackState == Player.STATE_IDLE) return
+        val currentMediaItem = controller.currentMediaItem
+        val currentMediaLyrics = currentMediaItem?.mediaMetadata
+            ?.extras
+            ?.getString("lyrics")
+            ?.takeIf { it.isNotBlank() }
         mutableState.value = mutableState.value.copy(
-            currentTrack = mutableState.value.currentTrack ?: controller.currentMediaItem?.toMusicTrack(),
+            currentTrack = mutableState.value.currentTrack ?: currentMediaItem?.toMusicTrack(),
             positionMs = controller.currentPosition.coerceAtLeast(0),
             durationMs = controller.duration.takeIf { it > 0 } ?: mutableState.value.durationMs,
             bufferedMs = controller.bufferedPosition.coerceAtLeast(0),
-            lyrics = mutableState.value.lyrics ?: controller.currentMediaItem?.mediaMetadata
-                ?.extras
-                ?.getString("lyrics")
-                ?.takeIf { it.isNotBlank() },
+            lyrics = if (currentMediaItem != null) currentMediaLyrics else mutableState.value.lyrics,
         )
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -115,35 +115,38 @@ class KotlinProviderRepository : ProviderMusicRepository {
         smartReplacementUseOriginalLyrics: Boolean,
     ): PlaybackPayload {
         initialize()
-        val originalProviderId = track.source.ifBlank { splitResourceId(track.providerId ?: track.id).first }
+        val originalTrack = track.forPlaybackResolution()
+        val originalProviderId = originalTrack.source.ifBlank {
+            splitResourceId(originalTrack.providerId ?: originalTrack.id).first
+        }
         val originalProvider = providerMap[originalProviderId]
         val quality = if (isCellularConnection()) {
             cellularAudioQualityPolicy.policy
         } else {
             wifiAudioQualityPolicy.policy
         }
-        val direct = originalProvider?.resolve(track, quality)
+        val direct = originalProvider?.resolve(originalTrack, quality)
         if (direct != null) return direct
         if (unavailablePolicy == UnavailablePlaybackPolicy.Skip) {
-            error("media unavailable: ${track.id}")
+            error("media unavailable: ${originalTrack.id}")
         }
 
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
-            .flatMap { provider -> provider.search("${track.title} ${track.artists}").tracks }
+            .flatMap { provider -> provider.search("${originalTrack.title} ${originalTrack.artists}").tracks }
             .mapNotNull { candidate ->
-                val score = replacementScore(track, candidate)
+                val score = replacementScore(originalTrack, candidate)
                 if (score < smartReplacementMinScore) return@mapNotNull null
                 val provider = providerMap[candidate.source] ?: return@mapNotNull null
                 val payload = provider.resolve(candidate, quality) ?: return@mapNotNull null
                 score to payload.copy(
                     isSmartReplacement = true,
-                    originalId = track.id,
-                    originalTitle = track.title,
-                    originalArtists = track.artists,
-                    originalAlbum = track.album,
-                    originalSource = track.source,
-                    originalProviderName = track.providerName,
-                    originalCoverUrl = track.coverUrl,
+                    originalId = originalTrack.id,
+                    originalTitle = originalTrack.title,
+                    originalArtists = originalTrack.artists,
+                    originalAlbum = originalTrack.album,
+                    originalSource = originalTrack.source,
+                    originalProviderName = originalTrack.providerName,
+                    originalCoverUrl = originalTrack.coverUrl,
                     replacementId = candidate.id,
                     replacementTitle = candidate.title,
                     replacementArtists = candidate.artists,
@@ -153,15 +156,15 @@ class KotlinProviderRepository : ProviderMusicRepository {
                     replacementCoverUrl = candidate.coverUrl,
                     replacementStrategy = "title_artist_duration",
                     replacementScore = score,
-                    title = if (smartReplacementUseOriginalMetadata) track.title else candidate.title,
-                    artists = if (smartReplacementUseOriginalMetadata) track.artists else candidate.artists,
-                    album = if (smartReplacementUseOriginalMetadata) track.album else candidate.album,
-                    coverUrl = if (smartReplacementUseOriginalMetadata) track.coverUrl else candidate.coverUrl,
-                    lyrics = if (smartReplacementUseOriginalLyrics) track.lyrics ?: payload.lyrics else payload.lyrics,
+                    title = if (smartReplacementUseOriginalMetadata) originalTrack.title else candidate.title,
+                    artists = if (smartReplacementUseOriginalMetadata) originalTrack.artists else candidate.artists,
+                    album = if (smartReplacementUseOriginalMetadata) originalTrack.album else candidate.album,
+                    coverUrl = if (smartReplacementUseOriginalMetadata) originalTrack.coverUrl else candidate.coverUrl,
+                    lyrics = if (smartReplacementUseOriginalLyrics) originalTrack.lyrics ?: payload.lyrics else payload.lyrics,
                 )
             }
             .maxByOrNull { it.first }
-        return candidates?.second ?: error("media unavailable and no smart replacement: ${track.id}")
+        return candidates?.second ?: error("media unavailable and no smart replacement: ${originalTrack.id}")
     }
 
     override suspend fun authState(providerId: String): ProviderAuthState = requireProvider(providerId).authState()
@@ -357,6 +360,42 @@ class KotlinProviderRepository : ProviderMusicRepository {
         "qqmusic" to QQMusicProvider(http, credentials),
         "bilibili" to BilibiliProvider(http, credentials),
         "ytmusic" to YtMusicProvider(http, credentials),
+    )
+}
+
+internal fun MusicTrack.forPlaybackResolution(): MusicTrack {
+    if (!isSmartReplacement) return this
+    val restoredId = originalId ?: id
+    val restoredSource = originalSource
+        ?.takeIf { it.isNotBlank() }
+        ?: runCatching { splitResourceId(restoredId).first }.getOrDefault(source)
+    return copy(
+        id = restoredId,
+        title = originalTitle ?: title,
+        artists = originalArtists ?: artists,
+        album = originalAlbum ?: album,
+        source = restoredSource,
+        coverUrl = originalCoverUrl ?: coverUrl,
+        providerId = originalId ?: providerId,
+        providerName = originalProviderName ?: providerName,
+        isSmartReplacement = false,
+        originalId = null,
+        originalTitle = null,
+        originalArtists = null,
+        originalAlbum = null,
+        originalSource = null,
+        originalProviderName = null,
+        originalCoverUrl = null,
+        replacementId = null,
+        replacementTitle = null,
+        replacementArtists = null,
+        replacementAlbum = null,
+        replacementSource = null,
+        replacementProviderName = null,
+        replacementCoverUrl = null,
+        replacementStrategy = null,
+        replacementScore = null,
+        isUnavailable = false,
     )
 }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryPlaybackResolutionTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryPlaybackResolutionTest.kt
@@ -1,0 +1,67 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class KotlinProviderRepositoryPlaybackResolutionTest {
+    @Test
+    fun smartReplacementRestoresOriginalIdentityBeforeResolving() {
+        val replaced = MusicTrack(
+            id = "netease:123",
+            title = "替换标题",
+            artists = "替换歌手",
+            album = "替换专辑",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            coverUrl = "https://example.com/replacement.jpg",
+            providerId = "netease:123",
+            providerName = "QQ 音乐",
+            isSmartReplacement = true,
+            originalId = "netease:123",
+            originalTitle = "原始标题",
+            originalArtists = "原始歌手",
+            originalAlbum = "原始专辑",
+            originalSource = "netease",
+            originalProviderName = "网易云音乐",
+            originalCoverUrl = "https://example.com/original.jpg",
+            replacementId = "qqmusic:456",
+            replacementTitle = "替换标题",
+            replacementArtists = "替换歌手",
+            replacementAlbum = "替换专辑",
+            replacementSource = "qqmusic",
+            replacementProviderName = "QQ 音乐",
+        )
+
+        val restored = replaced.forPlaybackResolution()
+
+        assertEquals("netease:123", restored.id)
+        assertEquals("netease:123", restored.providerId)
+        assertEquals("netease", restored.source)
+        assertEquals("网易云音乐", restored.providerName)
+        assertEquals("原始标题", restored.title)
+        assertEquals("原始歌手", restored.artists)
+        assertEquals("原始专辑", restored.album)
+        assertEquals("https://example.com/original.jpg", restored.coverUrl)
+        assertFalse(restored.isSmartReplacement)
+        assertNull(restored.originalId)
+        assertNull(restored.replacementId)
+    }
+
+    @Test
+    fun regularTrackKeepsItsPlaybackIdentity() {
+        val track = MusicTrack(
+            id = "qqmusic:456",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            providerId = "qqmusic:456",
+            providerName = "QQ 音乐",
+        )
+
+        assertEquals(track, track.forPlaybackResolution())
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsRegressionNotes.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsRegressionNotes.kt
@@ -1,0 +1,3 @@
+package org.feeluown.mobile
+
+// Regression coverage for Android lyric transitions lives in the platform integration path.

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsRegressionNotes.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsRegressionNotes.kt
@@ -1,3 +1,0 @@
-package org.feeluown.mobile
-
-// Regression coverage for Android lyric transitions lives in the platform integration path.

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCodecSmartReplacementTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCodecSmartReplacementTest.kt
@@ -1,0 +1,45 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaybackQueueCodecSmartReplacementTest {
+    @Test
+    fun persistedSmartReplacementKeepsOriginalIdentityForRestartResolution() {
+        val track = MusicTrack(
+            id = "netease:123",
+            title = "原始标题",
+            artists = "原始歌手",
+            album = "原始专辑",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:123",
+            providerName = "QQ 音乐",
+            isSmartReplacement = true,
+            originalId = "netease:123",
+            originalTitle = "原始标题",
+            originalArtists = "原始歌手",
+            originalAlbum = "原始专辑",
+            originalSource = "netease",
+            originalProviderName = "网易云音乐",
+            replacementId = "qqmusic:456",
+            replacementSource = "qqmusic",
+            replacementProviderName = "QQ 音乐",
+        )
+        val snapshot = PlaybackQueueSnapshot(
+            mainQueue = listOf(track),
+            originalMainQueue = listOf(track),
+            queueIndex = 0,
+        )
+
+        val restored = PlaybackQueueCodec.decode(PlaybackQueueCodec.encode(snapshot)).mainQueue.single()
+        val resolutionTrack = restored.forPlaybackResolution()
+
+        assertTrue(restored.isSmartReplacement)
+        assertEquals("qqmusic", restored.source)
+        assertEquals("netease", resolutionTrack.source)
+        assertEquals("netease:123", resolutionTrack.id)
+        assertEquals("netease:123", resolutionTrack.providerId)
+    }
+}


### PR DESCRIPTION
## What changed
- Refresh Android lyrics from the active Media3 `MediaItem` instead of retaining the previous non-null lyric value across track transitions.
- Restore a persisted smart-replacement track back to its original track identity before provider resolution, then allow normal direct playback / smart replacement to run again.
- Add regression coverage for smart-replacement identity restoration and queue codec restart behavior.

## Root cause
1. `AndroidNativeAudioEngine.updatePosition()` preferred the existing `lyrics` value whenever it was non-null, so a transition to the next media item could keep the previous song's lyrics.
2. Smart replacement updates the current queue track with replacement-source metadata while retaining the original track/provider id. After app restart, that persisted mixed identity could be sent to the wrong Kotlin provider resolver.

## Impact
- Lyrics follow the currently playing media item when advancing to the next song, including clearing lyrics when the next item has none.
- Restarting the app and resuming a persisted smart-replaced queue item resolves from the original provider identity and can smart-replace again if necessary.

## Validation
- Added common tests for original playback identity restoration.
- Added a queue codec regression test covering persisted smart-replacement restart state.
- PR CI should run the repository's configured build/test checks.