### PR TITLE
feat: add NetEase discovery content

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -1034,7 +1034,7 @@ class FuoPlayerController(
             isLoading = true
             runCatching { debugLogRepository.exportLogFile(lines) }
                 .onSuccess { message = it }
-                .onFailure { setError(it) }
+                .onFailure(::setError)
             isLoading = false
         }
     }
@@ -1697,7 +1697,7 @@ class FuoPlayerController(
                         selectedLocalPlaylistTracks = updated.toMusicTracks()
                     }
                 }
-                if (showMessage) {
+                if (showLoading) {
                     message = if (loaded.isEmpty()) "暂无本地歌单" else "本地歌单 ${loaded.size} 个"
                 }
             }
@@ -4639,7 +4639,8 @@ class FuoPlayerController(
         map { section -> section.copy(tracks = section.tracks.filterNot { it.id == trackId }) }
 
     private fun ProviderFeature.isDeferredHomeFeature(): Boolean {
-        return category == ProviderFeatureCategory.Music ||
+        return (category == ProviderFeatureCategory.Music &&
+            (contentType == ProviderContentType.Songs || contentType == ProviderContentType.Videos)) ||
             (category == ProviderFeatureCategory.Recommend &&
                 (id.endsWith("_daily_songs") || isDynamicQueueFeature() || isBilibiliRecommendedVideos()))
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -1034,7 +1034,7 @@ class FuoPlayerController(
             isLoading = true
             runCatching { debugLogRepository.exportLogFile(lines) }
                 .onSuccess { message = it }
-                .onFailure(::setError)
+                .onFailure { setError(it) }
             isLoading = false
         }
     }
@@ -1697,7 +1697,7 @@ class FuoPlayerController(
                         selectedLocalPlaylistTracks = updated.toMusicTracks()
                     }
                 }
