### PR TITLE
Add playlist playback stats and show frequently-played playlists in Mine section

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -114,6 +114,13 @@ data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
     val dynamicCoverColorEnabled: Boolean = false,
+    val playlistPlaybackStats: Map<String, PlaylistPlaybackStat> = emptyMap(),
+)
+
+@Serializable
+data class PlaylistPlaybackStat(
+    val playCount: Long = 0,
+    val lastPlayedAtMillis: Long = 0,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -114,6 +114,7 @@ data class AppSettings(
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
     val dynamicCoverColorEnabled: Boolean = false,
+    val playlistPlaybackStatsVersion: Int = 0,
     val playlistPlaybackStats: Map<String, PlaylistPlaybackStat> = emptyMap(),
 )
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -92,6 +92,8 @@ private const val DYNAMIC_QUEUE_PREFETCH_REMAINING = 2
 private const val LIST_PREFETCH_REMAINING = 8
 private const val PLAYBACK_PLAN_LOOKAHEAD = 8
 private const val PLAYLIST_BACKGROUND_PAGE_INTERVAL_MS = 3_000L
+private const val MAX_PLAYLIST_PLAYBACK_STATS = 500
+private const val PLAYLIST_STATS_KEY_SEPARATOR = "::"
 private val DEFAULT_DEBUG_LOG_LEVEL_FILTERS = setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error)
 
 class FuoPlayerController(
@@ -3315,12 +3317,15 @@ class FuoPlayerController(
     private fun recordPlaylistPlayback(playlist: ProviderPlaylist) {
         val key = playlist.playbackStatsKey()
         val previous = playlistPlaybackStats[key] ?: PlaylistPlaybackStat()
-        playlistPlaybackStats = playlistPlaybackStats + (
+        playlistPlaybackStats = (playlistPlaybackStats + (
             key to previous.copy(
                 playCount = previous.playCount + 1,
                 lastPlayedAtMillis = currentTimeMillis(),
             )
-        )
+        )).entries
+            .sortedByDescending { it.value.lastPlayedAtMillis }
+            .take(MAX_PLAYLIST_PLAYBACK_STATS)
+            .associate { it.toPair() }
         persistSettings()
     }
 
@@ -4692,6 +4697,11 @@ class FuoPlayerController(
         themeColorScheme = settings.themeColorScheme
         dynamicCoverColorEnabled = settings.dynamicCoverColorEnabled
         playlistPlaybackStats = settings.playlistPlaybackStats
+            .mapKeys { (key, _) -> key.replace("\u0000", PLAYLIST_STATS_KEY_SEPARATOR) }
+            .entries
+            .sortedByDescending { it.value.lastPlayedAtMillis }
+            .take(MAX_PLAYLIST_PLAYBACK_STATS)
+            .associate { it.toPair() }
         pauseOnOtherAppPlayback = settings.pauseOnOtherAppPlayback
     }
 
@@ -4738,7 +4748,8 @@ class FuoPlayerController(
         )
     }
 
-    private fun ProviderPlaylist.playbackStatsKey(): String = "$providerId\u0000$id"
+    private fun ProviderPlaylist.playbackStatsKey(): String =
+        "$providerId$PLAYLIST_STATS_KEY_SEPARATOR$id"
 
     private suspend fun updateResourceCacheLimit() {
         resourceCacheRepository.updateLimit(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -93,6 +93,9 @@ private const val LIST_PREFETCH_REMAINING = 8
 private const val PLAYBACK_PLAN_LOOKAHEAD = 8
 private const val PLAYLIST_BACKGROUND_PAGE_INTERVAL_MS = 3_000L
 private const val MAX_PLAYLIST_PLAYBACK_STATS = 500
+private const val MAX_PLAYLIST_STATS_KEY_LENGTH = 2_048
+private const val MAX_PLAYLIST_PLAY_COUNT = 1_000_000_000L
+private const val PLAYLIST_PLAYBACK_STATS_VERSION = 1
 private const val PLAYLIST_STATS_KEY_SEPARATOR = "::"
 private val DEFAULT_DEBUG_LOG_LEVEL_FILTERS = setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error)
 
@@ -4696,12 +4699,7 @@ class FuoPlayerController(
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
         dynamicCoverColorEnabled = settings.dynamicCoverColorEnabled
-        playlistPlaybackStats = settings.playlistPlaybackStats
-            .mapKeys { (key, _) -> key.replace("\u0000", PLAYLIST_STATS_KEY_SEPARATOR) }
-            .entries
-            .sortedByDescending { it.value.lastPlayedAtMillis }
-            .take(MAX_PLAYLIST_PLAYBACK_STATS)
-            .associate { it.toPair() }
+        playlistPlaybackStats = normalizedPlaylistPlaybackStats(settings)
         pauseOnOtherAppPlayback = settings.pauseOnOtherAppPlayback
     }
 
@@ -4743,6 +4741,7 @@ class FuoPlayerController(
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
             dynamicCoverColorEnabled = dynamicCoverColorEnabled,
+            playlistPlaybackStatsVersion = PLAYLIST_PLAYBACK_STATS_VERSION,
             playlistPlaybackStats = playlistPlaybackStats,
             pauseOnOtherAppPlayback = pauseOnOtherAppPlayback,
         )
@@ -4944,4 +4943,20 @@ class FuoPlayerController(
         contains("media not found", ignoreCase = true) || contains("MediaNotFound", ignoreCase = true)
 
     private fun Int.mbToBytes(): Long = this.toLong() * 1024L * 1024L
+}
+
+internal fun normalizedPlaylistPlaybackStats(settings: AppSettings): Map<String, PlaylistPlaybackStat> {
+    if (settings.playlistPlaybackStatsVersion != PLAYLIST_PLAYBACK_STATS_VERSION) return emptyMap()
+    return settings.playlistPlaybackStats.entries
+        .asSequence()
+        .filter { (key, stat) ->
+            key.isNotBlank() &&
+                key.length <= MAX_PLAYLIST_STATS_KEY_LENGTH &&
+                key.none(Char::isISOControl) &&
+                stat.playCount in 1..MAX_PLAYLIST_PLAY_COUNT &&
+                stat.lastPlayedAtMillis > 0
+        }
+        .sortedByDescending { it.value.lastPlayedAtMillis }
+        .take(MAX_PLAYLIST_PLAYBACK_STATS)
+        .associate { it.toPair() }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
 
 @Serializable
 enum class SearchScope {
@@ -131,6 +132,8 @@ class FuoPlayerController(
     var providerCookieInputs by mutableStateOf<Map<String, String>>(emptyMap())
         private set
     var providerHeaderInputs by mutableStateOf<Map<String, ProviderHeaderInput>>(emptyMap())
+    var playlistPlaybackStats by mutableStateOf<Map<String, PlaylistPlaybackStat>>(emptyMap())
+        private set
     var providerOAuthInputs by mutableStateOf<Map<String, ProviderOAuthInput>>(emptyMap())
     var ytmusicOAuthFlow by mutableStateOf<YtMusicOAuthFlowUiState?>(null)
         private set
@@ -3257,6 +3260,7 @@ class FuoPlayerController(
         val loadedTracks = selectedPlaylistTracks
         val track = loadedTracks.getOrNull(index) ?: return
         selectedPlaylistBackgroundLoadJob?.cancel()
+        recordPlaylistPlayback(playlist)
         play(track, loadedTracks, index, sourcePlaylistId = playlist.id)
         if (selectedPlaylistTracksHasMore && queuePlaylistId == playlist.id) {
             selectedPlaylistBackgroundLoadJob = scope.launch {
@@ -3279,6 +3283,45 @@ class FuoPlayerController(
                 }
             }
         }
+    }
+
+    fun sortedMinePlaylists(playlists: List<ProviderPlaylist>): List<ProviderPlaylist> =
+        playlists.withIndex().sortedWith(
+            compareByDescending<IndexedValue<ProviderPlaylist>> {
+                playlistPlaybackStats[it.value.playbackStatsKey()]?.lastPlayedAtMillis ?: 0
+            }.thenBy { it.index },
+        ).map { it.value }
+
+    fun frequentlyPlayedPlaylists(): List<ProviderPlaylist> {
+        val playlists = (minePlaylistSections + mineFavoritePlaylistSections)
+            .filterNot { it.isLoginRequired }
+            .flatMap { it.playlists }
+            .distinctBy { it.playbackStatsKey() }
+        return playlists.sortedWith(
+            compareByDescending<ProviderPlaylist> {
+                playlistPlaybackStats[it.playbackStatsKey()]?.playCount ?: 0
+            }.thenByDescending {
+                playlistPlaybackStats[it.playbackStatsKey()]?.lastPlayedAtMillis ?: 0
+            },
+        ).filter { (playlistPlaybackStats[it.playbackStatsKey()]?.playCount ?: 0) > 0 }
+    }
+
+    fun categoryForMinePlaylist(playlist: ProviderPlaylist): ProviderFeatureCategory =
+        if (mineFavoritePlaylistSections.any { section ->
+                section.playlists.any { it.playbackStatsKey() == playlist.playbackStatsKey() }
+            }
+        ) ProviderFeatureCategory.MineFavoritePlaylists else ProviderFeatureCategory.MinePlaylists
+
+    private fun recordPlaylistPlayback(playlist: ProviderPlaylist) {
+        val key = playlist.playbackStatsKey()
+        val previous = playlistPlaybackStats[key] ?: PlaylistPlaybackStat()
+        playlistPlaybackStats = playlistPlaybackStats + (
+            key to previous.copy(
+                playCount = previous.playCount + 1,
+                lastPlayedAtMillis = currentTimeMillis(),
+            )
+        )
+        persistSettings()
     }
 
     fun playFromSelectedFeature(index: Int) {
@@ -4648,6 +4691,7 @@ class FuoPlayerController(
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
         dynamicCoverColorEnabled = settings.dynamicCoverColorEnabled
+        playlistPlaybackStats = settings.playlistPlaybackStats
         pauseOnOtherAppPlayback = settings.pauseOnOtherAppPlayback
     }
 
@@ -4689,9 +4733,12 @@ class FuoPlayerController(
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
             dynamicCoverColorEnabled = dynamicCoverColorEnabled,
+            playlistPlaybackStats = playlistPlaybackStats,
             pauseOnOtherAppPlayback = pauseOnOtherAppPlayback,
         )
     }
+
+    private fun ProviderPlaylist.playbackStatsKey(): String = "$providerId\u0000$id"
 
     private suspend fun updateResourceCacheLimit() {
         resourceCacheRepository.updateLimit(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -247,6 +247,7 @@ fun MinePlaylistsSection(
     val showLocalPlaylists = controller.playlistFilter == PlaylistFilter.All ||
         controller.playlistFilter == PlaylistFilter.Local
     val visibleSections = remember(sections) { sections.filterNot { it.isLoginRequired } }
+    val frequentPlaylists = controller.frequentlyPlayedPlaylists()
     val lockedProviders = remember(sections) {
         sections.filter { it.isLoginRequired }
             .map { it.feature }
@@ -270,6 +271,18 @@ fun MinePlaylistsSection(
                     EmptyProviderContentHint(controller.playlistFilter.emptyTitle())
                 }
             } else {
+                if (controller.playlistFilter == PlaylistFilter.All && frequentPlaylists.isNotEmpty()) {
+                    item(key = "header:frequent-playlists") {
+                        Text("我的常听", style = MaterialTheme.typography.titleMedium)
+                    }
+                    item(key = "playlists:frequent") {
+                        ProviderPlaylistGrid(
+                            playlists = frequentPlaylists,
+                            onClick = { controller.openPlaylist(it, controller.categoryForMinePlaylist(it)) },
+                            maxRows = 2,
+                        )
+                    }
+                }
                 if (showLocalPlaylists) {
                     localPlaylistSectionItems(
                         controller = controller,
@@ -527,10 +540,11 @@ fun androidx.compose.foundation.lazy.LazyListScope.playlistSectionItems(
         }
         contentSection.playlists.isNotEmpty() -> {
             item(key = "playlists:${contentSection.feature.id}") {
-                ProviderPlaylistGrid(
-                    playlists = contentSection.playlists,
-                    onClick = { controller.openPlaylist(it, contentSection.feature.category) },
-                )
+            ProviderPlaylistGrid(
+                playlists = controller.sortedMinePlaylists(contentSection.playlists),
+                onClick = { controller.openPlaylist(it, contentSection.feature.category) },
+                onMore = { controller.openFeature(contentSection.feature) },
+            )
             }
         }
         else -> item(key = "empty:${contentSection.feature.id}") {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/MineHomeSection.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+private const val MINE_PLAYLIST_STATS_KEY_SEPARATOR = "::"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MineHomeSection(
@@ -70,7 +72,7 @@ fun MineHomeSection(
                 .fillMaxWidth(),
         ) {
             when (controller.mineSection) {
-            MineSection.Playlists -> MinePlaylistsSection(
+                MineSection.Playlists -> MinePlaylistsSection(
                     controller = controller,
                     showFilter = !isWideLayout,
                     modifier = Modifier.fillMaxSize(),
@@ -104,6 +106,7 @@ fun MineHomeSection(
         }
     }
 }
+
 @Composable
 fun MineSectionChips(
     controller: FuoPlayerController,
@@ -238,6 +241,7 @@ fun MinePlaylistsSection(
     val fileActions = LocalLocalPlaylistFileActions.current
     val userSections = controller.minePlaylistSections
     val favoriteSections = controller.mineFavoritePlaylistSections
+    val playbackStats = controller.playlistPlaybackStats
     val sections = when (controller.playlistFilter) {
         PlaylistFilter.All -> userSections + favoriteSections
         PlaylistFilter.UserPlaylists -> userSections
@@ -247,7 +251,14 @@ fun MinePlaylistsSection(
     val showLocalPlaylists = controller.playlistFilter == PlaylistFilter.All ||
         controller.playlistFilter == PlaylistFilter.Local
     val visibleSections = remember(sections) { sections.filterNot { it.isLoginRequired } }
-    val frequentPlaylists = controller.frequentlyPlayedPlaylists()
+    val frequentPlaylists = remember(userSections, favoriteSections, playbackStats) {
+        frequentlyPlayedMinePlaylists(
+            playlists = (userSections + favoriteSections)
+                .filterNot { it.isLoginRequired }
+                .flatMap { it.playlists },
+            playbackStats = playbackStats,
+        )
+    }
     val lockedProviders = remember(sections) {
         sections.filter { it.isLoginRequired }
             .map { it.feature }
@@ -295,6 +306,7 @@ fun MinePlaylistsSection(
                     playlistSectionItems(
                         controller = controller,
                         contentSection = contentSection,
+                        playbackStats = playbackStats,
                         onCreatePlaylist = { providerId ->
                             selectedCreateProviderId = providerId
                             showCreateDialog = true
@@ -519,6 +531,7 @@ fun LocalPlaylistImportDialog(
 fun androidx.compose.foundation.lazy.LazyListScope.playlistSectionItems(
     controller: FuoPlayerController,
     contentSection: ProviderContentSection,
+    playbackStats: Map<String, PlaylistPlaybackStat>,
     onCreatePlaylist: (String) -> Unit,
 ) {
     item(key = "header:${contentSection.feature.id}") {
@@ -540,11 +553,11 @@ fun androidx.compose.foundation.lazy.LazyListScope.playlistSectionItems(
         }
         contentSection.playlists.isNotEmpty() -> {
             item(key = "playlists:${contentSection.feature.id}") {
-            ProviderPlaylistGrid(
-                playlists = controller.sortedMinePlaylists(contentSection.playlists),
-                onClick = { controller.openPlaylist(it, contentSection.feature.category) },
-                onMore = { controller.openFeature(contentSection.feature) },
-            )
+                ProviderPlaylistGrid(
+                    playlists = sortedMinePlaylistsSnapshot(contentSection.playlists, playbackStats),
+                    onClick = { controller.openPlaylist(it, contentSection.feature.category) },
+                    onMore = { controller.openFeature(contentSection.feature) },
+                )
             }
         }
         else -> item(key = "empty:${contentSection.feature.id}") {
@@ -611,3 +624,51 @@ fun MineMediaItemsSection(
         }
     }
 }
+
+internal fun minePlaylistPlaybackStatsKey(playlist: ProviderPlaylist): String =
+    "${playlist.providerId}$MINE_PLAYLIST_STATS_KEY_SEPARATOR${playlist.id}"
+
+internal fun sortedMinePlaylistsSnapshot(
+    playlists: List<ProviderPlaylist>,
+    playbackStats: Map<String, PlaylistPlaybackStat>,
+): List<ProviderPlaylist> = playlists
+    .mapIndexed { index, playlist ->
+        RankedMinePlaylist(
+            playlist = playlist,
+            stat = playbackStats[minePlaylistPlaybackStatsKey(playlist)],
+            originalIndex = index,
+        )
+    }
+    .sortedWith(
+        compareByDescending<RankedMinePlaylist> { it.stat?.lastPlayedAtMillis ?: 0L }
+            .thenBy { it.originalIndex },
+    )
+    .map { it.playlist }
+
+internal fun frequentlyPlayedMinePlaylists(
+    playlists: List<ProviderPlaylist>,
+    playbackStats: Map<String, PlaylistPlaybackStat>,
+): List<ProviderPlaylist> = playlists
+    .distinctBy(::minePlaylistPlaybackStatsKey)
+    .mapIndexedNotNull { index, playlist ->
+        val stat = playbackStats[minePlaylistPlaybackStatsKey(playlist)]
+            ?.takeIf { it.playCount > 0 }
+            ?: return@mapIndexedNotNull null
+        RankedMinePlaylist(
+            playlist = playlist,
+            stat = stat,
+            originalIndex = index,
+        )
+    }
+    .sortedWith(
+        compareByDescending<RankedMinePlaylist> { it.stat?.playCount ?: 0L }
+            .thenByDescending { it.stat?.lastPlayedAtMillis ?: 0L }
+            .thenBy { it.originalIndex },
+    )
+    .map { it.playlist }
+
+private data class RankedMinePlaylist(
+    val playlist: ProviderPlaylist,
+    val stat: PlaylistPlaybackStat?,
+    val originalIndex: Int,
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -518,7 +518,7 @@ fun ProviderPlaylistGrid(
     maxRows: Int? = null,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
-    val columns = layoutInfo.gridColumns
+    val columns = layoutInfo.gridColumns.coerceAtLeast(1)
     val spacing = if (layoutInfo.useWideLayout) 8.dp else 12.dp
     val capacity = columns * (maxRows ?: 2)
     val isLimited = maxRows != null || onMore != null
@@ -532,33 +532,36 @@ fun ProviderPlaylistGrid(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        val cells: List<ProviderPlaylist?> = visiblePlaylists.map { it } +
-            if (hasMore && onMore != null) listOf(null) else emptyList()
+        val cells = visiblePlaylists.map<ProviderPlaylist, PlaylistGridCell> { PlaylistGridCell.Playlist(it) } +
+            if (hasMore && onMore != null) listOf(PlaylistGridCell.More) else emptyList()
         cells.chunked(columns).forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
-                row.forEach { playlist ->
-                    if (playlist == null) {
-                        Surface(
-                            modifier = Modifier
-                                .weight(1f)
-                                .aspectRatio(1f)
-                                .clickable(role = Role.Button) { onMore?.invoke() },
-                            shape = MaterialTheme.shapes.medium,
-                            color = MaterialTheme.colorScheme.surfaceVariant,
-                        ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                Text("更多", style = MaterialTheme.typography.titleMedium)
+                row.forEach { cell ->
+                    when (cell) {
+                        PlaylistGridCell.More -> {
+                            Surface(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .aspectRatio(1f)
+                                    .clickable(role = Role.Button) { onMore?.invoke() },
+                                shape = MaterialTheme.shapes.medium,
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text("更多", style = MaterialTheme.typography.titleMedium)
+                                }
                             }
                         }
-                    } else {
-                        ProviderPlaylistCard(
-                            playlist = playlist,
-                            onClick = { onClick(playlist) },
-                            modifier = Modifier.weight(1f),
-                        )
+                        is PlaylistGridCell.Playlist -> {
+                            ProviderPlaylistCard(
+                                playlist = cell.value,
+                                onClick = { onClick(cell.value) },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
                     }
                 }
                 repeat(columns - row.size) {
@@ -567,6 +570,11 @@ fun ProviderPlaylistGrid(
             }
         }
     }
+}
+
+private sealed interface PlaylistGridCell {
+    data class Playlist(val value: ProviderPlaylist) : PlaylistGridCell
+    data object More : PlaylistGridCell
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -161,6 +161,7 @@ fun ProviderContentHomeSection(
                                     ProviderPlaylistGrid(
                                         playlists = contentSection.playlists,
                                         onClick = { controller.openPlaylist(it, contentSection.feature.category) },
+                                        onMore = { controller.openFeature(contentSection.feature) },
                                     )
                                 }
                             }
@@ -513,25 +514,52 @@ fun RecommendationButton(
 fun ProviderPlaylistGrid(
     playlists: List<ProviderPlaylist>,
     onClick: (ProviderPlaylist) -> Unit,
+    onMore: (() -> Unit)? = null,
+    maxRows: Int? = null,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
     val columns = layoutInfo.gridColumns
     val spacing = if (layoutInfo.useWideLayout) 8.dp else 12.dp
+    val capacity = columns * (maxRows ?: 2)
+    val isLimited = maxRows != null || onMore != null
+    val hasMore = isLimited && playlists.size > capacity
+    val visiblePlaylists = when {
+        hasMore && onMore != null -> playlists.take(capacity - 1)
+        hasMore -> playlists.take(capacity)
+        else -> playlists
+    }
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        playlists.chunked(columns).forEach { row ->
+        val cells: List<ProviderPlaylist?> = visiblePlaylists.map { it } +
+            if (hasMore && onMore != null) listOf(null) else emptyList()
+        cells.chunked(columns).forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
                 row.forEach { playlist ->
-                    ProviderPlaylistCard(
-                        playlist = playlist,
-                        onClick = { onClick(playlist) },
-                        modifier = Modifier.weight(1f),
-                    )
+                    if (playlist == null) {
+                        Surface(
+                            modifier = Modifier
+                                .weight(1f)
+                                .aspectRatio(1f)
+                                .clickable(role = Role.Button) { onMore?.invoke() },
+                            shape = MaterialTheme.shapes.medium,
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Text("更多", style = MaterialTheme.typography.titleMedium)
+                            }
+                        }
+                    } else {
+                        ProviderPlaylistCard(
+                            playlist = playlist,
+                            onClick = { onClick(playlist) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
                 repeat(columns - row.size) {
                     Spacer(Modifier.weight(1f))

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -115,6 +115,29 @@ class AppSettingsRepositoryTest {
         assertTrue(settings.pauseOnOtherAppPlayback)
     }
 
+    @Test
+    fun playlistPlaybackStatsRoundTripWithProviderPlaylistKey() = runTest {
+        val dataStore = FakePreferencesDataStore()
+        val first = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+        first.awaitSettings()
+        val stat = PlaylistPlaybackStat(playCount = 3, lastPlayedAtMillis = 1234)
+
+        first.update { settings ->
+            settings.copy(playlistPlaybackStats = mapOf("netease::playlist:123" to stat))
+        }
+        val restored = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        ).awaitSettings()
+
+        assertEquals(stat, restored.playlistPlaybackStats["netease::playlist:123"])
+    }
+
     private class FakePreferencesDataStore(
         initial: Preferences = emptyPreferences(),
     ) : DataStore<Preferences> {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -127,7 +127,10 @@ class AppSettingsRepositoryTest {
         val stat = PlaylistPlaybackStat(playCount = 3, lastPlayedAtMillis = 1234)
 
         first.update { settings ->
-            settings.copy(playlistPlaybackStats = mapOf("netease::playlist:123" to stat))
+            settings.copy(
+                playlistPlaybackStatsVersion = 1,
+                playlistPlaybackStats = mapOf("netease::playlist:123" to stat),
+            )
         }
         val restored = DataStoreAppSettingsRepository(
             dataStore = dataStore,
@@ -136,6 +139,28 @@ class AppSettingsRepositoryTest {
         ).awaitSettings()
 
         assertEquals(stat, restored.playlistPlaybackStats["netease::playlist:123"])
+    }
+
+    @Test
+    fun incompatibleOrInvalidPlaylistPlaybackStatsAreDiscarded() {
+        val legacy = AppSettings(
+            playlistPlaybackStats = mapOf(
+                "netease\u0000playlist:123" to PlaylistPlaybackStat(2, 1234),
+            ),
+        )
+        val currentWithInvalidEntry = AppSettings(
+            playlistPlaybackStatsVersion = 1,
+            playlistPlaybackStats = mapOf(
+                "netease\u0000playlist:123" to PlaylistPlaybackStat(2, 1234),
+                "netease::playlist:456" to PlaylistPlaybackStat(3, 5678),
+            ),
+        )
+
+        assertTrue(normalizedPlaylistPlaybackStats(legacy).isEmpty())
+        assertEquals(
+            setOf("netease::playlist:456"),
+            normalizedPlaylistPlaybackStats(currentWithInvalidEntry).keys,
+        )
     }
 
     private class FakePreferencesDataStore(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/MinePlaylistRankingTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/MinePlaylistRankingTest.kt
@@ -1,0 +1,73 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MinePlaylistRankingTest {
+    @Test
+    fun neteasePlaylistUsesCanonicalPlaybackStatsKey() {
+        val playlist = neteasePlaylist("987654321")
+
+        assertEquals(
+            "netease::playlist:netease:987654321",
+            minePlaylistPlaybackStatsKey(playlist),
+        )
+    }
+
+    @Test
+    fun frequentlyPlayedNeteasePlaylistIsRankedFromStatsSnapshot() {
+        val netease = neteasePlaylist("987654321")
+        val qqmusic = ProviderPlaylist(
+            id = "playlist:qqmusic:abc",
+            title = "QQ Playlist",
+            providerId = "qqmusic",
+            providerName = "QQ 音乐",
+        )
+        val playbackStats = mapOf(
+            minePlaylistPlaybackStatsKey(netease) to PlaylistPlaybackStat(
+                playCount = 4,
+                lastPlayedAtMillis = 2_000,
+            ),
+            minePlaylistPlaybackStatsKey(qqmusic) to PlaylistPlaybackStat(
+                playCount = 2,
+                lastPlayedAtMillis = 3_000,
+            ),
+        )
+
+        assertEquals(
+            listOf(netease, qqmusic),
+            frequentlyPlayedMinePlaylists(
+                playlists = listOf(qqmusic, netease, netease),
+                playbackStats = playbackStats,
+            ),
+        )
+    }
+
+    @Test
+    fun minePlaylistSortKeepsUnplayedOrderAfterPlayedItems() {
+        val first = neteasePlaylist("1")
+        val second = neteasePlaylist("2")
+        val played = neteasePlaylist("3")
+        val playbackStats = mapOf(
+            minePlaylistPlaybackStatsKey(played) to PlaylistPlaybackStat(
+                playCount = 1,
+                lastPlayedAtMillis = 5_000,
+            ),
+        )
+
+        assertEquals(
+            listOf(played, first, second),
+            sortedMinePlaylistsSnapshot(
+                playlists = listOf(first, second, played),
+                playbackStats = playbackStats,
+            ),
+        )
+    }
+
+    private fun neteasePlaylist(identifier: String) = ProviderPlaylist(
+        id = "playlist:netease:$identifier",
+        title = "NetEase Playlist $identifier",
+        providerId = "netease",
+        providerName = "网易云音乐",
+    )
+}


### PR DESCRIPTION
### Motivation
- Record per-playlist playback metadata to surface frequently-played playlists and improve playlist ordering. 
- Provide a UX for quickly accessing frequently-played items and a "more" affordance when playlists exceed the grid capacity.

### Description
- Add `PlaylistPlaybackStat` and a `playlistPlaybackStats: Map<String, PlaylistPlaybackStat>` field to `AppSettings` to persist playback metrics. 
- Track playback in `FuoPlayerController` by introducing `playlistPlaybackStats` state, `recordPlaylistPlayback`, `sortedMinePlaylists`, `frequentlyPlayedPlaylists`, and `categoryForMinePlaylist`, and wire load/save via `currentSettings()` and settings restoration. 
- Integrate stat recording into playlist playback flow by calling `recordPlaylistPlayback` from `playSelectedPlaylistFrom`, and use `currentTimeMillis()` for timestamps. 
- Update UI: show a "我的常听" (frequently-played) block in `MinePlaylistsSection`, sort playlist grids via `sortedMinePlaylists`, and extend `ProviderPlaylistGrid` with `onMore`/`maxRows` to render a "更多" tile when there are more playlists than the grid capacity.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76d6e011488321b7610ddf32523ff5)