### PR TITLE
feat: show recommended new songs as an entry

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -149,12 +149,14 @@ fun ProviderContentHomeSection(
                     val forYouSections = visibleSections.filter {
                         it.feature.isDailySongs() ||
                             it.feature.isPrivateFm() ||
-                            it.feature.isBilibiliRecommendedVideos()
+                            it.feature.isBilibiliRecommendedVideos() ||
+                            it.feature.isRecommendedNewSongs()
                     }
                     val otherSections = visibleSections.filterNot {
                         it.feature.isDailySongs() ||
                             it.feature.isPrivateFm() ||
-                            it.feature.isBilibiliRecommendedVideos()
+                            it.feature.isBilibiliRecommendedVideos() ||
+                            it.feature.isRecommendedNewSongs()
                     }
                     if (forYouSections.isNotEmpty()) {
                         item(key = "header:for-you") {
@@ -327,7 +329,7 @@ fun ForYouRecommendGrid(
                                 modifier = Modifier.weight(1f),
                             )
                         }
-                        section.feature.isBilibiliRecommendedVideos() -> {
+                        section.feature.isBilibiliRecommendedVideos() || section.feature.isRecommendedNewSongs() -> {
                             RecommendationEntryButton(
                                 feature = section.feature,
                                 enabled = enabled,
@@ -979,6 +981,10 @@ fun ProviderFeature.isDailySongs(): Boolean {
 
 fun ProviderFeature.isBilibiliRecommendedVideos(): Boolean {
     return providerId == "bilibili" && id == "bilibili_recommended_videos"
+}
+
+fun ProviderFeature.isRecommendedNewSongs(): Boolean {
+    return providerId == "netease" && id == "netease_recommended_new_songs"
 }
 
 fun ProviderFeature.toDisplayTrack(): MusicTrack {


### PR DESCRIPTION
## What changed

Adjust the NetEase recommendation presentation after #47 was merged.

- keep `推荐新歌` in the Recommend category
- stop rendering its song list directly on the recommendation home page
- place `推荐新歌` in the existing `为你推荐` entry grid
- reuse the existing recommendation entry card treatment
- opening the entry navigates to the existing Feature detail page, where the recommended-song list is displayed

## Scope

This is presentation-only. The NetEase recommendation endpoint and song mapping introduced in #47 are unchanged.

## Validation

The branch contains one UI file change only; CI will run on this PR.