### PR TITLE
ci: add job environments

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -13,6 +13,7 @@ jobs:
   build-release-apks:
     name: Build signed multi-ABI release APK
     runs-on: ubuntu-latest
+    environment: android-apk
     timeout-minutes: 45
     env:
       FUO_SIGNING_STORE_FILE: ${{ github.workspace }}/signing/fuo-evolve.jks

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -11,6 +11,7 @@ jobs:
     name: Build signed multi-ABI release APK
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: android-release-build
     timeout-minutes: 45
     permissions:
       contents: read
@@ -83,6 +84,7 @@ jobs:
     needs: build-release-apks
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: android-release
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -16,6 +16,7 @@ jobs:
   build-debug-app:
     name: Build debug iOS app
     runs-on: macos-26
+    environment: ios-debug-app
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
Squash the GitHub Actions environment updates into a single commit.

- add an environment to the Android APK job
- add environments to Android release build/publish jobs
- keep the existing github-pages environment unchanged
- add an environment to the iOS debug job