### PR TITLE
feat: use NetEase home entry artwork

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/BilibiliContentRepository.kt
@@ -195,6 +195,13 @@ fun createFuoProviderRepository(
         persistentCache = persistentCache,
         isCellularConnection = isCellularConnection,
     )
+    val withNeteaseHomeEntries = NeteaseHomeEntryRepository(
+        delegate = delegate,
+        homeEntries = NeteaseHomeEntryClient(
+            http = ProviderHttpClient(persistentCache = persistentCache),
+            credentials = credentials,
+        ),
+    )
     val qqmusicHttp = ProviderHttpClient(persistentCache = persistentCache)
     val qqmusic = QQMusicContentProvider(
         http = qqmusicHttp,
@@ -209,7 +216,7 @@ fun createFuoProviderRepository(
         credentials = credentials,
     )
     val withQQMusicContent = QQMusicContentRepository(
-        delegate,
+        withNeteaseHomeEntries,
         qqmusic,
         qqmusicUserLibrary,
         qqmusicArtistDetails,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
@@ -1,0 +1,175 @@
+package org.feeluown.mobile
+
+import io.ktor.http.Parameters
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+
+/**
+ * Loads the artwork used by NetEase Cloud Music's discovery-page circular entries.
+ * The core provider stays responsible for the actual feature content; this wrapper
+ * only primes presentation metadata before NetEase feature sections are shown.
+ */
+internal class NeteaseHomeEntryRepository(
+    private val delegate: ProviderMusicRepository,
+    private val homeEntries: NeteaseHomeEntryClient,
+) : ProviderMusicRepository by delegate {
+    override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
+        loadFeaturePage(feature, 0, PROVIDER_PAGE_SIZE)
+
+    override suspend fun loadFeaturePage(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        if (
+            feature.providerId == NETEASE_PROVIDER_ID &&
+            (feature.category == ProviderFeatureCategory.Recommend || feature.category == ProviderFeatureCategory.Music)
+        ) {
+            homeEntries.ensureLoaded()
+        }
+        return delegate.loadFeaturePage(feature, offset, limit)
+    }
+}
+
+internal class NeteaseHomeEntryClient(
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) {
+    private val mutex = Mutex()
+    private val attemptedAuthModes = mutableSetOf<Boolean>()
+
+    suspend fun ensureLoaded() {
+        val saved = credentials.read(NETEASE_PROVIDER_ID)
+        val cookie = saved?.cookieHeader?.takeIf { it.isNotBlank() }
+            ?: saved?.cookies
+                ?.takeIf { it.isNotEmpty() }
+                ?.entries
+                ?.joinToString("; ") { (key, value) -> "$key=$value" }
+        val authenticated = !cookie.isNullOrBlank()
+
+        mutex.withLock {
+            if (authenticated in attemptedAuthModes) return
+            attemptedAuthModes += authenticated
+
+            val covers = runCatching { fetchCovers(cookie) }.getOrDefault(emptyMap())
+            if (covers.isNotEmpty()) publishNeteaseHomeEntryCovers(covers)
+        }
+    }
+
+    private suspend fun fetchCovers(cookie: String?): Map<String, String> {
+        val response = http.postForm(
+            providerId = NETEASE_PROVIDER_ID,
+            url = "$NETEASE_BASE/api/homepage/dragon/ball/static",
+            form = Parameters.build {},
+            headers = buildMap {
+                put("Referer", "$NETEASE_BASE/")
+                put("Origin", NETEASE_BASE)
+                put("User-Agent", NETEASE_HOME_USER_AGENT)
+                cookie?.takeIf { it.isNotBlank() }?.let { put("Cookie", it) }
+            },
+            cacheKey = "netease:homepage:dragon-ball:$authenticatedCacheKey",
+            cachePolicy = ProviderCachePolicies.recommendation,
+        )
+        val root = providerJson.parseToJsonElement(response.value).asObject()
+        val entries = root.array("data").mapNotNull { element ->
+            val item = runCatching { element.asObject() }.getOrNull() ?: return@mapNotNull null
+            val iconUrl = item.stringOrNull("iconUrl")
+                ?: item.stringOrNull("iconUrl2")
+                ?: return@mapNotNull null
+            NeteaseHomeEntry(
+                name = item.string("name"),
+                iconUrl = iconUrl,
+                url = item.string("url"),
+            )
+        }
+        return mapNeteaseHomeEntryCovers(entries)
+    }
+
+    private val authenticatedCacheKey: String
+        get() = "static"
+}
+
+internal data class NeteaseHomeEntry(
+    val name: String,
+    val iconUrl: String,
+    val url: String = "",
+)
+
+internal fun mapNeteaseHomeEntryCovers(entries: List<NeteaseHomeEntry>): Map<String, String> = buildMap {
+    NETEASE_HOME_ENTRY_ALIASES.forEach { (featureId, aliases) ->
+        findNeteaseHomeEntryCover(entries, aliases)?.let { coverUrl ->
+            put(featureId, coverUrl)
+        }
+    }
+}
+
+internal fun neteaseHomeEntryCoverUrl(featureId: String): String? =
+    neteaseHomeEntryCovers[neteaseFeatureBaseId(featureId)]
+
+internal fun neteaseFeatureBaseId(featureId: String): String =
+    featureId.substringBefore("^filters^").substringBefore('|')
+
+private fun publishNeteaseHomeEntryCovers(covers: Map<String, String>) {
+    neteaseHomeEntryCovers = neteaseHomeEntryCovers + covers
+}
+
+private fun findNeteaseHomeEntryCover(
+    entries: List<NeteaseHomeEntry>,
+    aliases: List<String>,
+): String? {
+    val normalizedAliases = aliases.map(::normalizeNeteaseHomeEntryName)
+    normalizedAliases.forEach { alias ->
+        entries.firstOrNull { normalizeNeteaseHomeEntryName(it.name) == alias }
+            ?.iconUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+    }
+    normalizedAliases.forEach { alias ->
+        entries.firstOrNull {
+            val name = normalizeNeteaseHomeEntryName(it.name)
+            alias.isNotBlank() && (name.contains(alias) || alias.contains(name))
+        }?.iconUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+    }
+    return null
+}
+
+private fun normalizeNeteaseHomeEntryName(value: String): String =
+    value.lowercase()
+        .replace(" ", "")
+        .replace("-", "")
+        .replace("_", "")
+
+private var neteaseHomeEntryCovers: Map<String, String> = emptyMap()
+
+private val NETEASE_HOME_ENTRY_ALIASES = mapOf(
+    "netease_daily_songs" to listOf("每日推荐"),
+    "netease_daily_playlists" to listOf("每日推荐"),
+    "netease_recommended_new_songs" to listOf("新歌新碟", "新歌"),
+    "netease_radio" to listOf("私人漫游", "私人FM"),
+    "netease_toplists" to listOf("排行榜"),
+    "netease_playlist_square" to listOf("歌单"),
+    "netease_artist_square" to listOf("歌手"),
+    "netease_mv_square" to listOf("MV广场", "MV"),
+    "netease_styles" to listOf("曲风", "风格"),
+    "netease_new_songs" to listOf("新歌新碟", "新歌"),
+    "netease_new_albums" to listOf("新歌新碟", "新碟", "数字专辑"),
+    "netease_top_artists" to listOf("歌手"),
+    "netease_highquality_playlists" to listOf("歌单"),
+    "netease_recommended_mvs" to listOf("MV"),
+    "netease_top_mvs" to listOf("MV排行", "MV", "排行榜"),
+)
+
+private const val NETEASE_PROVIDER_ID = "netease"
+private const val NETEASE_BASE = "https://music.163.com"
+private const val NETEASE_HOME_USER_AGENT =
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
@@ -75,7 +75,7 @@ internal class NeteaseHomeEntryClient(
                 put("User-Agent", NETEASE_HOME_USER_AGENT)
                 cookie?.takeIf { it.isNotBlank() }?.let { put("Cookie", it) }
             },
-            cacheKey = "netease:homepage:dragon-ball:$authenticatedCacheKey",
+            cacheKey = "netease:homepage:dragon-ball",
             cachePolicy = ProviderCachePolicies.recommendation,
         )
         val root = providerJson.parseToJsonElement(response.value).asObject()
@@ -92,9 +92,6 @@ internal class NeteaseHomeEntryClient(
         }
         return mapNeteaseHomeEntryCovers(entries)
     }
