### PR TITLE
feat: support Android system share links

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -58,11 +58,21 @@
                     android:pathPrefix="/FuoEvolve/r"
                     android:scheme="https" />
             </intent-filter>
-            <intent-filter>
+        </activity>
+        <activity
+            android:name=".ShareReceiverActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter android:label="用 FuoEvolve 打开">
                 <action android:name="android.intent.action.SEND" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-
+                <data android:mimeType="text/*" />
+            </intent-filter>
+            <intent-filter android:label="用 FuoEvolve 搜索">
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidSharedTextResolver.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidSharedTextResolver.kt
@@ -1,0 +1,66 @@
+package org.feeluown.mobile
+
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val SHARED_LINK_CONNECT_TIMEOUT_MS = 4_000
+private const val SHARED_LINK_READ_TIMEOUT_MS = 4_000
+private const val MAX_SHARED_LINK_REDIRECTS = 6
+private val ANDROID_SHARED_URL_REGEX = Regex("""https?://[^\s<>\"'，。！？、；]+""", RegexOption.IGNORE_CASE)
+private val SHORT_SHARE_HOSTS = setOf(
+    "163cn.tv",
+    "www.163cn.tv",
+    "b23.tv",
+    "www.b23.tv",
+    "bili2233.cn",
+    "www.bili2233.cn",
+    "c6.y.qq.com",
+    "url.cn",
+)
+
+suspend fun resolveAndroidSharedText(text: String): String = withContext(Dispatchers.IO) {
+    if (text.isBlank() || parseSharedResource(text) != null) return@withContext text
+    var resolvedText = text
+    for (match in ANDROID_SHARED_URL_REGEX.findAll(text)) {
+        val originalUrl = match.value.trimEnd('.', ',', ':', ';', '!', '?', ')', ']', '}', '。', '，', '：', '；', '！', '？')
+        if (!shouldExpandSharedUrl(originalUrl)) continue
+        val expandedUrl = runCatching { followRedirects(originalUrl) }.getOrNull()
+            ?.takeIf { it.isNotBlank() && it != originalUrl }
+            ?: continue
+        resolvedText = resolvedText.replace(originalUrl, expandedUrl)
+        if (parseSharedResource(resolvedText) != null) return@withContext resolvedText
+    }
+    resolvedText
+}
+
+private fun shouldExpandSharedUrl(url: String): Boolean = runCatching {
+    URL(url).host.lowercase() in SHORT_SHARE_HOSTS
+}.getOrDefault(false)
+
+private fun followRedirects(sourceUrl: String): String {
+    var currentUrl = sourceUrl
+    repeat(MAX_SHARED_LINK_REDIRECTS) {
+        val connection = (URL(currentUrl).openConnection() as HttpURLConnection).apply {
+            instanceFollowRedirects = false
+            connectTimeout = SHARED_LINK_CONNECT_TIMEOUT_MS
+            readTimeout = SHARED_LINK_READ_TIMEOUT_MS
+            requestMethod = "GET"
+            setRequestProperty("User-Agent", "Mozilla/5.0 (Android) FuoEvolve")
+            setRequestProperty("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+        }
+        val nextUrl = try {
+            val responseCode = connection.responseCode
+            if (responseCode !in 300..399) return currentUrl
+            val location = connection.getHeaderField("Location")?.takeIf { it.isNotBlank() }
+                ?: return currentUrl
+            URL(URL(currentUrl), location).toString()
+        } finally {
+            connection.disconnect()
+        }
+        if (nextUrl == currentUrl) return currentUrl
+        currentUrl = nextUrl
+    }
+    return currentUrl
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ShareReceiverActivity.kt
@@ -1,0 +1,64 @@
+package org.feeluown.mobile
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+
+class ShareReceiverActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val sharedText = sharedTextFrom(intent)
+        if (sharedText.isNullOrBlank()) {
+            openMainActivity()
+            return
+        }
+        lifecycleScope.launch {
+            val resolvedText = resolveAndroidSharedText(sharedText)
+            if (parseSharedResource(resolvedText) != null) {
+                openMainActivity(resolvedText)
+                return@launch
+            }
+            val query = sharedSearchQuery(resolvedText)
+            if (!query.isNullOrBlank()) {
+                val controller = (application as FuoEvolveApplication).controller
+                controller.onQueryChange(query)
+                controller.openSearch()
+                controller.search()
+                controller.showMessage("未识别为已支持音源链接，已按分享内容搜索")
+                openMainActivity()
+            } else {
+                openMainActivity(resolvedText)
+            }
+        }
+    }
+
+    private fun sharedTextFrom(intent: Intent?): String? {
+        val action = intent?.action ?: return null
+        val text = when (action) {
+            Intent.ACTION_SEND -> intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+            Intent.ACTION_PROCESS_TEXT -> intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)?.toString()
+            else -> null
+        }?.takeIf { it.isNotBlank() }
+        val subject = intent.getCharSequenceExtra(Intent.EXTRA_SUBJECT)
+            ?.toString()
+            ?.takeIf { it.isNotBlank() && !text.orEmpty().contains(it) }
+        return listOfNotNull(subject, text).joinToString("\n").takeIf { it.isNotBlank() }
+    }
+
+    private fun openMainActivity(sharedText: String? = null) {
+        val mainIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            if (sharedText != null) {
+                action = Intent.ACTION_SEND
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, sharedText)
+            } else {
+                action = Intent.ACTION_MAIN
+            }
+        }
+        startActivity(mainIntent)
+        finish()
+    }
+}

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -4,9 +4,13 @@
         <domain includeSubdomains="true">music.163.com</domain>
         <domain includeSubdomains="true">music.126.net</domain>
         <domain includeSubdomains="true">vod.126.net</domain>
