### PR TITLE
fix: load NetEase explore artwork from homepage blocks

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepository.kt
@@ -3,17 +3,20 @@ package org.feeluown.mobile
 import io.ktor.http.Parameters
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonObject
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.array
 import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.obj
 import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.string
 import org.feeluown.mobile.provider.core.stringOrNull
 import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.netease.NeteaseWeApi
 
 /**
- * Loads the artwork used by NetEase Cloud Music's discovery-page circular entries.
+ * Loads artwork from NetEase Cloud Music's mobile discovery homepage.
  * The core provider stays responsible for the actual feature content; this wrapper
  * only primes presentation metadata before NetEase feature sections are shown.
  */
@@ -65,32 +68,32 @@ internal class NeteaseHomeEntryClient(
     }
 
     private suspend fun fetchCovers(cookie: String?): Map<String, String> {
+        // The discovery homepage itself is a WeAPI endpoint. Besides the circular
+        // shortcut block, it also carries artwork for new releases, styles, video
+        // recommendations and charts, which gives the Explore entries useful
+        // server-provided artwork even when a dedicated dragon-ball icon is absent.
+        val payload = NeteaseWeApi.encrypt("""{"refresh":false}""")
         val response = http.postForm(
             providerId = NETEASE_PROVIDER_ID,
-            url = "$NETEASE_BASE/api/homepage/dragon/ball/static",
-            form = Parameters.build {},
+            url = "$NETEASE_BASE/weapi/homepage/block/page",
+            form = Parameters.build {
+                append("params", payload.params)
+                append("encSecKey", payload.encSecKey)
+            },
             headers = buildMap {
                 put("Referer", "$NETEASE_BASE/")
                 put("Origin", NETEASE_BASE)
                 put("User-Agent", NETEASE_HOME_USER_AGENT)
-                cookie?.takeIf { it.isNotBlank() }?.let { put("Cookie", it) }
+                put("Cookie", neteaseHomepageCookie(cookie))
             },
-            cacheKey = "netease:homepage:dragon-ball",
+            cacheKey = "netease:homepage:block-page",
             cachePolicy = ProviderCachePolicies.recommendation,
         )
         val root = providerJson.parseToJsonElement(response.value).asObject()
-        val entries = root.array("data").mapNotNull { element ->
-            val item = runCatching { element.asObject() }.getOrNull() ?: return@mapNotNull null
-            val iconUrl = item.stringOrNull("iconUrl")
-                ?: item.stringOrNull("iconUrl2")
-                ?: return@mapNotNull null
-            NeteaseHomeEntry(
-                name = item.string("name"),
-                iconUrl = iconUrl,
-                url = item.string("url"),
-            )
+        val blocks = root.obj("data")?.array("blocks").orEmpty().mapNotNull { element ->
+            runCatching { element.asObject() }.getOrNull()
         }
-        return mapNeteaseHomeEntryCovers(entries)
+        return mapNeteaseHomepageCovers(blocks)
     }
 }
 
@@ -99,6 +102,26 @@ internal data class NeteaseHomeEntry(
     val iconUrl: String,
     val url: String = "",
 )
