### PR TITLE
fix: restore QQ Music artist details

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
@@ -4,6 +4,7 @@ import org.feeluown.mobile.provider.bilibili.BilibiliContentProvider
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
+import org.feeluown.mobile.provider.qqmusic.QQMusicArtistDetailProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
 
@@ -203,7 +204,16 @@ fun createFuoProviderRepository(
         http = qqmusicHttp,
         credentials = credentials,
     )
-    val withQQMusicContent = QQMusicContentRepository(delegate, qqmusic, qqmusicUserLibrary)
+    val qqmusicArtistDetails = QQMusicArtistDetailProvider(
+        http = qqmusicHttp,
+        credentials = credentials,
+    )
+    val withQQMusicContent = QQMusicContentRepository(
+        delegate,
+        qqmusic,
+        qqmusicUserLibrary,
+        qqmusicArtistDetails,
+    )
     val bilibili = BilibiliContentProvider(
         http = ProviderHttpClient(persistentCache = persistentCache),
         credentials = credentials,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile
 
+import org.feeluown.mobile.provider.qqmusic.QQMusicArtistDetailProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
 
@@ -12,6 +13,7 @@ internal class QQMusicContentRepository(
     private val delegate: ProviderMusicRepository,
     private val qqmusic: QQMusicContentProvider,
     private val userLibrary: QQMusicUserLibrary,
+    private val artistDetails: QQMusicArtistDetailProvider,
 ) : ProviderMusicRepository by delegate {
     override suspend fun features(): List<ProviderFeature> {
         val base = delegate.features()
@@ -43,7 +45,10 @@ internal class QQMusicContentRepository(
         val extras = runCatching { qqmusic.searchExtras(keyword) }.getOrElse { return base }
         return base.copy(
             playlists = replaceQQMusic(base.playlists, extras.playlists) { it.providerId },
-            artists = replaceQQMusic(base.artists, extras.artists) { it.providerId },
+            artists = replaceQQMusic(
+                base.artists,
+                extras.artists.map(artistDetails::normalizeArtist),
+            ) { it.providerId },
             albums = replaceQQMusic(base.albums, extras.albums) { it.providerId },
             videos = replaceQQMusic(base.videos, extras.videos) { it.providerId },
         )
@@ -81,7 +86,7 @@ internal class QQMusicContentRepository(
         offset: Int,
         limit: Int,
     ): ProviderContentSection = if (feature.providerId == QQMUSIC_PROVIDER_ID) {
-        if (ProviderFeatureFilterCodec.requestId(feature.id) == QQMUSIC_USER_PLAYLISTS_FEATURE_ID) {
+        val section = if (ProviderFeatureFilterCodec.requestId(feature.id) == QQMUSIC_USER_PLAYLISTS_FEATURE_ID) {
             val auth = delegate.authState(QQMUSIC_PROVIDER_ID)
             if (!auth.isLoggedIn) {
                 ProviderContentSection(feature = feature, isLoginRequired = true)
@@ -91,6 +96,7 @@ internal class QQMusicContentRepository(
         } else {
             qqmusic.loadFeature(feature, offset, limit)
         }
+        normalizeQQMusicArtists(section)
     } else {
         delegate.loadFeaturePage(feature, offset, limit)
     }
@@ -122,12 +128,72 @@ internal class QQMusicContentRepository(
             delegate.playlistTracks(playlist)
         }
 
+    override suspend fun mediaItemDetail(item: ProviderMediaItem): ProviderMediaItemDetail =
+        mediaItemDetailPage(item, 0, 0, PROVIDER_PAGE_SIZE)
+
+    override suspend fun mediaItemDetailPage(
+        item: ProviderMediaItem,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail {
+        if (item.providerId != QQMUSIC_PROVIDER_ID || item.type != ProviderMediaItemType.Artist) {
+            return delegate.mediaItemDetailPage(item, tracksOffset, albumsOffset, limit)
+        }
+
+        val normalized = artistDetails.normalizeArtist(item)
+        val base = runCatching {
+            delegate.mediaItemDetailPage(normalized, tracksOffset, albumsOffset, limit)
+        }.getOrNull()
+        val trackPage = artistDetails.loadTracksPage(normalized, tracksOffset, limit)
+        val baseItem = base?.item
+        val mergedItem = (baseItem ?: trackPage.item).copy(
+            id = trackPage.item.id,
+            coverUrl = trackPage.item.coverUrl ?: baseItem?.coverUrl,
+            providerUrl = trackPage.item.providerUrl,
+            trackCount = trackPage.total ?: baseItem?.trackCount ?: trackPage.item.trackCount,
+        )
+        return ProviderMediaItemDetail(
+            item = mergedItem,
+            tracks = trackPage.tracks,
+            albums = base?.albums.orEmpty(),
+            tracksNextOffset = trackPage.nextOffset,
+            tracksHasMore = trackPage.hasMore,
+            albumsNextOffset = base?.albumsNextOffset ?: albumsOffset,
+            albumsHasMore = base?.albumsHasMore ?: false,
+        )
+    }
+
+    override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> =
+        if (item.providerId == QQMUSIC_PROVIDER_ID && item.type == ProviderMediaItemType.Artist) {
+            artistDetails.loadTracksPage(
+                item = artistDetails.normalizeArtist(item),
+                offset = 0,
+                limit = MAX_ARTIST_TRACKS,
+            ).tracks
+        } else {
+            delegate.mediaItemTracks(item)
+        }
+
     private suspend fun enrichQQMusicAuth(base: ProviderAuthState): ProviderAuthState {
         if (!base.isLoggedIn) return base
         val userName = runCatching { userLibrary.userName() }.getOrNull()
             ?.takeIf { it.isNotBlank() }
             ?: return base
         return base.copy(userName = userName)
+    }
+
+    private fun normalizeQQMusicArtists(section: ProviderContentSection): ProviderContentSection {
+        if (section.mediaItems.isEmpty()) return section
+        return section.copy(
+            mediaItems = section.mediaItems.map { item ->
+                if (item.providerId == QQMUSIC_PROVIDER_ID && item.type == ProviderMediaItemType.Artist) {
+                    artistDetails.normalizeArtist(item)
+                } else {
+                    item
+                }
+            },
+        )
     }
 
     private fun <T> replaceQQMusic(
@@ -139,5 +205,6 @@ internal class QQMusicContentRepository(
     private companion object {
         const val QQMUSIC_PROVIDER_ID = "qqmusic"
         const val QQMUSIC_USER_PLAYLISTS_FEATURE_ID = "qqmusic_user_playlists"
+        const val MAX_ARTIST_TRACKS = 300
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicArtistDetailProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicArtistDetailProvider.kt
@@ -1,0 +1,312 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemType
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.md5Hex
+import org.feeluown.mobile.provider.core.mediaItemKey
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.splitResourceId
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.trackKey
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+import kotlin.random.Random
+
+/**
+ * Loads QQ Music artist tracks using singer MID, which is the identifier expected by
+ * the current singer-song endpoint. It also normalizes legacy QQ artist cover URLs.
+ */
+class QQMusicArtistDetailProvider(
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) {
+    fun normalizeArtist(item: ProviderMediaItem): ProviderMediaItem {
+        if (item.providerId != ID || item.type != ProviderMediaItemType.Artist) return item
+        val rawIdentifier = splitResourceId(item.id, "artist").second
+        val mid = rawIdentifier.takeUnless(::isNumericId)
+            ?: artistMidFromCover(item.coverUrl)
+        return normalizeArtist(item, mid)
+    }
+
+    suspend fun loadTracksPage(
+        item: ProviderMediaItem,
+        offset: Int,
+        limit: Int,
+    ): QQMusicArtistTrackPage {
+        val mid = resolveSingerMid(item)
+        val normalized = normalizeArtist(item, mid)
+        if (mid.isNullOrBlank()) {
+            return QQMusicArtistTrackPage(normalized, emptyList(), offset, false, normalized.trackCount)
+        }
+        val requestLimit = limit.coerceAtLeast(1)
+        val root = rpc(
+            """
+            {"singerSongList":{"method":"GetSingerSongList","param":{"order":1,"singerMid":${jsonString(mid)},"begin":$offset,"num":$requestLimit},"module":"musichall.song_list_server"}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:artist-tracks:$mid:$offset:$requestLimit",
+            cachePolicy = ProviderCachePolicies.detail,
+        )
+        val data = root.obj("singerSongList")?.obj("data")
+            ?: root.obj("data")
+            ?: JsonObject(emptyMap())
+        val rawValues = data.array("songList").ifEmpty { data.array("songlist") }
+        val tracks = rawValues.mapNotNull { value ->
+            runCatching { song(value.asObject()) }.getOrNull()
+        }.filter { it.id.substringAfterLast(':').isNotBlank() }
+            .distinctBy { it.id }
+        val total = data.int("totalNum")
+            ?: data.int("total")
+            ?: data.int("songnum")
+            ?: data.int("song_count")
+        val nextOffset = offset + rawValues.size
+        val hasMore = total?.let { nextOffset < it } ?: (rawValues.size >= requestLimit)
+        return QQMusicArtistTrackPage(
+            item = normalized.copy(trackCount = total ?: normalized.trackCount),
+            tracks = tracks,
+            nextOffset = nextOffset,
+            hasMore = hasMore,
+            total = total,
+        )
+    }
+
+    private suspend fun resolveSingerMid(item: ProviderMediaItem): String? {
+        val normalized = normalizeArtist(item)
+        val rawIdentifier = splitResourceId(normalized.id, "artist").second
+        if (rawIdentifier.isNotBlank() && !isNumericId(rawIdentifier)) return rawIdentifier
+        artistMidFromCover(normalized.coverUrl)?.let { return it }
+        if (item.title.isBlank()) return null
+
+        val root = rpc(
+            """
+            {"singerSearch":{"module":"music.search.SearchCgiService","method":"DoSearchForQQMusicDesktop","param":{"num_per_page":10,"page_num":1,"search_type":1,"query":${jsonString(item.title)}}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:artist-mid:${item.title}",
+            cachePolicy = ProviderCachePolicies.search,
+        )
+        val searchData = root.obj("singerSearch")?.obj("data") ?: root.obj("singerSearch")
+        val body = searchData?.obj("body") ?: searchData ?: JsonObject(emptyMap())
+        val values = body.obj("singer")?.array("list").orEmpty()
+        val expectedNumericId = rawIdentifier.takeIf(::isNumericId)
+        val candidates = values.mapNotNull { value -> runCatching { value.asObject() }.getOrNull() }
+        val matched = candidates.firstOrNull { candidate ->
+            expectedNumericId != null && singerNumericId(candidate) == expectedNumericId
+        } ?: candidates.firstOrNull { candidate -> singerName(candidate) == item.title }
+            ?: candidates.firstOrNull()
+        return matched?.let(::singerMid)?.takeIf(String::isNotBlank)
+    }
+
+    private fun normalizeArtist(item: ProviderMediaItem, mid: String?): ProviderMediaItem {
+        val correctedCover = item.coverUrl
+            ?.replace("https://y.qq.com/music/photo_new/", "https://y.gtimg.cn/music/photo_new/")
+            ?.replace("http://y.qq.com/music/photo_new/", "https://y.gtimg.cn/music/photo_new/")
+        val cover = correctedCover
+            ?: mid?.takeIf(String::isNotBlank)?.let(::artistCover)
+        if (mid.isNullOrBlank()) return item.copy(coverUrl = cover)
+        return item.copy(
+            id = mediaItemKey(ProviderMediaItemType.Artist, ID, mid),
+            coverUrl = cover ?: artistCover(mid),
+            providerUrl = "https://y.qq.com/n/ryqq/singer/$mid",
+        )
+    }
+
+    private fun song(value: JsonObject): MusicTrack {
+        val item = value.obj("songInfo") ?: value
+        val identifier = item.string("songmid")
+            .ifBlank { item.string("mid") }
+            .ifBlank { item.string("song_id") }
+            .ifBlank { item.string("songid") }
+            .ifBlank { item.string("id") }
+        val singerItems = item.array("singer")
+        val artists = singerItems.map { singerValue ->
+            val singer = singerValue.asObject()
+            singer.string("name").ifBlank { singer.string("singer_name") }
+        }.filter(String::isNotBlank).joinToString(" / ").ifBlank {
+            item.string("singer_name").ifBlank { item.string("singername") }
+        }
+        val album = item.obj("album")
+        val albumName = item.string("albumname")
+            .ifBlank { item.string("album_name") }
+            .ifBlank { album?.string("name").orEmpty() }
+        val albumId = item.string("albumid")
+            .ifBlank { item.string("album_id") }
+            .ifBlank { album?.string("id").orEmpty() }
+        val albumMid = item.string("albummid")
+            .ifBlank { item.string("album_mid") }
+            .ifBlank { album?.string("mid").orEmpty() }
+        val firstSinger = singerItems.firstOrNull()?.asObject()
+        val artistIdentifier = firstSinger?.string("mid")
+            ?.ifBlank { firstSinger.string("singer_mid") }
+            ?.ifBlank { firstSinger.string("singerMID") }
+            ?.ifBlank { firstSinger.string("id") }
+            ?.ifBlank { firstSinger.string("singer_id") }
+        val rawDuration = item.long("interval") ?: item.long("duration")
+        return MusicTrack(
+            id = trackKey(ID, identifier),
+            title = item.string("songname")
+                .ifBlank { item.string("name") }
+                .ifBlank { item.string("title") }
+                .ifBlank { item.string("songorig") },
+            artists = artists,
+            album = albumName,
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = item.stringOrNull("picurl")
+                ?: album?.stringOrNull("picurl")
+                ?: albumMid.takeIf(String::isNotBlank)?.let(::albumCover),
+            durationMs = rawDuration?.let { if (it < 100_000) it * 1_000 else it },
+            providerId = trackKey(ID, identifier),
+            providerName = NAME,
+            artistItemId = artistIdentifier?.takeIf(String::isNotBlank)?.let {
+                mediaItemKey(ProviderMediaItemType.Artist, ID, it)
+            },
+            albumItemId = (albumId.takeIf(String::isNotBlank) ?: albumMid.takeIf(String::isNotBlank))?.let {
+                mediaItemKey(ProviderMediaItemType.Album, ID, it)
+            },
+            providerUrl = "https://y.qq.com/n/ryqq/songDetail/$identifier",
+        )
+    }
+
+    private suspend fun rpc(
+        payload: String,
+        cacheKey: String? = null,
+        cachePolicy: org.feeluown.mobile.provider.core.network.ProviderCachePolicy = ProviderCachePolicies.none,
+    ): JsonObject {
+        val request = qqRpcPayload(payload)
+        return http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$U_BASE/cgi-bin/musicu.fcg",
+                mapOf(
+                    "_" to currentTimeMillis().toString(),
+                    "sign" to contentSign(request),
+                    "data" to request,
+                ),
+            ),
+            headers = authenticatedHeaders(),
+            cacheKey = cacheKey,
+            cachePolicy = cachePolicy,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+    }
+
+    private fun qqRpcPayload(payload: String): String {
+        val root = providerJson.parseToJsonElement(payload).jsonObject
+        val common = mapOf(
+            "loginUin" to JsonPrimitive("0"),
+            "hostUin" to JsonPrimitive(0),
+            "g_tk" to JsonPrimitive(5_381),
+            "inCharset" to JsonPrimitive("utf8"),
+            "outCharset" to JsonPrimitive("utf-8"),
+            "notice" to JsonPrimitive(0),
+            "platform" to JsonPrimitive("yqq"),
+            "needNewCode" to JsonPrimitive(0),
+        )
+        val mergedComm = JsonObject(common + (root.obj("comm") ?: emptyMap()))
+        return providerJson.encodeToString(
+            JsonObject.serializer(),
+            JsonObject(root + ("comm" to mergedComm)),
+        )
+    }
+
+    private suspend fun authenticatedHeaders(): Map<String, String> = buildMap {
+        put("User-Agent", DEFAULT_USER_AGENT)
+        put("Referer", "https://y.qq.com/")
+        cookieHeader(credentials.read(ID)).takeIf(String::isNotBlank)?.let { put("Cookie", it) }
+    }
+
+    private fun queryUrl(base: String, params: Map<String, String>): String {
+        val encoded = params.entries.joinToString("&") { (key, value) ->
+            "${encodeUrlComponent(key)}=${encodeUrlComponent(value)}"
+        }
+        return if (encoded.isBlank()) base else "$base?$encoded"
+    }
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val intValue = byte.toInt() and 0xff
+            if (
+                intValue in 0x30..0x39 ||
+                intValue in 0x41..0x5a ||
+                intValue in 0x61..0x7a ||
+                intValue in setOf(45, 46, 95, 126)
+            ) {
+                append(intValue.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[intValue ushr 4])
+                append("0123456789ABCDEF"[intValue and 15])
+            }
+        }
+    }
+
+    private fun jsonString(value: String): String =
+        "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+
+    private fun singerNumericId(item: JsonObject): String = item.string("singer_id")
+        .ifBlank { item.string("singerID") }
+        .ifBlank { item.string("singerid") }
+        .ifBlank { item.string("id") }
+
+    private fun singerMid(item: JsonObject): String = item.string("singer_mid")
+        .ifBlank { item.string("singerMID") }
+        .ifBlank { item.string("singermid") }
+        .ifBlank { item.string("mid") }
+
+    private fun singerName(item: JsonObject): String = item.string("singer_name")
+        .ifBlank { item.string("singerName") }
+        .ifBlank { item.string("singername") }
+        .ifBlank { item.string("name") }
+
+    private fun artistMidFromCover(url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        return ARTIST_COVER_MID.find(url)?.groupValues?.getOrNull(1)?.takeIf(String::isNotBlank)
+    }
+
+    private fun isNumericId(value: String): Boolean = value.isNotBlank() && value.all(Char::isDigit)
+
+    private fun artistCover(mid: String): String =
+        "https://y.gtimg.cn/music/photo_new/T001R300x300M000$mid.jpg"
+
+    private fun albumCover(mid: String): String =
+        "https://y.gtimg.cn/music/photo_new/T002R300x300M000$mid.jpg"
+
+    private fun contentSign(data: String): String {
+        val randomPart = buildString {
+            repeat(Random.nextInt(10, 17)) {
+                append(SIGN_ALPHABET[Random.nextInt(SIGN_ALPHABET.length)])
+            }
+        }
+        return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}" 
+    }
+
+    private companion object {
+        const val ID = "qqmusic"
+        const val NAME = "QQ 音乐"
+        const val U_BASE = "https://u.y.qq.com"
+        const val DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
+        const val SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+        val ARTIST_COVER_MID = Regex("T001R\\d+x\\d+M000([A-Za-z0-9]+)\\.jpg")
+    }
+}
+
+data class QQMusicArtistTrackPage(
+    val item: ProviderMediaItem,
+    val tracks: List<MusicTrack>,
+    val nextOffset: Int,
+    val hasMore: Boolean,
+    val total: Int?,
+)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicArtistDetailProviderTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicArtistDetailProviderTest.kt
@@ -1,0 +1,99 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.qqmusic.QQMusicArtistDetailProvider
+
+class QQMusicArtistDetailProviderTest {
+    @Test
+    fun normalizesArtistMidAndCoverHost() {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine { addHandler { respond("{}") } }
+            },
+        )
+        val provider = QQMusicArtistDetailProvider(client, InMemoryProviderCredentialStore())
+        val item = ProviderMediaItem(
+            id = "artist:qqmusic:101",
+            title = "周杰伦",
+            providerId = "qqmusic",
+            providerName = "QQ 音乐",
+            type = ProviderMediaItemType.Artist,
+            coverUrl = "https://y.qq.com/music/photo_new/T001R300x300M0000025NhlN2yWrP4.jpg",
+        )
+
+        val normalized = provider.normalizeArtist(item)
+
+        assertTrue(normalized.id.endsWith("0025NhlN2yWrP4"))
+        assertEquals(
+            "https://y.gtimg.cn/music/photo_new/T001R300x300M0000025NhlN2yWrP4.jpg",
+            normalized.coverUrl,
+        )
+        client.close()
+    }
+
+    @Test
+    fun loadsArtistTracksWithSingerMid() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("/cgi-bin/musicu.fcg", request.url.encodedPath)
+                        val data = request.url.parameters["data"].orEmpty()
+                        assertTrue(data.contains("singerSongList"))
+                        assertTrue(data.contains("musichall.song_list_server"))
+                        assertTrue(data.contains("\"singerMid\":\"0025NhlN2yWrP4\""))
+                        respond(
+                            """
+                            {
+                              "singerSongList":{
+                                "data":{
+                                  "totalNum":1,
+                                  "songList":[
+                                    {
+                                      "songInfo":{
+                                        "mid":"song-mid",
+                                        "name":"测试歌曲",
+                                        "singer":[{"id":4558,"mid":"0025NhlN2yWrP4","name":"周杰伦"}],
+                                        "album":{"id":1,"mid":"album-mid","name":"测试专辑"},
+                                        "interval":180
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val provider = QQMusicArtistDetailProvider(client, InMemoryProviderCredentialStore())
+        val item = ProviderMediaItem(
+            id = "artist:qqmusic:0025NhlN2yWrP4",
+            title = "周杰伦",
+            providerId = "qqmusic",
+            providerName = "QQ 音乐",
+            type = ProviderMediaItemType.Artist,
+        )
+
+        val page = provider.loadTracksPage(item, offset = 0, limit = 20)
+
+        assertEquals("测试歌曲", page.tracks.single().title)
+        assertEquals("周杰伦", page.tracks.single().artists)
+        assertEquals(180_000, page.tracks.single().durationMs)
+        assertTrue(page.tracks.single().artistItemId.orEmpty().endsWith("0025NhlN2yWrP4"))
+        assertEquals(1, page.total)
+        assertFalse(page.hasMore)
+        client.close()
+    }
+}


### PR DESCRIPTION
修复 QQ 音乐歌手详情页歌曲列表为空以及歌手图片缺失的问题。

- 歌手歌曲接口改为使用 singer MID 与当前 singer-song service 请求格式
- 兼容搜索结果只返回数值 singer ID 的情况，按歌手信息解析 MID
- 修正 QQ 音乐歌手/专辑图片 fallback 域名
- 保留现有专辑列表加载，并新增歌手详情回归测试