### PR TITLE
feat: support rich lyrics from QQ Music and NetEase

### DIFF
--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.android.kt
@@ -1,0 +1,26 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.Inflater
+
+internal actual fun qrcInflate(data: ByteArray): ByteArray? = runCatching {
+    val inflater = Inflater()
+    try {
+        inflater.setInput(data)
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(4 * 1024)
+        while (!inflater.finished()) {
+            val count = inflater.inflate(buffer)
+            if (count > 0) {
+                output.write(buffer, 0, count)
+            } else if (inflater.needsInput() || inflater.needsDictionary()) {
+                break
+            } else {
+                error("QQ QRC zlib stream made no progress")
+            }
+        }
+        output.toByteArray().takeIf { it.isNotEmpty() }
+    } finally {
+        inflater.end()
+    }
+}.getOrNull()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1753,15 +1753,22 @@ fun attachLyricTranslations(lines: List<LyricLine>, translationRaw: String?): Li
     if (translationLines.isEmpty()) return lines
     val byTime = translationLines
         .groupBy { it.timeMs }
-        .mapValues { (_, value) -> value.first().text }
+        .mapValues { (_, value) ->
+            value.flatMap { secondary ->
+                listOfNotNull(secondary.text, secondary.translation)
+            }
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .distinct()
+                .joinToString("\n")
+        }
     return lines.map { line ->
         if (line.timeMs == Long.MAX_VALUE || !line.translation.isNullOrBlank()) return@map line
         val exact = byTime[line.timeMs]
-        val nearest = translationLines
-            .minByOrNull { kotlin.math.abs(it.timeMs - line.timeMs) }
-            ?.takeIf { kotlin.math.abs(it.timeMs - line.timeMs) <= 50 }
-            ?.text
-        line.copy(translation = exact ?: nearest)
+        val nearestTime = byTime.keys
+            .minByOrNull { kotlin.math.abs(it - line.timeMs) }
+            ?.takeIf { kotlin.math.abs(it - line.timeMs) <= 50 }
+        line.copy(translation = exact ?: nearestTime?.let(byTime::get))
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
@@ -37,9 +37,9 @@ fun composeRichLyrics(
                 .filter(String::isNotBlank)
                 .filter { it != line.text.trim() }
                 .distinct()
-            if (values.isNotEmpty()) {
+            values.forEach { value ->
                 append(formatRichLrcTimestamp(line.timeMs))
-                append(values.joinToString(RICH_LYRIC_LINE_SEPARATOR))
+                append(value)
                 append('\n')
             }
         }
@@ -47,8 +47,6 @@ fun composeRichLyrics(
 
     return composeLyricsWithTranslation(primary, secondary.takeIf(String::isNotBlank))
 }
-
-internal const val RICH_LYRIC_LINE_SEPARATOR = "\u2028"
 
 private data class TimedRichText(val timeMs: Long, val text: String)
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
@@ -1,0 +1,116 @@
+package org.feeluown.mobile
+
+import kotlin.math.abs
+
+/**
+ * Composes provider lyric tracks into the app's existing lyric transport format.
+ * The main LRC/YRC/QRC-derived track keeps its timing. Translation,
+ * romanization and annotation tracks are aligned and rendered as secondary
+ * lines through the existing translation slot for backward-compatible styling.
+ */
+fun composeRichLyrics(
+    main: String,
+    translation: String? = null,
+    romanization: String? = null,
+    annotation: String? = null,
+): String {
+    val primary = main.trimEnd()
+    if (primary.isBlank()) return primary
+
+    val secondaryTracks = listOf(translation, romanization, annotation)
+        .mapNotNull { it?.trim()?.takeIf(String::isNotBlank) }
+    if (secondaryTracks.isEmpty()) return primary
+    if (secondaryTracks.size == 1) return composeLyricsWithTranslation(primary, secondaryTracks.first())
+
+    val primaryLines = parseTimedRichTrack(primary)
+    val parsedTracks = secondaryTracks.map(::parseTimedRichTrack).filter { it.isNotEmpty() }
+    if (primaryLines.isEmpty() || parsedTracks.isEmpty()) {
+        return composeLyricsWithTranslation(primary, secondaryTracks.first())
+    }
+
+    val secondary = buildString {
+        primaryLines.forEachIndexed { index, line ->
+            val values = parsedTracks.mapNotNull { track ->
+                alignedSecondaryText(track, line.timeMs, index, primaryLines.size)
+            }
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .filter { it != line.text.trim() }
+                .distinct()
+            if (values.isNotEmpty()) {
+                append(formatRichLrcTimestamp(line.timeMs))
+                append(values.joinToString(RICH_LYRIC_LINE_SEPARATOR))
+                append('\n')
+            }
+        }
+    }.trimEnd()
+
+    return composeLyricsWithTranslation(primary, secondary.takeIf(String::isNotBlank))
+}
+
+internal const val RICH_LYRIC_LINE_SEPARATOR = "\u2028"
+
+private data class TimedRichText(val timeMs: Long, val text: String)
+
+private fun parseTimedRichTrack(raw: String): List<TimedRichText> = buildList {
+    raw.lineSequence().forEach { originalLine ->
+        val line = originalLine.trim()
+        if (line.isBlank()) return@forEach
+
+        richWordLineRegex.matchEntire(line)?.let { match ->
+            val time = match.groupValues[1].toLongOrNull() ?: return@let
+            val text = match.groupValues[3].replace(richWordTimestampRegex, "").trim()
+            if (text.isNotBlank()) add(TimedRichText(time, text))
+            return@forEach
+        }
+
+        val timestamps = richLrcTimestampRegex.findAll(line).toList()
+        if (timestamps.isEmpty()) return@forEach
+        val text = line.replace(richLrcTimestampRegex, "").trim()
+        if (text.isBlank()) return@forEach
+        timestamps.forEach { timestamp ->
+            parseRichLrcTime(timestamp)?.let { time -> add(TimedRichText(time, text)) }
+        }
+    }
+}.sortedBy(TimedRichText::timeMs)
+
+private fun alignedSecondaryText(
+    track: List<TimedRichText>,
+    primaryTimeMs: Long,
+    primaryIndex: Int,
+    primarySize: Int,
+): String? {
+    val nearest = track.minByOrNull { abs(it.timeMs - primaryTimeMs) }
+    if (nearest != null && abs(nearest.timeMs - primaryTimeMs) <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS) {
+        return nearest.text
+    }
+    return track.getOrNull(primaryIndex)
+        ?.takeIf { track.size == primarySize && abs(it.timeMs - primaryTimeMs) <= RICH_LYRIC_INDEX_TOLERANCE_MS }
+        ?.text
+}
+
+private fun parseRichLrcTime(match: MatchResult): Long? {
+    val minutes = match.groupValues[1].toLongOrNull() ?: return null
+    val seconds = match.groupValues[2].toLongOrNull() ?: return null
+    val fraction = match.groupValues[3]
+        .takeIf(String::isNotBlank)
+        ?.padEnd(3, '0')
+        ?.take(3)
+        ?.toLongOrNull()
+        ?: 0L
+    return minutes * 60_000L + seconds * 1_000L + fraction
+}
+
+private fun formatRichLrcTimestamp(timeMs: Long): String {
+    val normalized = timeMs.coerceAtLeast(0L)
+    val minutes = normalized / 60_000L
+    val seconds = (normalized % 60_000L) / 1_000L
+    val millis = normalized % 1_000L
+    return "[${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}]"
+}
+
+private val richLrcTimestampRegex = Regex("""\[(\d{1,3}):(\d{1,2})(?:\.(\d{1,3}))?]""")
+private val richWordLineRegex = Regex("""^\[(\d+),(\d+)](.*)$""")
+private val richWordTimestampRegex = Regex("""\(\d+,\d+(?:,\d+)?\)""")
+private const val RICH_LYRIC_ALIGNMENT_TOLERANCE_MS = 350L
+private const val RICH_LYRIC_INDEX_TOLERANCE_MS = 1_500L

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
@@ -20,7 +20,7 @@ fun toTimedLineLrc(rawLyrics: String?): String? {
             append(line.text.trim())
             append('\n')
             line.translation
-                ?.split(RICH_LYRIC_LINE_SEPARATOR)
+                ?.lineSequence()
                 ?.map(String::trim)
                 ?.filter(String::isNotBlank)
                 ?.filter { it != line.text.trim() }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
@@ -20,11 +20,14 @@ fun toTimedLineLrc(rawLyrics: String?): String? {
             append(line.text.trim())
             append('\n')
             line.translation
-                ?.trim()
-                ?.takeIf { it.isNotBlank() && it != line.text.trim() }
-                ?.let { translation ->
+                ?.split(RICH_LYRIC_LINE_SEPARATOR)
+                ?.map(String::trim)
+                ?.filter(String::isNotBlank)
+                ?.filter { it != line.text.trim() }
+                ?.distinct()
+                ?.forEach { secondaryLine ->
                     append(timestamp)
-                    append(translation)
+                    append(secondaryLine)
                     append('\n')
                 }
         }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -25,6 +25,7 @@ import org.feeluown.mobile.ProviderPlaylistDetail
 import org.feeluown.mobile.ProviderSearchResults
 import org.feeluown.mobile.ProviderVideo
 import org.feeluown.mobile.VideoPlaybackPayload
+import org.feeluown.mobile.composeRichLyrics
 import org.feeluown.mobile.provider.core.BaseKotlinProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.ProviderCredentials
@@ -912,7 +913,34 @@ class NeteaseProvider(
         val hasMore: Boolean,
     )
 
-    private suspend fun lyric(identifier: String): String? = runCatching {
+    private suspend fun lyric(identifier: String): String? {
+        richLyric(identifier)?.let { return it }
+        return legacyLyric(identifier)
+    }
+
+    private suspend fun richLyric(identifier: String): String? = runCatching {
+        val root = http.postForm(
+            ID,
+            "$BASE/api/song/lyric/v1",
+            Parameters.build {
+                append("id", identifier)
+                append("cp", "false")
+                append("tv", "0")
+                append("lv", "0")
+                append("rv", "0")
+                append("kv", "0")
+                append("yv", "0")
+                append("ytv", "0")
+                append("yrv", "0")
+            },
+            neteaseAuthenticatedHeaders(),
+            cacheKey = "netease:lyric-v1-rich:$identifier",
+            cachePolicy = ProviderCachePolicies.lyric,
+        ).value.let { parseNeteaseResponse(it) }
+        composeNeteaseRichLyrics(root)
+    }.getOrNull()
+
+    private suspend fun legacyLyric(identifier: String): String? = runCatching {
         val root = http.getText(
             ID,
             queryUrl(
@@ -922,6 +950,7 @@ class NeteaseProvider(
                     "lv" to "-1",
                     "kv" to "-1",
                     "tv" to "-1",
+                    "rv" to "-1",
                     "yv" to "-1",
                 ),
             ),
@@ -929,16 +958,32 @@ class NeteaseProvider(
             cacheKey = "netease:lyric-yrc-tr:$identifier",
             cachePolicy = ProviderCachePolicies.lyric,
         ).value.let { parseNeteaseResponse(it) }
+        composeNeteaseRichLyrics(root)
+    }.getOrNull()
+
+    private fun composeNeteaseRichLyrics(root: JsonObject): String? {
         val yrc = root.obj("yrc")?.stringOrNull("lyric")
         val lrc = root.obj("lrc")?.stringOrNull("lyric")
-        val main = yrc ?: lrc ?: return@runCatching null
-        val translation = when {
-            yrc != null -> root.obj("ytlrc")?.stringOrNull("lyric")
+        val main = yrc ?: lrc ?: return null
+        val translation = if (yrc != null) {
+            root.obj("ytlrc")?.stringOrNull("lyric")
                 ?: root.obj("tlyric")?.stringOrNull("lyric")
-            else -> root.obj("tlyric")?.stringOrNull("lyric")
+        } else {
+            root.obj("tlyric")?.stringOrNull("lyric")
         }
-        org.feeluown.mobile.composeLyricsWithTranslation(main, translation)
-    }.getOrNull()
+        val romanization = if (yrc != null) {
+            root.obj("yromalrc")?.stringOrNull("lyric")
+                ?: root.obj("yrlyric")?.stringOrNull("lyric")
+                ?: root.obj("romalrc")?.stringOrNull("lyric")
+        } else {
+            root.obj("romalrc")?.stringOrNull("lyric")
+        }
+        return composeRichLyrics(
+            main = main,
+            translation = translation,
+            romanization = romanization,
+        )
+    }
 
     private suspend fun currentUserId(): String? = runCatching { requestCurrentUserId() }.getOrNull()
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -900,7 +900,7 @@ class QQMusicProvider(
         val FEATURES = listOf(
             ProviderFeature("qqmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
             ProviderFeature("qqmusic_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
-            ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Music, ProviderContentType.Playlists, true),
+            ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
             ProviderFeature("qqmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
         )
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -21,6 +21,7 @@ import org.feeluown.mobile.ProviderPlaylistDetail
 import org.feeluown.mobile.ProviderSearchResults
 import org.feeluown.mobile.ProviderVideo
 import org.feeluown.mobile.VideoPlaybackPayload
+import org.feeluown.mobile.composeRichLyrics
 import org.feeluown.mobile.provider.core.BaseKotlinProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
@@ -753,7 +754,33 @@ class QQMusicProvider(
         return lyric(id)
     }
 
-    private suspend fun lyric(identifier: String): String? = runCatching {
+    private suspend fun lyric(identifier: String): String? {
+        richLyric(identifier)?.let { return it }
+        return legacyLyric(identifier)
+    }
+
+    private suspend fun richLyric(identifier: String): String? = runCatching {
+        val root = rpc(
+            """
+            {"req_0":{"module":"music.musichallSong.PlayLyricInfo","method":"GetPlayLyricInfo","param":{"songMid":${jsonString(identifier)},"type":1,"crypt":1,"lrc_t":0,"qrc":1,"qrc_t":0,"roma":1,"roma_t":0,"trans":1,"trans_t":0,"needSingingAnnotations":true}}}
+            """.trimIndent(),
+            cacheKey = "qqmusic:lyric-v2:$identifier",
+            cachePolicy = ProviderCachePolicies.lyric,
+        )
+        val data = root.obj("req_0")?.obj("data") ?: return@runCatching null
+        val main = decodeQqLyricPayload(data.stringOrNull("lyric")) ?: return@runCatching null
+        val translation = decodeQqLyricPayload(data.stringOrNull("trans"))
+        val romanization = decodeQqLyricPayload(data.stringOrNull("roma"))
+        val annotation = decodeQqLyricPayload(data.stringOrNull("singingAnnotationsLyric"))
+        composeRichLyrics(
+            main = main,
+            translation = translation,
+            romanization = romanization,
+            annotation = annotation,
+        )
+    }.getOrNull()
+
+    private suspend fun legacyLyric(identifier: String): String? = runCatching {
         val root = http.getText(
             providerId = ID,
             url = queryUrl(
@@ -873,7 +900,7 @@ class QQMusicProvider(
         val FEATURES = listOf(
             ProviderFeature("qqmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
             ProviderFeature("qqmusic_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
-            ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
+            ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Music, ProviderContentType.Playlists, true),
             ProviderFeature("qqmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
         )
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
@@ -1,0 +1,82 @@
+package org.feeluown.mobile.provider.qqmusic
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal fun decodeQqLyricPayload(raw: String?): String? {
+    val value = raw?.trim()?.takeIf(String::isNotBlank) ?: return null
+    val decoded = if (qqEncryptedHexRegex.matches(value) && value.length % 16 == 0) {
+        decryptQqQrc(value) ?: return null
+    } else {
+        value
+    }
+    return normalizeQqLyricText(decoded).takeIf(String::isNotBlank)
+}
+
+@OptIn(ExperimentalUnsignedTypes::class)
+internal fun decryptQqQrc(encrypted: String): String? = runCatching {
+    val cipherBytes = encrypted.hexToByteArrayOrNull() ?: return@runCatching null
+    if (cipherBytes.isEmpty() || cipherBytes.size % 8 != 0) return@runCatching null
+
+    val key = QQ_QRC_KEY.encodeToByteArray()
+    val schedule = Array(3) { Array(16) { UByteArray(6) } }
+    QQMusicQrcDes.tripleDESKeySetup(key, schedule, QQMusicQrcDes.DECRYPT)
+    val plain = ByteArray(cipherBytes.size)
+    val output = ByteArray(8)
+    var offset = 0
+    while (offset < cipherBytes.size) {
+        QQMusicQrcDes.tripleDESCrypt(cipherBytes.copyOfRange(offset, offset + 8), output, schedule)
+        output.copyInto(plain, destinationOffset = offset)
+        offset += 8
+    }
+    qrcInflate(plain)?.decodeToString()
+}.getOrNull()
+
+internal fun normalizeQqLyricText(raw: String): String {
+    val lyric = extractQrcXmlLyric(raw) ?: raw
+    return lyric.lineSequence().joinToString("\n") { line ->
+        if (qrcLineHeaderRegex.containsMatchIn(line.trim())) {
+            qrcWordTimestampRegex.replace(line) { match ->
+                "(${match.groupValues[1]},${match.groupValues[2]},0)"
+            }
+        } else {
+            line
+        }
+    }.trim()
+}
+
+private fun extractQrcXmlLyric(raw: String): String? {
+    val match = qrcXmlLyricRegex.find(raw) ?: return null
+    return decodeXmlEntities(match.groupValues[1])
+}
+
+private fun decodeXmlEntities(value: String): String = value
+    .replace("&#13;", "\r")
+    .replace("&#10;", "\n")
+    .replace("&quot;", "\"")
+    .replace("&apos;", "'")
+    .replace("&lt;", "<")
+    .replace("&gt;", ">")
+    .replace("&amp;", "&")
+
+private fun String.hexToByteArrayOrNull(): ByteArray? {
+    if (length % 2 != 0) return null
+    val result = ByteArray(length / 2)
+    var index = 0
+    while (index < length) {
+        val high = this[index].digitToIntOrNull(16) ?: return null
+        val low = this[index + 1].digitToIntOrNull(16) ?: return null
+        result[index / 2] = ((high shl 4) or low).toByte()
+        index += 2
+    }
+    return result
+}
+
+internal expect fun qrcInflate(data: ByteArray): ByteArray?
+
+private const val QQ_QRC_KEY = "!@#)(*$%123ZXC!@!@#)(NHL"
+private val qqEncryptedHexRegex = Regex("""^[0-9A-Fa-f]+$""")
+private val qrcLineHeaderRegex = Regex("""^\[\d+,\d+]""")
+private val qrcWordTimestampRegex = Regex("""\((\d+),(\d+)\)""")
+private val qrcXmlLyricRegex = Regex(
+    """LyricContent="(.*?)"""",
+    setOf(RegexOption.DOT_MATCHES_ALL),
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
@@ -76,7 +76,4 @@ private const val QQ_QRC_KEY = "!@#)(*$%123ZXC!@!@#)(NHL"
 private val qqEncryptedHexRegex = Regex("""^[0-9A-Fa-f]+$""")
 private val qrcLineHeaderRegex = Regex("""^\[\d+,\d+]""")
 private val qrcWordTimestampRegex = Regex("""\((\d+),(\d+)\)""")
-private val qrcXmlLyricRegex = Regex(
-    """LyricContent="(.*?)"""",
-    setOf(RegexOption.DOT_MATCHES_ALL),
-)
+private val qrcXmlLyricRegex = Regex("LyricContent=\"([^\"]*)\"")

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodec.kt
@@ -32,15 +32,52 @@ internal fun decryptQqQrc(encrypted: String): String? = runCatching {
 
 internal fun normalizeQqLyricText(raw: String): String {
     val lyric = extractQrcXmlLyric(raw) ?: raw
-    return lyric.lineSequence().joinToString("\n") { line ->
-        if (qrcLineHeaderRegex.containsMatchIn(line.trim())) {
-            qrcWordTimestampRegex.replace(line) { match ->
-                "(${match.groupValues[1]},${match.groupValues[2]},0)"
+    return lyric.lineSequence().joinToString("\n", transform = ::normalizeQrcLine).trim()
+}
+
+private fun normalizeQrcLine(originalLine: String): String {
+    val line = originalLine.trim()
+    val headerMatch = qrcLineHeaderRegex.find(line) ?: return originalLine
+    val header = headerMatch.value
+    val body = line.substring(headerMatch.range.last + 1)
+    val timestamps = qrcWordTimestampRegex.findAll(body).toList()
+    if (timestamps.isEmpty()) return line
+
+    // QQ QRC puts each word timestamp after the corresponding text, e.g.
+    // [1000,1000]你(1000,200)好(1200,300). The app's YRC parser expects
+    // the timestamp before the word, so move each timing token in front of its
+    // text instead of only adding the third YRC field. Otherwise the text before
+    // the first timestamp (the first word of every line) is dropped and all word
+    // timings are shifted by one word.
+    if (timestamps.first().range.first > 0) {
+        return buildString {
+            append(header)
+            var textStart = 0
+            timestamps.forEach { timestamp ->
+                val text = body.substring(textStart, timestamp.range.first)
+                appendNormalizedWordTimestamp(timestamp)
+                append(text)
+                textStart = timestamp.range.last + 1
             }
-        } else {
-            line
+            if (textStart < body.length) {
+                append(body.substring(textStart))
+            }
         }
-    }.trim()
+    }
+
+    // Already prefix-timed input (YRC-like) only needs the QQ two-field timing
+    // normalized to the parser's three-field form.
+    return header + qrcWordTimestampRegex.replace(body) { match ->
+        "(${match.groupValues[1]},${match.groupValues[2]},0)"
+    }
+}
+
+private fun StringBuilder.appendNormalizedWordTimestamp(match: MatchResult) {
+    append('(')
+    append(match.groupValues[1])
+    append(',')
+    append(match.groupValues[2])
+    append(",0)")
 }
 
 private fun extractQrcXmlLyric(raw: String): String? {
@@ -75,5 +112,5 @@ internal expect fun qrcInflate(data: ByteArray): ByteArray?
 private const val QQ_QRC_KEY = "!@#)(*$%123ZXC!@!@#)(NHL"
 private val qqEncryptedHexRegex = Regex("""^[0-9A-Fa-f]+$""")
 private val qrcLineHeaderRegex = Regex("""^\[\d+,\d+]""")
-private val qrcWordTimestampRegex = Regex("""\((\d+),(\d+)\)""")
+private val qrcWordTimestampRegex = Regex("""\((\d+),(\d+)(?:,\d+)?\)""")
 private val qrcXmlLyricRegex = Regex("LyricContent=\"([^\"]*)\"")

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcDes.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcDes.kt
@@ -1,0 +1,263 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlin.experimental.or
+
+/*
+ * QRC uses QQ Music's DES-compatible key schedule rather than JCE DESede.
+ * Adapted for Kotlin Multiplatform from the GPL-3.0 implementation in
+ * cy745/lddc-android, itself based on WXRIW/QQMusicDecoder.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+@OptIn(ExperimentalUnsignedTypes::class)
+internal object QQMusicQrcDes {
+    const val ENCRYPT: UInt = 1u
+    const val DECRYPT: UInt = 0u
+
+    private fun bitNum(a: ByteArray, b: Int, c: Int): UInt =
+        ((((a[(b / 32) * 4 + 3 - (b % 32) / 8].toInt() ushr (7 - (b % 8)))) and 1) shl c).toUInt()
+
+    private fun bitNumIntr(a: UInt, b: Int, c: Int): Byte =
+        ((((a shr (31 - b)) and 1u).toInt()) shl c).toByte()
+
+    private fun bitNumIntl(a: UInt, b: Int, c: Int): UInt =
+        ((a shl b) and 0x80000000u) shr c
+
+    private fun sboxBit(a: Byte): UInt =
+        ((a.toInt() and 0x20) or ((a.toInt() and 0x1f) ushr 1) or ((a.toInt() and 0x01) shl 4)).toUInt()
+
+    private val sbox1 = byteArrayOf(
+        14, 4, 13, 1, 2, 15, 11, 8, 3, 10, 6, 12, 5, 9, 0, 7,
+        0, 15, 7, 4, 14, 2, 13, 1, 10, 6, 12, 11, 9, 5, 3, 8,
+        4, 1, 14, 8, 13, 6, 2, 11, 15, 12, 9, 7, 3, 10, 5, 0,
+        15, 12, 8, 2, 4, 9, 1, 7, 5, 11, 3, 14, 10, 0, 6, 13,
+    )
+    private val sbox2 = byteArrayOf(
+        15, 1, 8, 14, 6, 11, 3, 4, 9, 7, 2, 13, 12, 0, 5, 10,
+        3, 13, 4, 7, 15, 2, 8, 15, 12, 0, 1, 10, 6, 9, 11, 5,
+        0, 14, 7, 11, 10, 4, 13, 1, 5, 8, 12, 6, 9, 3, 2, 15,
+        13, 8, 10, 1, 3, 15, 4, 2, 11, 6, 7, 12, 0, 5, 14, 9,
+    )
+    private val sbox3 = byteArrayOf(
+        10, 0, 9, 14, 6, 3, 15, 5, 1, 13, 12, 7, 11, 4, 2, 8,
+        13, 7, 0, 9, 3, 4, 6, 10, 2, 8, 5, 14, 12, 11, 15, 1,
+        13, 6, 4, 9, 8, 15, 3, 0, 11, 1, 2, 12, 5, 10, 14, 7,
+        1, 10, 13, 0, 6, 9, 8, 7, 4, 15, 14, 3, 11, 5, 2, 12,
+    )
+    private val sbox4 = byteArrayOf(
+        7, 13, 14, 3, 0, 6, 9, 10, 1, 2, 8, 5, 11, 12, 4, 15,
+        13, 8, 11, 5, 6, 15, 0, 3, 4, 7, 2, 12, 1, 10, 14, 9,
+        10, 6, 9, 0, 12, 11, 7, 13, 15, 1, 3, 14, 5, 2, 8, 4,
+        3, 15, 0, 6, 10, 10, 13, 8, 9, 4, 5, 11, 12, 7, 2, 14,
+    )
+    private val sbox5 = byteArrayOf(
+        2, 12, 4, 1, 7, 10, 11, 6, 8, 5, 3, 15, 13, 0, 14, 9,
+        14, 11, 2, 12, 4, 7, 13, 1, 5, 0, 15, 10, 3, 9, 8, 6,
+        4, 2, 1, 11, 10, 13, 7, 8, 15, 9, 12, 5, 6, 3, 0, 14,
+        11, 8, 12, 7, 1, 14, 2, 13, 6, 15, 0, 9, 10, 4, 5, 3,
+    )
+    private val sbox6 = byteArrayOf(
+        12, 1, 10, 15, 9, 2, 6, 8, 0, 13, 3, 4, 14, 7, 5, 11,
+        10, 15, 4, 2, 7, 12, 9, 5, 6, 1, 13, 14, 0, 11, 3, 8,
+        9, 14, 15, 5, 2, 8, 12, 3, 7, 0, 4, 10, 1, 13, 11, 6,
+        4, 3, 2, 12, 9, 5, 15, 10, 11, 14, 1, 7, 6, 0, 8, 13,
+    )
+    private val sbox7 = byteArrayOf(
+        4, 11, 2, 14, 15, 0, 8, 13, 3, 12, 9, 7, 5, 10, 6, 1,
+        13, 0, 11, 7, 4, 9, 1, 10, 14, 3, 5, 12, 2, 15, 8, 6,
+        1, 4, 11, 13, 12, 3, 7, 14, 10, 15, 6, 8, 0, 5, 9, 2,
+        6, 11, 13, 8, 1, 4, 10, 7, 9, 5, 0, 15, 14, 2, 3, 12,
+    )
+    private val sbox8 = byteArrayOf(
+        13, 2, 8, 4, 6, 15, 11, 1, 10, 9, 3, 14, 5, 0, 12, 7,
+        1, 15, 13, 8, 10, 3, 7, 4, 12, 5, 6, 11, 0, 14, 9, 2,
+        7, 11, 4, 1, 9, 12, 14, 2, 0, 6, 10, 13, 15, 3, 5, 8,
+        2, 1, 14, 7, 4, 10, 8, 13, 15, 12, 9, 0, 3, 5, 6, 11,
+    )
+
+    private fun keySchedule(key: ByteArray, schedule: Array<UByteArray>, mode: UInt) {
+        val keyRndShift = uintArrayOf(1u, 1u, 2u, 2u, 2u, 2u, 2u, 2u, 1u, 2u, 2u, 2u, 2u, 2u, 2u, 1u)
+        val keyPermC = uintArrayOf(
+            56u, 48u, 40u, 32u, 24u, 16u, 8u, 0u, 57u, 49u, 41u, 33u, 25u, 17u,
+            9u, 1u, 58u, 50u, 42u, 34u, 26u, 18u, 10u, 2u, 59u, 51u, 43u, 35u,
+        )
+        val keyPermD = uintArrayOf(
+            62u, 54u, 46u, 38u, 30u, 22u, 14u, 6u, 61u, 53u, 45u, 37u, 29u, 21u,
+            13u, 5u, 60u, 52u, 44u, 36u, 28u, 20u, 12u, 4u, 27u, 19u, 11u, 3u,
+        )
+        val keyComp = uintArrayOf(
+            13u, 16u, 10u, 23u, 0u, 4u, 2u, 27u, 14u, 5u, 20u, 9u,
+            22u, 18u, 11u, 3u, 25u, 7u, 15u, 6u, 26u, 19u, 12u, 1u,
+            40u, 51u, 30u, 36u, 46u, 54u, 29u, 39u, 50u, 44u, 32u, 47u,
+            43u, 48u, 38u, 55u, 33u, 52u, 45u, 41u, 49u, 35u, 28u, 31u,
+        )
+
+        var c = 0u
+        var d = 0u
+        for (i in 0 until 28) c = c or bitNum(key, keyPermC[i].toInt(), 31 - i)
+        for (i in 0 until 28) d = d or bitNum(key, keyPermD[i].toInt(), 31 - i)
+
+        for (i in 0 until 16) {
+            c = ((c shl keyRndShift[i].toInt()) or (c shr (28 - keyRndShift[i].toInt()))) and 0xfffffff0u
+            d = ((d shl keyRndShift[i].toInt()) or (d shr (28 - keyRndShift[i].toInt()))) and 0xfffffff0u
+
+            val toGen = if (mode == DECRYPT) 15 - i else i
+            schedule[toGen].fill(0u)
+            for (j in 0 until 24) {
+                schedule[toGen][j / 8] = (
+                    schedule[toGen][j / 8].toInt() or bitNumIntr(c, keyComp[j].toInt(), 7 - (j % 8)).toInt()
+                    ).toUByte()
+            }
+            for (j in 24 until 48) {
+                schedule[toGen][j / 8] = (
+                    schedule[toGen][j / 8].toInt() or bitNumIntr(d, keyComp[j].toInt() - 27, 7 - (j % 8)).toInt()
+                    ).toUByte()
+            }
+        }
+    }
+
+    private fun ip(state: UIntArray, block: ByteArray) {
+        state[0] = bitNum(block, 57, 31) or bitNum(block, 49, 30) or
+            bitNum(block, 41, 29) or bitNum(block, 33, 28) or
+            bitNum(block, 25, 27) or bitNum(block, 17, 26) or
+            bitNum(block, 9, 25) or bitNum(block, 1, 24) or
+            bitNum(block, 59, 23) or bitNum(block, 51, 22) or
+            bitNum(block, 43, 21) or bitNum(block, 35, 20) or
+            bitNum(block, 27, 19) or bitNum(block, 19, 18) or
+            bitNum(block, 11, 17) or bitNum(block, 3, 16) or
+            bitNum(block, 61, 15) or bitNum(block, 53, 14) or
+            bitNum(block, 45, 13) or bitNum(block, 37, 12) or
+            bitNum(block, 29, 11) or bitNum(block, 21, 10) or
+            bitNum(block, 13, 9) or bitNum(block, 5, 8) or
+            bitNum(block, 63, 7) or bitNum(block, 55, 6) or
+            bitNum(block, 47, 5) or bitNum(block, 39, 4) or
+            bitNum(block, 31, 3) or bitNum(block, 23, 2) or
+            bitNum(block, 15, 1) or bitNum(block, 7, 0)
+        state[1] = bitNum(block, 56, 31) or bitNum(block, 48, 30) or
+            bitNum(block, 40, 29) or bitNum(block, 32, 28) or
+            bitNum(block, 24, 27) or bitNum(block, 16, 26) or
+            bitNum(block, 8, 25) or bitNum(block, 0, 24) or
+            bitNum(block, 58, 23) or bitNum(block, 50, 22) or
+            bitNum(block, 42, 21) or bitNum(block, 34, 20) or
+            bitNum(block, 26, 19) or bitNum(block, 18, 18) or
+            bitNum(block, 10, 17) or bitNum(block, 2, 16) or
+            bitNum(block, 60, 15) or bitNum(block, 52, 14) or
+            bitNum(block, 44, 13) or bitNum(block, 36, 12) or
+            bitNum(block, 28, 11) or bitNum(block, 20, 10) or
+            bitNum(block, 12, 9) or bitNum(block, 4, 8) or
+            bitNum(block, 62, 7) or bitNum(block, 54, 6) or
+            bitNum(block, 46, 5) or bitNum(block, 38, 4) or
+            bitNum(block, 30, 3) or bitNum(block, 22, 2) or
+            bitNum(block, 14, 1) or bitNum(block, 6, 0)
+    }
+
+    private fun invIp(state: UIntArray, block: ByteArray) {
+        block[3] = bitNumIntr(state[1], 7, 7) or bitNumIntr(state[0], 7, 6) or
+            bitNumIntr(state[1], 15, 5) or bitNumIntr(state[0], 15, 4) or
+            bitNumIntr(state[1], 23, 3) or bitNumIntr(state[0], 23, 2) or
+            bitNumIntr(state[1], 31, 1) or bitNumIntr(state[0], 31, 0)
+        block[2] = bitNumIntr(state[1], 6, 7) or bitNumIntr(state[0], 6, 6) or
+            bitNumIntr(state[1], 14, 5) or bitNumIntr(state[0], 14, 4) or
+            bitNumIntr(state[1], 22, 3) or bitNumIntr(state[0], 22, 2) or
+            bitNumIntr(state[1], 30, 1) or bitNumIntr(state[0], 30, 0)
+        block[1] = bitNumIntr(state[1], 5, 7) or bitNumIntr(state[0], 5, 6) or
+            bitNumIntr(state[1], 13, 5) or bitNumIntr(state[0], 13, 4) or
+            bitNumIntr(state[1], 21, 3) or bitNumIntr(state[0], 21, 2) or
+            bitNumIntr(state[1], 29, 1) or bitNumIntr(state[0], 29, 0)
+        block[0] = bitNumIntr(state[1], 4, 7) or bitNumIntr(state[0], 4, 6) or
+            bitNumIntr(state[1], 12, 5) or bitNumIntr(state[0], 12, 4) or
+            bitNumIntr(state[1], 20, 3) or bitNumIntr(state[0], 20, 2) or
+            bitNumIntr(state[1], 28, 1) or bitNumIntr(state[0], 28, 0)
+        block[7] = bitNumIntr(state[1], 3, 7) or bitNumIntr(state[0], 3, 6) or
+            bitNumIntr(state[1], 11, 5) or bitNumIntr(state[0], 11, 4) or
+            bitNumIntr(state[1], 19, 3) or bitNumIntr(state[0], 19, 2) or
+            bitNumIntr(state[1], 27, 1) or bitNumIntr(state[0], 27, 0)
+        block[6] = bitNumIntr(state[1], 2, 7) or bitNumIntr(state[0], 2, 6) or
+            bitNumIntr(state[1], 10, 5) or bitNumIntr(state[0], 10, 4) or
+            bitNumIntr(state[1], 18, 3) or bitNumIntr(state[0], 18, 2) or
+            bitNumIntr(state[1], 26, 1) or bitNumIntr(state[0], 26, 0)
+        block[5] = bitNumIntr(state[1], 1, 7) or bitNumIntr(state[0], 1, 6) or
+            bitNumIntr(state[1], 9, 5) or bitNumIntr(state[0], 9, 4) or
+            bitNumIntr(state[1], 17, 3) or bitNumIntr(state[0], 17, 2) or
+            bitNumIntr(state[1], 25, 1) or bitNumIntr(state[0], 25, 0)
+        block[4] = bitNumIntr(state[1], 0, 7) or bitNumIntr(state[0], 0, 6) or
+            bitNumIntr(state[1], 8, 5) or bitNumIntr(state[0], 8, 4) or
+            bitNumIntr(state[1], 16, 3) or bitNumIntr(state[0], 16, 2) or
+            bitNumIntr(state[1], 24, 1) or bitNumIntr(state[0], 24, 0)
+    }
+
+    private fun f(state: UInt, keyBytes: UByteArray): UInt {
+        val lrgState = UByteArray(6)
+        val t1 = bitNumIntl(state, 31, 0) or ((state and 0xf0000000u) shr 1) or
+            bitNumIntl(state, 4, 5) or bitNumIntl(state, 3, 6) or
+            ((state and 0x0f000000u) shr 3) or bitNumIntl(state, 8, 11) or
+            bitNumIntl(state, 7, 12) or ((state and 0x00f00000u) shr 5) or
+            bitNumIntl(state, 12, 17) or bitNumIntl(state, 11, 18) or
+            ((state and 0x000f0000u) shr 7) or bitNumIntl(state, 16, 23)
+        val t2 = bitNumIntl(state, 15, 0) or ((state and 0x0000f000u) shl 15) or
+            bitNumIntl(state, 20, 5) or bitNumIntl(state, 19, 6) or
+            ((state and 0x00000f00u) shl 13) or bitNumIntl(state, 24, 11) or
+            bitNumIntl(state, 23, 12) or ((state and 0x000000f0u) shl 11) or
+            bitNumIntl(state, 28, 17) or bitNumIntl(state, 27, 18) or
+            ((state and 0x0000000fu) shl 9) or bitNumIntl(state, 0, 23)
+
+        lrgState[0] = ((t1 shr 24) and 0xffu).toUByte()
+        lrgState[1] = ((t1 shr 16) and 0xffu).toUByte()
+        lrgState[2] = ((t1 shr 8) and 0xffu).toUByte()
+        lrgState[3] = ((t2 shr 24) and 0xffu).toUByte()
+        lrgState[4] = ((t2 shr 16) and 0xffu).toUByte()
+        lrgState[5] = ((t2 shr 8) and 0xffu).toUByte()
+        for (i in 0..5) lrgState[i] = (lrgState[i].toInt() xor keyBytes[i].toInt()).toUByte()
+
+        var res = (sbox1[sboxBit((lrgState[0].toInt() ushr 2).toByte()).toInt()].toUInt() shl 28) or
+            (sbox2[sboxBit((((lrgState[0].toInt() and 0x03) shl 4) or (lrgState[1].toInt() ushr 4)).toByte()).toInt()].toUInt() shl 24) or
+            (sbox3[sboxBit((((lrgState[1].toInt() and 0x0f) shl 2) or (lrgState[2].toInt() ushr 6)).toByte()).toInt()].toUInt() shl 20) or
+            (sbox4[sboxBit((lrgState[2].toInt() and 0x3f).toByte()).toInt()].toUInt() shl 16) or
+            (sbox5[sboxBit((lrgState[3].toInt() ushr 2).toByte()).toInt()].toUInt() shl 12) or
+            (sbox6[sboxBit((((lrgState[3].toInt() and 0x03) shl 4) or (lrgState[4].toInt() ushr 4)).toByte()).toInt()].toUInt() shl 8) or
+            (sbox7[sboxBit((((lrgState[4].toInt() and 0x0f) shl 2) or (lrgState[5].toInt() ushr 6)).toByte()).toInt()].toUInt() shl 4) or
+            sbox8[sboxBit((lrgState[5].toInt() and 0x3f).toByte()).toInt()].toUInt()
+
+        res = bitNumIntl(res, 15, 0) or bitNumIntl(res, 6, 1) or bitNumIntl(res, 19, 2) or
+            bitNumIntl(res, 20, 3) or bitNumIntl(res, 28, 4) or bitNumIntl(res, 11, 5) or
+            bitNumIntl(res, 27, 6) or bitNumIntl(res, 16, 7) or bitNumIntl(res, 0, 8) or
+            bitNumIntl(res, 14, 9) or bitNumIntl(res, 22, 10) or bitNumIntl(res, 25, 11) or
+            bitNumIntl(res, 4, 12) or bitNumIntl(res, 17, 13) or bitNumIntl(res, 30, 14) or
+            bitNumIntl(res, 9, 15) or bitNumIntl(res, 1, 16) or bitNumIntl(res, 7, 17) or
+            bitNumIntl(res, 23, 18) or bitNumIntl(res, 13, 19) or bitNumIntl(res, 31, 20) or
+            bitNumIntl(res, 26, 21) or bitNumIntl(res, 2, 22) or bitNumIntl(res, 8, 23) or
+            bitNumIntl(res, 18, 24) or bitNumIntl(res, 12, 25) or bitNumIntl(res, 29, 26) or
+            bitNumIntl(res, 5, 27) or bitNumIntl(res, 21, 28) or bitNumIntl(res, 10, 29) or
+            bitNumIntl(res, 3, 30) or bitNumIntl(res, 24, 31)
+        return res
+    }
+
+    private fun crypt(input: ByteArray, output: ByteArray, roundKeys: Array<UByteArray>) {
+        val state = UIntArray(2)
+        ip(state, input)
+        for (index in 0 until 15) {
+            val next = state[1]
+            state[1] = f(state[1], roundKeys[index]) xor state[0]
+            state[0] = next
+        }
+        state[0] = f(state[1], roundKeys[15]) xor state[0]
+        invIp(state, output)
+    }
+
+    fun tripleDESKeySetup(key: ByteArray, schedule: Array<Array<UByteArray>>, mode: UInt) {
+        if (mode == ENCRYPT) {
+            keySchedule(key.copyOfRange(0, 8), schedule[0], mode)
+            keySchedule(key.copyOfRange(8, 16), schedule[1], DECRYPT)
+            keySchedule(key.copyOfRange(16, 24), schedule[2], mode)
+        } else {
+            keySchedule(key.copyOfRange(16, 24), schedule[0], mode)
+            keySchedule(key.copyOfRange(8, 16), schedule[1], ENCRYPT)
+            keySchedule(key.copyOfRange(0, 8), schedule[2], mode)
+        }
+    }
+
+    fun tripleDESCrypt(input: ByteArray, output: ByteArray, schedule: Array<Array<UByteArray>>) {
+        crypt(input, output, schedule[0])
+        crypt(output, output, schedule[1])
+        crypt(output, output, schedule[2])
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertTrue
 
 class RichLyricsTest {
     @Test
-    fun mergesTranslationAndRomanizationIntoExistingSecondaryStyle() {
+    fun rendersTranslationAndRomanizationOnSeparateLines() {
         val raw = composeRichLyrics(
             main = "[00:01.000]Hello\n[00:03.000]World",
             translation = "[00:01.020]你好\n[00:03.000]世界",
@@ -16,8 +16,9 @@ class RichLyricsTest {
         val lines = parseLyrics(raw)
         assertEquals(2, lines.size)
         assertEquals("Hello", lines[0].text)
-        assertEquals("你好${RICH_LYRIC_LINE_SEPARATOR}hello", lines[0].translation)
-        assertEquals("世界${RICH_LYRIC_LINE_SEPARATOR}world", lines[1].translation)
+        assertEquals("你好\nhello", lines[0].translation)
+        assertEquals("世界\nworld", lines[1].translation)
+        assertTrue(!raw.contains('\u2028'))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
@@ -1,0 +1,47 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RichLyricsTest {
+    @Test
+    fun mergesTranslationAndRomanizationIntoExistingSecondaryStyle() {
+        val raw = composeRichLyrics(
+            main = "[00:01.000]Hello\n[00:03.000]World",
+            translation = "[00:01.020]你好\n[00:03.000]世界",
+            romanization = "[00:01.000]hello\n[00:03.030]world",
+        )
+
+        val lines = parseLyrics(raw)
+        assertEquals(2, lines.size)
+        assertEquals("Hello", lines[0].text)
+        assertEquals("你好${RICH_LYRIC_LINE_SEPARATOR}hello", lines[0].translation)
+        assertEquals("世界${RICH_LYRIC_LINE_SEPARATOR}world", lines[1].translation)
+    }
+
+    @Test
+    fun preservesWordTimedPrimaryTrack() {
+        val raw = composeRichLyrics(
+            main = "[1000,2000](1000,500,0)Hel(1500,1500,0)lo",
+            translation = "[00:01.000]你好",
+            romanization = "[00:01.000]hello",
+        )
+
+        val line = parseLyrics(raw).single()
+        assertEquals("Hello", line.text)
+        assertEquals(2, line.words?.size)
+        assertTrue(line.translation?.contains("你好") == true)
+        assertTrue(line.translation?.contains("hello") == true)
+    }
+
+    @Test
+    fun translationOnlyPayloadStaysBackwardCompatible() {
+        val main = "[00:01.000]Hello"
+        val translation = "[00:01.000]你好"
+        assertEquals(
+            composeLyricsWithTranslation(main, translation),
+            composeRichLyrics(main, translation = translation),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
@@ -19,6 +19,20 @@ class TimedLineLyricsTest {
     }
 
     @Test
+    fun emitsTimestampForEveryRichSecondaryLine() {
+        val lyrics = composeRichLyrics(
+            main = "[11820,2220](11820,120,0)The (11940,420,0)club",
+            translation = "[00:11.820]这俱乐部",
+            romanization = "[00:11.820]the club",
+        )
+
+        assertEquals(
+            "[00:11.820]The club\n[00:11.820]这俱乐部\n[00:11.820]the club",
+            toTimedLineLrc(lyrics),
+        )
+    }
+
+    @Test
     fun normalizesLrcTimestampsAndKeepsTranslations() {
         val lyrics = """
             [ar:Example]

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodecTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodecTest.kt
@@ -1,0 +1,29 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import org.feeluown.mobile.parseLyrics
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class QQMusicQrcCodecTest {
+    @Test
+    fun decryptsKnownQrcPayloadAndNormalizesWordTiming() {
+        val encrypted = "d6a2be95d64473721b73c97024a81f8507967be980ad83772d7a8ec317a07c96417882618bc1a7d2ad434fb8500fa4b1"
+        val decoded = decodeQqLyricPayload(encrypted)
+        val line = parseLyrics(decoded).single()
+
+        assertEquals("Hello world", line.text)
+        assertEquals(2, line.words?.size)
+        assertEquals(1_000L, line.words?.first()?.startMs)
+        assertEquals(500L, line.words?.first()?.durationMs)
+    }
+
+    @Test
+    fun extractsQrcXmlAndKeepsRegularLrcUntouched() {
+        val xml = """<?xml version="1.0"?><QrcInfos><LyricInfo><Lyric_1 LyricContent="[1000,500]Hi(1000,500)"/></LyricInfo></QrcInfos>"""
+        assertEquals(
+            "[1000,500]Hi(1000,500,0)",
+            normalizeQqLyricText(xml),
+        )
+        assertEquals("[00:01.00]Hi", normalizeQqLyricText("[00:01.00]Hi"))
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodecTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcCodecTest.kt
@@ -18,11 +18,28 @@ class QQMusicQrcCodecTest {
     }
 
     @Test
-    fun extractsQrcXmlAndKeepsRegularLrcUntouched() {
-        val xml = """<?xml version="1.0"?><QrcInfos><LyricInfo><Lyric_1 LyricContent="[1000,500]Hi(1000,500)"/></LyricInfo></QrcInfos>"""
+    fun convertsQrcSuffixTimingsWithoutDroppingFirstWord() {
+        val xml = """<?xml version="1.0"?><QrcInfos><LyricInfo><Lyric_1 LyricContent="[1000,1000]Hello(1000,500) world(1500,500)"/></LyricInfo></QrcInfos>"""
+        val normalized = normalizeQqLyricText(xml)
+
         assertEquals(
-            "[1000,500]Hi(1000,500,0)",
-            normalizeQqLyricText(xml),
+            "[1000,1000](1000,500,0)Hello(1500,500,0) world",
+            normalized,
+        )
+
+        val line = parseLyrics(normalized).single()
+        assertEquals("Hello world", line.text)
+        assertEquals(2, line.words?.size)
+        assertEquals("Hello", line.words?.first()?.text)
+        assertEquals(1_000L, line.words?.first()?.startMs)
+        assertEquals(500L, line.words?.first()?.durationMs)
+    }
+
+    @Test
+    fun keepsAlreadyPrefixTimedQrcAndRegularLrcCompatible() {
+        assertEquals(
+            "[1000,500](1000,500,0)Hi",
+            normalizeQqLyricText("[1000,500](1000,500)Hi"),
         )
         assertEquals("[00:01.00]Hi", normalizeQqLyricText("[00:01.00]Hi"))
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSDataCompressionAlgorithmZlib
+import platform.posix.memcpy
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+internal actual fun qrcInflate(data: ByteArray): ByteArray? = runCatching {
+    if (data.isEmpty()) return@runCatching null
+    val compressed = data.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
+    }
+    val decompressed = compressed.decompressedDataUsingAlgorithm(
+        algorithm = NSDataCompressionAlgorithmZlib,
+        error = null,
+    ) ?: return@runCatching null
+    val size = decompressed.length.toInt()
+    if (size <= 0) return@runCatching null
+    ByteArray(size).also { output ->
+        output.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), decompressed.bytes, decompressed.length)
+        }
+    }
+}.getOrNull()

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
@@ -1,28 +1,50 @@
 package org.feeluown.mobile.provider.qqmusic
 
-import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.usePinned
-import platform.Foundation.NSData
-import platform.Foundation.NSDataCompressionAlgorithmZlib
-import platform.posix.memcpy
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.getPointer
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.refTo
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import platform.zlib.ZLIB_VERSION
+import platform.zlib.Z_NO_FLUSH
+import platform.zlib.Z_OK
+import platform.zlib.Z_STREAM_END
+import platform.zlib.inflate
+import platform.zlib.inflateEnd
+import platform.zlib.inflateInit_
+import platform.zlib.z_stream
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class)
 internal actual fun qrcInflate(data: ByteArray): ByteArray? = runCatching {
     if (data.isEmpty()) return@runCatching null
-    val compressed = data.usePinned { pinned ->
-        NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
-    }
-    val decompressed = compressed.decompressedDataUsingAlgorithm(
-        NSDataCompressionAlgorithmZlib,
-        error = null,
-    ) ?: return@runCatching null
-    val size = decompressed.length.toInt()
-    if (size <= 0) return@runCatching null
-    ByteArray(size).also { output ->
-        output.usePinned { pinned ->
-            memcpy(pinned.addressOf(0), decompressed.bytes, decompressed.length)
+    memScoped {
+        val stream = alloc<z_stream>()
+        stream.zalloc = null
+        stream.zfree = null
+        stream.opaque = null
+        check(inflateInit_(stream.ptr, ZLIB_VERSION, sizeOf<z_stream>().toInt()) == Z_OK) {
+            "QQ QRC inflateInit_ failed"
+        }
+        try {
+            stream.next_in = data.refTo(0).getPointer(this).reinterpret()
+            stream.avail_in = data.size.toUInt()
+            val output = mutableListOf<Byte>()
+            val bufferSize = 4 * 1024
+            val buffer = ByteArray(bufferSize)
+            do {
+                stream.next_out = buffer.refTo(0).getPointer(this).reinterpret()
+                stream.avail_out = bufferSize.toUInt()
+                val result = inflate(stream.ptr, Z_NO_FLUSH)
+                check(result == Z_OK || result == Z_STREAM_END) { "QQ QRC inflate error: $result" }
+                val produced = bufferSize - stream.avail_out.toInt()
+                output.addAll(buffer.take(produced))
+                if (result == Z_STREAM_END) break
+            } while (stream.avail_out == 0u)
+            output.toByteArray().takeIf { it.isNotEmpty() }
+        } finally {
+            inflateEnd(stream.ptr)
         }
     }
 }.getOrNull()

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
@@ -1,21 +1,7 @@
 package org.feeluown.mobile.provider.qqmusic
 
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.getPointer
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.refTo
-import kotlinx.cinterop.reinterpret
-import kotlinx.cinterop.sizeOf
-import platform.zlib.ZLIB_VERSION
-import platform.zlib.Z_NO_FLUSH
-import platform.zlib.Z_OK
-import platform.zlib.Z_STREAM_END
-import platform.zlib.inflate
-import platform.zlib.inflateEnd
-import platform.zlib.inflateInit_
-import platform.zlib.z_stream
+import kotlinx.cinterop.*
+import platform.zlib.*
 
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun qrcInflate(data: ByteArray): ByteArray? = runCatching {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
@@ -15,7 +15,7 @@ internal actual fun qrcInflate(data: ByteArray): ByteArray? = runCatching {
         NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
     }
     val decompressed = compressed.decompressedDataUsingAlgorithm(
-        algorithm = NSDataCompressionAlgorithmZlib,
+        NSDataCompressionAlgorithmZlib,
         error = null,
     ) ?: return@runCatching null
     val size = decompressed.length.toInt()

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicQrcInflater.ios.kt
@@ -4,6 +4,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.getPointer
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.sizeOf


### PR DESCRIPTION
## Summary
- switch QQ Music lyrics to `GetPlayLyricInfo` with legacy fallback
- decode encrypted QRC word-timed lyrics and support translation, romanization, and singing annotations
- switch NetEase to `/api/song/lyric/v1` with legacy fallback and consume word-timed, translation, and romanization tracks when available
- keep the existing lyric parser/rendering style while composing additional secondary lyric lines
- preserve ColorOS line-level lock-screen lyrics by assigning timestamps to every rich secondary line
- add cross-platform QRC zlib handling and lyric/QRC regression tests

## Compatibility
- existing LRC/YRC and translation-only payloads keep the current transport/rendering path
- provider failures fall back to the previous lyric APIs
- mini-player behavior remains unchanged; rich secondary lyrics extend the existing full-player secondary lyric style
