### PR TITLE
feat: improve romanized lyric rendering

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -1268,6 +1268,11 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         LyricFontSize.Medium -> MaterialTheme.typography.bodyMedium
         LyricFontSize.Large -> MaterialTheme.typography.bodyLarge
     }
+    val romanizationStyle = when (fontSize) {
+        LyricFontSize.Small -> MaterialTheme.typography.labelMedium
+        LyricFontSize.Medium -> MaterialTheme.typography.bodySmall
+        LyricFontSize.Large -> MaterialTheme.typography.bodyMedium
+    }
     val linePadding = when (fontSize) {
         LyricFontSize.Small -> 6.dp
         LyricFontSize.Medium -> 7.dp
@@ -1298,6 +1303,31 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         .padding(vertical = linePadding),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
+                    line.romanization?.takeIf { it.isNotBlank() }?.let { romanization ->
+                        if (active && !line.romanizationWords.isNullOrEmpty()) {
+                            KaraokeLyricText(
+                                words = line.romanizationWords,
+                                positionMs = renderPositionMs,
+                                style = romanizationStyle,
+                                activeColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
+                                inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f),
+                                fontWeight = FontWeight.Medium,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        } else {
+                            Text(
+                                text = romanization,
+                                style = romanizationStyle,
+                                color = if (active) {
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f)
+                                },
+                                fontWeight = if (active) FontWeight.Medium else FontWeight.Normal,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
                     if (active && !line.words.isNullOrEmpty()) {
                         KaraokeLyricText(
                             words = line.words,
@@ -1365,13 +1395,14 @@ private fun KaraokeLyricText(
     style: TextStyle,
     activeColor: Color,
     inactiveColor: Color,
+    fontWeight: FontWeight = FontWeight.SemiBold,
     modifier: Modifier = Modifier,
 ) {
     val text = remember(words) { words.joinToString("") { it.text } }
     val textMeasurer = rememberTextMeasurer()
     val fontSize = style.fontSize
-    val wordWidths = remember(words, fontSize, textMeasurer) {
-        val measureStyle = style.copy(fontWeight = FontWeight.SemiBold)
+    val wordWidths = remember(words, fontSize, fontWeight, textMeasurer) {
+        val measureStyle = style.copy(fontWeight = fontWeight)
         words.map { word ->
             textMeasurer.measure(
                 text = word.text,
@@ -1381,7 +1412,7 @@ private fun KaraokeLyricText(
         }
     }
     val progress = karaokeFillProgress(words, positionMs.value, wordWidths)
-    val textStyle = style.copy(fontWeight = FontWeight.SemiBold)
+    val textStyle = style.copy(fontWeight = fontWeight)
 
     BoxWithConstraints(modifier = modifier) {
         val layoutResult = remember(text, textStyle, constraints.maxWidth, textMeasurer) {
@@ -1718,6 +1749,8 @@ data class LyricLine(
     val text: String,
     val translation: String? = null,
     val words: List<LyricWord>? = null,
+    val romanization: String? = null,
+    val romanizationWords: List<LyricWord>? = null,
 )
 
 private data class RawLyricLine(
@@ -1727,24 +1760,55 @@ private data class RawLyricLine(
 )
 
 const val LYRIC_TRANSLATION_MARKER = "\n__FUO_LYRIC_TRANSLATION__\n"
+const val LYRIC_ROMANIZATION_MARKER = "\n__FUO_LYRIC_ROMANIZATION__\n"
 
-fun composeLyricsWithTranslation(main: String, translation: String?): String {
+fun composeLyricsWithTranslation(main: String, translation: String?): String =
+    composeLyricsWithRichTracks(main = main, translation = translation)
+
+fun composeLyricsWithRichTracks(
+    main: String,
+    translation: String? = null,
+    romanization: String? = null,
+): String {
     val trimmedMain = main.trimEnd()
-    val trimmedTranslation = translation?.trim()?.takeIf { it.isNotBlank() } ?: return trimmedMain
-    return trimmedMain + LYRIC_TRANSLATION_MARKER + trimmedTranslation
+    val trimmedRomanization = romanization?.trim()?.takeIf(String::isNotBlank)
+    val trimmedTranslation = translation?.trim()?.takeIf(String::isNotBlank)
+    if (trimmedRomanization == null && trimmedTranslation == null) return trimmedMain
+    return buildString {
+        append(trimmedMain)
+        trimmedRomanization?.let {
+            append(LYRIC_ROMANIZATION_MARKER)
+            append(it)
+        }
+        trimmedTranslation?.let {
+            append(LYRIC_TRANSLATION_MARKER)
+            append(it)
+        }
+    }
 }
 
 fun parseLyrics(raw: String?): List<LyricLine> {
     if (raw.isNullOrBlank()) return emptyList()
-    val parts = raw.split(LYRIC_TRANSLATION_MARKER, limit = 2)
-    val main = parts[0]
-    val translationRaw = parts.getOrNull(1)
-    val lines = if (main.lineSequence().any { yrcLineHeaderRegex.containsMatchIn(it.trim()) }) {
-        parseYrc(main)
+    val translationParts = raw.split(LYRIC_TRANSLATION_MARKER, limit = 2)
+    val mainAndRomanization = translationParts[0]
+    val translationRaw = translationParts.getOrNull(1)
+    val romanizationParts = mainAndRomanization.split(LYRIC_ROMANIZATION_MARKER, limit = 2)
+    val main = romanizationParts[0]
+    val romanizationRaw = romanizationParts.getOrNull(1)
+    val lines = parseLyricTrack(main)
+    return attachLyricRomanization(
+        lines = attachLyricTranslations(lines, translationRaw),
+        romanizationRaw = romanizationRaw,
+    )
+}
+
+private fun parseLyricTrack(raw: String?): List<LyricLine> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return if (raw.lineSequence().any { yrcLineHeaderRegex.containsMatchIn(it.trim()) }) {
+        parseYrc(raw)
     } else {
-        parseLrc(main)
+        parseLrc(raw)
     }
-    return attachLyricTranslations(lines, translationRaw)
 }
 
 fun attachLyricTranslations(lines: List<LyricLine>, translationRaw: String?): List<LyricLine> {
@@ -1771,6 +1835,59 @@ fun attachLyricTranslations(lines: List<LyricLine>, translationRaw: String?): Li
         line.copy(translation = exact ?: nearestTime?.let(byTime::get))
     }
 }
+
+fun attachLyricRomanization(lines: List<LyricLine>, romanizationRaw: String?): List<LyricLine> {
+    if (romanizationRaw.isNullOrBlank() || lines.isEmpty()) return lines
+    val romanizationLines = parseLyricTrack(romanizationRaw)
+        .filter { it.timeMs != Long.MAX_VALUE }
+    if (romanizationLines.isEmpty()) return lines
+    val primaryTimedSize = lines.count { it.timeMs != Long.MAX_VALUE }
+    return lines.mapIndexed { index, line ->
+        if (line.timeMs == Long.MAX_VALUE || !line.romanization.isNullOrBlank()) return@mapIndexed line
+        val secondary = alignedRomanizationLine(
+            track = romanizationLines,
+            primaryTimeMs = line.timeMs,
+            primaryIndex = index,
+            primarySize = primaryTimedSize,
+        ) ?: return@mapIndexed line
+        val romanization = listOfNotNull(secondary.text, secondary.translation)
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .distinct()
+            .joinToString("\n")
+            .takeIf { it.isNotBlank() && it != line.text.trim() }
+            ?: return@mapIndexed line
+        val words = secondary.words
+            ?.takeIf { secondary.translation.isNullOrBlank() && secondary.text.trim() == romanization }
+        line.copy(
+            romanization = romanization,
+            romanizationWords = words,
+        )
+    }
+}
+
+private fun alignedRomanizationLine(
+    track: List<LyricLine>,
+    primaryTimeMs: Long,
+    primaryIndex: Int,
+    primarySize: Int,
+): LyricLine? {
+    val nearest = track.minByOrNull { kotlin.math.abs(it.timeMs - primaryTimeMs) }
+    if (
+        nearest != null &&
+        kotlin.math.abs(nearest.timeMs - primaryTimeMs) <= LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS
+    ) {
+        return nearest
+    }
+    return track.getOrNull(primaryIndex)
+        ?.takeIf {
+            track.size == primarySize &&
+                kotlin.math.abs(it.timeMs - primaryTimeMs) <= LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS
+        }
+}
+
+private const val LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS = 350L
+private const val LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS = 1_500L
 
 fun parseYrc(raw: String?): List<LyricLine> {
     if (raw.isNullOrBlank()) return emptyList()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.json.longOrNull
 import kotlin.math.abs
 
 /**
- * Composes provider lyric tracks into the app's existing lyric transport format.
- * The main LRC/YRC/QRC-derived track keeps its timing. Translation,
- * romanization and annotation tracks are aligned and rendered as secondary
- * lines through the existing translation slot for backward-compatible styling.
+ * Composes provider lyric tracks into the app's lyric transport format.
+ * The primary LRC/YRC/QRC-derived track keeps its timing. Romanization is kept
+ * as an independent rich track so word timing can be rendered above the primary
+ * lyric, while translation and annotation remain lower secondary lines.
  */
 fun composeRichLyrics(
     main: String,
@@ -22,39 +22,50 @@ fun composeRichLyrics(
     val primary = stripStructuredYrcMetadata(main).trimEnd()
     if (primary.isBlank()) return primary
 
-    val secondaryTracks = listOf(translation, romanization, annotation)
+    val romanizationTrack = romanization
+        ?.let(::stripStructuredYrcMetadata)
+        ?.trim()
+        ?.takeIf(String::isNotBlank)
+    val secondaryTracks = listOf(translation, annotation)
         .mapNotNull { raw ->
             raw?.let(::stripStructuredYrcMetadata)
                 ?.trim()
                 ?.takeIf(String::isNotBlank)
         }
-    if (secondaryTracks.isEmpty()) return primary
-    if (secondaryTracks.size == 1) return composeLyricsWithTranslation(primary, secondaryTracks.first())
 
-    val primaryLines = parseTimedRichTrack(primary)
-    val parsedTracks = secondaryTracks.map(::parseTimedRichTrack).filter { it.isNotEmpty() }
-    if (primaryLines.isEmpty() || parsedTracks.isEmpty()) {
+    if (romanizationTrack == null && secondaryTracks.isEmpty()) return primary
+    if (romanizationTrack == null && secondaryTracks.size == 1) {
         return composeLyricsWithTranslation(primary, secondaryTracks.first())
     }
 
-    val secondary = buildString {
-        primaryLines.forEachIndexed { index, line ->
-            val values = parsedTracks.mapNotNull { track ->
-                alignedSecondaryText(track, line.timeMs, index, primaryLines.size)
+    val primaryLines = parseTimedRichTrack(primary)
+    val parsedTracks = secondaryTracks.map(::parseTimedRichTrack).filter { it.isNotEmpty() }
+    val secondary = when {
+        secondaryTracks.isEmpty() -> null
+        primaryLines.isEmpty() || parsedTracks.isEmpty() -> secondaryTracks.first()
+        else -> buildString {
+            primaryLines.forEachIndexed { index, line ->
+                val values = parsedTracks.mapNotNull { track ->
+                    alignedSecondaryText(track, line.timeMs, index, primaryLines.size)
+                }
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .filter { it != line.text.trim() }
+                    .distinct()
+                values.forEach { value ->
+                    append(formatRichLrcTimestamp(line.timeMs))
+                    append(value)
+                    append('\n')
+                }
             }
-                .map(String::trim)
-                .filter(String::isNotBlank)
-                .filter { it != line.text.trim() }
-                .distinct()
-            values.forEach { value ->
-                append(formatRichLrcTimestamp(line.timeMs))
-                append(value)
-                append('\n')
-            }
-        }
-    }.trimEnd()
+        }.trimEnd().takeIf(String::isNotBlank)
+    }
 
-    return composeLyricsWithTranslation(primary, secondary.takeIf(String::isNotBlank))
+    return composeLyricsWithRichTracks(
+        main = primary,
+        translation = secondary,
+        romanization = romanizationTrack,
+    )
 }
 
 private data class TimedRichText(val timeMs: Long, val text: String)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/TimedLineLyrics.kt
@@ -1,8 +1,9 @@
 package org.feeluown.mobile
 
 /**
- * Converts the app's supported lyric formats (LRC/YRC plus optional translation)
- * into plain timed line-level LRC suitable for platform media-session extensions.
+ * Converts the app's supported lyric formats (LRC/YRC plus optional secondary
+ * tracks) into plain timed line-level LRC suitable for platform media-session
+ * extensions.
  *
  * ColorOS accepts this line-level LRC as the required `lyric` payload. Word-level
  * `rawLyric` is intentionally omitted until FuoEvolve can serialize a compatible
@@ -19,13 +20,14 @@ fun toTimedLineLrc(rawLyrics: String?): String? {
             append(timestamp)
             append(line.text.trim())
             append('\n')
-            line.translation
-                ?.lineSequence()
-                ?.map(String::trim)
-                ?.filter(String::isNotBlank)
-                ?.filter { it != line.text.trim() }
-                ?.distinct()
-                ?.forEach { secondaryLine ->
+            listOf(line.translation, line.romanization)
+                .filterNotNull()
+                .flatMap { secondary -> secondary.lineSequence().toList() }
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .filter { it != line.text.trim() }
+                .distinct()
+                .forEach { secondaryLine ->
                     append(timestamp)
                     append(secondaryLine)
                     append('\n')

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
@@ -2,11 +2,12 @@ package org.feeluown.mobile
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RichLyricsTest {
     @Test
-    fun rendersTranslationAndRomanizationOnSeparateLines() {
+    fun keepsTranslationAndRomanizationOnDedicatedTracks() {
         val raw = composeRichLyrics(
             main = "[00:01.000]Hello\n[00:03.000]World",
             translation = "[00:01.020]你好\n[00:03.000]世界",
@@ -16,24 +17,34 @@ class RichLyricsTest {
         val lines = parseLyrics(raw)
         assertEquals(2, lines.size)
         assertEquals("Hello", lines[0].text)
-        assertEquals("你好\nhello", lines[0].translation)
-        assertEquals("世界\nworld", lines[1].translation)
+        assertEquals("你好", lines[0].translation)
+        assertEquals("hello", lines[0].romanization)
+        assertEquals("世界", lines[1].translation)
+        assertEquals("world", lines[1].romanization)
+        assertNull(lines[0].romanizationWords)
         assertTrue(!raw.contains('\u2028'))
     }
 
     @Test
-    fun preservesWordTimedPrimaryTrack() {
+    fun preservesWordTimedPrimaryAndRomanizationTracks() {
         val raw = composeRichLyrics(
             main = "[1000,2000](1000,500,0)Hel(1500,1500,0)lo",
             translation = "[00:01.000]你好",
-            romanization = "[00:01.000]hello",
+            romanization = "[1000,2000](1000,500,0)hel(1500,1500,0)lo",
         )
 
         val line = parseLyrics(raw).single()
         assertEquals("Hello", line.text)
         assertEquals(2, line.words?.size)
-        assertTrue(line.translation?.contains("你好") == true)
-        assertTrue(line.translation?.contains("hello") == true)
+        assertEquals("你好", line.translation)
+        assertEquals("hello", line.romanization)
+        assertEquals(
+            listOf(
+                LyricWord(1_000, 500, "hel"),
+                LyricWord(1_500, 1_500, "lo"),
+            ),
+            line.romanizationWords,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- render romanized lyrics above the primary lyric using smaller typography
- preserve romanization word timing and reuse the existing karaoke fill when the provider supplies per-word timing
- fall back to plain small romanization when only line timing is available
- keep translation below the primary lyric and preserve timed-line export compatibility

## Validation
- Android APK PR workflow #220: passed
- iOS Debug App PR workflow #302: simulator build, device build, packaging and uploads passed
- added common tests covering dedicated translation/romanization tracks and word-timed romanization
- independently compiled and asserted the lyric parser paths for word-timed and line-timed romanization