### PR TITLE
feat: add ColorOS lock-screen lyrics

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -176,6 +176,7 @@ class AndroidNativeAudioEngine(
             return
         }
         val currentItem = controller.currentMediaItem ?: return
+        if (!currentItem.mediaId.endsWith(":${pending.trackId}")) return
         val currentIndex = controller.currentMediaItemIndex
         if (currentIndex < 0) return
         val lineLyrics = toTimedLineLrc(pending.lyrics) ?: return

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 class AndroidNativeAudioEngine(
     private val context: Context,
@@ -22,6 +24,7 @@ class AndroidNativeAudioEngine(
     private val mutableState = MutableStateFlow(PlaybackState())
     private var mediaController: MediaController? = null
     private var controllerConnecting = false
+    private var pendingLockScreenLyrics: PendingLockScreenLyrics? = null
 
     override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
     override val resolvesResourcesInternally: Boolean = true
@@ -44,6 +47,7 @@ class AndroidNativeAudioEngine(
                     audioDecoderInfo = mutableState.value.audioDecoderInfo,
                     audioFormatInfo = mutableState.value.audioFormatInfo,
                 )
+                applyPendingLockScreenLyrics()
             }
         }
         scope.launch {
@@ -127,6 +131,16 @@ class AndroidNativeAudioEngine(
         mutableState.value = mutableState.value.copy(positionMs = normalizedPosition)
     }
 
+    /**
+     * Publishes timed lyrics through the OPlus/ColorOS media-session extension.
+     * Non-OPlus Android builds simply ignore the extra metadata.
+     */
+    internal fun publishLockScreenLyrics(trackId: String, lyrics: String?) {
+        val normalizedLyrics = lyrics?.takeIf { it.isNotBlank() } ?: return
+        pendingLockScreenLyrics = PendingLockScreenLyrics(trackId, normalizedLyrics)
+        applyPendingLockScreenLyrics()
+    }
+
     private fun connectController() {
         if (mediaController != null || controllerConnecting) return
         controllerConnecting = true
@@ -138,6 +152,7 @@ class AndroidNativeAudioEngine(
                 runCatching { future.get() }
                     .onSuccess { controller ->
                         mediaController = controller
+                        applyPendingLockScreenLyrics()
                     }
                     .onFailure { throwable ->
                         Log.e(TAG, "connect media controller failed", throwable)
@@ -149,6 +164,53 @@ class AndroidNativeAudioEngine(
             },
             ContextCompat.getMainExecutor(context),
         )
+    }
+
+    private fun applyPendingLockScreenLyrics() {
+        val pending = pendingLockScreenLyrics ?: return
+        val controller = mediaController ?: return
+        val track = mutableState.value.currentTrack ?: return
+        if (track.id != pending.trackId) return
+        if (!controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
+            Log.w(TAG, "media session does not allow metadata replacement for ColorOS lyrics")
+            return
+        }
+        val currentItem = controller.currentMediaItem ?: return
+        val currentIndex = controller.currentMediaItemIndex
+        if (currentIndex < 0) return
+        val lineLyrics = toTimedLineLrc(pending.lyrics) ?: return
+        val lyricInfo = JSONObject()
+            .put("songName", track.title)
+            .put("artist", track.artists)
+            .put("songId", track.id)
+            .put("lyric", lineLyrics)
+            .toString()
+        val currentExtras = currentItem.mediaMetadata.extras
+        if (currentExtras?.getString(OPLUS_LYRIC_INFO_KEY) == lyricInfo) {
+            pendingLockScreenLyrics = null
+            return
+        }
+        val extras = Bundle(currentExtras ?: Bundle.EMPTY).apply {
+            putString("lyrics", pending.lyrics)
+            putString(OPLUS_LYRIC_INFO_KEY, lyricInfo)
+        }
+        val updatedItem = currentItem.buildUpon()
+            .setMediaMetadata(
+                currentItem.mediaMetadata.buildUpon()
+                    .setExtras(extras)
+                    .build(),
+            )
+            .build()
+        runCatching {
+            // URI and playback configuration stay unchanged, so Media3 can update
+            // ProgressiveMediaSource metadata without rebuilding the source.
+            controller.replaceMediaItem(currentIndex, updatedItem)
+        }.onSuccess {
+            pendingLockScreenLyrics = null
+            Log.d(TAG, "published ColorOS lock-screen lyrics trackId=${track.id}")
+        }.onFailure { throwable ->
+            Log.w(TAG, "failed to publish ColorOS lock-screen lyrics trackId=${track.id}", throwable)
+        }
     }
 
     private fun updatePosition() {
@@ -204,7 +266,13 @@ class AndroidNativeAudioEngine(
         )
     }
 
+    private data class PendingLockScreenLyrics(
+        val trackId: String,
+        val lyrics: String,
+    )
+
     private companion object {
         private const val TAG = "FuoAudioEngine"
+        private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -4,10 +4,13 @@ import android.app.Application
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 class FuoEvolveApplication : Application() {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -112,6 +115,19 @@ class FuoEvolveApplication : Application() {
                 override fun next() {
                     controller.next()
                 }
+            }
+            appScope.launch {
+                snapshotFlow {
+                    controller.playbackState.let { state ->
+                        state.currentTrack?.id to state.lyrics
+                    }
+                }
+                    .distinctUntilChanged()
+                    .collect { (trackId, lyrics) ->
+                        if (trackId != null && !lyrics.isNullOrBlank()) {
+                            playbackEngine.publishLockScreenLyrics(trackId, lyrics)
+                        }
+                    }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
@@ -1,0 +1,36 @@
+package org.feeluown.mobile
+
+/**
+ * Converts the app's supported lyric formats (LRC/YRC plus optional translation)
+ * into plain timed line-level LRC suitable for platform media-session extensions.
+ */
+fun toTimedLineLrc(rawLyrics: String?): String? {
+    val timedLines = parseLyrics(rawLyrics)
+        .filter { it.timeMs != Long.MAX_VALUE && it.text.isNotBlank() }
+    if (timedLines.isEmpty()) return null
+
+    return buildString {
+        timedLines.forEach { line ->
+            val timestamp = formatLrcTimestamp(line.timeMs)
+            append(timestamp)
+            append(line.text.trim())
+            append('\n')
+            line.translation
+                ?.trim()
+                ?.takeIf { it.isNotBlank() && it != line.text.trim() }
+                ?.let { translation ->
+                    append(timestamp)
+                    append(translation)
+                    append('\n')
+                }
+        }
+    }.trimEnd()
+}
+
+private fun formatLrcTimestamp(timeMs: Long): String {
+    val normalized = timeMs.coerceAtLeast(0L)
+    val minutes = normalized / 60_000L
+    val seconds = (normalized % 60_000L) / 1_000L
+    val millis = normalized % 1_000L
+    return "[${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}]"
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
@@ -1,0 +1,40 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TimedLineLyricsTest {
+    @Test
+    fun convertsYrcWordsToColorOsCompatibleLineLrc() {
+        val lyrics = composeLyricsWithTranslation(
+            "[11820,2220](11820,120,0)The (11940,420,0)club",
+            "[00:11.820]这俱乐部",
+        )
+
+        assertEquals(
+            "[00:11.820]The club\n[00:11.820]这俱乐部",
+            toTimedLineLrc(lyrics),
+        )
+    }
+
+    @Test
+    fun normalizesLrcTimestampsAndKeepsTranslations() {
+        val lyrics = """
+            [ar:Example]
+            [00:01.5]Hello
+            [00:01.5]你好
+            [01:02.03]World
+        """.trimIndent()
+
+        assertEquals(
+            "[00:01.500]Hello\n[00:01.500]你好\n[01:02.030]World",
+            toTimedLineLrc(lyrics),
+        )
+    }
+
+    @Test
+    fun ignoresUntimedLyricsForLockScreenTimeline() {
+        assertNull(toTimedLineLrc("plain lyrics without timestamps"))
+    }
+}


### PR DESCRIPTION
## Summary
- publish timed lyrics to the active Media3 session via OPlus/ColorOS `MediaMetadata` extra `lyricInfo`
- bridge the controller's asynchronously loaded lyrics into Android playback metadata without adding a second lyric fetch
- normalize existing LRC/YRC lyrics to line-level LRC and preserve timed translations
- keep the media URI/playback configuration unchanged when replacing metadata so playback can continue seamlessly

## Tests
- add common tests for YRC conversion, translated LRC normalization, and untimed lyric rejection
- GitHub Actions will validate the Android/shared build

## Notes
The integration uses the player-provided `lyricInfo` protocol consumed by the ColorOS/OPlus lock-screen lyrics pipeline. Other Android systems ignore this extra metadata.