### PR TITLE
feat: expand QQ Music mine library

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/QQMusicContentRepository.kt
@@ -18,12 +18,13 @@ internal class QQMusicContentRepository(
     override suspend fun features(): List<ProviderFeature> {
         val base = delegate.features()
         if (base.none { it.providerId == QQMUSIC_PROVIDER_ID }) return base
+        val qqFeatures = (qqmusic.features + QQMUSIC_MINE_FEATURES).distinctBy { it.id }
         return buildList {
             var inserted = false
             base.forEach { feature ->
                 if (feature.providerId == QQMUSIC_PROVIDER_ID) {
                     if (!inserted) {
-                        addAll(qqmusic.features)
+                        addAll(qqFeatures)
                         inserted = true
                     }
                 } else {
@@ -86,12 +87,19 @@ internal class QQMusicContentRepository(
         offset: Int,
         limit: Int,
     ): ProviderContentSection = if (feature.providerId == QQMUSIC_PROVIDER_ID) {
-        val section = if (ProviderFeatureFilterCodec.requestId(feature.id) == QQMUSIC_USER_PLAYLISTS_FEATURE_ID) {
+        val featureId = ProviderFeatureFilterCodec.requestId(feature.id)
+        val section = if (featureId in QQMUSIC_USER_LIBRARY_FEATURE_IDS) {
             val auth = delegate.authState(QQMUSIC_PROVIDER_ID)
             if (!auth.isLoggedIn) {
                 ProviderContentSection(feature = feature, isLoginRequired = true)
             } else {
-                userLibrary.loadPlaylists(feature, offset, limit)
+                when (featureId) {
+                    QQMUSIC_USER_PLAYLISTS_FEATURE_ID -> userLibrary.loadPlaylists(feature, offset, limit)
+                    QQMUSIC_FAVORITE_PLAYLISTS_FEATURE_ID -> userLibrary.loadFavoritePlaylists(feature, offset, limit)
+                    QQMUSIC_FOLLOWED_ARTISTS_FEATURE_ID -> userLibrary.loadFollowedArtists(feature, offset, limit)
+                    QQMUSIC_FAVORITE_ALBUMS_FEATURE_ID -> userLibrary.loadFavoriteAlbums(feature, offset, limit)
+                    else -> ProviderContentSection(feature = feature)
+                }
             }
         } else {
             qqmusic.loadFeature(feature, offset, limit)
@@ -205,6 +213,46 @@ internal class QQMusicContentRepository(
     private companion object {
         const val QQMUSIC_PROVIDER_ID = "qqmusic"
         const val QQMUSIC_USER_PLAYLISTS_FEATURE_ID = "qqmusic_user_playlists"
+        const val QQMUSIC_FAVORITE_PLAYLISTS_FEATURE_ID = "qqmusic_favorite_playlists"
+        const val QQMUSIC_FOLLOWED_ARTISTS_FEATURE_ID = "qqmusic_followed_artists"
+        const val QQMUSIC_FAVORITE_ALBUMS_FEATURE_ID = "qqmusic_favorite_albums"
         const val MAX_ARTIST_TRACKS = 300
+
+        val QQMUSIC_USER_LIBRARY_FEATURE_IDS = setOf(
+            QQMUSIC_USER_PLAYLISTS_FEATURE_ID,
+            QQMUSIC_FAVORITE_PLAYLISTS_FEATURE_ID,
+            QQMUSIC_FOLLOWED_ARTISTS_FEATURE_ID,
+            QQMUSIC_FAVORITE_ALBUMS_FEATURE_ID,
+        )
+
+        val QQMUSIC_MINE_FEATURES = listOf(
+            ProviderFeature(
+                QQMUSIC_FAVORITE_PLAYLISTS_FEATURE_ID,
+                QQMUSIC_PROVIDER_ID,
+                "QQ 音乐",
+                "收藏歌单",
+                ProviderFeatureCategory.MineFavoritePlaylists,
+                ProviderContentType.Playlists,
+                true,
+            ),
+            ProviderFeature(
+                QQMUSIC_FOLLOWED_ARTISTS_FEATURE_ID,
+                QQMUSIC_PROVIDER_ID,
+                "QQ 音乐",
+                "关注歌手",
+                ProviderFeatureCategory.Mine,
+                ProviderContentType.Artists,
+                true,
+            ),
+            ProviderFeature(
+                QQMUSIC_FAVORITE_ALBUMS_FEATURE_ID,
+                QQMUSIC_PROVIDER_ID,
+                "QQ 音乐",
+                "收藏专辑",
+                ProviderFeatureCategory.Mine,
+                ProviderContentType.Albums,
+                true,
+            ),
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -1,15 +1,22 @@
 package org.feeluown.mobile.provider.qqmusic
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.feeluown.mobile.ProviderContentSection
 import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemType
 import org.feeluown.mobile.ProviderPlaylist
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.array
 import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.boolean
 import org.feeluown.mobile.provider.core.cookieHeader
 import org.feeluown.mobile.provider.core.int
 import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.md5Hex
+import org.feeluown.mobile.provider.core.mediaItemKey
 import org.feeluown.mobile.provider.core.obj
 import org.feeluown.mobile.provider.core.parseCookies
 import org.feeluown.mobile.provider.core.playlistKey
@@ -17,14 +24,16 @@ import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.string
 import org.feeluown.mobile.provider.core.stringOrNull
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+import kotlin.random.Random
 
 /**
- * Reads the QQ Music account profile and user-created playlists.
+ * Reads the QQ Music account profile and Mine library content.
  *
- * QQ Music's profile-homepage endpoint is the primary source. It can return
- * the nickname, "我喜欢" and created playlists together and does not require
- * the legacy `hostuin` parameter. The older user-created-playlist endpoint is
- * retained only as a fallback for an unambiguously numeric QQ number.
+ * The profile-homepage endpoint remains the primary source for the nickname,
+ * "我喜欢" and created playlists. Favorite playlists/albums and followed singers
+ * are loaded from QQ Music's current musicu services using the encrypted UIN from
+ * the account profile (or the credential when it is already available).
  */
 internal class QQMusicUserLibrary(
     private val http: ProviderHttpClient,
@@ -50,6 +59,111 @@ internal class QQMusicUserLibrary(
             nextOffset = offset + page.size,
             hasMore = snapshot.playlists.size > offset + page.size,
         )
+    }
+
+    suspend fun loadFavoritePlaylists(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection = runCatching {
+        val euin = encryptedUin()
+        val root = rpc(
+            """
+            {"favoritePlaylists":{"module":"music.musicasset.PlaylistFavRead","method":"CgiGetPlaylistFavInfo","param":{"uin":${jsonString(euin)},"offset":$offset,"size":$limit}}}
+            """.trimIndent(),
+        )
+        val data = rpcData(root, "favoritePlaylists")
+        val rawValues = firstNonEmpty(
+            data.array("v_list"),
+            data.array("v_playlist"),
+            data.array("list"),
+        )
+        val playlists = rawValues.mapNotNull { value ->
+            runCatching { playlistFromFavorite(value.asObject()) }.getOrNull()
+        }.distinctBy { it.id }
+        val total = data.int("total")
+        val nextOffset = offset + rawValues.size
+        ProviderContentSection(
+            feature = feature,
+            playlists = playlists,
+            nextOffset = nextOffset,
+            hasMore = data.int("hasmore")?.let { it != 0 }
+                ?: total?.let { nextOffset < it }
+                ?: (rawValues.size >= limit),
+        )
+    }.getOrElse {
+        ProviderContentSection(feature = feature, errorMessage = "QQ 音乐收藏歌单加载失败")
+    }
+
+    suspend fun loadFollowedArtists(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection = runCatching {
+        val euin = encryptedUin()
+        val root = rpc(
+            """
+            {"followedArtists":{"module":"music.concern.RelationList","method":"GetFollowSingerList","param":{"HostUin":${jsonString(euin)},"From":$offset,"Size":$limit}}}
+            """.trimIndent(),
+        )
+        val data = rpcData(root, "followedArtists")
+        val rawValues = firstNonEmpty(
+            data.array("List"),
+            data.array("list"),
+            data.array("singerList"),
+        )
+        val artists = rawValues.mapNotNull { value ->
+            runCatching { artistFromFollow(value.asObject()) }.getOrNull()
+        }.distinctBy { it.id }
+        val total = data.int("Total") ?: data.int("total")
+        val nextOffset = offset + rawValues.size
+        ProviderContentSection(
+            feature = feature,
+            mediaItems = artists,
+            nextOffset = nextOffset,
+            hasMore = when {
+                data.containsKey("HasMore") -> data.boolean("HasMore")
+                data.containsKey("hasMore") -> data.boolean("hasMore")
+                total != null -> nextOffset < total
+                else -> rawValues.size >= limit
+            },
+        )
+    }.getOrElse {
+        ProviderContentSection(feature = feature, errorMessage = "QQ 音乐关注歌手加载失败")
+    }
+
+    suspend fun loadFavoriteAlbums(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection = runCatching {
+        val euin = encryptedUin()
+        val root = rpc(
+            """
+            {"favoriteAlbums":{"module":"music.musicasset.AlbumFavRead","method":"CgiGetAlbumFavInfo","param":{"euin":${jsonString(euin)},"offset":$offset,"size":$limit}}}
+            """.trimIndent(),
+        )
+        val data = rpcData(root, "favoriteAlbums")
+        val rawValues = firstNonEmpty(
+            data.array("v_list"),
+            data.array("v_album"),
+            data.array("list"),
+        )
+        val albums = rawValues.mapNotNull { value ->
+            runCatching { albumFromFavorite(value.asObject()) }.getOrNull()
+        }.distinctBy { it.id }
+        val total = data.int("total")
+        val nextOffset = offset + rawValues.size
+        ProviderContentSection(
+            feature = feature,
+            mediaItems = albums,
+            nextOffset = nextOffset,
+            hasMore = data.int("hasmore")?.let { it != 0 }
+                ?: total?.let { nextOffset < it }
+                ?: (rawValues.size >= limit),
+        )
+    }.getOrElse {
+        ProviderContentSection(feature = feature, errorMessage = "QQ 音乐收藏专辑加载失败")
     }
 
     private suspend fun snapshot(): QQMusicUserLibrarySnapshot {
@@ -96,6 +210,20 @@ internal class QQMusicUserLibrary(
         throw lastFailure ?: IllegalStateException("QQ Music profile is unavailable")
     }
 
+    private suspend fun encryptedUin(): String {
+        currentEncryptedUin()?.let { return it }
+        val accountIds = currentAccountIds()
+        if (accountIds.isEmpty()) error("QQ Music account id is unavailable")
+        var lastFailure: Throwable? = null
+        accountIds.forEach { accountId ->
+            val profile = runCatching { profileHome(accountId) }
+                .onFailure { lastFailure = it }
+                .getOrNull()
+            profile?.encryptedUin?.takeIf(String::isNotBlank)?.let { return it }
+        }
+        throw lastFailure ?: IllegalStateException("QQ Music encrypted uin is unavailable")
+    }
+
     private suspend fun profileHome(accountId: String): ProfileHomeResult {
         val root = http.getText(
             providerId = ID,
@@ -138,6 +266,14 @@ internal class QQMusicUserLibrary(
             ?: data.stringOrNull("hostname")
             ?: data.stringOrNull("nickname")
             ?: data.stringOrNull("nick")
+        val encryptedUin = creator?.stringOrNull("encrypt_uin")
+            ?: creator?.stringOrNull("encryptUin")
+            ?: creator?.stringOrNull("encuin")
+            ?: creator?.stringOrNull("euin")
+            ?: data.stringOrNull("encrypt_uin")
+            ?: data.stringOrNull("encryptUin")
+            ?: data.stringOrNull("encuin")
+            ?: data.stringOrNull("euin")
 
         val favoriteValues = data.array("mymusic")
         val createdValues = firstNonEmpty(
@@ -181,6 +317,7 @@ internal class QQMusicUserLibrary(
 
         return ProfileHomeResult(
             userName = userName?.takeIf { it.isNotBlank() },
+            encryptedUin = encryptedUin?.takeIf { it.isNotBlank() },
             playlists = playlists,
             hasPlaylistPayload = hasPlaylistPayload,
         )
@@ -283,9 +420,99 @@ internal class QQMusicUserLibrary(
         )
     }
 
+    private fun playlistFromFavorite(item: JsonObject): ProviderPlaylist? {
+        val identifier = item.string("tid")
+            .ifBlank { item.string("dissid") }
+            .ifBlank { item.string("id") }
+            .takeIf(String::isNotBlank)
+            ?: return null
+        return ProviderPlaylist(
+            id = playlistKey(ID, identifier),
+            title = item.string("title")
+                .ifBlank { item.string("dissname") }
+                .ifBlank { item.string("name") }
+                .ifBlank { "未命名歌单" },
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("picurl")
+                ?: item.stringOrNull("picUrl")
+                ?: item.stringOrNull("cover")
+                ?: item.stringOrNull("logo")
+                ?: item.stringOrNull("albumPicUrl"),
+            description = item.string("desc").ifBlank { item.string("nickname") },
+            playCount = item.long("play_cnt")
+                ?: item.long("listennum")
+                ?: item.long("listen_num"),
+            trackCount = item.int("songnum")
+                ?: item.int("songNum")
+                ?: item.int("song_cnt"),
+            providerUrl = "https://y.qq.com/n/ryqq/playlist/$identifier",
+        )
+    }
+
+    private fun artistFromFollow(item: JsonObject): ProviderMediaItem? {
+        val identifier = item.string("MID")
+            .ifBlank { item.string("mid") }
+            .ifBlank { item.string("SingerMid") }
+            .ifBlank { item.string("singerMid") }
+            .takeIf(String::isNotBlank)
+            ?: return null
+        return ProviderMediaItem(
+            id = mediaItemKey(ProviderMediaItemType.Artist, ID, identifier),
+            title = item.string("Name")
+                .ifBlank { item.string("name") }
+                .ifBlank { item.string("SingerName") },
+            providerId = ID,
+            providerName = NAME,
+            type = ProviderMediaItemType.Artist,
+            coverUrl = item.stringOrNull("AvatarUrl")
+                ?: item.stringOrNull("avatarUrl")
+                ?: item.stringOrNull("picUrl")
+                ?: artistCover(identifier),
+            description = item.string("Desc").ifBlank { item.string("desc") },
+            providerUrl = "https://y.qq.com/n/ryqq/singer/$identifier",
+        )
+    }
+
+    private fun albumFromFavorite(item: JsonObject): ProviderMediaItem? {
+        val albumId = item.string("id")
+            .ifBlank { item.string("albumID") }
+            .ifBlank { item.string("albumId") }
+        val mid = item.string("mid")
+            .ifBlank { item.string("albumMid") }
+            .ifBlank { item.string("albumMID") }
+            .ifBlank { item.string("pmid") }
+        val identifier = albumId.ifBlank { mid }.takeIf(String::isNotBlank) ?: return null
+        val artists = firstNonEmpty(item.array("v_singer"), item.array("singer"))
+            .map { value ->
+                val singer = value.asObject()
+                singer.string("name").ifBlank { singer.string("singerName") }
+            }
+            .filter(String::isNotBlank)
+            .joinToString(" / ")
+        return ProviderMediaItem(
+            id = mediaItemKey(ProviderMediaItemType.Album, ID, identifier),
+            title = item.string("name")
+                .ifBlank { item.string("albumName") }
+                .ifBlank { item.string("title") },
+            providerId = ID,
+            providerName = NAME,
+            type = ProviderMediaItemType.Album,
+            coverUrl = item.stringOrNull("picurl")
+                ?: item.stringOrNull("picUrl")
+                ?: item.stringOrNull("logo")
+                ?: mid.takeIf(String::isNotBlank)?.let(::albumCover),
+            description = artists,
+            providerUrl = "https://y.qq.com/n/ryqq/albumDetail/$identifier",
+            trackCount = item.int("songnum")
+                ?: item.int("songNum")
+                ?: item.int("song_count"),
+        )
+    }
+
     private suspend fun currentAccountIds(): List<String> {
-        val stored = credentials.read(ID) ?: return emptyList()
-        val values = parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
+        val values = qqCookies()
+        if (values.isEmpty()) return emptyList()
         val loginType = values["login_type"]?.toIntOrNull()
         val isWechat = loginType == WECHAT_LOGIN_TYPE ||
             !values["wxopenid"].isNullOrBlank() ||
@@ -296,6 +523,19 @@ internal class QQMusicUserLibrary(
             listOf("uin", "str_musicid", "musicid", "wxuin")
         }
         return keys.mapNotNull { key -> normalizeAccountId(values[key]) }.distinct()
+    }
+
+    private suspend fun currentEncryptedUin(): String? {
+        val values = qqCookies()
+        return listOf("encryptUin", "encrypt_uin", "encuin", "euin")
+            .asSequence()
+            .mapNotNull { key -> values[key]?.trim()?.takeIf(String::isNotBlank) }
+            .firstOrNull()
+    }
+
+    private suspend fun qqCookies(): Map<String, String> {
+        val stored = credentials.read(ID) ?: return emptyMap()
+        return parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
     }
 
     private fun normalizeAccountId(raw: String?): String? {
@@ -310,6 +550,71 @@ internal class QQMusicUserLibrary(
 
     private fun isLikelyQqNumber(value: String): Boolean =
         value.length in MIN_QQ_UIN_LENGTH..MAX_QQ_UIN_LENGTH && value.all(Char::isDigit)
+
+    private suspend fun rpc(payload: String): JsonObject {
+        val request = qqRpcPayload(payload)
+        return http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$RPC_BASE/cgi-bin/musicu.fcg",
+                mapOf(
+                    "_" to currentTimeMillis().toString(),
+                    "sign" to contentSign(request),
+                    "data" to request,
+                ),
+            ),
+            headers = authenticatedHeaders("https://y.qq.com/"),
+            cacheKey = null,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+    }
+
+    private suspend fun qqRpcPayload(payload: String): String {
+        val root = providerJson.parseToJsonElement(payload).jsonObject
+        val values = qqCookies()
+        val uin = values["wxuin"]?.removePrefix("o")?.takeIf(String::isNotBlank)
+            ?: values["uin"]?.removePrefix("o")?.takeIf(String::isNotBlank)
+            ?: values["str_musicid"]?.takeIf(String::isNotBlank)
+            ?: values["musicid"]?.takeIf(String::isNotBlank)
+            ?: "0"
+        val tokenSource = listOf("qqmusic_key", "p_skey", "skey", "p_lskey", "lskey")
+            .asSequence()
+            .mapNotNull { values[it] }
+            .firstOrNull()
+            .orEmpty()
+        val token = if (tokenSource.isBlank()) {
+            5_381L
+        } else {
+            var hash = 5_381L
+            tokenSource.forEach { character ->
+                hash = (hash * 33 + character.code) and 0xffff_ffffL
+            }
+            hash and 0x7fff_ffffL
+        }
+        val common = mapOf(
+            "loginUin" to JsonPrimitive(uin),
+            "hostUin" to JsonPrimitive(0),
+            "g_tk" to JsonPrimitive(token),
+            "inCharset" to JsonPrimitive("utf8"),
+            "outCharset" to JsonPrimitive("utf-8"),
+            "notice" to JsonPrimitive(0),
+            "platform" to JsonPrimitive("yqq"),
+            "needNewCode" to JsonPrimitive(0),
+        )
+        val mergedComm = JsonObject(common + (root.obj("comm") ?: emptyMap()))
+        return providerJson.encodeToString(
+            JsonObject.serializer(),
+            JsonObject(root + ("comm" to mergedComm)),
+        )
+    }
+
+    private fun rpcData(root: JsonObject, key: String): JsonObject {
+        val envelope = root.obj(key) ?: root
+        val code = envelope.int("code")
+        if (code != null && code != 0) {
+            error(envelope.errorMessage().ifBlank { "QQ Music request failed (code=$code)" })
+        }
+        return envelope.obj("data") ?: envelope
+    }
 
     private suspend fun authenticatedHeaders(referer: String): Map<String, String> = buildMap {
         put("User-Agent", DEFAULT_USER_AGENT)
@@ -342,6 +647,24 @@ internal class QQMusicUserLibrary(
         }
     }
 
+    private fun jsonString(value: String): String =
+        "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+
+    private fun contentSign(data: String): String {
+        val randomPart = buildString {
+            repeat(Random.nextInt(10, 17)) {
+                append(CONTENT_SIGN_ALPHABET[Random.nextInt(CONTENT_SIGN_ALPHABET.length)])
+            }
+        }
+        return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}" 
+    }
+
+    private fun albumCover(mid: String): String =
+        "https://y.gtimg.cn/music/photo_new/T002R300x300M000$mid.jpg"
+
+    private fun artistCover(mid: String): String =
+        "https://y.gtimg.cn/music/photo_new/T001R300x300M000$mid.jpg"
+
     private fun firstNonEmpty(vararg values: List<kotlinx.serialization.json.JsonElement>): List<kotlinx.serialization.json.JsonElement> =
         values.firstOrNull { it.isNotEmpty() }.orEmpty()
 
@@ -357,10 +680,12 @@ internal class QQMusicUserLibrary(
 
     private data class ProfileHomeResult(
         val userName: String? = null,
+        val encryptedUin: String? = null,
         val playlists: List<ProviderPlaylist> = emptyList(),
         val hasPlaylistPayload: Boolean = false,
     ) {
-        fun isMeaningful(): Boolean = userName != null || playlists.isNotEmpty() || hasPlaylistPayload
+        fun isMeaningful(): Boolean =
+            userName != null || encryptedUin != null || playlists.isNotEmpty() || hasPlaylistPayload
     }
 
     private companion object {
@@ -368,12 +693,14 @@ internal class QQMusicUserLibrary(
         const val NAME = "QQ 音乐"
         const val BASE = "https://c.y.qq.com"
         const val PROFILE_BASE = "https://c6.y.qq.com"
+        const val RPC_BASE = "https://u.y.qq.com"
         const val FAVORITE_DIR_ID = 201
         const val PRIVATE_PLAYLIST_CODE = 4000
         const val WECHAT_LOGIN_TYPE = 2
         const val MIN_QQ_UIN_LENGTH = 5
         const val MAX_QQ_UIN_LENGTH = 12
         const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
+        const val CONTENT_SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
     }
 }
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicUserLibraryTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertTrue
 import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
 import org.feeluown.mobile.provider.core.ProviderCredentials
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.qqmusic.QQMusicArtistDetailProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicContentProvider
 import org.feeluown.mobile.provider.qqmusic.QQMusicUserLibrary
 
@@ -52,7 +53,12 @@ class QQMusicUserLibraryTest {
         val delegate = KotlinProviderRepository(http, credentials)
         val content = QQMusicContentProvider(http, credentials)
         val userLibrary = QQMusicUserLibrary(http, credentials)
-        val repository = QQMusicContentRepository(delegate, content, userLibrary)
+        val repository = QQMusicContentRepository(
+            delegate,
+            content,
+            userLibrary,
+            QQMusicArtistDetailProvider(http, credentials),
+        )
         repository.updateEnabledProviders(setOf("qqmusic"))
 
         val auth = repository.loginWithCookies(
@@ -70,6 +76,158 @@ class QQMusicUserLibraryTest {
         assertEquals("playlist:qqmusic:created-tid", section.playlists[1].id)
         assertEquals(88, section.playlists[0].trackCount)
         assertEquals(2, profileRequests)
+        http.close()
+    }
+
+    @Test
+    fun mineLibraryAddsFavoritePlaylistsFollowedArtistsAndFavoriteAlbums() = runTest {
+        var profileRequests = 0
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/rsc/fcgi-bin/fcg_get_profile_homepage.fcg" -> {
+                                profileRequests += 1
+                                assertEquals("123456", request.url.parameters["userid"])
+                                respond(
+                                    """
+                                    {
+                                      "code":0,
+                                      "data":{
+                                        "creator":{
+                                          "nick":"测试用户",
+                                          "encrypt_uin":"encrypted-user"
+                                        },
+                                        "mymusic":[],
+                                        "mydiss":{"list":[]}
+                                      }
+                                    }
+                                    """.trimIndent(),
+                                )
+                            }
+                            "/cgi-bin/musicu.fcg" -> {
+                                assertEquals("u.y.qq.com", request.url.host)
+                                val data = request.url.parameters["data"].orEmpty()
+                                when {
+                                    data.contains("CgiGetPlaylistFavInfo") -> {
+                                        assertTrue(data.contains("encrypted-user"))
+                                        respond(
+                                            """
+                                            {
+                                              "favoritePlaylists":{
+                                                "code":0,
+                                                "data":{
+                                                  "total":1,
+                                                  "hasmore":0,
+                                                  "v_list":[
+                                                    {
+                                                      "tid":7001,
+                                                      "title":"收藏歌单",
+                                                      "picurl":"https://example.test/playlist.jpg",
+                                                      "songnum":31,
+                                                      "play_cnt":900
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                            """.trimIndent(),
+                                        )
+                                    }
+                                    data.contains("GetFollowSingerList") -> {
+                                        assertTrue(data.contains("encrypted-user"))
+                                        respond(
+                                            """
+                                            {
+                                              "followedArtists":{
+                                                "code":0,
+                                                "data":{
+                                                  "Total":1,
+                                                  "HasMore":false,
+                                                  "List":[
+                                                    {
+                                                      "MID":"artist-mid",
+                                                      "Name":"关注歌手",
+                                                      "Desc":"歌手简介",
+                                                      "AvatarUrl":"https://example.test/artist.jpg"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                            """.trimIndent(),
+                                        )
+                                    }
+                                    data.contains("CgiGetAlbumFavInfo") -> {
+                                        assertTrue(data.contains("encrypted-user"))
+                                        respond(
+                                            """
+                                            {
+                                              "favoriteAlbums":{
+                                                "code":0,
+                                                "data":{
+                                                  "total":1,
+                                                  "hasmore":0,
+                                                  "v_list":[
+                                                    {
+                                                      "id":9001,
+                                                      "mid":"album-mid",
+                                                      "name":"收藏专辑",
+                                                      "pmid":"album-mid",
+                                                      "songnum":12,
+                                                      "v_singer":[{"name":"专辑歌手"}]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                            """.trimIndent(),
+                                        )
+                                    }
+                                    else -> error("unexpected QQ Music RPC: $data")
+                                }
+                            }
+                            else -> error("unexpected request: ${request.url}")
+                        }
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            ProviderCredentials(cookies = mapOf("uin" to "123456", "qqmusic_key" to "test-key")),
+        )
+        val repository = QQMusicContentRepository(
+            KotlinProviderRepository(http, credentials),
+            QQMusicContentProvider(http, credentials),
+            QQMusicUserLibrary(http, credentials),
+            QQMusicArtistDetailProvider(http, credentials),
+        )
+        repository.updateEnabledProviders(setOf("qqmusic"))
+
+        val features = repository.features()
+        val playlistFeature = features.first { it.id == "qqmusic_favorite_playlists" }
+        val artistFeature = features.first { it.id == "qqmusic_followed_artists" }
+        val albumFeature = features.first { it.id == "qqmusic_favorite_albums" }
+        assertEquals(ProviderFeatureCategory.MineFavoritePlaylists, playlistFeature.category)
+        assertEquals(ProviderContentType.Artists, artistFeature.contentType)
+        assertEquals(ProviderContentType.Albums, albumFeature.contentType)
+
+        val playlists = repository.loadFeaturePage(playlistFeature, 0, 20)
+        val artists = repository.loadFeaturePage(artistFeature, 0, 20)
+        val albums = repository.loadFeaturePage(albumFeature, 0, 20)
+
+        assertEquals(listOf("收藏歌单"), playlists.playlists.map { it.title })
+        assertEquals("playlist:qqmusic:7001", playlists.playlists.single().id)
+        assertEquals(31, playlists.playlists.single().trackCount)
+        assertEquals(listOf("关注歌手"), artists.mediaItems.map { it.title })
+        assertEquals("artist:qqmusic:artist-mid", artists.mediaItems.single().id)
+        assertEquals(listOf("收藏专辑"), albums.mediaItems.map { it.title })
+        assertEquals("album:qqmusic:9001", albums.mediaItems.single().id)
+        assertEquals("专辑歌手", albums.mediaItems.single().description)
+        assertEquals(3, profileRequests)
         http.close()
     }
 


### PR DESCRIPTION
## Summary
- add QQ Music favorite playlists to the existing Mine playlist flow
- add QQ Music followed artists to the existing Mine artists flow
- add QQ Music favorite albums to the existing Mine albums flow
- resolve the encrypted QQ Music UIN from existing credentials or the profile homepage before loading account library data
- keep QQ-specific parsing and requests isolated in `QQMusicUserLibrary`

## Implementation
- expose three login-required QQ Music Mine features without adding new UI models
- use `music.musicasset.PlaylistFavRead/CgiGetPlaylistFavInfo` for favorite playlists
- use `music.concern.RelationList/GetFollowSingerList` for followed artists
- use `music.musicasset.AlbumFavRead/CgiGetAlbumFavInfo` for favorite albums
- normalize followed artists through the existing QQ artist-detail path
- preserve the existing profile-homepage and legacy created-playlist fallback behavior

## Validation
- added MockEngine coverage for feature categories, encrypted-UIN resolution, pagination payloads, and playlist/artist/album mapping
- updated the existing QQ user-library repository test to construct the current artist-detail decorator explicitly

## Scope
This PR only expands QQ Music content shown under Mine; discovery/recommendation and playback behavior are unchanged.