+
+internal fun mapNeteaseHomepageCovers(blocks: List<JsonObject>): Map<String, String> {
+    val entries = blocks
+        .filter { block -> block.string("blockCode") == NETEASE_DRAGON_BALL_BLOCK }
+        .flatMap(::neteaseHomepageResources)
+        .mapNotNull { resource ->
+            val iconUrl = neteaseUiImageUrl(resource) ?: return@mapNotNull null
+            val title = resource.obj("uiElement")?.obj("mainTitle")?.string("title").orEmpty()
+            if (title.isBlank()) return@mapNotNull null
+            NeteaseHomeEntry(
+                name = title,
+                iconUrl = iconUrl,
+                url = resource.string("action"),
+            )
+        }
+
+    // Block artwork is a fallback for Explore features that are not represented by
+    // a circular shortcut. Exact shortcut icons win when both are available.
+    return mapNeteaseHomepageBlockCovers(blocks) + mapNeteaseHomeEntryCovers(entries)
+}
 
 internal fun mapNeteaseHomeEntryCovers(entries: List<NeteaseHomeEntry>): Map<String, String> = buildMap {
     NETEASE_HOME_ENTRY_ALIASES.forEach { (featureId, aliases) ->
@@ -117,6 +140,53 @@ internal fun neteaseFeatureBaseId(featureId: String): String =
 private fun publishNeteaseHomeEntryCovers(covers: Map<String, String>) {
     neteaseHomeEntryCovers = neteaseHomeEntryCovers + covers
 }
+
+private fun mapNeteaseHomepageBlockCovers(blocks: List<JsonObject>): Map<String, String> = buildMap {
+    NETEASE_HOME_BLOCK_ALIASES.forEach { (featureId, blockCodes) ->
+        findNeteaseHomepageBlockCover(blocks, blockCodes)?.let { coverUrl ->
+            put(featureId, coverUrl)
+        }
+    }
+}
+
+private fun findNeteaseHomepageBlockCover(
+    blocks: List<JsonObject>,
+    blockCodes: List<String>,
+): String? {
+    blockCodes.forEach { code ->
+        blocks.firstOrNull { it.string("blockCode") == code }
+            ?.let(::firstNeteaseHomepageImage)
+            ?.takeIf(String::isNotBlank)
+            ?.let { return it }
+    }
+    return null
+}
+
+private fun firstNeteaseHomepageImage(block: JsonObject): String? {
+    neteaseUiImageUrl(block)?.let { return it }
+    block.array("creatives").forEach { creativeElement ->
+        val creative = runCatching { creativeElement.asObject() }.getOrNull() ?: return@forEach
+        neteaseUiImageUrl(creative)?.let { return it }
+        creative.array("resources").forEach { resourceElement ->
+            val resource = runCatching { resourceElement.asObject() }.getOrNull() ?: return@forEach
+            neteaseUiImageUrl(resource)?.let { return it }
+        }
+    }
+    return null
+}
+
+private fun neteaseHomepageResources(block: JsonObject): List<JsonObject> =
+    block.array("creatives").flatMap { creativeElement ->
+        val creative = runCatching { creativeElement.asObject() }.getOrNull() ?: return@flatMap emptyList()
+        creative.array("resources").mapNotNull { resourceElement ->
+            runCatching { resourceElement.asObject() }.getOrNull()
+        }
+    }
+
+private fun neteaseUiImageUrl(value: JsonObject): String? =
+    value.obj("uiElement")
+        ?.obj("image")
+        ?.let { image -> image.stringOrNull("imageUrl") ?: image.stringOrNull("imageUrl2") }
 
 private fun findNeteaseHomeEntryCover(
     entries: List<NeteaseHomeEntry>,
@@ -138,6 +208,24 @@ private fun findNeteaseHomeEntryCover(
             ?.let { return it }
     }
     return null
+}
+
+private fun neteaseHomepageCookie(cookie: String?): String {
+    val values = cookie.orEmpty()
+        .split(';')
+        .map(String::trim)
+        .filter(String::isNotBlank)
+        .filterNot { item ->
+            val key = item.substringBefore('=').trim()
+            key.equals("appver", ignoreCase = true) ||
+                key.equals("os", ignoreCase = true) ||
+                key.equals("__remember_me", ignoreCase = true)
+        }
+        .toMutableList()
+    values += "__remember_me=true"
+    values += "appver=8.10.90"
+    values += "os=ios"
+    return values.joinToString("; ")
 }
 
 private fun normalizeNeteaseHomeEntryName(value: String): String =
@@ -166,7 +254,22 @@ private val NETEASE_HOME_ENTRY_ALIASES = mapOf(
     "netease_top_mvs" to listOf("MV排行", "MV", "排行榜"),
 )
 
+private val NETEASE_HOME_BLOCK_ALIASES = mapOf(
+    "netease_recommended_new_songs" to listOf("HOMEPAGE_BLOCK_NEW_ALBUM_NEW_SONG"),
+    "netease_new_songs" to listOf("HOMEPAGE_BLOCK_NEW_ALBUM_NEW_SONG"),
+    "netease_new_albums" to listOf("HOMEPAGE_BLOCK_NEW_ALBUM_NEW_SONG"),
+    "netease_styles" to listOf("HOMEPAGE_BLOCK_STYLE_RCMD", "HOMEPAGE_BLOCK_OFFICIAL_PLAYLIST"),
+    "netease_mv_square" to listOf("HOMEPAGE_MUSIC_MLOG", "HOMEPAGE_BLOCK_VIDEO_PLAYLIST"),
+    "netease_recommended_mvs" to listOf("HOMEPAGE_MUSIC_MLOG", "HOMEPAGE_BLOCK_VIDEO_PLAYLIST"),
+    "netease_top_mvs" to listOf("HOMEPAGE_BLOCK_VIDEO_PLAYLIST", "HOMEPAGE_MUSIC_MLOG", "HOMEPAGE_BLOCK_TOPLIST"),
+    "netease_toplists" to listOf("HOMEPAGE_BLOCK_TOPLIST"),
+    "netease_playlist_square" to listOf("HOMEPAGE_BLOCK_PLAYLIST_RCMD"),
+    "netease_daily_playlists" to listOf("HOMEPAGE_BLOCK_PLAYLIST_RCMD"),
+    "netease_highquality_playlists" to listOf("HOMEPAGE_BLOCK_PLAYLIST_RCMD"),
+)
+
+private const val NETEASE_DRAGON_BALL_BLOCK = "HOMEPAGE_BLOCK_OLD_DRAGON_BALL"
 private const val NETEASE_PROVIDER_ID = "netease"
 private const val NETEASE_BASE = "https://music.163.com"
 private const val NETEASE_HOME_USER_AGENT =
-    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_2 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148"

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/NeteaseHomeEntryRepositoryTest.kt
@@ -3,6 +3,10 @@ package org.feeluown.mobile
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.providerJson
 
 class NeteaseHomeEntryRepositoryTest {
     @Test
@@ -22,6 +26,86 @@ class NeteaseHomeEntryRepositoryTest {
         assertEquals("style.png", covers["netease_styles"])
         assertEquals("mv.png", covers["netease_mv_square"])
         assertEquals("mv.png", covers["netease_top_mvs"])
+    }
+
+    @Test
+    fun mapsHomepageBlockArtworkToExploreFeatures() {
+        val root = providerJson.parseToJsonElement(
+            """
+            {
+              "data": {
+                "blocks": [
+                  {
+                    "blockCode": "HOMEPAGE_BLOCK_OLD_DRAGON_BALL",
+                    "creatives": [
+                      {
+                        "resources": [
+                          {
+                            "action": "orpheus://songrcmd",
+                            "uiElement": {
+                              "mainTitle": {"title": "每日推荐"},
+                              "image": {"imageUrl": "daily.png"}
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "blockCode": "HOMEPAGE_BLOCK_NEW_ALBUM_NEW_SONG",
+                    "creatives": [
+                      {
+                        "resources": [
+                          {"uiElement": {"image": {"imageUrl": "new.jpg"}}}
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "blockCode": "HOMEPAGE_BLOCK_STYLE_RCMD",
+                    "creatives": [
+                      {
+                        "resources": [
+                          {"uiElement": {"image": {"imageUrl": "style.jpg"}}}
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "blockCode": "HOMEPAGE_MUSIC_MLOG",
+                    "creatives": [
+                      {
+                        "resources": [
+                          {"uiElement": {"image": {"imageUrl": "video.jpg"}}}
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "blockCode": "HOMEPAGE_BLOCK_TOPLIST",
+                    "creatives": [
+                      {
+                        "resources": [
+                          {"uiElement": {"image": {"imageUrl": "rank.jpg"}}}
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.trimIndent(),
+        ).asObject()
+        val blocks = root.obj("data")!!.array("blocks").map { it.asObject() }
+
+        val covers = mapNeteaseHomepageCovers(blocks)
+
+        assertEquals("daily.png", covers["netease_daily_songs"])
+        assertEquals("new.jpg", covers["netease_new_songs"])
+        assertEquals("style.jpg", covers["netease_styles"])
+        assertEquals("video.jpg", covers["netease_mv_square"])
+        assertEquals("video.jpg", covers["netease_top_mvs"])
+        assertEquals("rank.jpg", covers["netease_toplists"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace the ineffective plain `/api/homepage/dragon/ball/static` call with the actual mobile homepage WeAPI request
- parse `HOMEPAGE_BLOCK_OLD_DRAGON_BALL` shortcut artwork from `uiElement.image.imageUrl`
- reuse artwork from relevant homepage blocks for Explore entries that have no circular shortcut, including new releases, styles, MV/video and toplists
- preserve returned shortcut icons as the highest-priority artwork
- add coverage for homepage block parsing and feature mapping

## Root cause
The previous implementation posted directly to `/api/homepage/dragon/ball/static`. NetEase's dragon-ball endpoint is an encrypted mobile endpoint and may also return an empty list without login/guest auth. The homepage block endpoint is a WeAPI endpoint and already contains the shortcut/resource images needed here, so this uses the protocol FuoEvolve already supports.