### PR TITLE
debug: expose QQ Music MV URL response details

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -284,7 +284,37 @@ class QQMusicProvider(
             {"getMvUrl":{"module":"music.stream.MvUrlProxy","method":"GetMvUrls","param":{"vids":[${jsonString(identifier)}],"request_type":10003,"guid":${jsonString(guid)},"videoformat":1,"format":265,"dolby":1,"use_new_domain":1,"use_ipv6":1}}}
             """.trimIndent(),
         )
-        val data = root.obj("getMvUrl")?.obj("data")?.obj(identifier) ?: return VideoPlaybackPayload(video = video)
+        val response = root.obj("getMvUrl")
+        val dataRoot = response?.obj("data")
+        val data = dataRoot?.obj(identifier)
+
+        fun debugMessage(reason: String): String {
+            fun describe(format: String): String {
+                val items = data?.array(format).orEmpty()
+                if (items.isEmpty()) return "$format: <empty>"
+                return items.mapIndexed { index, value ->
+                    val item = value.asObject()
+                    val urlCount = item.array("url").count { it.asString().isNotBlank() }
+                    val commCount = item.array("comm_url").count { it.asString().isNotBlank() }
+                    val freeflowCount = item.array("freeflow_url").count { it.asString().isNotBlank() }
+                    val hasM3u8 = !item.stringOrNull("m3u8").isNullOrBlank()
+                    "$format[$index] code=${item.int("code")} url=$urlCount comm=$commCount freeflow=$freeflowCount m3u8=$hasM3u8 filetype=${item.int("filetype")} format=${item.int("format")}"
+                }.joinToString("\n")
+            }
+
+            return buildString {
+                appendLine("QQ MV 调试信息：$reason")
+                appendLine("vid=$identifier")
+                appendLine("response.code=${response?.int("code")}")
+                appendLine("data.keys=${dataRoot?.keys?.joinToString(",") ?: "<none>"}")
+                appendLine(describe("mp4"))
+                appendLine(describe("hls"))
+                append("raw=")
+                append(response?.toString()?.take(1_600) ?: "<none>")
+            }
+        }
+
+        if (data == null) error(debugMessage("接口未返回当前 VID 数据"))
         val url = sequenceOf("mp4", "hls")
             .flatMap { format -> data.array(format).asSequence() }
             .map { it.asObject() }
@@ -300,7 +330,7 @@ class QQMusicProvider(
                 }.asSequence()
             }
             .firstOrNull()
-            ?: return VideoPlaybackPayload(video = video)
+            ?: error(debugMessage("没有可播放地址"))
         return VideoPlaybackPayload(
             video = video,
             url = url,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicMvPlaybackTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/QQMusicMvPlaybackTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.mock.respond
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
@@ -124,6 +125,62 @@ class QQMusicMvPlaybackTest {
         val payload = provider.videoPlaybackPayload(video)
 
         assertEquals("https://media.example/test.m3u8", payload.url)
+        client.close()
+    }
+
+    @Test
+    fun reportsResponseDetailsWhenMvHasNoPlayableUrl() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler {
+                        respond(
+                            """
+                            {
+                              "getMvUrl": {
+                                "code": 0,
+                                "data": {
+                                  "test-empty": {
+                                    "svp_flag": 1,
+                                    "mp4": [
+                                      {
+                                        "code": 0,
+                                        "url": [],
+                                        "freeflow_url": [],
+                                        "comm_url": [],
+                                        "m3u8": "",
+                                        "filetype": 0,
+                                        "format": 265
+                                      }
+                                    ],
+                                    "hls": []
+                                  }
+                                }
+                              }
+                            }
+                            """.trimIndent(),
+                        )
+                    }
+                }
+            },
+        )
+        val provider = QQMusicProvider(client, InMemoryProviderCredentialStore())
+        val video = ProviderVideo(
+            id = "video:qqmusic:test-empty",
+            title = "空地址测试 MV",
+            providerId = "qqmusic",
+            providerName = "QQ 音乐",
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            provider.videoPlaybackPayload(video)
+        }
+
+        assertTrue(error.message.orEmpty().contains("QQ MV 调试信息：没有可播放地址"))
+        assertTrue(error.message.orEmpty().contains("vid=test-empty"))
+        assertTrue(error.message.orEmpty().contains("response.code=0"))
+        assertTrue(error.message.orEmpty().contains("mp4[0] code=0 url=0 comm=0 freeflow=0 m3u8=false"))
+        assertTrue(error.message.orEmpty().contains("\"svp_flag\":1"))
         client.close()
     }
 }


### PR DESCRIPTION
## 说明

针对部分 QQ 音乐 MV 仍显示“视频地址不可用”的情况，增加临时诊断信息，方便直接从 MV 页面确认 `GetMvUrls` 的真实返回结构。

## 改动

- 当 QQ MV 接口未返回当前 VID，或 MP4/HLS 均没有可播放地址时，不再静默返回空 `VideoPlaybackPayload`，而是抛出带诊断信息的错误；现有视频页面会直接展示该错误内容。
- 诊断信息包含：VID、接口 code、data keys、MP4/HLS 条目数量与各条目的 code、url/comm_url/freeflow_url 数量、m3u8 状态、filetype/format，以及截断后的原始 `getMvUrl` 响应。
- 正常可播放 MV 的行为不变。
- 增加回归测试，覆盖“接口有 MV 数据但所有地址均为空”时的诊断输出。

这批信息主要用于定位当前「美丽世界 / 南征北战NZBZ」这类 MV 的实际返回值，确认原因后可再收敛或移除 raw 调试输出。