### PR TITLE
fix: normalize QQ Music hostuin

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -200,13 +200,18 @@ internal class QQMusicUserLibrary(
     private suspend fun currentUin(): String? {
         val stored = credentials.read(ID) ?: return null
         val values = parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
-        return values["wxuin"]
-            ?.removePrefix("o")
-            ?.takeIf { it.isNotBlank() }
-            ?: values["uin"]
-                ?.removePrefix("o")
-                ?.takeIf { it.isNotBlank() }
+        val loginType = values["login_type"]?.toIntOrNull()
+        val candidates = if (loginType == WECHAT_LOGIN_TYPE) {
+            listOf(values["wxuin"], values["uin"])
+        } else {
+            listOf(values["uin"], values["wxuin"])
+        }
+        return candidates.asSequence().mapNotNull(::normalizeUin).firstOrNull()
     }
+
+    private fun normalizeUin(raw: String?): String? = raw
+        ?.filter { character -> character.isDigit() }
+        ?.takeIf { digits -> digits.isNotBlank() && digits.any { character -> character != '0' } }
 
     private suspend fun authenticatedHeaders(referer: String): Map<String, String> = buildMap {
         put("User-Agent", DEFAULT_USER_AGENT)
@@ -256,6 +261,7 @@ internal class QQMusicUserLibrary(
         const val BASE = "https://c.y.qq.com"
         const val FAVORITE_DIR_ID = 201
         const val PRIVATE_PLAYLIST_CODE = 4000
+        const val WECHAT_LOGIN_TYPE = 2
         const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
     }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
@@ -142,4 +142,86 @@ class QQMusicUserLibraryTest {
         assertEquals(66, section.playlists.first().trackCount)
         http.close()
     }
+
+    @Test
+    fun normalizesQqUinBeforeLoadingUserLibrary() = runTest {
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("123456", request.url.parameters["hostuin"])
+                        respond(
+                            """
+                            {
+                              "code":0,
+                              "data":{
+                                "hostname":"QQ 用户",
+                                "disslist":[{"dirid":201,"tid":"liked","diss_name":"我喜欢"}]
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            org.feeluown.mobile.provider.core.ProviderCredentials(
+                cookies = mapOf(
+                    "login_type" to "1",
+                    "uin" to "o12abc3456",
+                    "wxuin" to "not-a-number",
+                    "qqmusic_key" to "test-key",
+                ),
+            ),
+        )
+
+        val userName = QQMusicUserLibrary(http, credentials).userName()
+
+        assertEquals("QQ 用户", userName)
+        http.close()
+    }
+
+    @Test
+    fun wechatLoginPrefersNormalizedWxuin() = runTest {
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("987654", request.url.parameters["hostuin"])
+                        respond(
+                            """
+                            {
+                              "code":0,
+                              "data":{
+                                "hostname":"微信用户",
+                                "disslist":[{"dirid":201,"tid":"liked","diss_name":"我喜欢"}]
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            org.feeluown.mobile.provider.core.ProviderCredentials(
+                cookies = mapOf(
+                    "login_type" to "2",
+                    "uin" to "123456",
+                    "wxuin" to "o987xyz654",
+                    "qqmusic_key" to "test-key",
+                ),
+            ),
+        )
+
+        val userName = QQMusicUserLibrary(http, credentials).userName()
+
+        assertEquals("微信用户", userName)
+        http.close()
+    }
 }


### PR DESCRIPTION
## Summary
- normalize QQ Music account UIN before calling `fcg_user_created_diss`
- prefer `uin` for normal QQ login and `wxuin` for `login_type=2` WeChat login
- strip all non-digit characters, matching the upstream QQMusicApi cookie normalization behavior
- ignore all-zero candidates so an invalid `uin=0` can fall back to the other account cookie
- add MockEngine regression coverage for both QQ and WeChat login cookie shapes

## Why
After #51, some logged-in accounts could see `hostuin para invalid!` in **我的歌单** because the user-library code always preferred raw `wxuin` and only removed a leading `o`. QQ Music's user-created-playlist endpoint expects a numeric `hostuin`.

## Validation
- branch is based directly on current `master`
- diff is limited to `QQMusicUserLibrary.kt` and `QQMusicUserLibraryTest.kt`
- PR Actions will validate Android/iOS builds