-
-    private val authenticatedCacheKey: String
-        get() = "static"
 }
 
 internal data class NeteaseHomeEntry(
@@ -135,7 +132,7 @@ private fun findNeteaseHomeEntryCover(
     normalizedAliases.forEach { alias ->
         entries.firstOrNull {
             val name = normalizeNeteaseHomeEntryName(it.name)
-            alias.isNotBlank() && (name.contains(alias) || alias.contains(name))
+            name.isNotBlank() && alias.isNotBlank() && (name.contains(alias) || alias.contains(name))
         }?.iconUrl
             ?.takeIf { it.isNotBlank() }
             ?.let { return it }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TrackRow.kt
@@ -118,7 +118,7 @@ fun CoverBox(
 ) {
     PlatformCoverArt(
         title = track.title,
-        imageUrl = track.coverUrl,
+        imageUrl = track.coverUrl ?: neteaseHomeEntryCoverUrl(track.id),
         modifier = Modifier
             .then(modifier)
             .clip(RoundedCornerShape(cornerRadius)),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepositoryTest.kt
@@ -1,0 +1,35 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NeteaseHomeEntryRepositoryTest {
+    @Test
+    fun mapsHomepageEntriesToExploreFeatures() {
+        val covers = mapNeteaseHomeEntryCovers(
+            listOf(
+                NeteaseHomeEntry("每日推荐", "daily.png"),
+                NeteaseHomeEntry("新歌新碟", "new.png"),
+                NeteaseHomeEntry("排行榜", "rank.png"),
+                NeteaseHomeEntry("曲风", "style.png"),
+                NeteaseHomeEntry("MV", "mv.png"),
+            ),
+        )
+
+        assertEquals("daily.png", covers["netease_daily_songs"])
+        assertEquals("new.png", covers["netease_new_songs"])
+        assertEquals("style.png", covers["netease_styles"])
+        assertEquals("mv.png", covers["netease_mv_square"])
+        assertEquals("mv.png", covers["netease_top_mvs"])
+    }
+
+    @Test
+    fun normalizesFilteredFeatureIds() {
+        assertEquals(
+            "netease_mv_square",
+            neteaseFeatureBaseId("netease_mv_square|area=全部|type=全部^filters^encoded"),
+        )
+        assertNull(neteaseHomeEntryCoverUrl("netease:12345"))
+    }
+}


### PR DESCRIPTION
## Summary
- load NetEase discovery-page entry metadata from `/api/homepage/dragon/ball/static`
- map returned `iconUrl` values to matching NetEase feature entries
- use those images as feature-card artwork while keeping existing placeholders as fallback
- avoid repeated requests per auth mode and cover the mapping with common tests

The endpoint is the mobile discovery-page circular-entry API used for entries such as 每日推荐、歌单、排行榜、新歌新碟等.