-                if (showLoading) {
+                if (showMessage) {
                     message = if (loaded.isEmpty()) "暂无本地歌单" else "本地歌单 ${loaded.size} 个"
                 }
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -75,6 +75,15 @@ fun ProviderContentHomeSection(
                         EmptyProviderContentHint(title)
                     }
                 } else if (section == HomeSection.Music) {
+                    val entrySections = visibleSections.filter {
+                        it.feature.contentType == ProviderContentType.Songs ||
+                            it.feature.contentType == ProviderContentType.Videos
+                    }
+                    val previewSections = visibleSections.filter {
+                        it.feature.contentType == ProviderContentType.Playlists ||
+                            it.feature.contentType == ProviderContentType.Artists ||
+                            it.feature.contentType == ProviderContentType.Albums
+                    }
                     if (visibleSections.isNotEmpty()) {
                         item(key = "header:explore") {
                             ProviderFeatureHeader(
@@ -86,10 +95,53 @@ fun ProviderContentHomeSection(
                                     .joinToString(" / "),
                             )
                         }
+                    }
+                    if (entrySections.isNotEmpty()) {
                         item(key = "explore-grid") {
                             ProviderFeatureCoverGrid(
-                                features = visibleSections.map { it.feature },
+                                features = entrySections.map { it.feature },
                                 onClick = controller::openFeature,
+                            )
+                        }
+                    }
+                    previewSections.forEach { contentSection ->
+                        item(key = "header:${contentSection.feature.id}") {
+                            ProviderFeatureHeader(feature = contentSection.feature)
+                        }
+                        when {
+                            contentSection.errorMessage != null -> item(key = "error:${contentSection.feature.id}") {
+                                ProviderContentMessage(contentSection.errorMessage)
+                            }
+                            contentSection.playlists.isNotEmpty() -> {
+                                item(key = "playlists:${contentSection.feature.id}") {
+                                    ProviderPlaylistGrid(
+                                        playlists = contentSection.playlists,
+                                        onClick = { controller.openPlaylist(it, contentSection.feature.category) },
+                                        onMore = { controller.openFeature(contentSection.feature) },
+                                        maxRows = 2,
+                                    )
+                                }
+                            }
+                            contentSection.mediaItems.isNotEmpty() -> {
+                                item(key = "media-items:${contentSection.feature.id}") {
+                                    ProviderMediaItemGrid(
+                                        items = contentSection.mediaItems,
+                                        onClick = controller::openMediaItem,
+                                        onMore = { controller.openFeature(contentSection.feature) },
+                                        maxRows = 2,
+                                    )
+                                }
+                            }
+                            else -> item(key = "empty:${contentSection.feature.id}") {
+                                ProviderContentMessage("暂无内容")
+                            }
+                        }
+                    }
+                    if (lockedProviders.isNotEmpty()) {
+                        item(key = "locked-providers:${section.name}") {
+                            ProviderLockedSummary(
+                                providers = lockedProviders,
+                                onClick = { controller.openSettings(it.providerId) },
                             )
                         }
                     }
@@ -585,6 +637,19 @@ fun ProviderPlaylistMoreCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    ProviderCollectionMoreCard(
+        subtitle = "全部歌单",
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ProviderCollectionMoreCard(
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
     Column(
         modifier = modifier
@@ -616,7 +681,7 @@ fun ProviderPlaylistMoreCard(
             overflow = TextOverflow.Ellipsis,
         )
         Text(
-            text = "全部歌单",
+            text = subtitle,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
@@ -670,31 +735,59 @@ fun ProviderMediaItemGrid(
     items: List<ProviderMediaItem>,
     onClick: (ProviderMediaItem) -> Unit,
     onItemVisible: ((Int) -> Unit)? = null,
+    onMore: (() -> Unit)? = null,
+    maxRows: Int? = null,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
-    val columns = layoutInfo.gridColumns
+    val columns = layoutInfo.gridColumns.coerceAtLeast(1)
     val spacing = if (layoutInfo.useWideLayout) 8.dp else 12.dp
+    val capacity = columns * (maxRows ?: 2)
+    val isLimited = maxRows != null || onMore != null
+    val hasMore = isLimited && items.size > capacity
+    val visibleItems = when {
+        hasMore && onMore != null -> items.take(capacity - 1)
+        hasMore -> items.take(capacity)
+        else -> items
+    }
+    val itemType = items.firstOrNull()?.type
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        items.chunked(columns).forEachIndexed { rowIndex, row ->
+        val cells = visibleItems.map<ProviderMediaItem, MediaItemGridCell> { MediaItemGridCell.Item(it) } +
+            if (hasMore && onMore != null) listOf(MediaItemGridCell.More) else emptyList()
+        cells.chunked(columns).forEachIndexed { rowIndex, row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
-                row.forEachIndexed { columnIndex, item ->
-                    val index = rowIndex * columns + columnIndex
-                    if (onItemVisible != null) {
-                        LaunchedEffect(index, items.size) {
-                            onItemVisible(index)
+                row.forEachIndexed { columnIndex, cell ->
+                    when (cell) {
+                        MediaItemGridCell.More -> {
+                            ProviderCollectionMoreCard(
+                                subtitle = when (itemType) {
+                                    ProviderMediaItemType.Artist -> "全部歌手"
+                                    ProviderMediaItemType.Album -> "全部专辑"
+                                    null -> "全部内容"
+                                },
+                                onClick = { onMore?.invoke() },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        is MediaItemGridCell.Item -> {
+                            val index = rowIndex * columns + columnIndex
+                            if (onItemVisible != null) {
+                                LaunchedEffect(index, items.size) {
+                                    onItemVisible(index)
+                                }
+                            }
+                            ProviderMediaItemCard(
+                                item = cell.value,
+                                onClick = { onClick(cell.value) },
+                                modifier = Modifier.weight(1f),
+                            )
                         }
                     }
-                    ProviderMediaItemCard(
-                        item = item,
-                        onClick = { onClick(item) },
-                        modifier = Modifier.weight(1f),
-                    )
                 }
                 repeat(columns - row.size) {
                     Spacer(Modifier.weight(1f))
@@ -702,6 +795,11 @@ fun ProviderMediaItemGrid(
             }
         }
     }
+}
+
+private sealed interface MediaItemGridCell {
+    data class Item(val value: ProviderMediaItem) : MediaItemGridCell
+    data object More : MediaItemGridCell
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -61,7 +61,16 @@ class NeteaseProvider(
         val playlists = searchType(keyword, 1000).array("playlists").map { it.asObject().toPlaylist() }
         val artists = searchType(keyword, 100).array("artists").map { artist(it.asObject()) }
         val albums = searchType(keyword, 10).array("albums").map { album(it.asObject()) }
-        return ProviderSearchResults(tracks = tracks, playlists = playlists, artists = artists, albums = albums)
+        val videos = searchType(keyword, 1004).array("mvs").mapNotNull { value ->
+            runCatching { mvVideo(value.asObject()) }.getOrNull()
+        }
+        return ProviderSearchResults(
+            tracks = tracks,
+            playlists = playlists,
+            artists = artists,
+            albums = albums,
+            videos = videos,
+        )
     }
 
     override suspend fun trackDetail(identifier: String) = songDetail(rawIdentifier(identifier))?.let { song(it) }
@@ -339,6 +348,85 @@ class NeteaseProvider(
                     .value.let { parseNeteaseResponse(it) }
                 val playlists = root.array("list")
                 ProviderContentSection(feature, playlists = playlists.drop(offset).take(limit).map { it.asObject().toPlaylist() }, nextOffset = offset + limit, hasMore = playlists.size > offset + limit)
+            }
+            "netease_new_songs" -> {
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/v1/discovery/new/songs",
+                    """{"areaId":0,"total":true}""",
+                )
+                val songs = root.array("data")
+                val page = songs.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    tracks = page.map(::song),
+                    nextOffset = offset + page.size,
+                    hasMore = songs.size > offset + page.size,
+                )
+            }
+            "netease_new_albums" -> {
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/album/new",
+                    """{"limit":$limit,"offset":$offset,"total":true,"area":"ALL"}""",
+                )
+                val values = root.array("albums")
+                ProviderContentSection(
+                    feature = feature,
+                    mediaItems = values.mapNotNull { value -> runCatching { album(value.asObject()) }.getOrNull() },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("more") || root.int("total")?.let { offset + values.size < it } == true || values.size == limit,
+                )
+            }
+            "netease_top_artists" -> {
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/artist/top",
+                    """{"limit":$limit,"offset":$offset,"total":true}""",
+                )
+                val values = root.array("artists")
+                ProviderContentSection(
+                    feature = feature,
+                    mediaItems = values.mapNotNull { value -> runCatching { artist(value.asObject()) }.getOrNull() },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("more") || values.size == limit,
+                )
+            }
+            "netease_highquality_playlists" -> {
+                val requestLimit = (offset + limit).coerceAtLeast(limit)
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/playlist/highquality/list",
+                    """{"cat":"全部","limit":$requestLimit,"lasttime":0,"total":true}""",
+                )
+                val values = root.array("playlists")
+                val page = values.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    playlists = page.mapNotNull { value -> runCatching { value.asObject().toPlaylist() }.getOrNull() },
+                    nextOffset = offset + page.size,
+                    hasMore = values.size > offset + page.size || root.boolean("more"),
+                )
+            }
+            "netease_recommended_mvs" -> {
+                val root = neteaseWeApiPost("$BASE/weapi/personalized/mv", "{}")
+                val values = root.array("result")
+                val page = values.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    videos = page.mapNotNull { value -> runCatching { mvVideo(value.asObject()) }.getOrNull() },
+                    nextOffset = offset + page.size,
+                    hasMore = values.size > offset + page.size,
+                )
+            }
+            "netease_top_mvs" -> {
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/mv/toplist",
+                    """{"area":"","limit":$limit,"offset":$offset,"total":true}""",
+                )
+                val values = root.array("data")
+                ProviderContentSection(
+                    feature = feature,
+                    videos = values.mapNotNull { value -> runCatching { mvVideo(value.asObject()) }.getOrNull() },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("hasMore") || values.size == limit,
+                )
             }
             "netease_daily_playlists" -> {
                 val root = neteaseWeApiPost("$BASE/api/discovery/recommend/resource", "{}")
@@ -764,6 +852,25 @@ class NeteaseProvider(
         providerUrl = "https://music.163.com/#/album?id=${value.string("id")}",
     )
 
+    private fun mvVideo(value: JsonObject): ProviderVideo {
+        val identifier = value.string("id").ifBlank { value.string("mvId") }
+        val artists = value.array("artists")
+            .map { it.asObject().string("name") }
+            .filter(String::isNotBlank)
+            .joinToString(" / ")
+            .ifBlank { value.string("artistName") }
+        return video(
+            identifier = identifier,
+            title = value.string("name").ifBlank { value.string("title") },
+            artists = artists,
+            coverUrl = value.stringOrNull("cover")
+                ?: value.stringOrNull("coverUrl")
+                ?: value.stringOrNull("picUrl"),
+            durationMs = value.long("duration") ?: value.long("durationMs"),
+            providerUrl = "https://music.163.com/#/mv?id=$identifier",
+        )
+    }
+
     private suspend fun mutatePlaylist(action: String, playlist: ProviderPlaylist, track: org.feeluown.mobile.MusicTrack): ProviderMutationResult {
         val (_, playlistId) = splitResourceId(playlist.id, "playlist")
         val (_, trackId) = splitResourceId(track.providerId ?: track.id)
@@ -821,6 +928,12 @@ class NeteaseProvider(
             ProviderFeature("netease_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
             ProviderFeature("netease_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
             ProviderFeature("netease_toplists", ID, NAME, "排行榜", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
+            ProviderFeature("netease_new_songs", ID, NAME, "新歌速递", ProviderFeatureCategory.Music, ProviderContentType.Songs, false),
+            ProviderFeature("netease_new_albums", ID, NAME, "新碟上架", ProviderFeatureCategory.Music, ProviderContentType.Albums, false),
+            ProviderFeature("netease_top_artists", ID, NAME, "热门歌手", ProviderFeatureCategory.Music, ProviderContentType.Artists, false),
+            ProviderFeature("netease_highquality_playlists", ID, NAME, "精品歌单", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
+            ProviderFeature("netease_recommended_mvs", ID, NAME, "推荐 MV", ProviderFeatureCategory.Music, ProviderContentType.Videos, false),
+            ProviderFeature("netease_top_mvs", ID, NAME, "MV 排行", ProviderFeatureCategory.Music, ProviderContentType.Videos, false),
             ProviderFeature("netease_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
             ProviderFeature("netease_favorite_songs", ID, NAME, "收藏歌曲", ProviderFeatureCategory.Mine, ProviderContentType.Songs, true),
             ProviderFeature("netease_cloud_songs", ID, NAME, "云盘歌曲", ProviderFeatureCategory.Mine, ProviderContentType.Songs, true),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseDiscoveryFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseDiscoveryFeatureTest.kt
@@ -1,0 +1,141 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.netease.NeteaseProvider
+
+class NeteaseDiscoveryFeatureTest {
+    @Test
+    fun exposesDiscoveryFeaturesUsingExistingContentTypes() = runTest {
+        val client = ProviderHttpClient(
+            httpClient = HttpClient(MockEngine) {
+                engine { addHandler { respond("{\"code\":200}") } }
+            },
+        )
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val features = provider.features.associateBy { it.id }
+
+        assertEquals(ProviderContentType.Songs, features["netease_new_songs"]?.contentType)
+        assertEquals(ProviderContentType.Albums, features["netease_new_albums"]?.contentType)
+        assertEquals(ProviderContentType.Artists, features["netease_top_artists"]?.contentType)
+        assertEquals(ProviderContentType.Playlists, features["netease_highquality_playlists"]?.contentType)
+        assertEquals(ProviderContentType.Videos, features["netease_recommended_mvs"]?.contentType)
+        assertEquals(ProviderContentType.Videos, features["netease_top_mvs"]?.contentType)
+        listOf(
+            "netease_new_songs",
+            "netease_new_albums",
+            "netease_top_artists",
+            "netease_highquality_playlists",
+            "netease_recommended_mvs",
+            "netease_top_mvs",
+        ).forEach { id ->
+            val feature = assertNotNull(features[id])
+            assertEquals(ProviderFeatureCategory.Music, feature.category)
+            assertFalse(feature.requiresLogin)
+        }
+
+        client.close()
+    }
+
+    @Test
+    fun mapsDiscoveryResponsesIntoExistingModels() = runTest {
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    val json = when (request.url.encodedPath) {
+                        "/weapi/v1/discovery/new/songs" -> """
+                            {"code":200,"data":[{"id":1,"name":"新歌","artists":[{"id":11,"name":"歌手"}],"album":{"id":21,"name":"专辑","picUrl":"song-cover"}}]}
+                        """.trimIndent()
+                        "/weapi/album/new" -> """
+                            {"code":200,"albums":[{"id":2,"name":"新碟","picUrl":"album-cover"}],"total":1}
+                        """.trimIndent()
+                        "/weapi/artist/top" -> """
+                            {"code":200,"artists":[{"id":3,"name":"热门歌手","picUrl":"artist-cover"}],"more":false}
+                        """.trimIndent()
+                        "/weapi/playlist/highquality/list" -> """
+                            {"code":200,"playlists":[{"id":4,"name":"精品歌单","coverImgUrl":"playlist-cover","trackCount":20}],"more":false}
+                        """.trimIndent()
+                        "/weapi/personalized/mv" -> """
+                            {"code":200,"result":[{"id":5,"name":"推荐 MV","artistName":"MV 歌手","picUrl":"mv-cover","duration":123000}]}
+                        """.trimIndent()
+                        "/weapi/mv/toplist" -> """
+                            {"code":200,"data":[{"id":6,"name":"排行 MV","artists":[{"name":"排行歌手"}],"cover":"top-mv-cover","duration":234000}],"hasMore":false}
+                        """.trimIndent()
+                        else -> error("unexpected NetEase request: ${request.url}")
+                    }
+                    respond(json)
+                }
+            }
+        }
+        val client = ProviderHttpClient(httpClient = httpClient)
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+        val features = provider.features.associateBy { it.id }
+
+        val songs = provider.loadFeature(assertNotNull(features["netease_new_songs"]), 0, 20)
+        assertEquals("新歌", songs.tracks.single().title)
+        assertEquals("歌手", songs.tracks.single().artists)
+
+        val albums = provider.loadFeature(assertNotNull(features["netease_new_albums"]), 0, 20)
+        assertEquals("新碟", albums.mediaItems.single().title)
+        assertEquals(ProviderMediaItemType.Album, albums.mediaItems.single().type)
+
+        val artists = provider.loadFeature(assertNotNull(features["netease_top_artists"]), 0, 20)
+        assertEquals("热门歌手", artists.mediaItems.single().title)
+        assertEquals(ProviderMediaItemType.Artist, artists.mediaItems.single().type)
+
+        val playlists = provider.loadFeature(assertNotNull(features["netease_highquality_playlists"]), 0, 20)
+        assertEquals("精品歌单", playlists.playlists.single().title)
+
+        val recommendedMvs = provider.loadFeature(assertNotNull(features["netease_recommended_mvs"]), 0, 20)
+        assertEquals("推荐 MV", recommendedMvs.videos.single().title)
+        assertEquals("MV 歌手", recommendedMvs.videos.single().artists)
+
+        val topMvs = provider.loadFeature(assertNotNull(features["netease_top_mvs"]), 0, 20)
+        assertEquals("排行 MV", topMvs.videos.single().title)
+        assertEquals("排行歌手", topMvs.videos.single().artists)
+
+        client.close()
+    }
+
+    @Test
+    fun includesMvResultsInNeteaseSearch() = runTest {
+        var requestIndex = 0
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    requestIndex += 1
+                    val json = when (requestIndex) {
+                        1 -> "{\"code\":200,\"result\":{\"songs\":[]}}"
+                        2 -> "{\"code\":200,\"result\":{\"playlists\":[]}}"
+                        3 -> "{\"code\":200,\"result\":{\"artists\":[]}}"
+                        4 -> "{\"code\":200,\"result\":{\"albums\":[]}}"
+                        5 -> """
+                            {"code":200,"result":{"mvs":[{"id":99,"name":"搜索 MV","artistName":"搜索歌手","cover":"search-cover","duration":345000}]}}
+                        """.trimIndent()
+                        else -> error("unexpected search request #$requestIndex")
+                    }
+                    respond(json)
+                }
+            }
+        }
+        val client = ProviderHttpClient(httpClient = httpClient)
+        val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
+
+        val result = provider.search("test")
+
+        assertEquals(5, requestIndex)
+        assertTrue(result.tracks.isEmpty())
+        assertEquals("搜索 MV", result.videos.single().title)
+        assertEquals("搜索歌手", result.videos.single().artists)
+        client.close()
+    }
+}


### PR DESCRIPTION
## What changed

Expand the built-in NetEase provider using the existing provider feature/detail UI instead of introducing new page layouts.

- add MV results to NetEase search
- add `新歌速递`
- add `新碟上架`
- add `热门歌手`
- add `精品歌单`
- add `推荐 MV`
- add `MV 排行`
- reuse the existing song / album / artist / playlist / video detail presentation
- add MockEngine coverage for feature metadata, response mapping, and MV search

## Explore presentation

Keep the Explore page consistent with the existing layouts and drive the presentation by `ProviderContentType` rather than provider-specific UI rules.

- `Songs` and `Videos` stay as feature entry cards and load their content after opening the feature
- `Playlists`, `Artists`, and `Albums` load preview content directly on Explore
- collection previews render at most two grid rows
- when more content is available, the final grid cell uses the same `查看更多` card pattern as the existing playlist grid and opens the existing feature page for the full view
- artist/album More cards reuse the playlist More-card visual treatment, with `全部歌手` / `全部专辑` subtitles

## Implementation notes

The new endpoints continue to use the existing Kotlin/Ktor NetEase provider and its WEAPI encryption path. The endpoint mapping follows the corresponding NetEase Cloud Music API capabilities (`v1/discovery/new/songs`, `album/new`, `artist/top`, `playlist/highquality/list`, `personalized/mv`, and `mv/toplist`).

No recent-playback content is included in this PR.

## Validation

- added shared MockEngine tests for feature metadata, response mapping, and MV search
- the original provider-only revision passed Android `:androidApp:assembleRelease` CI and the iOS simulator debug build
- the latest Explore-preview revision is running Android and iOS CI
- local `:shared:allTests` could not be executed in the current execution environment
