### PR TITLE
集中智能替换设置并修复无匹配后停止播放

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -139,7 +139,7 @@ class KotlinProviderRepository : ProviderMusicRepository {
         val direct = originalProvider?.resolve(mediaTrack, quality)
         if (direct != null) return direct
         if (unavailablePolicy == UnavailablePlaybackPolicy.Skip) {
-            error("media unavailable: ${mediaTrack.id}")
+            error("media not found: ${mediaTrack.id}")
         }
 
         val candidates = selectedProvidersForReplacement(smartReplacementProviderIds, originalProviderId)
@@ -149,7 +149,7 @@ class KotlinProviderRepository : ProviderMusicRepository {
             minScore = smartReplacementMinScore,
             scoreOf = { candidate -> replacementScore(mediaTrack, candidate) },
             resolve = { candidate -> providerMap[candidate.source]?.resolve(candidate, quality) },
-        ) ?: error("media unavailable and no smart replacement: ${mediaTrack.id}")
+        ) ?: error("media not found after smart replacement: ${mediaTrack.id}")
         val (candidate, score, payload) = selected
         return annotateSmartReplacement(
             payload = payload,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -180,6 +180,7 @@ fun SettingsScreen(
                     )
                     AudioQualitySettingsPanel(controller)
                     PlaybackPolicySettingsPanel(controller)
+                    SmartReplacementSettingsPanel(controller)
                 }
                 Column(
                     modifier = Modifier
@@ -211,6 +212,7 @@ fun SettingsScreen(
                 )
                 AudioQualitySettingsPanel(controller)
                 PlaybackPolicySettingsPanel(controller)
+                SmartReplacementSettingsPanel(controller)
                 PlayerDisplaySettingsPanel(controller)
                 LocalMusicScanSettingsPanel(controller)
                 DownloadSettingsPanel(controller)
@@ -543,28 +545,30 @@ private fun ProviderDisplaySettingsDialog(
         title = { Text(provider.providerName) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("显示与替换设置", style = MaterialTheme.typography.bodyMedium)
-                ProviderDisplaySection.entries.forEach { section ->
-                    val selected = controller.isProviderShownIn(provider.providerId, section)
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(section.label)
-                        IconButton(
-                            enabled = !controller.isLoading && (selected || section != ProviderDisplaySection.Replace),
-                            onClick = {
-                                controller.onProviderShownInChange(provider.providerId, section, !selected)
-                            },
+                Text("显示设置", style = MaterialTheme.typography.bodyMedium)
+                ProviderDisplaySection.entries
+                    .filter { it != ProviderDisplaySection.Replace }
+                    .forEach { section ->
+                        val selected = controller.isProviderShownIn(provider.providerId, section)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Icon(
-                                imageVector = if (selected) Icons.Filled.CheckCircle else Icons.Filled.RadioButtonUnchecked,
-                                contentDescription = if (selected) "关闭${section.label}" else "开启${section.label}",
-                            )
+                            Text(section.label)
+                            IconButton(
+                                enabled = !controller.isLoading,
+                                onClick = {
+                                    controller.onProviderShownInChange(provider.providerId, section, !selected)
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = if (selected) Icons.Filled.CheckCircle else Icons.Filled.RadioButtonUnchecked,
+                                    contentDescription = if (selected) "关闭${section.label}" else "开启${section.label}",
+                                )
+                            }
                         }
                     }
-                }
             }
         },
         confirmButton = { TextButton(onClick = onDismissRequest) { Text("完成") } },
@@ -573,7 +577,7 @@ private fun ProviderDisplaySettingsDialog(
 
 private fun providerDisplaySummary(controller: FuoPlayerController, providerId: String): String {
     return ProviderDisplaySection.entries
-        .filter { controller.isProviderShownIn(providerId, it) }
+        .filter { it != ProviderDisplaySection.Replace && controller.isProviderShownIn(providerId, it) }
         .joinToString("、") { it.label }
         .ifBlank { "未显示" }
 }
@@ -966,38 +970,136 @@ fun PlaybackPolicySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
-            if (controller.unavailablePlaybackPolicy == UnavailablePlaybackPolicy.SmartReplace) {
+        }
+    }
+}
+
+@Composable
+fun SmartReplacementSettingsPanel(controller: FuoPlayerController) {
+    val enabled = controller.unavailablePlaybackPolicy == UnavailablePlaybackPolicy.SmartReplace
+    val providers = controller.orderedProviders()
+    val presets = listOf(
+        "宽松" to 0.45,
+        "平衡" to DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
+        "严格" to 0.70,
+    )
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "智能替换",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = if (enabled) {
+                    "原音源无法播放时，从所选音源中搜索并匹配可播放版本"
+                } else {
+                    "当前资源不可用策略为“跳过”，切换为智能替换后以下设置生效"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "替换音源",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (providers.isEmpty()) {
                 Text(
-                    text = "替换设置",
-                    style = MaterialTheme.typography.bodyMedium,
+                    text = "没有已启用的音源",
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "最低打分",
-                            style = MaterialTheme.typography.bodyMedium,
+            } else {
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    providers.forEach { provider ->
+                        val selected = controller.isProviderShownIn(
+                            provider.providerId,
+                            ProviderDisplaySection.Replace,
                         )
-                        Text(
-                            text = formatSmartReplacementScore(controller.smartReplacementMinScore),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        FilterChip(
+                            selected = selected,
+                            enabled = enabled && !controller.isLoading,
+                            onClick = {
+                                controller.onSmartReplacementProviderEnabledChange(
+                                    provider.providerId,
+                                    !selected,
+                                )
+                            },
+                            label = { Text(provider.providerName) },
+                            colors = settingsFilterChipColors(),
                         )
                     }
-                    Slider(
-                        value = controller.smartReplacementMinScore.toFloat(),
-                        onValueChange = {
-                            controller.onSmartReplacementMinScoreChange(roundSmartReplacementScore(it.toDouble()))
-                        },
-                        valueRange = 0f..1f,
-                        steps = 19,
-                        enabled = !controller.isLoading,
+                }
+                Text(
+                    text = if (providers.size < 2) {
+                        "仅启用一个音源时无法跨源替换；播放时会自动排除歌曲自身来源"
+                    } else {
+                        "播放时会自动排除歌曲自身来源；候选音源顺序沿用上方音源排序"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = "匹配严格度",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                presets.forEach { (label, score) ->
+                    FilterChip(
+                        selected = kotlin.math.abs(controller.smartReplacementMinScore - score) < 0.001,
+                        enabled = enabled && !controller.isLoading,
+                        onClick = { controller.onSmartReplacementMinScoreChange(score) },
+                        label = { Text(label) },
+                        colors = settingsFilterChipColors(),
                     )
                 }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "最低匹配分",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = formatSmartReplacementScore(controller.smartReplacementMinScore),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Slider(
+                    value = controller.smartReplacementMinScore.toFloat(),
+                    onValueChange = {
+                        controller.onSmartReplacementMinScoreChange(roundSmartReplacementScore(it.toDouble()))
+                    },
+                    valueRange = 0f..1f,
+                    steps = 19,
+                    enabled = enabled && !controller.isLoading,
+                )
+                Text(
+                    text = "分数越高匹配越严格；自定义滑块会覆盖上方预设",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -983,6 +983,17 @@ fun SmartReplacementSettingsPanel(controller: FuoPlayerController) {
         "平衡" to DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
         "严格" to 0.70,
     )
+    fun isPresetScore(score: Double): Boolean = presets.any { (_, presetScore) ->
+        kotlin.math.abs(score - presetScore) < 0.001
+    }
+    var customScoreExpanded by remember {
+        mutableStateOf(!isPresetScore(controller.smartReplacementMinScore))
+    }
+    LaunchedEffect(controller.smartReplacementMinScore) {
+        if (!isPresetScore(controller.smartReplacementMinScore)) {
+            customScoreExpanded = true
+        }
+    }
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surfaceContainer,
@@ -1062,44 +1073,57 @@ fun SmartReplacementSettingsPanel(controller: FuoPlayerController) {
             ) {
                 presets.forEach { (label, score) ->
                     FilterChip(
-                        selected = kotlin.math.abs(controller.smartReplacementMinScore - score) < 0.001,
+                        selected = !customScoreExpanded &&
+                            kotlin.math.abs(controller.smartReplacementMinScore - score) < 0.001,
                         enabled = enabled && !controller.isLoading,
-                        onClick = { controller.onSmartReplacementMinScoreChange(score) },
+                        onClick = {
+                            customScoreExpanded = false
+                            controller.onSmartReplacementMinScoreChange(score)
+                        },
                         label = { Text(label) },
                         colors = settingsFilterChipColors(),
                     )
                 }
+                FilterChip(
+                    selected = customScoreExpanded,
+                    enabled = enabled && !controller.isLoading,
+                    onClick = { customScoreExpanded = true },
+                    label = { Text("自定义") },
+                    colors = settingsFilterChipColors(),
+                )
             }
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "最低匹配分",
-                        style = MaterialTheme.typography.bodyMedium,
+            if (customScoreExpanded) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "最低匹配分",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            text = formatSmartReplacementScore(controller.smartReplacementMinScore),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Slider(
+                        value = controller.smartReplacementMinScore.toFloat(),
+                        onValueChange = {
+                            controller.onSmartReplacementMinScoreChange(roundSmartReplacementScore(it.toDouble()))
+                        },
+                        valueRange = 0f..1f,
+                        steps = 19,
+                        enabled = enabled && !controller.isLoading,
                     )
                     Text(
-                        text = formatSmartReplacementScore(controller.smartReplacementMinScore),
-                        style = MaterialTheme.typography.bodyMedium,
+                        text = "分数越高匹配越严格",
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Slider(
-                    value = controller.smartReplacementMinScore.toFloat(),
-                    onValueChange = {
-                        controller.onSmartReplacementMinScoreChange(roundSmartReplacementScore(it.toDouble()))
-                    },
-                    valueRange = 0f..1f,
-                    steps = 19,
-                    enabled = enabled && !controller.isLoading,
-                )
-                Text(
-                    text = "分数越高匹配越严格；自定义滑块会覆盖上方预设",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
         }
     }


### PR DESCRIPTION
## 改动

- 将替换音源从单个音源的「显示与替换设置」中移出，音源配置恢复为纯显示设置
- 新增独立「智能替换」设置块，集中配置替换音源、匹配严格度预设与最低匹配分
- 智能替换关闭时保留配置但禁用相关控件，并提示其生效条件
- 替换源顺序沿用全局音源排序，播放时继续自动排除歌曲自身来源
- 修复原媒体不可用或智能替换没有可播放匹配时错误语义不一致的问题，使现有恢复逻辑能够标记当前曲目不可用并自动跳到下一首

## 根因

Controller 和 Android PlaybackService 的不可用恢复逻辑只识别 `media not found` / `MediaNotFound`，但 ProviderRepository 在直接无媒体和智能替换无匹配时抛出的是 `media unavailable...`，导致错误没有进入 `isUnavailable + skip` 分支，而是停在 Error 状态。

## 验证重点

- 设置页在窄屏/宽屏布局下都出现独立智能替换卡片
- 每个音源的显示设置不再包含「替换」
- 替换音源至少保留一个，沿用现有 Controller 约束
- 智能替换无匹配时当前歌曲标记不可用并继续下一首
- Android PlaybackService 通过既有 `media not found` 识别路径进入恢复逻辑