### PR TITLE
feat: integrate ColorOS live lyrics protocol

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -60,7 +60,6 @@ class AndroidNativeAudioEngine(
 
     override fun prepareLoading(track: MusicTrack) {
         pendingLockScreenLyrics = null
-        clearCurrentLockScreenLyrics()
         mutableState.value = mutableState.value.copy(
             status = PlayerStatus.Loading,
             currentTrack = track,
@@ -144,7 +143,7 @@ class AndroidNativeAudioEngine(
         if (normalizedLyrics == null) {
             pendingLockScreenLyrics = null
             if (mutableState.value.currentTrack?.id == trackId) {
-                clearCurrentLockScreenLyrics()
+                clearCurrentLockScreenLyrics(trackId)
             }
             return
         }
@@ -193,7 +192,7 @@ class AndroidNativeAudioEngine(
         val lineLyrics = toTimedLineLrc(pending.lyrics)
         if (lineLyrics == null) {
             pendingLockScreenLyrics = null
-            clearCurrentLockScreenLyrics()
+            clearCurrentLockScreenLyrics(pending.trackId)
             return
         }
         val lyricInfo = buildLockScreenLyricInfo(track, lineLyrics)
@@ -203,7 +202,6 @@ class AndroidNativeAudioEngine(
             return
         }
         val extras = Bundle(currentExtras ?: Bundle.EMPTY).apply {
-            putString("lyrics", pending.lyrics)
             putString(OPLUS_LYRIC_INFO_KEY, lyricInfo)
         }
         replaceMediaItemMetadata(controller, currentIndex, currentItem, extras)
@@ -216,10 +214,11 @@ class AndroidNativeAudioEngine(
             }
     }
 
-    private fun clearCurrentLockScreenLyrics() {
+    private fun clearCurrentLockScreenLyrics(trackId: String? = null) {
         val controller = mediaController ?: return
         if (!controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) return
         val currentItem = controller.currentMediaItem ?: return
+        if (trackId != null && !currentItem.matchesTrack(trackId)) return
         val currentExtras = currentItem.mediaMetadata.extras ?: return
         if (!currentExtras.containsKey(OPLUS_LYRIC_INFO_KEY)) return
         val currentIndex = controller.currentMediaItemIndex
@@ -264,15 +263,20 @@ class AndroidNativeAudioEngine(
     private fun updatePosition() {
         val controller = mediaController ?: return
         if (controller.playbackState == Player.STATE_IDLE) return
-        mutableState.value = mutableState.value.copy(
-            currentTrack = mutableState.value.currentTrack ?: controller.currentMediaItem?.toMusicTrack(),
+        val currentState = mutableState.value
+        val currentItem = controller.currentMediaItem
+        val sessionLyrics = currentItem
+            ?.takeIf { item -> currentState.currentTrack?.let { item.matchesTrack(it.id) } ?: true }
+            ?.mediaMetadata
+            ?.extras
+            ?.getString("lyrics")
+            ?.takeIf { it.isNotBlank() }
+        mutableState.value = currentState.copy(
+            currentTrack = currentState.currentTrack ?: currentItem?.toMusicTrack(),
             positionMs = controller.currentPosition.coerceAtLeast(0),
-            durationMs = controller.duration.takeIf { it > 0 } ?: mutableState.value.durationMs,
+            durationMs = controller.duration.takeIf { it > 0 } ?: currentState.durationMs,
             bufferedMs = controller.bufferedPosition.coerceAtLeast(0),
-            lyrics = mutableState.value.lyrics ?: controller.currentMediaItem?.mediaMetadata
-                ?.extras
-                ?.getString("lyrics")
-                ?.takeIf { it.isNotBlank() },
+            lyrics = currentState.lyrics ?: sessionLyrics,
         )
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 class AndroidNativeAudioEngine(
     private val context: Context,
@@ -22,6 +24,7 @@ class AndroidNativeAudioEngine(
     private val mutableState = MutableStateFlow(PlaybackState())
     private var mediaController: MediaController? = null
     private var controllerConnecting = false
+    private var pendingLockScreenLyrics: PendingLockScreenLyrics? = null
 
     override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
     override val resolvesResourcesInternally: Boolean = true
@@ -44,6 +47,7 @@ class AndroidNativeAudioEngine(
                     audioDecoderInfo = mutableState.value.audioDecoderInfo,
                     audioFormatInfo = mutableState.value.audioFormatInfo,
                 )
+                applyPendingLockScreenLyrics()
             }
         }
         scope.launch {
@@ -55,6 +59,8 @@ class AndroidNativeAudioEngine(
     }
 
     override fun prepareLoading(track: MusicTrack) {
+        pendingLockScreenLyrics = null
+        clearCurrentLockScreenLyrics()
         mutableState.value = mutableState.value.copy(
             status = PlayerStatus.Loading,
             currentTrack = track,
@@ -113,6 +119,8 @@ class AndroidNativeAudioEngine(
     }
 
     override fun stop() {
+        pendingLockScreenLyrics = null
+        clearCurrentLockScreenLyrics()
         mediaController?.stop()
         FuoPlaybackService.stop(context)
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Idle, positionMs = 0)
@@ -127,6 +135,23 @@ class AndroidNativeAudioEngine(
         mutableState.value = mutableState.value.copy(positionMs = normalizedPosition)
     }
 
+    /**
+     * Publishes complete timed lyrics through the OPlus/ColorOS media-session extension.
+     * Other Android systems ignore this metadata extra.
+     */
+    internal fun publishLockScreenLyrics(trackId: String, lyrics: String?) {
+        val normalizedLyrics = lyrics?.takeIf { it.isNotBlank() }
+        if (normalizedLyrics == null) {
+            pendingLockScreenLyrics = null
+            if (mutableState.value.currentTrack?.id == trackId) {
+                clearCurrentLockScreenLyrics()
+            }
+            return
+        }
+        pendingLockScreenLyrics = PendingLockScreenLyrics(trackId, normalizedLyrics)
+        applyPendingLockScreenLyrics()
+    }
+
     private fun connectController() {
         if (mediaController != null || controllerConnecting) return
         controllerConnecting = true
@@ -138,6 +163,7 @@ class AndroidNativeAudioEngine(
                 runCatching { future.get() }
                     .onSuccess { controller ->
                         mediaController = controller
+                        applyPendingLockScreenLyrics()
                     }
                     .onFailure { throwable ->
                         Log.e(TAG, "connect media controller failed", throwable)
@@ -150,6 +176,90 @@ class AndroidNativeAudioEngine(
             ContextCompat.getMainExecutor(context),
         )
     }
+
+    private fun applyPendingLockScreenLyrics() {
+        val pending = pendingLockScreenLyrics ?: return
+        val controller = mediaController ?: return
+        val track = mutableState.value.currentTrack ?: return
+        if (track.id != pending.trackId) return
+        if (!controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
+            Log.w(TAG, "media session does not allow metadata replacement for ColorOS lyrics")
+            return
+        }
+        val currentItem = controller.currentMediaItem ?: return
+        if (!currentItem.matchesTrack(pending.trackId)) return
+        val currentIndex = controller.currentMediaItemIndex
+        if (currentIndex < 0) return
+        val lineLyrics = toTimedLineLrc(pending.lyrics)
+        if (lineLyrics == null) {
+            pendingLockScreenLyrics = null
+            clearCurrentLockScreenLyrics()
+            return
+        }
+        val lyricInfo = buildLockScreenLyricInfo(track, lineLyrics)
+        val currentExtras = currentItem.mediaMetadata.extras
+        if (currentExtras?.getString(OPLUS_LYRIC_INFO_KEY) == lyricInfo) {
+            pendingLockScreenLyrics = null
+            return
+        }
+        val extras = Bundle(currentExtras ?: Bundle.EMPTY).apply {
+            putString("lyrics", pending.lyrics)
+            putString(OPLUS_LYRIC_INFO_KEY, lyricInfo)
+        }
+        replaceMediaItemMetadata(controller, currentIndex, currentItem, extras)
+            .onSuccess {
+                pendingLockScreenLyrics = null
+                Log.d(TAG, "published ColorOS lock-screen lyrics trackId=${track.id}")
+            }
+            .onFailure { throwable ->
+                Log.w(TAG, "failed to publish ColorOS lock-screen lyrics trackId=${track.id}", throwable)
+            }
+    }
+
+    private fun clearCurrentLockScreenLyrics() {
+        val controller = mediaController ?: return
+        if (!controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) return
+        val currentItem = controller.currentMediaItem ?: return
+        val currentExtras = currentItem.mediaMetadata.extras ?: return
+        if (!currentExtras.containsKey(OPLUS_LYRIC_INFO_KEY)) return
+        val currentIndex = controller.currentMediaItemIndex
+        if (currentIndex < 0) return
+        val extras = Bundle(currentExtras).apply {
+            remove(OPLUS_LYRIC_INFO_KEY)
+        }
+        replaceMediaItemMetadata(controller, currentIndex, currentItem, extras)
+            .onFailure { throwable ->
+                Log.w(TAG, "failed to clear ColorOS lock-screen lyrics", throwable)
+            }
+    }
+
+    private fun replaceMediaItemMetadata(
+        controller: MediaController,
+        currentIndex: Int,
+        currentItem: MediaItem,
+        extras: Bundle,
+    ): Result<Unit> = runCatching {
+        // Preserve URI and playback configuration; only session-visible metadata changes.
+        val updatedItem = currentItem.buildUpon()
+            .setMediaMetadata(
+                currentItem.mediaMetadata.buildUpon()
+                    .setExtras(extras)
+                    .build(),
+            )
+            .build()
+        controller.replaceMediaItem(currentIndex, updatedItem)
+    }
+
+    private fun MediaItem.matchesTrack(trackId: String): Boolean =
+        mediaId.endsWith(":$trackId")
+
+    private fun buildLockScreenLyricInfo(track: MusicTrack, lineLyrics: String): String =
+        JSONObject()
+            .put("songName", track.title)
+            .put("artist", track.artists)
+            .put("songId", track.id)
+            .put("lyric", lineLyrics)
+            .toString()
 
     private fun updatePosition() {
         val controller = mediaController ?: return
@@ -204,7 +314,13 @@ class AndroidNativeAudioEngine(
         )
     }
 
+    private data class PendingLockScreenLyrics(
+        val trackId: String,
+        val lyrics: String,
+    )
+
     private companion object {
         private const val TAG = "FuoAudioEngine"
+        private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -4,10 +4,13 @@ import android.app.Application
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 class FuoEvolveApplication : Application() {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -112,6 +115,19 @@ class FuoEvolveApplication : Application() {
                 override fun next() {
                     controller.next()
                 }
+            }
+            appScope.launch {
+                snapshotFlow {
+                    controller.playbackState.let { state ->
+                        state.currentTrack?.id to state.lyrics
+                    }
+                }
+                    .distinctUntilChanged()
+                    .collect { (trackId, lyrics) ->
+                        if (trackId != null) {
+                            playbackEngine.publishLockScreenLyrics(trackId, lyrics)
+                        }
+                    }
             }
         }
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -446,6 +446,7 @@ class FuoPlaybackService : MediaSessionService() {
     ): MediaItem {
         val url = payload.url
         require(url.isNotBlank()) { "Playback URL is blank" }
+        val lineLyrics = toTimedLineLrc(payload.lyrics)
         val extras = Bundle().apply {
             putString("source", track.source)
             putString("source_type", track.sourceType.name)
@@ -470,6 +471,9 @@ class FuoPlaybackService : MediaSessionService() {
             putString("replacement_strategy", track.replacementStrategy.orEmpty())
             putDouble("replacement_score", track.replacementScore ?: 0.0)
             putString("lyrics", payload.lyrics.orEmpty())
+            lineLyrics?.let { lyrics ->
+                putString(OPLUS_LYRIC_INFO_KEY, buildLockScreenLyricInfo(track, lyrics))
+            }
             putString("audio_quality", payload.audioQuality.orEmpty())
             putString("playback_parts", JSONArray().apply {
                 parts.forEach { part -> put(JSONObject().put("id", part.id).put("title", part.title).put("duration_ms", part.durationMs)) }
@@ -491,6 +495,14 @@ class FuoPlaybackService : MediaSessionService() {
             )
             .build()
     }
+
+    private fun buildLockScreenLyricInfo(track: MusicTrack, lineLyrics: String): String =
+        JSONObject()
+            .put("songName", track.title)
+            .put("artist", track.artists)
+            .put("songId", track.id)
+            .put("lyric", lineLyrics)
+            .toString()
 
     private fun createMediaSource(mediaItem: MediaItem, headers: Map<String, String>): ProgressiveMediaSource {
         val url = mediaItem.localConfiguration?.uri?.toString().orEmpty()
@@ -717,6 +729,7 @@ class FuoPlaybackService : MediaSessionService() {
         private const val EXTRA_PLAN = "plan"
         private const val PLAYBACK_RESOLVE_TIMEOUT_MS = 30_000L
         private const val TAG = "FuoPlaybackService"
+        private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
         private val MEDIA_AUDIO_ATTRIBUTES = AudioAttributes.Builder()
             .setUsage(C.USAGE_MEDIA)
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
@@ -1,0 +1,40 @@
+package org.feeluown.mobile
+
+/**
+ * Converts the app's supported lyric formats (LRC/YRC plus optional translation)
+ * into plain timed line-level LRC suitable for platform media-session extensions.
+ *
+ * ColorOS accepts this line-level LRC as the required `lyric` payload. Word-level
+ * `rawLyric` is intentionally omitted until FuoEvolve can serialize a compatible
+ * word timeline rather than passing provider-specific YRC through unchanged.
+ */
+fun toTimedLineLrc(rawLyrics: String?): String? {
+    val timedLines = parseLyrics(rawLyrics)
+        .filter { it.timeMs != Long.MAX_VALUE && it.text.isNotBlank() }
+    if (timedLines.isEmpty()) return null
+
+    return buildString {
+        timedLines.forEach { line ->
+            val timestamp = formatLrcTimestamp(line.timeMs)
+            append(timestamp)
+            append(line.text.trim())
+            append('\n')
+            line.translation
+                ?.trim()
+                ?.takeIf { it.isNotBlank() && it != line.text.trim() }
+                ?.let { translation ->
+                    append(timestamp)
+                    append(translation)
+                    append('\n')
+                }
+        }
+    }.trimEnd()
+}
+
+private fun formatLrcTimestamp(timeMs: Long): String {
+    val normalized = timeMs.coerceAtLeast(0L)
+    val minutes = normalized / 60_000L
+    val seconds = (normalized % 60_000L) / 1_000L
+    val millis = normalized % 1_000L
+    return "[${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}]"
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
@@ -1,0 +1,40 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TimedLineLyricsTest {
+    @Test
+    fun convertsYrcWordsToColorOsCompatibleLineLrc() {
+        val lyrics = composeLyricsWithTranslation(
+            "[11820,2220](11820,120,0)The (11940,420,0)club",
+            "[00:11.820]这俱乐部",
+        )
+
+        assertEquals(
+            "[00:11.820]The club\n[00:11.820]这俱乐部",
+            toTimedLineLrc(lyrics),
+        )
+    }
+
+    @Test
+    fun normalizesLrcTimestampsAndKeepsTranslations() {
+        val lyrics = """
+            [ar:Example]
+            [00:01.5]Hello
+            [00:01.5]你好
+            [01:02.03]World
+        """.trimIndent()
+
+        assertEquals(
+            "[00:01.500]Hello\n[00:01.500]你好\n[01:02.030]World",
+            toTimedLineLrc(lyrics),
+        )
+    }
+
+    @Test
+    fun ignoresUntimedLyricsForLockScreenTimeline() {
+        assertNull(toTimedLineLrc("plain lyrics without timestamps"))
+    }
+}


### PR DESCRIPTION
## Summary
- publish the documented ColorOS/OPlus `lyricInfo` JSON through Media3 metadata
- include complete timed lyrics in the first `MediaItem` whenever lyrics are already available, avoiding the ColorOS metadata debounce race
- clear stale `lyricInfo` on track changes and stop, then submit newly loaded lyrics once when asynchronous lyric loading completes
- normalize FuoEvolve LRC/YRC into line-level timed LRC while preserving translations
- skip `lyricInfo` for untimed lyrics instead of advertising unusable lyric data

## Protocol behavior
- `lyric` is populated with normalized timed LRC
- `songName`, `artist`, and stable FuoEvolve track `songId` are included
- `rawLyric` is intentionally omitted for now because it is optional and FuoEvolve's provider-specific YRC should not be passed as an incompatible word-level payload
- metadata writes are deduplicated by comparing the existing `lyricInfo`

## Tests
- YRC-to-line-LRC normalization
- translated LRC preservation
- untimed lyric rejection

## Notes
Supersedes the closed experimental PR #44 with the protocol-recommended initial metadata injection and lifecycle cleanup.