### PR TITLE
feat: expand QQ Music discovery content

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
@@ -4,6 +4,7 @@ import org.feeluown.mobile.provider.bilibili.BilibiliContentProvider
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
+import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
 
 /**
  * Adds Bilibili browsing surfaces without changing the core provider repository.
@@ -192,9 +193,14 @@ fun createFuoProviderRepository(
         persistentCache = persistentCache,
         isCellularConnection = isCellularConnection,
     )
+    val qqmusic = QQMusicContentProvider(
+        http = ProviderHttpClient(persistentCache = persistentCache),
+        credentials = credentials,
+    )
+    val withQQMusicContent = QQMusicContentRepository(delegate, qqmusic)
     val bilibili = BilibiliContentProvider(
         http = ProviderHttpClient(persistentCache = persistentCache),
         credentials = credentials,
     )
-    return BilibiliContentRepository(delegate, bilibili)
+    return BilibiliContentRepository(withQQMusicContent, bilibili)
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
@@ -5,6 +5,7 @@ import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
 import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
+import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
 
 /**
  * Adds Bilibili browsing surfaces without changing the core provider repository.
@@ -193,11 +194,16 @@ fun createFuoProviderRepository(
         persistentCache = persistentCache,
         isCellularConnection = isCellularConnection,
     )
+    val qqmusicHttp = ProviderHttpClient(persistentCache = persistentCache)
     val qqmusic = QQMusicContentProvider(
-        http = ProviderHttpClient(persistentCache = persistentCache),
+        http = qqmusicHttp,
         credentials = credentials,
     )
-    val withQQMusicContent = QQMusicContentRepository(delegate, qqmusic)
+    val qqmusicUserLibrary = QQMusicUserLibrary(
+        http = qqmusicHttp,
+        credentials = credentials,
+    )
+    val withQQMusicContent = QQMusicContentRepository(delegate, qqmusic, qqmusicUserLibrary)
     val bilibili = BilibiliContentProvider(
         http = ProviderHttpClient(persistentCache = persistentCache),
         credentials = credentials,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
@@ -1,14 +1,17 @@
 package org.feeluown.mobile
 
 import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
+import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
 
 /**
  * Adds QQ Music discovery/search surfaces without changing the core provider repository.
- * Playback, authentication and user-library mutations continue to use the base QQ provider.
+ * Playback and mutations still go through [delegate]; QQ-specific discovery and
+ * user-library presentation are routed to their dedicated helpers.
  */
 internal class QQMusicContentRepository(
     private val delegate: ProviderMusicRepository,
     private val qqmusic: QQMusicContentProvider,
+    private val userLibrary: QQMusicUserLibrary,
 ) : ProviderMusicRepository by delegate {
     override suspend fun features(): List<ProviderFeature> {
         val base = delegate.features()
@@ -46,6 +49,30 @@ internal class QQMusicContentRepository(
         )
     }
 
+    override suspend fun authState(providerId: String): ProviderAuthState {
+        val base = delegate.authState(providerId)
+        return if (providerId == QQMUSIC_PROVIDER_ID) enrichQQMusicAuth(base) else base
+    }
+
+    override suspend fun refreshAuthState(providerId: String): ProviderAuthState {
+        val base = delegate.refreshAuthState(providerId)
+        return if (providerId == QQMUSIC_PROVIDER_ID) enrichQQMusicAuth(base) else base
+    }
+
+    override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState {
+        val base = delegate.loginWithCookies(providerId, cookiesJson)
+        return if (providerId == QQMUSIC_PROVIDER_ID) enrichQQMusicAuth(base) else base
+    }
+
+    override suspend fun loginWithHeaders(
+        providerId: String,
+        authorization: String,
+        cookie: String,
+    ): ProviderAuthState {
+        val base = delegate.loginWithHeaders(providerId, authorization, cookie)
+        return if (providerId == QQMUSIC_PROVIDER_ID) enrichQQMusicAuth(base) else base
+    }
+
     override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
         loadFeaturePage(feature, 0, PROVIDER_PAGE_SIZE)
 
@@ -54,7 +81,16 @@ internal class QQMusicContentRepository(
         offset: Int,
         limit: Int,
     ): ProviderContentSection = if (feature.providerId == QQMUSIC_PROVIDER_ID) {
-        qqmusic.loadFeature(feature, offset, limit)
+        if (ProviderFeatureFilterCodec.requestId(feature.id) == QQMUSIC_USER_PLAYLISTS_FEATURE_ID) {
+            val auth = delegate.authState(QQMUSIC_PROVIDER_ID)
+            if (!auth.isLoggedIn) {
+                ProviderContentSection(feature = feature, isLoginRequired = true)
+            } else {
+                userLibrary.loadPlaylists(feature, offset, limit)
+            }
+        } else {
+            qqmusic.loadFeature(feature, offset, limit)
+        }
     } else {
         delegate.loadFeaturePage(feature, offset, limit)
     }
@@ -86,6 +122,14 @@ internal class QQMusicContentRepository(
             delegate.playlistTracks(playlist)
         }
 
+    private suspend fun enrichQQMusicAuth(base: ProviderAuthState): ProviderAuthState {
+        if (!base.isLoggedIn) return base
+        val userName = runCatching { userLibrary.userName() }.getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: return base
+        return base.copy(userName = userName)
+    }
+
     private fun <T> replaceQQMusic(
         base: List<T>,
         qqItems: List<T>,
@@ -94,5 +138,6 @@ internal class QQMusicContentRepository(
 
     private companion object {
         const val QQMUSIC_PROVIDER_ID = "qqmusic"
+        const val QQMUSIC_USER_PLAYLISTS_FEATURE_ID = "qqmusic_user_playlists"
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
@@ -1,0 +1,98 @@
+package org.feeluown.mobile
+
+import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
+
+/**
+ * Adds QQ Music discovery/search surfaces without changing the core provider repository.
+ * Playback, authentication and user-library mutations continue to use the base QQ provider.
+ */
+internal class QQMusicContentRepository(
+    private val delegate: ProviderMusicRepository,
+    private val qqmusic: QQMusicContentProvider,
+) : ProviderMusicRepository by delegate {
+    override suspend fun features(): List<ProviderFeature> {
+        val base = delegate.features()
+        if (base.none { it.providerId == QQMUSIC_PROVIDER_ID }) return base
+        return buildList {
+            var inserted = false
+            base.forEach { feature ->
+                if (feature.providerId == QQMUSIC_PROVIDER_ID) {
+                    if (!inserted) {
+                        addAll(qqmusic.features)
+                        inserted = true
+                    }
+                } else {
+                    add(feature)
+                }
+            }
+        }
+    }
+
+    override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> =
+        searchAll(keyword, providerId).tracks
+
+    override suspend fun searchAll(keyword: String, providerId: String?): ProviderSearchResults {
+        val base = delegate.searchAll(keyword, providerId)
+        if (providerId != null && providerId != QQMUSIC_PROVIDER_ID) return base
+        val qqEnabled = providerId == QQMUSIC_PROVIDER_ID ||
+            delegate.features().any { it.providerId == QQMUSIC_PROVIDER_ID }
+        if (!qqEnabled) return base
+        val extras = runCatching { qqmusic.searchExtras(keyword) }.getOrElse { return base }
+        return base.copy(
+            playlists = replaceQQMusic(base.playlists, extras.playlists) { it.providerId },
+            artists = replaceQQMusic(base.artists, extras.artists) { it.providerId },
+            albums = replaceQQMusic(base.albums, extras.albums) { it.providerId },
+            videos = replaceQQMusic(base.videos, extras.videos) { it.providerId },
+        )
+    }
+
+    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+        loadFeaturePage(feature, 0, PROVIDER_PAGE_SIZE)
+
+    override suspend fun loadFeaturePage(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection = if (feature.providerId == QQMUSIC_PROVIDER_ID) {
+        qqmusic.loadFeature(feature, offset, limit)
+    } else {
+        delegate.loadFeaturePage(feature, offset, limit)
+    }
+
+    override suspend fun loadMoreFeatureTracks(feature: ProviderFeature): List<MusicTrack> =
+        if (feature.providerId == QQMUSIC_PROVIDER_ID) {
+            qqmusic.loadFeature(feature, 0, PROVIDER_PAGE_SIZE).tracks
+        } else {
+            delegate.loadMoreFeatureTracks(feature)
+        }
+
+    override suspend fun playlistDetail(playlist: ProviderPlaylist): ProviderPlaylistDetail =
+        playlistDetailPage(playlist, 0, PROVIDER_PAGE_SIZE)
+
+    override suspend fun playlistDetailPage(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail = if (playlist.providerId == QQMUSIC_PROVIDER_ID) {
+        qqmusic.playlistDetail(playlist, offset, limit)
+    } else {
+        delegate.playlistDetailPage(playlist, offset, limit)
+    }
+
+    override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> =
+        if (playlist.providerId == QQMUSIC_PROVIDER_ID) {
+            qqmusic.playlistTracks(playlist)
+        } else {
+            delegate.playlistTracks(playlist)
+        }
+
+    private fun <T> replaceQQMusic(
+        base: List<T>,
+        qqItems: List<T>,
+        providerId: (T) -> String,
+    ): List<T> = (base.filterNot { providerId(it) == QQMUSIC_PROVIDER_ID } + qqItems).distinct()
+
+    private companion object {
+        const val QQMUSIC_PROVIDER_ID = "qqmusic"
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicContentProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicContentProvider.kt
@@ -1,0 +1,892 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderContentType
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureCategory
+import org.feeluown.mobile.ProviderFeatureFilterCodec
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemType
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.boolean
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.md5Hex
+import org.feeluown.mobile.provider.core.mediaItemKey
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.parseCookies
+import org.feeluown.mobile.provider.core.playlistKey
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.trackKey
+import org.feeluown.mobile.provider.core.videoKey
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+import kotlin.random.Random
+
+/**
+ * Adds QQ Music public discovery and multi-type search on top of [QQMusicProvider].
+ * Playback, authentication, user-library operations, regular playlist details,
+ * artist/album details and video playback stay delegated to the core provider.
+ */
+class QQMusicContentProvider(
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+    private val delegate: QQMusicProvider = QQMusicProvider(http, credentials),
+) : KotlinMusicProvider by delegate {
+    override val features: List<ProviderFeature> = delegate.features + EXTRA_FEATURES
+
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        val base = delegate.search(keyword)
+        val extras = runCatching { searchExtras(keyword) }.getOrElse { ProviderSearchResults() }
+        return base.copy(
+            playlists = extras.playlists,
+            artists = extras.artists,
+            albums = extras.albums,
+            videos = extras.videos,
+        )
+    }
+
+    /**
+     * Fetches only non-song result types so repository integration can preserve
+     * the existing QQ song-search request instead of issuing it twice.
+     */
+    internal suspend fun searchExtras(keyword: String): ProviderSearchResults {
+        if (keyword.isBlank()) return ProviderSearchResults()
+        val root = rpc(
+            """
+            {
+              "singerSearch":{"module":"music.search.SearchCgiService","method":"DoSearchForQQMusicDesktop","param":{"num_per_page":30,"page_num":1,"search_type":1,"query":${jsonString(keyword)}}},
+              "albumSearch":{"module":"music.search.SearchCgiService","method":"DoSearchForQQMusicDesktop","param":{"num_per_page":30,"page_num":1,"search_type":2,"query":${jsonString(keyword)}}},
+              "playlistSearch":{"module":"music.search.SearchCgiService","method":"DoSearchForQQMusicDesktop","param":{"num_per_page":30,"page_num":1,"search_type":3,"query":${jsonString(keyword)}}},
+              "mvSearch":{"module":"music.search.SearchCgiService","method":"DoSearchForQQMusicDesktop","param":{"num_per_page":30,"page_num":1,"search_type":4,"query":${jsonString(keyword)}}}
+            }
+            """.trimIndent(),
+            cacheKey = "qqmusic:search-extras:$keyword",
+            cachePolicy = ProviderCachePolicies.search,
+        )
+        val singerBody = searchBody(root, "singerSearch")
+        val albumBody = searchBody(root, "albumSearch")
+        val playlistBody = searchBody(root, "playlistSearch")
+        val mvBody = searchBody(root, "mvSearch")
+
+        val singerValues = firstNonEmpty(
+            singerBody.obj("singer")?.array("list").orEmpty(),
+            singerBody.array("singer"),
+            singerBody.array("list"),
+        )
+        val albumValues = firstNonEmpty(
+            albumBody.obj("album")?.array("list").orEmpty(),
+            albumBody.array("album"),
+            albumBody.array("list"),
+        )
+        val playlistValues = firstNonEmpty(
+            playlistBody.obj("songlist")?.array("list").orEmpty(),
+            playlistBody.obj("playlist")?.array("list").orEmpty(),
+            playlistBody.array("songlist"),
+            playlistBody.array("playlist"),
+            playlistBody.array("list"),
+        )
+        val videoValues = firstNonEmpty(
+            mvBody.obj("mv")?.array("list").orEmpty(),
+            mvBody.obj("video")?.array("list").orEmpty(),
+            mvBody.array("mv"),
+            mvBody.array("video"),
+            mvBody.array("list"),
+        )
+
+        return ProviderSearchResults(
+            playlists = playlistValues.mapNotNull { value ->
+                runCatching { qqPlaylist(value.asObject()) }.getOrNull()
+            }.filter(::hasResourceId).distinctBy { it.id },
+            artists = singerValues.mapNotNull { value ->
+                runCatching { qqArtist(value.asObject()) }.getOrNull()
+            }.filter(::hasResourceId).distinctBy { it.id },
+            albums = albumValues.mapNotNull { value ->
+                runCatching { qqAlbum(value.asObject()) }.getOrNull()
+            }.filter(::hasResourceId).distinctBy { it.id },
+            videos = videoValues.mapNotNull { value ->
+                runCatching { qqVideo(value.asObject()) }.getOrNull()
+            }.filter(::hasResourceId).distinctBy { it.id },
+        )
+    }
+
+    override suspend fun loadFeature(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val request = parseQQMusicFeatureRequest(feature.id)
+        return when (request.baseId) {
+            QQMUSIC_TOPLISTS -> loadToplists(feature, offset, limit)
+            QQMUSIC_PLAYLIST_SQUARE -> loadPlaylistSquare(feature, request, offset, limit)
+            QQMUSIC_ARTIST_SQUARE -> loadArtistSquare(feature, request, offset, limit)
+            QQMUSIC_NEW_ALBUMS -> loadNewAlbums(feature, offset, limit)
+            QQMUSIC_MV_SQUARE -> loadMvSquare(feature, request, offset, limit)
+            else -> delegate.loadFeature(feature, offset, limit)
+        }
+    }
+
+    override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> =
+        if (playlist.isQQMusicToplist()) {
+            playlistDetail(playlist, 0, 1_000).tracks
+        } else {
+            delegate.playlistTracks(playlist)
+        }
+
+    override suspend fun playlistDetail(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail {
+        if (!playlist.isQQMusicToplist()) {
+            return delegate.playlistDetail(playlist, offset, limit)
+        }
+        val spec = parseToplistIdentifier(resourceId(playlist.id))
+            ?: return ProviderPlaylistDetail(playlist)
+        val periodJson = spec.period
+            .takeIf(String::isNotBlank)
+            ?.let { ",\"period\":${jsonString(it)}" }
+            .orEmpty()
+        val root = rpc(
+            """
+            {"detail":{"module":"musicToplist.ToplistInfoServer","method":"GetDetail","param":{"topId":${spec.topId},"offset":$offset,"num":$limit$periodJson}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:toplist:${spec.topId}:${spec.period}:$offset:$limit",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val detailData = root.obj("detail")?.obj("data")
+            ?: root.obj("data")
+            ?: JsonObject(emptyMap())
+        val metadata = detailData.obj("data") ?: detailData
+        val songValues = firstNonEmpty(
+            detailData.array("songInfoList"),
+            metadata.array("songInfoList"),
+            metadata.array("song"),
+            metadata.array("songlist"),
+        )
+        val tracks = songValues.mapNotNull { value ->
+            val item = value.asObject().obj("songInfo")
+                ?: value.asObject().obj("data")
+                ?: value.asObject()
+            runCatching { qqTrack(item) }.getOrNull()
+        }.filter(::hasResourceId)
+        val total = metadata.int("totalNum")
+            ?: metadata.int("total")
+            ?: metadata.int("songNum")
+            ?: playlist.trackCount
+        val actualPeriod = metadata.string("period").ifBlank { spec.period }
+        val actual = playlist.copy(
+            id = toplistPlaylistId(spec.topId, actualPeriod),
+            title = metadata.string("title").ifBlank { playlist.title },
+            coverUrl = metadata.stringOrNull("headPicUrl")
+                ?: metadata.stringOrNull("frontPicUrl")
+                ?: metadata.stringOrNull("picUrl")
+                ?: playlist.coverUrl,
+            description = metadata.string("intro")
+                .ifBlank { metadata.string("desc") }
+                .ifBlank { playlist.description },
+            playCount = metadata.long("listenNum")
+                ?: metadata.long("listenCount")
+                ?: playlist.playCount,
+            trackCount = total ?: tracks.size,
+            providerUrl = "https://y.qq.com/n/ryqq/toplist/${spec.topId}",
+        )
+        val nextOffset = offset + songValues.size
+        return ProviderPlaylistDetail(
+            playlist = actual,
+            tracks = tracks,
+            tracksNextOffset = nextOffset,
+            tracksHasMore = songValues.isNotEmpty() &&
+                (total?.let { nextOffset < it } ?: (songValues.size >= limit)),
+        )
+    }
+
+    private suspend fun loadToplists(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val root = rpc(
+            """
+            {"topList":{"module":"musicToplist.ToplistInfoServer","method":"GetAll","param":{}},"comm":{"ct":23,"cv":0,"platform":"h5","needNewCode":1}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:toplists",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val groups = root.obj("topList")?.obj("data")?.array("group").orEmpty()
+        val values = groups.flatMap { groupValue ->
+            val group = groupValue.asObject()
+            firstNonEmpty(
+                group.array("toplist"),
+                group.array("topList"),
+                group.array("list"),
+            )
+        }
+        val playlists = values.mapNotNull { value ->
+            val item = value.asObject()
+            val topId = item.int("topId")
+                ?: item.int("id")
+                ?: item.string("topId").toIntOrNull()
+                ?: item.string("id").toIntOrNull()
+                ?: return@mapNotNull null
+            val period = item.string("period")
+                .ifBlank { item.string("update_key") }
+                .ifBlank { item.string("updateKey") }
+            ProviderPlaylist(
+                id = toplistPlaylistId(topId, period),
+                title = item.string("title")
+                    .ifBlank { item.string("topTitle") }
+                    .ifBlank { item.string("name") },
+                providerId = ID,
+                providerName = NAME,
+                coverUrl = item.stringOrNull("headPicUrl")
+                    ?: item.stringOrNull("frontPicUrl")
+                    ?: item.stringOrNull("picUrl"),
+                description = item.string("intro").ifBlank { item.string("updateTips") },
+                playCount = item.long("listenNum") ?: item.long("listenCount"),
+                trackCount = item.int("totalNum")
+                    ?: item.int("songNum")
+                    ?: item.array("song").size.takeIf { it > 0 },
+                providerUrl = "https://y.qq.com/n/ryqq/toplist/$topId",
+            )
+        }.filter { it.title.isNotBlank() }
+        val page = playlists.drop(offset).take(limit)
+        return ProviderContentSection(
+            feature = feature,
+            playlists = page,
+            nextOffset = offset + page.size,
+            hasMore = playlists.size > offset + page.size,
+        )
+    }
+
+    private suspend fun loadPlaylistSquare(
+        feature: ProviderFeature,
+        request: QQMusicFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val categoryId = request.params["categoryId"]
+            .orEmpty()
+            .ifBlank { QQ_DEFAULT_PLAYLIST_CATEGORY_ID }
+        val sortId = request.params["sortId"]
+            .orEmpty()
+            .ifBlank { QQ_DEFAULT_PLAYLIST_SORT_ID }
+        val categories = runCatching { loadPlaylistCategories() }.getOrDefault(emptyList())
+        val end = offset + limit.coerceAtLeast(1) - 1
+        val root = http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$C_BASE/splcloud/fcgi-bin/fcg_get_diss_by_tag.fcg",
+                mapOf(
+                    "format" to "json",
+                    "inCharset" to "utf8",
+                    "outCharset" to "utf-8",
+                    "picmid" to "1",
+                    "categoryId" to categoryId,
+                    "sortId" to sortId,
+                    "sin" to offset.toString(),
+                    "ein" to end.toString(),
+                ),
+            ),
+            headers = publicHeaders(),
+            cacheKey = "qqmusic:playlist-square:$categoryId:$sortId:$offset:$limit",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        val data = root.obj("data") ?: root
+        val rawValues = firstNonEmpty(data.array("list"), data.array("disslist"))
+        val playlists = rawValues.mapNotNull { value ->
+            runCatching { qqPlaylist(value.asObject()) }.getOrNull()
+        }.filter(::hasResourceId)
+        val total = data.int("sum") ?: data.int("total")
+        val nextOffset = offset + rawValues.size
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(
+                feature,
+                qqMusicPlaylistSquareFilters(categories, categoryId, sortId),
+            ),
+            playlists = playlists,
+            nextOffset = nextOffset,
+            hasMore = total?.let { nextOffset < it } ?: (rawValues.size >= limit),
+        )
+    }
+
+    private suspend fun loadPlaylistCategories(): List<QQMusicPlaylistCategory> {
+        val root = http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$C_BASE/splcloud/fcgi-bin/fcg_get_diss_tag_conf.fcg",
+                mapOf(
+                    "format" to "json",
+                    "inCharset" to "utf8",
+                    "outCharset" to "utf-8",
+                ),
+            ),
+            headers = publicHeaders(),
+            cacheKey = "qqmusic:playlist-categories",
+            cachePolicy = ProviderCachePolicies.detail,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        return root.obj("data")?.array("categories").orEmpty().flatMap { categoryValue ->
+            val category = categoryValue.asObject()
+            firstNonEmpty(category.array("items"), category.array("item")).mapNotNull { itemValue ->
+                val item = itemValue.asObject()
+                val id = item.string("categoryId")
+                    .ifBlank { item.int("categoryId")?.toString().orEmpty() }
+                    .ifBlank { item.string("id") }
+                val name = item.string("categoryName").ifBlank { item.string("name") }
+                val usable = item["usable"] == null ||
+                    item.boolean("usable") ||
+                    item.int("usable")?.let { it != 0 } == true
+                if (id.isBlank() || name.isBlank() || !usable) {
+                    null
+                } else {
+                    QQMusicPlaylistCategory(id, name)
+                }
+            }
+        }.distinctBy { it.id }
+    }
+
+    private suspend fun loadArtistSquare(
+        feature: ProviderFeature,
+        request: QQMusicFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val area = request.params["area"].orEmpty().ifBlank { QQ_DEFAULT_ARTIST_FILTER }
+        val sex = request.params["sex"].orEmpty().ifBlank { QQ_DEFAULT_ARTIST_FILTER }
+        val genre = request.params["genre"].orEmpty().ifBlank { QQ_DEFAULT_ARTIST_FILTER }
+        val index = request.params["index"].orEmpty().ifBlank { QQ_DEFAULT_ARTIST_FILTER }
+
+        // QQ's singer-list endpoint is fixed at 80 rows per server page. Keep the
+        // repository's arbitrary page size by slicing the corresponding server page.
+        val serverPageStart = (offset / QQ_SINGER_PAGE_SIZE) * QQ_SINGER_PAGE_SIZE
+        val localOffset = offset - serverPageStart
+        val root = rpc(
+            """
+            {"singerList":{"module":"Music.SingerListServer","method":"get_singer_list","param":{"area":$area,"sex":$sex,"genre":$genre,"index":$index,"sin":$serverPageStart,"cur_page":${serverPageStart / QQ_SINGER_PAGE_SIZE + 1}}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:artist-square:$area:$sex:$genre:$index:$serverPageStart",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val data = root.obj("singerList")?.obj("data") ?: root.obj("data") ?: root
+        val rawValues = firstNonEmpty(data.array("singerlist"), data.array("list"))
+        val pageValues = rawValues.drop(localOffset).take(limit)
+        val artists = pageValues.mapNotNull { value ->
+            val item = value.asObject().obj("singer_info") ?: value.asObject()
+            runCatching { qqArtist(item) }.getOrNull()
+        }.filter(::hasResourceId)
+        val total = data.int("total") ?: data.int("totalNum") ?: data.int("total_num")
+        val nextOffset = offset + pageValues.size
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(
+                feature,
+                qqMusicArtistSquareFilters(area, sex, genre, index),
+            ),
+            mediaItems = artists,
+            nextOffset = nextOffset,
+            hasMore = total?.let { nextOffset < it }
+                ?: (localOffset + pageValues.size < rawValues.size || rawValues.size >= QQ_SINGER_PAGE_SIZE),
+        )
+    }
+
+    private suspend fun loadNewAlbums(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val root = rpc(
+            """
+            {"new_album":{"module":"newalbum.NewAlbumServer","method":"get_new_album_info","param":{"area":1,"sin":$offset,"num":$limit}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:new-albums:$offset:$limit",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val data = root.obj("new_album")?.obj("data") ?: root.obj("data") ?: root
+        val rawValues = firstNonEmpty(
+            data.array("albums"),
+            data.array("album_list"),
+            data.array("list"),
+        )
+        val albums = rawValues.mapNotNull { value ->
+            val item = value.asObject().obj("album") ?: value.asObject()
+            runCatching { qqAlbum(item) }.getOrNull()
+        }.filter(::hasResourceId)
+        val total = data.int("total") ?: data.int("totalNum") ?: data.int("total_num")
+        val nextOffset = offset + rawValues.size
+        return ProviderContentSection(
+            feature = feature,
+            mediaItems = albums,
+            nextOffset = nextOffset,
+            hasMore = total?.let { nextOffset < it } ?: (rawValues.size >= limit),
+        )
+    }
+
+    private suspend fun loadMvSquare(
+        feature: ProviderFeature,
+        request: QQMusicFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val area = request.params["area"].orEmpty().ifBlank { QQ_DEFAULT_MV_AREA }
+        val version = request.params["version"].orEmpty().ifBlank { QQ_DEFAULT_MV_VERSION }
+        val root = rpc(
+            """
+            {"mv_list":{"module":"MvService.MvInfoProServer","method":"GetAllocMvInfo","param":{"start":$offset,"size":$limit,"version_id":$version,"area_id":$area,"order":1}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:mv-square:$area:$version:$offset:$limit",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val data = root.obj("mv_list")?.obj("data") ?: root.obj("data") ?: root
+        val rawValues = firstNonEmpty(
+            data.array("list"),
+            data.array("mv_list"),
+            data.array("mvlist"),
+        )
+        val videos = rawValues.mapNotNull { value ->
+            val item = value.asObject().obj("mv_info") ?: value.asObject()
+            runCatching { qqVideo(item) }.getOrNull()
+        }.filter(::hasResourceId)
+        val total = data.int("total") ?: data.int("totalNum") ?: data.int("total_num")
+        val nextOffset = offset + rawValues.size
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(
+                feature,
+                qqMusicMvSquareFilters(area, version),
+            ),
+            videos = videos,
+            nextOffset = nextOffset,
+            hasMore = total?.let { nextOffset < it } ?: (rawValues.size >= limit),
+        )
+    }
+
+    private fun qqPlaylist(item: JsonObject): ProviderPlaylist {
+        val identifier = item.string("dissid")
+            .ifBlank { item.string("tid") }
+            .ifBlank { item.string("content_id") }
+            .ifBlank { item.string("id") }
+        return ProviderPlaylist(
+            id = playlistKey(ID, identifier),
+            title = item.string("dissname")
+                .ifBlank { item.string("title") }
+                .ifBlank { item.string("name") },
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("imgurl")
+                ?: item.stringOrNull("picurl")
+                ?: item.stringOrNull("picUrl")
+                ?: item.stringOrNull("cover")
+                ?: item.stringOrNull("logo"),
+            description = item.string("introduction")
+                .ifBlank { item.string("desc") }
+                .ifBlank { item.string("description") },
+            playCount = item.long("listennum")
+                ?: item.long("listen_num")
+                ?: item.long("visitnum"),
+            trackCount = item.int("song_count")
+                ?: item.int("songnum")
+                ?: item.int("total_song_num"),
+            providerUrl = "https://y.qq.com/n/ryqq/playlist/$identifier",
+        )
+    }
+
+    private fun qqArtist(item: JsonObject): ProviderMediaItem {
+        val identifier = item.string("singer_id")
+            .ifBlank { item.string("singerID") }
+            .ifBlank { item.string("singerid") }
+            .ifBlank { item.string("id") }
+            .ifBlank { item.string("singer_mid") }
+            .ifBlank { item.string("singerMID") }
+            .ifBlank { item.string("singermid") }
+            .ifBlank { item.string("mid") }
+        val mid = item.string("singer_mid")
+            .ifBlank { item.string("singerMID") }
+            .ifBlank { item.string("singermid") }
+            .ifBlank { item.string("mid") }
+        return ProviderMediaItem(
+            id = mediaItemKey(ProviderMediaItemType.Artist, ID, identifier),
+            title = item.string("singer_name")
+                .ifBlank { item.string("singerName") }
+                .ifBlank { item.string("singername") }
+                .ifBlank { item.string("name") }
+                .ifBlank { item.string("title") },
+            providerId = ID,
+            providerName = NAME,
+            type = ProviderMediaItemType.Artist,
+            coverUrl = item.stringOrNull("singer_pic")
+                ?: item.stringOrNull("singerPic")
+                ?: item.stringOrNull("pic")
+                ?: item.stringOrNull("picUrl")
+                ?: item.stringOrNull("picurl")
+                ?: mid.takeIf(String::isNotBlank)?.let(::artistCover),
+            description = item.string("desc").ifBlank { item.string("description") },
+            trackCount = item.int("song_num") ?: item.int("songnum"),
+            albumCount = item.int("album_num") ?: item.int("albumnum"),
+            providerUrl = "https://y.qq.com/n/ryqq/singer/$identifier",
+        )
+    }
+
+    private fun qqAlbum(item: JsonObject): ProviderMediaItem {
+        val album = item.obj("album") ?: item
+        val identifier = album.string("album_id")
+            .ifBlank { album.string("albumID") }
+            .ifBlank { album.string("albumid") }
+            .ifBlank { album.string("id") }
+            .ifBlank { album.string("album_mid") }
+            .ifBlank { album.string("albumMID") }
+            .ifBlank { album.string("albummid") }
+            .ifBlank { album.string("mid") }
+        val mid = album.string("album_mid")
+            .ifBlank { album.string("albumMID") }
+            .ifBlank { album.string("albummid") }
+            .ifBlank { album.string("mid") }
+        return ProviderMediaItem(
+            id = mediaItemKey(ProviderMediaItemType.Album, ID, identifier),
+            title = album.string("album_name")
+                .ifBlank { album.string("albumName") }
+                .ifBlank { album.string("albumname") }
+                .ifBlank { album.string("name") }
+                .ifBlank { album.string("title") },
+            providerId = ID,
+            providerName = NAME,
+            type = ProviderMediaItemType.Album,
+            coverUrl = album.stringOrNull("album_pic")
+                ?: album.stringOrNull("albumPic")
+                ?: album.stringOrNull("pic")
+                ?: album.stringOrNull("picUrl")
+                ?: album.stringOrNull("picurl")
+                ?: mid.takeIf(String::isNotBlank)?.let(::albumCover),
+            description = album.string("desc").ifBlank { album.string("description") },
+            trackCount = album.int("song_count")
+                ?: album.int("songnum")
+                ?: album.int("total_song_num"),
+            providerUrl = "https://y.qq.com/n/ryqq/albumDetail/$identifier",
+        )
+    }
+
+    private fun qqVideo(item: JsonObject): ProviderVideo {
+        val mv = item.obj("mv") ?: item
+        val identifier = mv.string("vid")
+            .ifBlank { mv.string("mv_id") }
+            .ifBlank { mv.string("id") }
+        val singerItems = firstNonEmpty(mv.array("singer"), mv.array("singers"))
+        val artists = singerItems.map { singerValue ->
+            val singer = singerValue.asObject()
+            singer.string("name").ifBlank { singer.string("singer_name") }
+        }.filter(String::isNotBlank).joinToString(" / ").ifBlank {
+            mv.string("singer_name")
+                .ifBlank { mv.string("singername") }
+                .ifBlank { mv.string("creator") }
+        }
+        val rawDuration = mv.long("duration")
+        val durationMs = mv.long("duration_ms")
+            ?: rawDuration?.let { if (it < 100_000) it * 1_000 else it }
+        return ProviderVideo(
+            id = videoKey(ID, identifier),
+            title = mv.string("mv_name")
+                .ifBlank { mv.string("mvName") }
+                .ifBlank { mv.string("name") }
+                .ifBlank { mv.string("title") },
+            artists = artists,
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = mv.stringOrNull("picurl")
+                ?: mv.stringOrNull("picUrl")
+                ?: mv.stringOrNull("pic")
+                ?: mv.stringOrNull("cover")
+                ?: mv.stringOrNull("cover_pic")
+                ?: mv.stringOrNull("poster_pic"),
+            durationMs = durationMs,
+            providerUrl = "https://y.qq.com/n/ryqq/mvdetail/$identifier",
+        )
+    }
+
+    private fun qqTrack(item: JsonObject): MusicTrack {
+        val song = item.obj("songInfo") ?: item
+        val identifier = song.string("songmid")
+            .ifBlank { song.string("mid") }
+            .ifBlank { song.string("song_id") }
+            .ifBlank { song.string("songid") }
+            .ifBlank { song.string("id") }
+        val singerItems = firstNonEmpty(song.array("singer"), song.array("singers"))
+        val artists = singerItems.map { singerValue ->
+            val singer = singerValue.asObject()
+            singer.string("name").ifBlank { singer.string("singer_name") }
+        }.filter(String::isNotBlank).joinToString(" / ").ifBlank {
+            song.string("singer_name").ifBlank { song.string("singername") }
+        }
+        val album = song.obj("album")
+        val albumName = song.string("albumname")
+            .ifBlank { song.string("album_name") }
+            .ifBlank { album?.string("name").orEmpty() }
+        val albumId = song.string("albumid")
+            .ifBlank { song.string("album_id") }
+            .ifBlank { album?.string("id").orEmpty() }
+        val albumMid = song.string("albummid")
+            .ifBlank { song.string("album_mid") }
+            .ifBlank { album?.string("mid").orEmpty() }
+        val firstSinger = singerItems.firstOrNull()?.asObject()
+        val artistId = firstSinger?.string("id")
+            ?.ifBlank { firstSinger.string("singer_id") }
+            ?.ifBlank { firstSinger.string("mid") }
+        val rawDuration = song.long("interval") ?: song.long("duration")
+        return MusicTrack(
+            id = trackKey(ID, identifier),
+            title = song.string("songname")
+                .ifBlank { song.string("name") }
+                .ifBlank { song.string("title") }
+                .ifBlank { song.string("songorig") },
+            artists = artists,
+            album = albumName,
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = song.stringOrNull("picurl")
+                ?: album?.stringOrNull("picurl")
+                ?: albumMid.takeIf(String::isNotBlank)?.let(::albumCover),
+            durationMs = rawDuration?.let { if (it < 100_000) it * 1_000 else it },
+            providerId = trackKey(ID, identifier),
+            providerName = NAME,
+            artistItemId = artistId?.takeIf(String::isNotBlank)?.let {
+                mediaItemKey(ProviderMediaItemType.Artist, ID, it)
+            },
+            albumItemId = (albumId.takeIf(String::isNotBlank) ?: albumMid.takeIf(String::isNotBlank))?.let {
+                mediaItemKey(ProviderMediaItemType.Album, ID, it)
+            },
+            providerUrl = "https://y.qq.com/n/ryqq/songDetail/$identifier",
+        )
+    }
+
+    private fun searchBody(root: JsonObject, key: String): JsonObject {
+        val data = root.obj(key)?.obj("data") ?: root.obj(key) ?: return JsonObject(emptyMap())
+        return data.obj("body") ?: data
+    }
+
+    private suspend fun rpc(
+        payload: String,
+        cacheKey: String? = null,
+        cachePolicy: org.feeluown.mobile.provider.core.network.ProviderCachePolicy = ProviderCachePolicies.none,
+    ): JsonObject {
+        val request = qqRpcPayload(payload)
+        return http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$U_BASE/cgi-bin/musicu.fcg",
+                mapOf(
+                    "_" to currentTimeMillis().toString(),
+                    "sign" to contentSign(request),
+                    "data" to request,
+                ),
+            ),
+            headers = authenticatedHeaders(),
+            cacheKey = cacheKey,
+            cachePolicy = cachePolicy,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+    }
+
+    private suspend fun qqRpcPayload(payload: String): String {
+        val root = providerJson.parseToJsonElement(payload).jsonObject
+        val cookies = qqCookies()
+        val uin = cookies["wxuin"]?.removePrefix("o")?.takeIf(String::isNotBlank)
+            ?: cookies["uin"]?.takeIf(String::isNotBlank)
+            ?: "0"
+        val tokenSource = listOf("qqmusic_key", "p_skey", "skey", "p_lskey", "lskey")
+            .asSequence()
+            .mapNotNull { cookies[it] }
+            .firstOrNull()
+            .orEmpty()
+        val token = if (tokenSource.isBlank()) {
+            5_381L
+        } else {
+            var hash = 5_381L
+            tokenSource.forEach { character ->
+                hash = (hash * 33 + character.code) and 0xffff_ffffL
+            }
+            hash and 0x7fff_ffffL
+        }
+        val common = mapOf(
+            "loginUin" to JsonPrimitive(uin),
+            "hostUin" to JsonPrimitive(0),
+            "g_tk" to JsonPrimitive(token),
+            "inCharset" to JsonPrimitive("utf8"),
+            "outCharset" to JsonPrimitive("utf-8"),
+            "notice" to JsonPrimitive(0),
+            "platform" to JsonPrimitive("yqq"),
+            "needNewCode" to JsonPrimitive(0),
+        )
+        val mergedComm = JsonObject(common + (root.obj("comm") ?: emptyMap()))
+        return providerJson.encodeToString(
+            JsonObject.serializer(),
+            JsonObject(root + ("comm" to mergedComm)),
+        )
+    }
+
+    private suspend fun authenticatedHeaders(): Map<String, String> = buildMap {
+        put("User-Agent", DEFAULT_USER_AGENT)
+        put("Referer", "https://y.qq.com/")
+        cookieHeader(credentials.read(ID)).takeIf(String::isNotBlank)?.let { put("Cookie", it) }
+    }
+
+    private fun publicHeaders(): Map<String, String> = mapOf(
+        "User-Agent" to DEFAULT_USER_AGENT,
+        "Referer" to "https://y.qq.com/",
+    )
+
+    private suspend fun qqCookies(): Map<String, String> {
+        val stored = credentials.read(ID) ?: return emptyMap()
+        return parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
+    }
+
+    private fun queryUrl(base: String, params: Map<String, String>): String {
+        val encoded = params.entries.joinToString("&") { (key, value) ->
+            "${encodeUrlComponent(key)}=${encodeUrlComponent(value)}"
+        }
+        return if (encoded.isBlank()) base else "$base?$encoded"
+    }
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val intValue = byte.toInt() and 0xff
+            if (
+                intValue in 0x30..0x39 ||
+                intValue in 0x41..0x5a ||
+                intValue in 0x61..0x7a ||
+                intValue in setOf(45, 46, 95, 126)
+            ) {
+                append(intValue.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[intValue ushr 4])
+                append("0123456789ABCDEF"[intValue and 15])
+            }
+        }
+    }
+
+    private fun jsonString(value: String): String =
+        "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+
+    private fun albumCover(mid: String): String =
+        "https://y.qq.com/music/photo_new/T002R300x300M000$mid.jpg"
+
+    private fun artistCover(mid: String): String =
+        "https://y.qq.com/music/photo_new/T001R300x300M000$mid.jpg"
+
+    private fun resourceId(value: String): String {
+        val prefix = "$ID:"
+        return value.substringAfter(prefix, value.substringAfterLast(':'))
+    }
+
+    private fun hasResourceId(item: ProviderPlaylist): Boolean = resourceId(item.id).isNotBlank()
+
+    private fun hasResourceId(item: ProviderMediaItem): Boolean = resourceId(item.id).isNotBlank()
+
+    private fun hasResourceId(item: ProviderVideo): Boolean = resourceId(item.id).isNotBlank()
+
+    private fun hasResourceId(item: MusicTrack): Boolean = resourceId(item.id).isNotBlank()
+
+    private fun toplistPlaylistId(topId: Int, period: String): String {
+        val suffix = if (period.isBlank()) topId.toString() else "$topId:$period"
+        return playlistKey(ID, "$TOPLIST_PREFIX$suffix")
+    }
+
+    private fun parseToplistIdentifier(identifier: String): ToplistSpec? {
+        if (!identifier.startsWith(TOPLIST_PREFIX)) return null
+        val parts = identifier.removePrefix(TOPLIST_PREFIX).split(':', limit = 2)
+        val topId = parts.firstOrNull()?.toIntOrNull() ?: return null
+        return ToplistSpec(topId, parts.getOrNull(1).orEmpty())
+    }
+
+    private fun ProviderPlaylist.isQQMusicToplist(): Boolean =
+        providerId == ID && resourceId(id).startsWith(TOPLIST_PREFIX)
+
+    private data class ToplistSpec(
+        val topId: Int,
+        val period: String,
+    )
+
+    private companion object {
+        const val ID = "qqmusic"
+        const val NAME = "QQ 音乐"
+        const val C_BASE = "https://c.y.qq.com"
+        const val U_BASE = "https://u.y.qq.com"
+        const val TOPLIST_PREFIX = "toplist:"
+        const val QQ_SINGER_PAGE_SIZE = 80
+        const val DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
+
+        val EXTRA_FEATURES = listOf(
+            ProviderFeature(
+                QQMUSIC_TOPLISTS,
+                ID,
+                NAME,
+                "排行榜",
+                ProviderFeatureCategory.Music,
+                ProviderContentType.Playlists,
+                false,
+            ),
+            ProviderFeature(
+                QQMUSIC_PLAYLIST_SQUARE,
+                ID,
+                NAME,
+                "歌单广场",
+                ProviderFeatureCategory.Music,
+                ProviderContentType.Playlists,
+                false,
+            ),
+            ProviderFeature(
+                QQMUSIC_ARTIST_SQUARE,
+                ID,
+                NAME,
+                "歌手广场",
+                ProviderFeatureCategory.Music,
+                ProviderContentType.Artists,
+                false,
+            ),
+            ProviderFeature(
+                QQMUSIC_NEW_ALBUMS,
+                ID,
+                NAME,
+                "新碟上架",
+                ProviderFeatureCategory.Music,
+                ProviderContentType.Albums,
+                false,
+            ),
+            ProviderFeature(
+                QQMUSIC_MV_SQUARE,
+                ID,
+                NAME,
+                "MV 广场",
+                ProviderFeatureCategory.Music,
+                ProviderContentType.Videos,
+                false,
+            ),
+        )
+    }
+}
+
+private fun <T> firstNonEmpty(vararg values: List<T>): List<T> =
+    values.firstOrNull { it.isNotEmpty() }.orEmpty()
+
+private fun contentSign(data: String): String {
+    val randomPart = buildString {
+        repeat(Random.nextInt(10, 17)) {
+            append(CONTENT_SIGN_ALPHABET[Random.nextInt(CONTENT_SIGN_ALPHABET.length)])
+        }
+    }
+    return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}" 
+}
+
+private const val CONTENT_SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicExplore.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicExplore.kt
@@ -1,0 +1,257 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import org.feeluown.mobile.ProviderFeatureFilterCodec
+import org.feeluown.mobile.ProviderFeatureFilterOption
+import org.feeluown.mobile.ProviderFeatureFilterSpec
+
+internal const val QQMUSIC_TOPLISTS = "qqmusic_toplists"
+internal const val QQMUSIC_PLAYLIST_SQUARE = "qqmusic_playlist_square"
+internal const val QQMUSIC_ARTIST_SQUARE = "qqmusic_artist_square"
+internal const val QQMUSIC_NEW_ALBUMS = "qqmusic_new_albums"
+internal const val QQMUSIC_MV_SQUARE = "qqmusic_mv_square"
+
+internal data class QQMusicFeatureRequest(
+    val baseId: String,
+    val params: Map<String, String>,
+)
+
+internal data class QQMusicPlaylistCategory(
+    val id: String,
+    val name: String,
+)
+
+internal fun parseQQMusicFeatureRequest(featureId: String): QQMusicFeatureRequest {
+    val parts = ProviderFeatureFilterCodec.requestId(featureId).split('|')
+    return QQMusicFeatureRequest(
+        baseId = parts.firstOrNull().orEmpty(),
+        params = parts.drop(1).mapNotNull { part ->
+            val separator = part.indexOf('=')
+            if (separator <= 0) return@mapNotNull null
+            part.substring(0, separator) to part.substring(separator + 1)
+        }.toMap(),
+    )
+}
+
+internal fun qqMusicFeatureId(baseId: String, vararg params: Pair<String, String>): String =
+    buildString {
+        append(baseId)
+        params.forEach { (key, value) ->
+            append('|')
+            append(key)
+            append('=')
+            append(value)
+        }
+    }
+
+internal fun qqMusicPlaylistSquareFilters(
+    categories: List<QQMusicPlaylistCategory>,
+    categoryId: String,
+    sortId: String,
+): List<ProviderFeatureFilterSpec> {
+    val normalizedCategories = buildList {
+        add(QQMusicPlaylistCategory(QQ_DEFAULT_PLAYLIST_CATEGORY_ID, "全部"))
+        addAll(categories.filter { it.id != QQ_DEFAULT_PLAYLIST_CATEGORY_ID })
+    }.distinctBy { it.id }
+    return listOf(
+        ProviderFeatureFilterSpec(
+            key = "categoryId",
+            title = "分类",
+            options = normalizedCategories.map { category ->
+                ProviderFeatureFilterOption(
+                    label = category.name,
+                    featureId = qqMusicFeatureId(
+                        QQMUSIC_PLAYLIST_SQUARE,
+                        "categoryId" to category.id,
+                        "sortId" to sortId,
+                    ),
+                    selected = category.id == categoryId,
+                )
+            },
+        ),
+        ProviderFeatureFilterSpec(
+            key = "sortId",
+            title = "排序",
+            options = listOf(
+                "5" to "热门",
+                "2" to "最新",
+            ).map { (value, label) ->
+                ProviderFeatureFilterOption(
+                    label = label,
+                    featureId = qqMusicFeatureId(
+                        QQMUSIC_PLAYLIST_SQUARE,
+                        "categoryId" to categoryId,
+                        "sortId" to value,
+                    ),
+                    selected = value == sortId,
+                )
+            },
+        ),
+    )
+}
+
+internal fun qqMusicArtistSquareFilters(
+    area: String,
+    sex: String,
+    genre: String,
+    index: String,
+): List<ProviderFeatureFilterSpec> = listOf(
+    ProviderFeatureFilterSpec(
+        key = "area",
+        title = "地区",
+        options = listOf(
+            "-100" to "全部",
+            "200" to "内地",
+            "2" to "港台",
+            "5" to "欧美",
+            "4" to "日本",
+            "3" to "韩国",
+            "6" to "其他",
+        ).map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_ARTIST_SQUARE,
+                    "area" to value,
+                    "sex" to sex,
+                    "genre" to genre,
+                    "index" to index,
+                ),
+                selected = value == area,
+            )
+        },
+    ),
+    ProviderFeatureFilterSpec(
+        key = "sex",
+        title = "类型",
+        options = listOf(
+            "-100" to "全部",
+            "0" to "男歌手",
+            "1" to "女歌手",
+            "2" to "组合",
+        ).map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_ARTIST_SQUARE,
+                    "area" to area,
+                    "sex" to value,
+                    "genre" to genre,
+                    "index" to index,
+                ),
+                selected = value == sex,
+            )
+        },
+    ),
+    ProviderFeatureFilterSpec(
+        key = "genre",
+        title = "流派",
+        options = listOf(
+            "-100" to "全部",
+            "1" to "流行",
+            "6" to "嘻哈",
+            "2" to "摇滚",
+            "4" to "电子",
+            "3" to "民谣",
+            "8" to "R&B",
+            "10" to "民歌",
+            "9" to "轻音乐",
+            "5" to "爵士",
+            "14" to "古典",
+            "25" to "乡村",
+            "20" to "蓝调",
+        ).map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_ARTIST_SQUARE,
+                    "area" to area,
+                    "sex" to sex,
+                    "genre" to value,
+                    "index" to index,
+                ),
+                selected = value == genre,
+            )
+        },
+    ),
+    ProviderFeatureFilterSpec(
+        key = "index",
+        title = "首字母",
+        options = buildList {
+            add("-100" to "热门")
+            ('A'..'Z').forEachIndexed { position, letter ->
+                add((position + 1).toString() to letter.toString())
+            }
+            add("27" to "#")
+        }.map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_ARTIST_SQUARE,
+                    "area" to area,
+                    "sex" to sex,
+                    "genre" to genre,
+                    "index" to value,
+                ),
+                selected = value == index,
+            )
+        },
+    ),
+)
+
+internal fun qqMusicMvSquareFilters(
+    area: String,
+    version: String,
+): List<ProviderFeatureFilterSpec> = listOf(
+    ProviderFeatureFilterSpec(
+        key = "area",
+        title = "地区",
+        options = listOf(
+            "15" to "全部",
+            "16" to "内地",
+            "17" to "港台",
+            "18" to "欧美",
+            "19" to "韩国",
+            "20" to "日本",
+        ).map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_MV_SQUARE,
+                    "area" to value,
+                    "version" to version,
+                ),
+                selected = value == area,
+            )
+        },
+    ),
+    ProviderFeatureFilterSpec(
+        key = "version",
+        title = "类型",
+        options = listOf(
+            "7" to "全部",
+            "8" to "MV",
+            "9" to "现场",
+            "10" to "翻唱",
+            "11" to "舞蹈",
+            "12" to "影视",
+            "13" to "综艺",
+            "14" to "儿歌",
+        ).map { (value, label) ->
+            ProviderFeatureFilterOption(
+                label = label,
+                featureId = qqMusicFeatureId(
+                    QQMUSIC_MV_SQUARE,
+                    "area" to area,
+                    "version" to value,
+                ),
+                selected = value == version,
+            )
+        },
+    ),
+)
+
+internal const val QQ_DEFAULT_PLAYLIST_CATEGORY_ID = "10000000"
+internal const val QQ_DEFAULT_PLAYLIST_SORT_ID = "5"
+internal const val QQ_DEFAULT_ARTIST_FILTER = "-100"
+internal const val QQ_DEFAULT_MV_AREA = "15"
+internal const val QQ_DEFAULT_MV_VERSION = "7"

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -29,7 +29,10 @@ internal class QQMusicUserLibrary(
     private val http: ProviderHttpClient,
     private val credentials: ProviderCredentialStore,
 ) {
-    suspend fun userName(): String? = snapshot().userName
+    suspend fun userName(): String? {
+        val uin = currentUin() ?: return null
+        return runCatching { snapshot(uin).userName }.getOrNull()
+    }
 
     suspend fun loadPlaylists(
         feature: ProviderFeature,
@@ -41,7 +44,12 @@ internal class QQMusicUserLibrary(
                 feature = feature,
                 errorMessage = "无法读取 QQ 音乐账号信息，请重新登录",
             )
-        val snapshot = snapshot(uin)
+        val snapshot = runCatching { snapshot(uin) }.getOrElse { throwable ->
+            return ProviderContentSection(
+                feature = feature,
+                errorMessage = throwable.message ?: "加载 QQ 音乐歌单失败",
+            )
+        }
         val page = snapshot.playlists.drop(offset).take(limit)
         return ProviderContentSection(
             feature = feature,
@@ -51,14 +59,8 @@ internal class QQMusicUserLibrary(
         )
     }
 
-    private suspend fun snapshot(): QQMusicUserLibrarySnapshot {
-        val uin = currentUin() ?: return QQMusicUserLibrarySnapshot()
-        return snapshot(uin)
-    }
-
     private suspend fun snapshot(uin: String): QQMusicUserLibrarySnapshot {
-        val created = runCatching { createdPlaylists(uin) }.getOrNull()
-            ?: CreatedPlaylistsResult()
+        val created = createdPlaylists(uin)
         var userName = created.userName
         var playlists = created.playlists
 
@@ -100,7 +102,17 @@ internal class QQMusicUserLibrary(
             headers = authenticatedHeaders("https://y.qq.com/portal/profile.html"),
             cacheKey = null,
         ).value.let { providerJson.parseToJsonElement(it).asObject() }
-        val data = root.obj("data") ?: return CreatedPlaylistsResult()
+        val data = root.obj("data")
+        if (data == null) {
+            val code = root.int("code")
+            if (code == PRIVATE_PLAYLIST_CODE) return CreatedPlaylistsResult()
+            val message = root.string("message").ifBlank { root.string("msg") }
+            error(
+                message.ifBlank {
+                    if (code != null) "QQ 音乐用户歌单加载失败（code=$code）" else "QQ 音乐用户歌单加载失败"
+                },
+            )
+        }
         val rawPlaylists = data.array("disslist")
         return CreatedPlaylistsResult(
             userName = data.stringOrNull("hostname")
@@ -243,6 +255,7 @@ internal class QQMusicUserLibrary(
         const val NAME = "QQ 音乐"
         const val BASE = "https://c.y.qq.com"
         const val FAVORITE_DIR_ID = 201
+        const val PRIVATE_PLAYLIST_CODE = 4000
         const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -1,0 +1,253 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.parseCookies
+import org.feeluown.mobile.provider.core.playlistKey
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+
+/**
+ * Reads the QQ Music account profile and user-created playlists.
+ *
+ * The user-created-playlist endpoint is the primary source because it returns
+ * both `hostname` and `disslist`. The older profile-homepage endpoint is kept
+ * only as a fallback for nickname / "我喜欢" when QQ omits them from disslist.
+ */
+internal class QQMusicUserLibrary(
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) {
+    suspend fun userName(): String? = snapshot().userName
+
+    suspend fun loadPlaylists(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val uin = currentUin()
+            ?: return ProviderContentSection(
+                feature = feature,
+                errorMessage = "无法读取 QQ 音乐账号信息，请重新登录",
+            )
+        val snapshot = snapshot(uin)
+        val page = snapshot.playlists.drop(offset).take(limit)
+        return ProviderContentSection(
+            feature = feature,
+            playlists = page,
+            nextOffset = offset + page.size,
+            hasMore = snapshot.playlists.size > offset + page.size,
+        )
+    }
+
+    private suspend fun snapshot(): QQMusicUserLibrarySnapshot {
+        val uin = currentUin() ?: return QQMusicUserLibrarySnapshot()
+        return snapshot(uin)
+    }
+
+    private suspend fun snapshot(uin: String): QQMusicUserLibrarySnapshot {
+        val created = runCatching { createdPlaylists(uin) }.getOrNull()
+            ?: CreatedPlaylistsResult()
+        var userName = created.userName
+        var playlists = created.playlists
+
+        if (userName.isNullOrBlank() || !created.hasFavorite) {
+            val home = runCatching { profileHome(uin) }.getOrNull()
+            if (userName.isNullOrBlank()) userName = home?.userName
+            if (!created.hasFavorite) {
+                home?.favoritePlaylist?.let { favorite ->
+                    playlists = (listOf(favorite) + playlists).distinctBy { it.id }
+                }
+            }
+        }
+        return QQMusicUserLibrarySnapshot(
+            userName = userName?.takeIf { it.isNotBlank() },
+            playlists = playlists.distinctBy { it.id },
+        )
+    }
+
+    private suspend fun createdPlaylists(uin: String): CreatedPlaylistsResult {
+        val root = http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$BASE/rsc/fcgi-bin/fcg_user_created_diss",
+                mapOf(
+                    "hostUin" to "0",
+                    "hostuin" to uin,
+                    "sin" to "0",
+                    "size" to "200",
+                    "g_tk" to "5381",
+                    "loginUin" to "0",
+                    "format" to "json",
+                    "inCharset" to "utf8",
+                    "outCharset" to "utf-8",
+                    "notice" to "0",
+                    "platform" to "yqq.json",
+                    "needNewCode" to "0",
+                ),
+            ),
+            headers = authenticatedHeaders("https://y.qq.com/portal/profile.html"),
+            cacheKey = null,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        val data = root.obj("data") ?: return CreatedPlaylistsResult()
+        val rawPlaylists = data.array("disslist")
+        return CreatedPlaylistsResult(
+            userName = data.stringOrNull("hostname")
+                ?: data.stringOrNull("nickname")
+                ?: data.stringOrNull("nick"),
+            playlists = rawPlaylists.mapNotNull { value ->
+                playlistFromCreated(value.asObject())
+            },
+            hasFavorite = rawPlaylists.any { value ->
+                val item = value.asObject()
+                item.int("dirid") == FAVORITE_DIR_ID || item.string("dirid").toIntOrNull() == FAVORITE_DIR_ID
+            },
+        )
+    }
+
+    private suspend fun profileHome(uin: String): ProfileHomeResult {
+        val root = http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$BASE/rsc/fcgi-bin/fcg_get_profile_homepage.fcg",
+                mapOf(
+                    "cid" to "205360838",
+                    "reqfrom" to "1",
+                    "userid" to uin,
+                ),
+            ),
+            headers = authenticatedHeaders("https://y.qq.com/"),
+            cacheKey = null,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        val data = root.obj("data") ?: return ProfileHomeResult()
+        val creator = data.obj("creator")
+        val userName = creator?.stringOrNull("nick")
+            ?: creator?.stringOrNull("nickname")
+            ?: creator?.stringOrNull("name")
+            ?: data.stringOrNull("hostname")
+            ?: data.stringOrNull("nickname")
+            ?: data.stringOrNull("nick")
+        val favorite = data.array("mymusic").firstOrNull()?.asObject()
+        val favoriteId = creator?.stringOrNull("fav_pid")
+            ?: favorite?.stringOrNull("id")
+        return ProfileHomeResult(
+            userName = userName,
+            favoritePlaylist = favoriteId?.let { identifier ->
+                ProviderPlaylist(
+                    id = playlistKey(ID, identifier),
+                    title = "我喜欢",
+                    providerId = ID,
+                    providerName = NAME,
+                    coverUrl = favorite?.stringOrNull("picurl")
+                        ?: favorite?.stringOrNull("cover")
+                        ?: favorite?.stringOrNull("logo"),
+                    trackCount = favorite?.int("num0") ?: favorite?.int("songnum"),
+                    providerUrl = "https://y.qq.com/n/ryqq/playlist/$identifier",
+                )
+            },
+        )
+    }
+
+    private fun playlistFromCreated(item: JsonObject): ProviderPlaylist? {
+        val dirId = item.int("dirid") ?: item.string("dirid").toIntOrNull()
+        val identifier = item.string("tid")
+            .ifBlank { item.string("dissid") }
+            .ifBlank { item.string("id") }
+            .takeIf { it.isNotBlank() }
+            ?: return null
+        return ProviderPlaylist(
+            id = playlistKey(ID, identifier),
+            title = item.string("diss_name")
+                .ifBlank { item.string("dissname") }
+                .ifBlank { item.string("title") }
+                .ifBlank { if (dirId == FAVORITE_DIR_ID) "我喜欢" else "未命名歌单" },
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("diss_cover")
+                ?: item.stringOrNull("logo")
+                ?: item.stringOrNull("picurl")
+                ?: item.stringOrNull("cover"),
+            description = item.string("desc"),
+            playCount = item.long("listen_num") ?: item.long("visitnum"),
+            trackCount = item.int("song_cnt") ?: item.int("songnum"),
+            providerUrl = "https://y.qq.com/n/ryqq/playlist/$identifier",
+        )
+    }
+
+    private suspend fun currentUin(): String? {
+        val stored = credentials.read(ID) ?: return null
+        val values = parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
+        return values["wxuin"]
+            ?.removePrefix("o")
+            ?.takeIf { it.isNotBlank() }
+            ?: values["uin"]
+                ?.removePrefix("o")
+                ?.takeIf { it.isNotBlank() }
+    }
+
+    private suspend fun authenticatedHeaders(referer: String): Map<String, String> = buildMap {
+        put("User-Agent", DEFAULT_USER_AGENT)
+        put("Referer", referer)
+        cookieHeader(credentials.read(ID)).takeIf { it.isNotBlank() }?.let { put("Cookie", it) }
+    }
+
+    private fun queryUrl(base: String, params: Map<String, String>): String {
+        val encoded = params.entries.joinToString("&") { (key, value) ->
+            "${encodeUrlComponent(key)}=${encodeUrlComponent(value)}"
+        }
+        return if (encoded.isBlank()) base else "$base?$encoded"
+    }
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val current = byte.toInt() and 0xff
+            if (
+                current in 0x30..0x39 ||
+                current in 0x41..0x5a ||
+                current in 0x61..0x7a ||
+                current in setOf(45, 46, 95, 126)
+            ) {
+                append(current.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[current ushr 4])
+                append("0123456789ABCDEF"[current and 15])
+            }
+        }
+    }
+
+    private data class CreatedPlaylistsResult(
+        val userName: String? = null,
+        val playlists: List<ProviderPlaylist> = emptyList(),
+        val hasFavorite: Boolean = false,
+    )
+
+    private data class ProfileHomeResult(
+        val userName: String? = null,
+        val favoritePlaylist: ProviderPlaylist? = null,
+    )
+
+    private companion object {
+        const val ID = "qqmusic"
+        const val NAME = "QQ 音乐"
+        const val BASE = "https://c.y.qq.com"
+        const val FAVORITE_DIR_ID = 201
+        const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
+    }
+}
+
+internal data class QQMusicUserLibrarySnapshot(
+    val userName: String? = null,
+    val playlists: List<ProviderPlaylist> = emptyList(),
+)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicContentProviderTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicContentProviderTest.kt
@@ -1,0 +1,215 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.qqmusic.QQMUSIC_ARTIST_SQUARE
+import org.feeluown.mobile.provider.qqmusic.QQMUSIC_MV_SQUARE
+import org.feeluown.mobile.provider.qqmusic.QQMUSIC_NEW_ALBUMS
+import org.feeluown.mobile.provider.qqmusic.QQMUSIC_PLAYLIST_SQUARE
+import org.feeluown.mobile.provider.qqmusic.QQMUSIC_TOPLISTS
+import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
+
+class QQMusicContentProviderTest {
+    @Test
+    fun exposesFirstBatchDiscoveryFeatures() {
+        val provider = QQMusicContentProvider(
+            ProviderHttpClient(
+                HttpClient(MockEngine) {
+                    engine { addHandler { respond("{}") } }
+                },
+            ),
+            InMemoryProviderCredentialStore(),
+        )
+        val ids = provider.features.map { it.id }.toSet()
+
+        assertTrue(QQMUSIC_TOPLISTS in ids)
+        assertTrue(QQMUSIC_PLAYLIST_SQUARE in ids)
+        assertTrue(QQMUSIC_ARTIST_SQUARE in ids)
+        assertTrue(QQMUSIC_NEW_ALBUMS in ids)
+        assertTrue(QQMUSIC_MV_SQUARE in ids)
+    }
+
+    @Test
+    fun searchesPlaylistsArtistsAlbumsAndMvs() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("/cgi-bin/musicu.fcg", request.url.encodedPath)
+                        val data = request.url.parameters["data"].orEmpty()
+                        assertTrue(data.contains("singerSearch"))
+                        assertTrue(data.contains("albumSearch"))
+                        assertTrue(data.contains("playlistSearch"))
+                        assertTrue(data.contains("mvSearch"))
+                        respond(
+                            """
+                            {
+                              "singerSearch":{"data":{"body":{"singer":{"list":[{"singerID":101,"singerMID":"singer-mid","singerName":"测试歌手"}]}}}},
+                              "albumSearch":{"data":{"body":{"album":{"list":[{"albumID":201,"albumMID":"album-mid","albumName":"测试专辑"}]}}}},
+                              "playlistSearch":{"data":{"body":{"songlist":{"list":[{"dissid":"301","dissname":"测试歌单","imgurl":"https://example.test/playlist.jpg"}]}}}},
+                              "mvSearch":{"data":{"body":{"mv":{"list":[{"vid":"mv-401","name":"测试 MV","singer":[{"name":"测试歌手"}]}]}}}}
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val provider = QQMusicContentProvider(client, InMemoryProviderCredentialStore())
+
+        val result = provider.searchExtras("测试")
+
+        assertEquals("测试歌单", result.playlists.single().title)
+        assertEquals("测试歌手", result.artists.single().title)
+        assertEquals("测试专辑", result.albums.single().title)
+        assertEquals("测试 MV", result.videos.single().title)
+        client.close()
+    }
+
+    @Test
+    fun loadsToplistsAndVirtualToplistDetail() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("/cgi-bin/musicu.fcg", request.url.encodedPath)
+                        val data = request.url.parameters["data"].orEmpty()
+                        when {
+                            data.contains("\"method\":\"GetAll\"") -> respond(
+                                """
+                                {"topList":{"data":{"group":[{"groupName":"巅峰榜","toplist":[{"topId":4,"title":"热歌榜","period":"2026-08-09","headPicUrl":"https://example.test/top.jpg","listenNum":1234,"song":[{"title":"预览歌曲"}]}]}]}}}
+                                """.trimIndent(),
+                            )
+                            data.contains("\"method\":\"GetDetail\"") -> {
+                                assertTrue(data.contains("\"topId\":4"))
+                                assertTrue(data.contains("2026-08-09"))
+                                respond(
+                                    """
+                                    {"detail":{"data":{"data":{"topId":4,"title":"热歌榜","period":"2026-08-09","totalNum":1,"headPicUrl":"https://example.test/top.jpg","song":[{"rank":1}]},"songInfoList":[{"mid":"song-mid","name":"榜单歌曲","singer":[{"id":11,"name":"榜单歌手"}],"album":{"id":22,"mid":"album-mid","name":"榜单专辑"},"interval":180}]}}}
+                                    """.trimIndent(),
+                                )
+                            }
+                            else -> error("unexpected musicu payload: $data")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = QQMusicContentProvider(client, InMemoryProviderCredentialStore())
+        val feature = provider.features.first { it.id == QQMUSIC_TOPLISTS }
+
+        val section = provider.loadFeature(feature, 0, 20)
+        val playlist = section.playlists.single()
+        assertEquals("热歌榜", playlist.title)
+        assertTrue(playlist.id.contains("toplist:4:2026-08-09"))
+
+        val detail = provider.playlistDetail(playlist, 0, 20)
+        assertEquals("榜单歌曲", detail.tracks.single().title)
+        assertEquals("榜单歌手", detail.tracks.single().artists)
+        assertEquals(180_000, detail.tracks.single().durationMs)
+        assertFalse(detail.tracksHasMore)
+        client.close()
+    }
+
+    @Test
+    fun loadsPlaylistArtistAlbumAndMvDiscovery() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/splcloud/fcgi-bin/fcg_get_diss_tag_conf.fcg" -> respond(
+                                """{"data":{"categories":[{"categoryGroupName":"语种","items":[{"categoryId":1,"categoryName":"华语","usable":1}]}]}}""",
+                            )
+                            "/splcloud/fcgi-bin/fcg_get_diss_by_tag.fcg" -> {
+                                assertEquals("10000000", request.url.parameters["categoryId"])
+                                assertEquals("5", request.url.parameters["sortId"])
+                                respond(
+                                    """{"data":{"sum":1,"list":[{"dissid":"playlist-1","dissname":"热门歌单","imgurl":"https://example.test/list.jpg","listennum":99,"song_count":20}]}}""",
+                                )
+                            }
+                            "/cgi-bin/musicu.fcg" -> {
+                                val data = request.url.parameters["data"].orEmpty()
+                                when {
+                                    data.contains("get_singer_list") -> respond(
+                                        """{"singerList":{"data":{"total":1,"singerlist":[{"singer_id":101,"singer_mid":"singer-mid","singer_name":"广场歌手"}]}}}""",
+                                    )
+                                    data.contains("get_new_album_info") -> {
+                                        assertTrue(data.contains("\"sin\":0"))
+                                        respond(
+                                            """{"new_album":{"data":{"total":1,"albums":[{"album_id":201,"album_mid":"album-mid","album_name":"新碟"}]}}}""",
+                                        )
+                                    }
+                                    data.contains("GetAllocMvInfo") -> {
+                                        assertTrue(data.contains("\"size\":20"))
+                                        respond(
+                                            """{"mv_list":{"data":{"total":1,"list":[{"vid":"mv-1","name":"广场 MV","singer":[{"name":"MV 歌手"}],"duration":200}]}}}""",
+                                        )
+                                    }
+                                    else -> error("unexpected musicu payload: $data")
+                                }
+                            }
+                            else -> error("unexpected request: ${request.url}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = QQMusicContentProvider(client, InMemoryProviderCredentialStore())
+
+        val playlistSection = provider.loadFeature(
+            provider.features.first { it.id == QQMUSIC_PLAYLIST_SQUARE },
+            0,
+            20,
+        )
+        assertEquals("热门歌单", playlistSection.playlists.single().title)
+        assertTrue(ProviderFeatureFilterCodec.filters(playlistSection.feature.id).isNotEmpty())
+
+        val artistSection = provider.loadFeature(
+            provider.features.first { it.id == QQMUSIC_ARTIST_SQUARE },
+            0,
+            20,
+        )
+        assertEquals("广场歌手", artistSection.mediaItems.single().title)
+        assertTrue(ProviderFeatureFilterCodec.filters(artistSection.feature.id).isNotEmpty())
+
+        val albumSection = provider.loadFeature(
+            provider.features.first { it.id == QQMUSIC_NEW_ALBUMS },
+            0,
+            20,
+        )
+        assertEquals("新碟", albumSection.mediaItems.single().title)
+
+        val mvSection = provider.loadFeature(
+            provider.features.first { it.id == QQMUSIC_MV_SQUARE },
+            0,
+            20,
+        )
+        assertEquals("广场 MV", mvSection.videos.single().title)
+        assertEquals(200_000, mvSection.videos.single().durationMs)
+        assertTrue(ProviderFeatureFilterCodec.filters(mvSection.feature.id).isNotEmpty())
+        client.close()
+    }
+
+    @Test
+    fun factoryExposesQQMusicDiscoveryFeatures() = runTest {
+        val repo = createFuoProviderRepository(InMemoryProviderCredentialStore())
+        repo.updateEnabledProviders(setOf("qqmusic"))
+
+        val ids = repo.features().filter { it.providerId == "qqmusic" }.map { it.id }.toSet()
+
+        assertTrue(QQMUSIC_TOPLISTS in ids)
+        assertTrue(QQMUSIC_PLAYLIST_SQUARE in ids)
+        assertTrue(QQMUSIC_ARTIST_SQUARE in ids)
+        assertTrue(QQMUSIC_NEW_ALBUMS in ids)
+        assertTrue(QQMUSIC_MV_SQUARE in ids)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
@@ -1,0 +1,145 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
+import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
+
+class QQMusicUserLibraryTest {
+    @Test
+    fun loginShowsUsernameAndMineLoadsCreatedPlaylists() = runTest {
+        var userLibraryRequests = 0
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("/rsc/fcgi-bin/fcg_user_created_diss", request.url.encodedPath)
+                        assertEquals("123456", request.url.parameters["hostuin"])
+                        userLibraryRequests += 1
+                        respond(
+                            """
+                            {
+                              "code":0,
+                              "data":{
+                                "hostname":"测试用户",
+                                "disslist":[
+                                  {
+                                    "dirid":201,
+                                    "tid":"liked-tid",
+                                    "diss_name":"我喜欢",
+                                    "diss_cover":"https://example.test/liked.jpg",
+                                    "song_cnt":88,
+                                    "listen_num":123
+                                  },
+                                  {
+                                    "dirid":202,
+                                    "tid":"created-tid",
+                                    "diss_name":"自建歌单",
+                                    "diss_cover":"https://example.test/created.jpg",
+                                    "song_cnt":12,
+                                    "listen_num":45
+                                  }
+                                ]
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        val delegate = KotlinProviderRepository(http, credentials)
+        val content = QQMusicContentProvider(http, credentials)
+        val userLibrary = QQMusicUserLibrary(http, credentials)
+        val repository = QQMusicContentRepository(delegate, content, userLibrary)
+        repository.updateEnabledProviders(setOf("qqmusic"))
+
+        val auth = repository.loginWithCookies(
+            "qqmusic",
+            """{"uin":"123456","qqmusic_key":"test-key"}""",
+        )
+        assertTrue(auth.isLoggedIn)
+        assertEquals("测试用户", auth.userName)
+
+        val feature = repository.features().first { it.id == "qqmusic_user_playlists" }
+        val section = repository.loadFeaturePage(feature, 0, 20)
+
+        assertEquals(listOf("我喜欢", "自建歌单"), section.playlists.map { it.title })
+        assertEquals("playlist:qqmusic:liked-tid", section.playlists[0].id)
+        assertEquals("playlist:qqmusic:created-tid", section.playlists[1].id)
+        assertEquals(88, section.playlists[0].trackCount)
+        assertEquals(2, userLibraryRequests)
+        http.close()
+    }
+
+    @Test
+    fun fallsBackToProfileHomepageForMissingFavoritePlaylist() = runTest {
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/rsc/fcgi-bin/fcg_user_created_diss" -> respond(
+                                """
+                                {
+                                  "code":0,
+                                  "data":{
+                                    "hostname":"测试用户",
+                                    "disslist":[
+                                      {"dirid":202,"tid":"created-tid","diss_name":"自建歌单"}
+                                    ]
+                                  }
+                                }
+                                """.trimIndent(),
+                            )
+                            "/rsc/fcgi-bin/fcg_get_profile_homepage.fcg" -> respond(
+                                """
+                                {
+                                  "code":0,
+                                  "data":{
+                                    "creator":{"nick":"测试用户"},
+                                    "mymusic":[{"id":"liked-fallback","num0":66}]
+                                  }
+                                }
+                                """.trimIndent(),
+                            )
+                            else -> error("unexpected request: ${request.url}")
+                        }
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            org.feeluown.mobile.provider.core.ProviderCredentials(
+                cookies = mapOf("uin" to "123456", "qqmusic_key" to "test-key"),
+            ),
+        )
+        val library = QQMusicUserLibrary(http, credentials)
+        val feature = ProviderFeature(
+            id = "qqmusic_user_playlists",
+            providerId = "qqmusic",
+            providerName = "QQ 音乐",
+            title = "我的歌单",
+            category = ProviderFeatureCategory.MinePlaylists,
+            contentType = ProviderContentType.Playlists,
+            requiresLogin = true,
+        )
+
+        val section = library.loadPlaylists(feature, 0, 20)
+
+        assertEquals(listOf("我喜欢", "自建歌单"), section.playlists.map { it.title })
+        assertEquals("playlist:qqmusic:liked-fallback", section.playlists.first().id)
+        assertEquals(66, section.playlists.first().trackCount)
+        http.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add QQ Music ranking, playlist square, artist square, new albums, and MV square discovery features
- add category/filter support for playlist, artist, and MV browsing using the existing provider feature filter model
- enrich QQ Music search with playlist, artist, album, and MV result types while keeping song search on the existing provider path
- restore QQ Music **我的歌单** by reading `fcg_user_created_diss` / `data.disslist` instead of relying on the older profile-homepage list shape
- populate QQ Music login-management `ProviderAuthState.userName` from the same user-library response (`data.hostname`)
- retain `fcg_get_profile_homepage.fcg` only as a fallback for nickname / **我喜欢** when QQ omits them from the created-playlist response
- model QQ Music rankings as read-only virtual playlists and route them through a QQ content repository decorator
- add shared MockEngine coverage for discovery parsing, ranking detail, multi-type search, QQ user-library parsing, username enrichment, and the **我喜欢** fallback

## Implementation notes
- keep playback and user-library mutations in the existing `QQMusicProvider`
- add `QQMusicContentProvider` + `QQMusicContentRepository` as the discovery/routing decorator
- add `QQMusicUserLibrary` so account profile + Mine playlist parsing is isolated from public discovery
- QQ Music auth remains valid even if the nickname request fails; username enrichment is best-effort and never turns a valid login into a failure
- Mine playlist request failures now surface as an error instead of being misreported as an empty **暂无内容** list
- use QQ Music `musicToplist.ToplistInfoServer/GetAll` + `GetDetail` for rankings
- use playlist category/list endpoints for the playlist square
- use `Music.SingerListServer/get_singer_list` for the artist square, including its 80-item server paging behavior
- use `newalbum.NewAlbumServer/get_new_album_info` for new albums
- use `MvService.MvInfoProServer/GetAllocMvInfo` for MV browsing
- use `DoSearchForQQMusicDesktop` search types 1/2/3/4 for artist/album/playlist/video search

## Validation
- latest Android signed release APK build passed (Actions run #154)
- latest iOS simulator debug build passed; the same Actions run is continuing with the device build/package steps
- focused shared MockEngine tests cover QQ username + Mine playlists and profile-homepage fallback
- `./gradlew :shared:allTests` cannot be executed locally in the current execution environment because the repository cannot be cloned there

## Notes
QQ Music endpoints are unofficial upstream interfaces, so parsing intentionally accepts common field-name variants and keeps provider-specific discovery/user-library logic isolated from the shared UI/domain model.