### PR TITLE
fix: restore smart replacement scoring and candidate selection

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -143,22 +143,21 @@ class KotlinProviderRepository : ProviderMusicRepository {
 
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
             .flatMap { provider -> provider.search("${mediaTrack.title} ${mediaTrack.artists}").tracks }
-            .mapNotNull { candidate ->
-                val score = replacementScore(mediaTrack, candidate)
-                if (score < smartReplacementMinScore) return@mapNotNull null
-                val provider = providerMap[candidate.source] ?: return@mapNotNull null
-                val payload = provider.resolve(candidate, quality) ?: return@mapNotNull null
-                score to annotateSmartReplacement(
-                    payload = payload,
-                    original = mediaTrack,
-                    candidate = candidate,
-                    score = score,
-                    useOriginalMetadata = smartReplacementUseOriginalMetadata,
-                    useOriginalLyrics = smartReplacementUseOriginalLyrics,
-                )
-            }
-            .maxByOrNull { it.first }
-        return candidates?.second ?: error("media unavailable and no smart replacement: ${mediaTrack.id}")
+        val selected = selectReplacementCandidate(
+            candidates = candidates,
+            minScore = smartReplacementMinScore,
+            scoreOf = { candidate -> replacementScore(mediaTrack, candidate) },
+            resolve = { candidate -> providerMap[candidate.source]?.resolve(candidate, quality) },
+        ) ?: error("media unavailable and no smart replacement: ${mediaTrack.id}")
+        val (candidate, score, payload) = selected
+        return annotateSmartReplacement(
+            payload = payload,
+            original = mediaTrack,
+            candidate = candidate,
+            score = score,
+            useOriginalMetadata = smartReplacementUseOriginalMetadata,
+            useOriginalLyrics = smartReplacementUseOriginalLyrics,
+        )
     }
 
     private suspend fun resolveKnownReplacement(
@@ -450,15 +449,18 @@ class KotlinProviderRepository : ProviderMusicRepository {
     }
 
     private fun replacementScore(origin: MusicTrack, candidate: MusicTrack): Double {
-        val originTitle = normalize(origin.title)
-        val candidateTitle = normalize(candidate.title)
+        if (candidate.source == BILIBILI_PROVIDER_ID) {
+            return bilibiliReplacementScore(origin, candidate)
+        }
+        val originTitle = normalizeReplacementText(origin.title)
+        val candidateTitle = normalizeReplacementText(candidate.title)
         val titleScore = when {
             originTitle == candidateTitle -> 1.0
             originTitle.contains(candidateTitle) || candidateTitle.contains(originTitle) -> 0.8
             else -> tokenSimilarity(originTitle, candidateTitle)
         }
-        val originArtists = normalize(origin.artists)
-        val candidateArtists = normalize(candidate.artists)
+        val originArtists = normalizeReplacementText(origin.artists)
+        val candidateArtists = normalizeReplacementText(candidate.artists)
         val artistScore = when {
             originArtists == candidateArtists -> 1.0
             originArtists.contains(candidateArtists) || candidateArtists.contains(originArtists) -> 0.8
@@ -471,8 +473,6 @@ class KotlinProviderRepository : ProviderMusicRepository {
         }
         return titleScore * 0.55 + artistScore * 0.35 + durationScore * 0.10
     }
-
-    private fun normalize(value: String): String = value.lowercase().replace(Regex("[^\\p{L}\\p{N}]"), "")
 
     private fun tokenSimilarity(left: String, right: String): Double {
         if (left.isBlank() || right.isBlank()) return 0.0
@@ -487,6 +487,78 @@ class KotlinProviderRepository : ProviderMusicRepository {
         "ytmusic" to YtMusicProvider(http, credentials),
     )
 }
+
+internal suspend fun <T> selectReplacementCandidate(
+    candidates: List<MusicTrack>,
+    minScore: Double,
+    scoreOf: (MusicTrack) -> Double,
+    resolve: suspend (MusicTrack) -> T?,
+): Triple<MusicTrack, Double, T>? {
+    val ranked = candidates
+        .map { candidate -> candidate to scoreOf(candidate) }
+        .filter { (_, score) -> score >= minScore }
+        .sortedByDescending { (_, score) -> score }
+    for ((candidate, score) in ranked) {
+        val resolved = resolve(candidate) ?: continue
+        return Triple(candidate, score, resolved)
+    }
+    return null
+}
+
+internal fun bilibiliReplacementScore(origin: MusicTrack, candidate: MusicTrack): Double {
+    val originTitle = normalizeReplacementText(origin.title)
+    val candidateTitle = normalizeReplacementText(candidate.title)
+    if (originTitle.isBlank() || candidateTitle.isBlank()) return 0.0
+
+    var score = 0.0
+    if (originTitle in candidateTitle) {
+        score += 0.40
+    }
+    if (replacementArtistMatchTexts(origin.artists).any { artist -> artist in candidateTitle }) {
+        score += 0.20
+    }
+    if (BILIBILI_REPLACEMENT_BONUS_KEYWORDS.any { keyword -> keyword in candidateTitle }) {
+        score += 0.10
+    }
+    if (
+        BILIBILI_REPLACEMENT_PENALTY_KEYWORDS.none { keyword -> keyword in originTitle } &&
+        BILIBILI_REPLACEMENT_PENALTY_KEYWORDS.any { keyword -> keyword in candidateTitle }
+    ) {
+        score -= 0.20
+    }
+    return applyReplacementDurationPenalty(score, origin, candidate)
+}
+
+private fun applyReplacementDurationPenalty(score: Double, origin: MusicTrack, candidate: MusicTrack): Double {
+    val originDuration = origin.durationMs
+    val candidateDuration = candidate.durationMs
+    if (originDuration != null && originDuration > 0 && candidateDuration != null && candidateDuration > 0) {
+        val diffRatio = kotlin.math.abs(originDuration - candidateDuration).toDouble() / originDuration.toDouble()
+        return (score - minOf(diffRatio * MAX_REPLACEMENT_DURATION_PENALTY, MAX_REPLACEMENT_DURATION_PENALTY))
+            .coerceAtLeast(0.0)
+    }
+    return score.coerceAtLeast(0.0)
+}
+
+private fun normalizeReplacementText(value: String): String =
+    value.lowercase().replace(Regex("[^\\p{L}\\p{N}]"), "")
+
+private fun replacementArtistMatchTexts(value: String): List<String> {
+    var parts = listOf(value)
+    REPLACEMENT_ARTIST_SEPARATORS.forEach { separator ->
+        parts = parts.flatMap { part -> part.split(separator) }
+    }
+    return parts
+        .map { part -> normalizeReplacementText(part.trim()) }
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
+private const val BILIBILI_PROVIDER_ID = "bilibili"
+private val BILIBILI_REPLACEMENT_BONUS_KEYWORDS = listOf("mv", "hires")
+private val BILIBILI_REPLACEMENT_PENALTY_KEYWORDS = listOf("cover", "翻唱", "remix")
+private val REPLACEMENT_ARTIST_SEPARATORS = listOf(" / ", "/", "、", ",", "，", ";", "；", "&", "+", "＋")
+private const val MAX_REPLACEMENT_DURATION_PENALTY = 0.30
 
 fun createKotlinProviderRepository(
     credentials: ProviderCredentialStore,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
@@ -1,0 +1,124 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class KotlinProviderRepositoryReplacementTest {
+    @Test
+    fun bilibiliScoreMatchesTitleArtistAndBonusKeywords() {
+        val origin = track(
+            source = "netease",
+            title = "Night Song",
+            artists = "Alice",
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "ALICE - night song Hi-Res MV",
+            artists = "Uploader",
+        )
+
+        assertEquals(0.70, bilibiliReplacementScore(origin, candidate), 0.0001)
+    }
+
+    @Test
+    fun bilibiliScorePenalizesCoverKeywords() {
+        val origin = track(
+            source = "netease",
+            title = "晴天",
+            artists = "周杰伦",
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "周杰伦 晴天 Cover 翻唱",
+            artists = "Uploader",
+        )
+
+        assertEquals(0.40, bilibiliReplacementScore(origin, candidate), 0.0001)
+    }
+
+    @Test
+    fun bilibiliScoreKeepsOriginalKeywordVersions() {
+        val origin = track(
+            source = "netease",
+            title = "晴天 Remix",
+            artists = "周杰伦",
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "周杰伦 晴天 REMIX",
+            artists = "Uploader",
+        )
+
+        assertEquals(0.60, bilibiliReplacementScore(origin, candidate), 0.0001)
+    }
+
+    @Test
+    fun bilibiliScoreAppliesRelativeDurationPenalty() {
+        val origin = track(
+            source = "netease",
+            title = "Night Song",
+            artists = "Alice",
+            durationMs = 200_000,
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "ALICE - night song Hi-Res MV",
+            artists = "Uploader",
+            durationMs = 300_000,
+        )
+
+        assertEquals(0.55, bilibiliReplacementScore(origin, candidate), 0.0001)
+    }
+
+    @Test
+    fun replacementSelectionResolvesInScoreOrderAndStopsAtFirstPlayableCandidate() = runTest {
+        val low = track("bilibili", "Low", "Uploader", id = "low")
+        val medium = track("ytmusic", "Medium", "Artist", id = "medium")
+        val high = track("qqmusic", "High", "Artist", id = "high")
+        val scores = mapOf(
+            low.id to 0.40,
+            medium.id to 0.80,
+            high.id to 0.95,
+        )
+        val attempts = mutableListOf<String>()
+
+        val selected = selectReplacementCandidate(
+            candidates = listOf(low, medium, high),
+            minScore = 0.55,
+            scoreOf = { candidate -> scores.getValue(candidate.id) },
+            resolve = { candidate ->
+                attempts += candidate.id
+                when (candidate.id) {
+                    high.id -> null
+                    medium.id -> "playable"
+                    else -> error("below-threshold candidate should not be resolved")
+                }
+            },
+        )
+
+        assertNotNull(selected)
+        assertEquals(listOf(high.id, medium.id), attempts)
+        assertEquals(medium.id, selected.first.id)
+        assertEquals(0.80, selected.second, 0.0001)
+        assertEquals("playable", selected.third)
+    }
+
+    private fun track(
+        source: String,
+        title: String,
+        artists: String,
+        durationMs: Long? = null,
+        id: String = "$source:$title",
+    ): MusicTrack = MusicTrack(
+        id = id,
+        title = title,
+        artists = artists,
+        album = "",
+        source = source,
+        sourceType = TrackSourceType.Provider,
+        durationMs = durationMs,
+        providerId = id,
+    )
+}


### PR DESCRIPTION
## What changed

- Restore the provider-specific Bilibili smart-replacement scoring behavior that existed before the Python provider runtime was migrated to Kotlin.
  - match the original title inside the Bilibili video title
  - match original artist names inside the video title instead of treating the uploader as the song artist
  - restore `mv` / `hires` bonus handling
  - restore conditional `cover` / `翻唱` / `remix` penalties
  - restore relative duration-difference penalties
- Rank all candidates before media resolution, then resolve candidates from highest score to lowest and stop at the first playable result.
- Keep the existing generic 55% title / 35% artist / 10% duration scoring path unchanged for non-Bilibili providers.
- Add common tests covering the migrated Bilibili scoring cases and the score-ordered short-circuit resolve behavior.

## Why

The Kotlin provider migration replaced the previous Bilibili-specific standby matcher with the generic music-provider scorer. Bilibili search results expose the uploader as `artists`, so otherwise-good results such as `ALICE - Night Song Hi-Res MV` could fall below the default replacement threshold even when the original artist is present in the video title.

The current selection path also resolved every candidate above the threshold before choosing the highest-scoring playable result. Sorting before resolution preserves the same selection semantics while avoiding unnecessary media-resolution requests once a higher-ranked playable candidate succeeds.

## Validation

- Added regression coverage for Bilibili title/artist/bonus matching, cover/remix handling, and relative duration penalties.
- Added coverage proving candidates below the threshold are not resolved and resolution stops at the first playable candidate in descending score order.