+        <domain includeSubdomains="true">163cn.tv</domain>
         <domain includeSubdomains="true">qqmusic.qq.com</domain>
+        <domain includeSubdomains="true">c6.y.qq.com</domain>
         <domain includeSubdomains="true">hdslb.com</domain>
         <domain includeSubdomains="true">bilivideo.com</domain>
         <domain includeSubdomains="true">bilivideo.cn</domain>
+        <domain includeSubdomains="true">b23.tv</domain>
+        <domain includeSubdomains="true">bili2233.cn</domain>
     </domain-config>
 </network-security-config>

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -7,6 +7,7 @@
         <domain includeSubdomains="true">163cn.tv</domain>
         <domain includeSubdomains="true">qqmusic.qq.com</domain>
         <domain includeSubdomains="true">c6.y.qq.com</domain>
+        <domain includeSubdomains="true">url.cn</domain>
         <domain includeSubdomains="true">hdslb.com</domain>
         <domain includeSubdomains="true">bilivideo.com</domain>
         <domain includeSubdomains="true">bilivideo.cn</domain>

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ShareResources.kt
@@ -131,26 +131,27 @@ fun ShareResourceRef.toSharePayload(): SharePayload {
 }
 
 fun parseSharedResource(text: String): ShareResourceRef? {
-    val appLinkMatch = FUO_EVOLVE_PAGES_REGEX.find(text)
-    val fuoMatch = FUO_URI_REGEX.find(text)
-    val match = appLinkMatch ?: fuoMatch ?: return null
-    val providerId = match.groupValues[1]
-    val namespace = match.groupValues[2].ifBlank { ShareResourceType.Song.namespace }
-    val identifier = match.groupValues[3]
-    val type = when (namespace) {
-        ShareResourceType.Song.namespace -> ShareResourceType.Song
-        ShareResourceType.Playlist.namespace -> ShareResourceType.Playlist
-        ShareResourceType.Artist.namespace -> ShareResourceType.Artist
-        ShareResourceType.Album.namespace -> ShareResourceType.Album
-        else -> return null
+    parseFuoSharedResource(text)?.let { return it }
+    return HTTP_URL_REGEX.findAll(text)
+        .map { match -> match.value.trimEnd(*URL_TRAILING_PUNCTUATION) }
+        .mapNotNull(::parseProviderSharedUrl)
+        .firstOrNull()
+}
+
+fun sharedSearchQuery(text: String): String? {
+    val title = SHARE_TITLE_REGEX.find(text)?.groupValues?.getOrNull(1)?.trim().orEmpty()
+    val artists = NETEASE_SHARE_ARTISTS_REGEX.find(text)?.groupValues?.getOrNull(1)?.trim().orEmpty()
+    if (title.isNotBlank()) {
+        return buildList {
+            add(title)
+            artists.takeIf { it.isNotBlank() }?.let(::add)
+        }.joinToString(" ")
     }
-    return ShareResourceRef(
-        type = type,
-        providerId = providerId,
-        providerName = providerId,
-        identifier = identifier,
-        title = "",
-    )
+    return HTTP_URL_REGEX.replace(text, " ")
+        .replace(SHARE_SOURCE_SUFFIX_REGEX, " ")
+        .replace(Regex("""\s+"""), " ")
+        .trim(' ', ':', '：', '-', '—')
+        .takeIf { it.isNotBlank() }
 }
 
 fun ShareResourceRef.toProviderTrackId(): String = "$providerId:$identifier"
@@ -186,6 +187,173 @@ const val FUO_EVOLVE_PAGES_BASE_URL = "https://feeluown.github.io/FuoEvolve/r"
 private val FUO_URI_REGEX = Regex("""fuo://([A-Za-z0-9_]+)/(?:(songs|playlists|artists|albums)/)?([A-Za-z0-9_-]+)""")
 private val FUO_EVOLVE_PAGES_REGEX =
     Regex("""https://feeluown\.github\.io/FuoEvolve/r/([A-Za-z0-9_]+)/(songs|playlists|artists|albums)/([A-Za-z0-9_-]+)""")
+private val HTTP_URL_REGEX = Regex("""https?://[^\s<>\"'，。！？、；]+""", RegexOption.IGNORE_CASE)
+private val NETEASE_RESOURCE_REGEX = Regex(
+    """https?://(?:music\.163\.com|y\.music\.163\.com)/(?:#/)?(?:m/|f/)?(song|playlist|artist|album)(?:[/?#]|$)""",
+    RegexOption.IGNORE_CASE,
+)
+private val BILIBILI_VIDEO_REGEX = Regex(
+    """https?://(?:(?:www|m)\.)?bilibili\.com/video/(BV[0-9A-Za-z]+)""",
+    RegexOption.IGNORE_CASE,
+)
+private val QQ_RESOURCE_REGEX = Regex(
+    """https?://y\.qq\.com/n/ryqq/(songDetail|playlist|singer|albumDetail|album)/([^/?#]+)""",
+    RegexOption.IGNORE_CASE,
+)
+private val YOUTUBE_SHORT_REGEX = Regex(
+    """https?://(?:www\.)?youtu\.be/([A-Za-z0-9_-]+)""",
+    RegexOption.IGNORE_CASE,
+)
+private val YOUTUBE_CHANNEL_REGEX = Regex(
+    """https?://music\.youtube\.com/channel/([A-Za-z0-9_-]+)""",
+    RegexOption.IGNORE_CASE,
+)
+private val YOUTUBE_BROWSE_REGEX = Regex(
+    """https?://music\.youtube\.com/browse/([A-Za-z0-9_-]+)""",
+    RegexOption.IGNORE_CASE,
+)
+private val SHARE_TITLE_REGEX = Regex("""《([^》]+)》""")
+private val NETEASE_SHARE_ARTISTS_REGEX = Regex("""分享\s*(.+?)\s*的(?:单曲|歌曲)《""")
+private val SHARE_SOURCE_SUFFIX_REGEX = Regex("""[（(]?\s*(?:来自\s*)?@?(?:网易云音乐|QQ音乐|哔哩哔哩|bilibili|YouTube Music|YouTube|Spotify|Apple Music)\s*[）)]?""", RegexOption.IGNORE_CASE)
+private val URL_TRAILING_PUNCTUATION = charArrayOf('.', ',', ':', ';', '!', '?', ')', ']', '}', '。', '，', '：', '；', '！', '？')
+
+private fun parseFuoSharedResource(text: String): ShareResourceRef? {
+    val appLinkMatch = FUO_EVOLVE_PAGES_REGEX.find(text)
+    val fuoMatch = FUO_URI_REGEX.find(text)
+    val match = appLinkMatch ?: fuoMatch ?: return null
+    val providerId = match.groupValues[1]
+    val namespace = match.groupValues[2].ifBlank { ShareResourceType.Song.namespace }
+    val identifier = match.groupValues[3]
+    val type = when (namespace) {
+        ShareResourceType.Song.namespace -> ShareResourceType.Song
+        ShareResourceType.Playlist.namespace -> ShareResourceType.Playlist
+        ShareResourceType.Artist.namespace -> ShareResourceType.Artist
+        ShareResourceType.Album.namespace -> ShareResourceType.Album
+        else -> return null
+    }
+    return ShareResourceRef(
+        type = type,
+        providerId = providerId,
+        providerName = providerId,
+        identifier = identifier,
+        title = "",
+    )
+}
+
+private fun parseProviderSharedUrl(url: String): ShareResourceRef? {
+    parseNeteaseUrl(url)?.let { return it }
+    parseBilibiliUrl(url)?.let { return it }
+    parseQqMusicUrl(url)?.let { return it }
+    return parseYtMusicUrl(url)
+}
+
+private fun parseNeteaseUrl(url: String): ShareResourceRef? {
+    val resource = NETEASE_RESOURCE_REGEX.find(url)?.groupValues?.getOrNull(1)?.lowercase() ?: return null
+    val identifier = queryParameter(url, "id") ?: return null
+    val type = when (resource) {
+        "song" -> ShareResourceType.Song
+        "playlist" -> ShareResourceType.Playlist
+        "artist" -> ShareResourceType.Artist
+        "album" -> ShareResourceType.Album
+        else -> return null
+    }
+    return providerResource(type, "netease", "网易云音乐", identifier, url)
+}
+
+private fun parseBilibiliUrl(url: String): ShareResourceRef? {
+    val bvid = BILIBILI_VIDEO_REGEX.find(url)?.groupValues?.getOrNull(1) ?: return null
+    val page = queryParameter(url, "p")?.toIntOrNull()?.takeIf { it > 0 }
+    val identifier = if (page == null) bvid else "paged_${bvid}__${page}"
+    return providerResource(ShareResourceType.Song, "bilibili", "哔哩哔哩", identifier, url)
+}
+
+private fun parseQqMusicUrl(url: String): ShareResourceRef? {
+    val pathMatch = QQ_RESOURCE_REGEX.find(url)
+    if (pathMatch != null) {
+        val type = when (pathMatch.groupValues[1].lowercase()) {
+            "songdetail" -> ShareResourceType.Song
+            "playlist" -> ShareResourceType.Playlist
+            "singer" -> ShareResourceType.Artist
+            "albumdetail", "album" -> ShareResourceType.Album
+            else -> null
+        }
+        if (type != null) {
+            return providerResource(type, "qqmusic", "QQ音乐", pathMatch.groupValues[2], url)
+        }
+    }
+    if (!url.contains("qq.com", ignoreCase = true)) return null
+    queryParameter(url, "songmid")?.let {
+        return providerResource(ShareResourceType.Song, "qqmusic", "QQ音乐", it, url)
+    }
+    queryParameter(url, "disstid")?.let {
+        return providerResource(ShareResourceType.Playlist, "qqmusic", "QQ音乐", it, url)
+    }
+    if (url.contains("taoge", ignoreCase = true) || url.contains("playlist", ignoreCase = true)) {
+        queryParameter(url, "id")?.let {
+            return providerResource(ShareResourceType.Playlist, "qqmusic", "QQ音乐", it, url)
+        }
+    }
+    queryParameter(url, "singermid")?.let {
+        return providerResource(ShareResourceType.Artist, "qqmusic", "QQ音乐", it, url)
+    }
+    queryParameter(url, "albummid")?.let {
+        return providerResource(ShareResourceType.Album, "qqmusic", "QQ音乐", it, url)
+    }
+    return null
+}
+
+private fun parseYtMusicUrl(url: String): ShareResourceRef? {
+    YOUTUBE_SHORT_REGEX.find(url)?.groupValues?.getOrNull(1)?.let {
+        return providerResource(ShareResourceType.Song, "ytmusic", "YouTube Music", it, url)
+    }
+    if (!url.contains("youtube.com", ignoreCase = true)) return null
+    if (url.contains("/watch", ignoreCase = true)) {
+        queryParameter(url, "v")?.let {
+            return providerResource(ShareResourceType.Song, "ytmusic", "YouTube Music", it, url)
+        }
+    }
+    if (url.contains("/playlist", ignoreCase = true)) {
+        queryParameter(url, "list")?.let {
+            return providerResource(ShareResourceType.Playlist, "ytmusic", "YouTube Music", it, url)
+        }
+    }
+    YOUTUBE_CHANNEL_REGEX.find(url)?.groupValues?.getOrNull(1)?.let {
+        return providerResource(ShareResourceType.Artist, "ytmusic", "YouTube Music", it, url)
+    }
+    YOUTUBE_BROWSE_REGEX.find(url)?.groupValues?.getOrNull(1)?.let { identifier ->
+        val type = when {
+            identifier.startsWith("UC", ignoreCase = true) -> ShareResourceType.Artist
+            identifier.startsWith("MPRE", ignoreCase = true) -> ShareResourceType.Album
+            else -> return null
+        }
+        return providerResource(type, "ytmusic", "YouTube Music", identifier, url)
+    }
+    return null
+}
+
+private fun providerResource(
+    type: ShareResourceType,
+    providerId: String,
+    providerName: String,
+    identifier: String,
+    providerUrl: String,
+): ShareResourceRef? = identifier
+    .takeIf { it.isNotBlank() }
+    ?.let {
+        ShareResourceRef(
+            type = type,
+            providerId = providerId,
+            providerName = providerName,
+            identifier = it,
+            title = "",
+            providerUrl = providerUrl,
+        )
+    }
+
+private fun queryParameter(url: String, name: String): String? {
+    val match = Regex("""(?:[?&#]|&amp;)${Regex.escape(name)}=([^&#\s]+)""", RegexOption.IGNORE_CASE).find(url)
+    return match?.groupValues?.getOrNull(1)?.trim()?.takeIf { it.isNotBlank() }
+}
 
 @OptIn(ExperimentalEncodingApi::class)
 private fun shareTitleData(title: String): String =

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ShareResourcesTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ShareResourcesTest.kt
@@ -1,0 +1,96 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ShareResourcesTest {
+    @Test
+    fun parsesNeteaseShareText() {
+        val resource = assertNotNull(
+            parseSharedResource(
+                "分享Fly By Midnight/Rachel Grae的单曲《Different Lives》: https://music.163.com/song?id=2151445143 (来自@网易云音乐)",
+            ),
+        )
+
+        assertEquals(ShareResourceType.Song, resource.type)
+        assertEquals("netease", resource.providerId)
+        assertEquals("2151445143", resource.identifier)
+    }
+
+    @Test
+    fun parsesNeteaseResourceTypes() {
+        assertResource("https://music.163.com/#/playlist?id=8416733444", ShareResourceType.Playlist, "netease", "8416733444")
+        assertResource("https://music.163.com/#/artist?id=6452", ShareResourceType.Artist, "netease", "6452")
+        assertResource("https://y.music.163.com/m/album?id=12345", ShareResourceType.Album, "netease", "12345")
+    }
+
+    @Test
+    fun parsesBilibiliVideoAndPage() {
+        assertResource(
+            "郭德纲于谦 相声《有钱人的生活》无唱助眠 https://www.bilibili.com/video/BV1gUu36kEd8?p=1&unique_k=2333",
+            ShareResourceType.Song,
+            "bilibili",
+            "paged_BV1gUu36kEd8__1",
+        )
+        assertResource(
+            "https://m.bilibili.com/video/BV1gUu36kEd8",
+            ShareResourceType.Song,
+            "bilibili",
+            "BV1gUu36kEd8",
+        )
+    }
+
+    @Test
+    fun parsesQqMusicLinks() {
+        assertResource("https://y.qq.com/n/ryqq/songDetail/0039MnYb0qxYhV", ShareResourceType.Song, "qqmusic", "0039MnYb0qxYhV")
+        assertResource("https://y.qq.com/n/ryqq/playlist/9237907994", ShareResourceType.Playlist, "qqmusic", "9237907994")
+        assertResource("https://y.qq.com/n/ryqq/singer/0025NhlN2yWrP4", ShareResourceType.Artist, "qqmusic", "0025NhlN2yWrP4")
+        assertResource("https://y.qq.com/n/ryqq/albumDetail/003fNnQZ1tZ6vK", ShareResourceType.Album, "qqmusic", "003fNnQZ1tZ6vK")
+        assertResource("https://i.y.qq.com/n2/m/share/details/taoge.html?id=9237907994", ShareResourceType.Playlist, "qqmusic", "9237907994")
+    }
+
+    @Test
+    fun parsesYouTubeMusicAndYouTubeLinks() {
+        assertResource("https://music.youtube.com/watch?v=dQw4w9WgXcQ", ShareResourceType.Song, "ytmusic", "dQw4w9WgXcQ")
+        assertResource("https://youtu.be/dQw4w9WgXcQ?t=42", ShareResourceType.Song, "ytmusic", "dQw4w9WgXcQ")
+        assertResource("https://music.youtube.com/playlist?list=PL123456", ShareResourceType.Playlist, "ytmusic", "PL123456")
+        assertResource("https://music.youtube.com/channel/UC123456", ShareResourceType.Artist, "ytmusic", "UC123456")
+        assertResource("https://music.youtube.com/browse/MPREb_123456", ShareResourceType.Album, "ytmusic", "MPREb_123456")
+    }
+
+    @Test
+    fun keepsFuoLinksCompatible() {
+        assertResource("fuo://netease/songs/12345", ShareResourceType.Song, "netease", "12345")
+        assertResource(
+            "https://feeluown.github.io/FuoEvolve/r/qqmusic/playlists/67890?d=abc",
+            ShareResourceType.Playlist,
+            "qqmusic",
+            "67890",
+        )
+    }
+
+    @Test
+    fun derivesSearchQueryForUnsupportedShareText() {
+        assertEquals(
+            "Different Lives Fly By Midnight/Rachel Grae",
+            sharedSearchQuery("分享Fly By Midnight/Rachel Grae的单曲《Different Lives》: https://163cn.tv/bcHb0TZS (来自@网易云音乐)"),
+        )
+        assertEquals(
+            "Some Song - Some Artist",
+            sharedSearchQuery("Some Song - Some Artist https://open.spotify.com/track/123 Spotify"),
+        )
+    }
+
+    private fun assertResource(
+        text: String,
+        type: ShareResourceType,
+        providerId: String,
+        identifier: String,
+    ) {
+        val resource = assertNotNull(parseSharedResource(text))
+        assertEquals(type, resource.type)
+        assertEquals(providerId, resource.providerId)
+        assertEquals(identifier, resource.identifier)
+    }
+}


### PR DESCRIPTION
## What changed

- Add a dedicated Android system share receiver for `ACTION_SEND` (`text/*`) and `ACTION_PROCESS_TEXT`.
- Expand known short links off the main thread before routing, including NetEase `163cn.tv`, Bilibili `b23.tv` / `bili2233.cn`, and common QQ Music short-link hosts.
- Parse provider URLs in shared code and route them to existing detail pages:
  - NetEase Cloud Music: songs, playlists, artists, albums
  - Bilibili: BV video links, including `p=` multipart selection
  - QQ Music: songs, playlists, singers, albums
  - YouTube Music / YouTube: songs/videos, playlists, artists/channels, albums where the URL exposes a stable provider identifier
- Preserve existing `fuo://` and FuoEvolve web deep links.
- Fall back to extracting a useful search query from unsupported share text (for example Spotify / Apple Music captions) instead of failing immediately.
- Add focused common tests for provider URL parsing and fallback query extraction.

## Why

Android already exposed FuoEvolve as a text share target, but the receiver ultimately only understood FuoEvolve's own deep links. Normal provider share text therefore ended with “无法识别分享链接”. This change reuses the existing provider detail/navigation flow and adds a small Android-only short-link expansion layer for share URLs that hide the real resource behind redirects.

## User impact

Sharing a supported music/video resource to FuoEvolve now opens the corresponding track, playlist, artist, or album page. The supplied NetEase and Bilibili examples are covered, including Bilibili multipart links. Unsupported platforms degrade to in-app search when the share caption contains usable title/artist text.

## Validation

- Verified the branch diff is limited to the share receiver, shared URL parser, Android network policy, and tests.
- Ran local Kotlin syntax checks for `ShareResources.kt` and `AndroidSharedTextResolver.kt`.
- Ran parser smoke checks for the supplied NetEase/Bilibili examples plus QQ Music and YouTube Music URL forms.
- Added `ShareResourcesTest` coverage for songs/playlists/artists/albums, Bilibili `p=`, legacy Fuo links, and unsupported-platform search fallback.

Full Gradle validation is left to repository CI because this execution environment does not have a usable repository checkout / GitHub CLI.