### PR TITLE
feat: refine NetEase recommendations

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -334,6 +334,22 @@ class NeteaseProvider(
                 val songs = root.obj("data")?.array("dailySongs").orEmpty()
                 ProviderContentSection(feature, tracks = songs.drop(offset).take(limit).map(::song), nextOffset = offset + limit, hasMore = songs.size > offset + limit)
             }
+            "netease_recommended_new_songs" -> {
+                val requestLimit = (offset + limit).coerceAtLeast(limit)
+                val root = neteaseWeApiPost(
+                    "$BASE/weapi/personalized/newsong",
+                    """{"type":"recommend","limit":$requestLimit,"areaId":0}""",
+                )
+                val values = root.array("result")
+                val songs = values.map { value -> value.asObject().obj("song") ?: value }
+                val page = songs.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    tracks = loadSongs(page),
+                    nextOffset = offset + page.size,
+                    hasMore = songs.size > offset + page.size,
+                )
+            }
             "netease_radio" -> {
                 val songs = http.getText(
                     ID,
@@ -925,14 +941,15 @@ class NeteaseProvider(
         )
         val FEATURES = listOf(
             ProviderFeature("netease_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
-            ProviderFeature("netease_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
+            ProviderFeature("netease_daily_playlists", ID, NAME, "每日推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
             ProviderFeature("netease_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
+            ProviderFeature("netease_recommended_new_songs", ID, NAME, "推荐新歌", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, false),
+            ProviderFeature("netease_recommended_mvs", ID, NAME, "推荐 MV", ProviderFeatureCategory.Recommend, ProviderContentType.Videos, false),
             ProviderFeature("netease_toplists", ID, NAME, "排行榜", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
             ProviderFeature("netease_new_songs", ID, NAME, "新歌速递", ProviderFeatureCategory.Music, ProviderContentType.Songs, false),
             ProviderFeature("netease_new_albums", ID, NAME, "新碟上架", ProviderFeatureCategory.Music, ProviderContentType.Albums, false),
             ProviderFeature("netease_top_artists", ID, NAME, "热门歌手", ProviderFeatureCategory.Music, ProviderContentType.Artists, false),
             ProviderFeature("netease_highquality_playlists", ID, NAME, "精品歌单", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
-            ProviderFeature("netease_recommended_mvs", ID, NAME, "推荐 MV", ProviderFeatureCategory.Music, ProviderContentType.Videos, false),
             ProviderFeature("netease_top_mvs", ID, NAME, "MV 排行", ProviderFeatureCategory.Music, ProviderContentType.Videos, false),
             ProviderFeature("netease_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
             ProviderFeature("netease_favorite_songs", ID, NAME, "收藏歌曲", ProviderFeatureCategory.Mine, ProviderContentType.Songs, true),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseDiscoveryFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseDiscoveryFeatureTest.kt
@@ -24,18 +24,24 @@ class NeteaseDiscoveryFeatureTest {
         val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
         val features = provider.features.associateBy { it.id }
 
+        assertEquals("每日推荐歌单", features["netease_daily_playlists"]?.title)
+        assertEquals(ProviderContentType.Songs, features["netease_recommended_new_songs"]?.contentType)
+        assertEquals(ProviderFeatureCategory.Recommend, features["netease_recommended_new_songs"]?.category)
+        assertFalse(assertNotNull(features["netease_recommended_new_songs"]).requiresLogin)
+        assertEquals(ProviderContentType.Videos, features["netease_recommended_mvs"]?.contentType)
+        assertEquals(ProviderFeatureCategory.Recommend, features["netease_recommended_mvs"]?.category)
+        assertFalse(assertNotNull(features["netease_recommended_mvs"]).requiresLogin)
+
         assertEquals(ProviderContentType.Songs, features["netease_new_songs"]?.contentType)
         assertEquals(ProviderContentType.Albums, features["netease_new_albums"]?.contentType)
         assertEquals(ProviderContentType.Artists, features["netease_top_artists"]?.contentType)
         assertEquals(ProviderContentType.Playlists, features["netease_highquality_playlists"]?.contentType)
-        assertEquals(ProviderContentType.Videos, features["netease_recommended_mvs"]?.contentType)
         assertEquals(ProviderContentType.Videos, features["netease_top_mvs"]?.contentType)
         listOf(
             "netease_new_songs",
             "netease_new_albums",
             "netease_top_artists",
             "netease_highquality_playlists",
-            "netease_recommended_mvs",
             "netease_top_mvs",
         ).forEach { id ->
             val feature = assertNotNull(features[id])
@@ -52,6 +58,9 @@ class NeteaseDiscoveryFeatureTest {
             engine {
                 addHandler { request ->
                     val json = when (request.url.encodedPath) {
+                        "/weapi/personalized/newsong" -> """
+                            {"code":200,"result":[{"id":7,"name":"推荐新歌","song":{"id":7,"name":"推荐新歌","artists":[{"id":17,"name":"推荐歌手"}],"album":{"id":27,"name":"推荐专辑","picUrl":"recommended-song-cover"}}}]}
+                        """.trimIndent()
                         "/weapi/v1/discovery/new/songs" -> """
                             {"code":200,"data":[{"id":1,"name":"新歌","artists":[{"id":11,"name":"歌手"}],"album":{"id":21,"name":"专辑","picUrl":"song-cover"}}]}
                         """.trimIndent()
@@ -79,6 +88,10 @@ class NeteaseDiscoveryFeatureTest {
         val client = ProviderHttpClient(httpClient = httpClient)
         val provider = NeteaseProvider(client, InMemoryProviderCredentialStore())
         val features = provider.features.associateBy { it.id }
+
+        val recommendedSongs = provider.loadFeature(assertNotNull(features["netease_recommended_new_songs"]), 0, 20)
+        assertEquals("推荐新歌", recommendedSongs.tracks.single().title)
+        assertEquals("推荐歌手", recommendedSongs.tracks.single().artists)
 
         val songs = provider.loadFeature(assertNotNull(features["netease_new_songs"]), 0, 20)
         assertEquals("新歌", songs.tracks.single().title)


### PR DESCRIPTION
## What changed

Refine the NetEase recommendation page after the discovery-content work from #45 was merged.

- rename `推荐歌单` to `每日推荐歌单` to match the actual daily recommendation API semantics
- add `推荐新歌` as a Recommend feature using NetEase `/api/personalized/newsong` via the existing WEAPI path
- move `推荐 MV` from Explore (`Music`) to Recommend
- keep `新歌速递`, `新碟上架`, `热门歌手`, `精品歌单`, `排行榜`, and `MV 排行` in Explore
- reuse the existing recommendation page rendering: recommended songs render as tracks, daily playlists as the existing playlist grid, and recommended MVs as the existing video list

## Implementation notes

No new page layout is introduced. The change only refines `ProviderFeatureCategory` placement and adds one NetEase recommendation endpoint mapping.

`推荐新歌` uses `/weapi/personalized/newsong` with `type=recommend`, `areaId=0`, and the requested limit. Responses support both nested `song` items and direct song objects before mapping through the existing song-detail normalization path.

## Tests

- update feature metadata assertions so `推荐 MV` is a Recommend feature rather than Explore
- add coverage for `推荐新歌` response mapping
- assert the `每日推荐歌单` label

CI will run on this PR.