### PR TITLE
合并网易云热门歌手与歌手广场入口

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -281,7 +281,11 @@ class KotlinProviderRepository : ProviderMusicRepository {
 
     override suspend fun features(): List<ProviderFeature> {
         initialize()
-        return enabledProviderIds.flatMap { providerMap[it]?.features.orEmpty() }
+        return enabledProviderIds
+            .flatMap { providerMap[it]?.features.orEmpty() }
+            .filterNot { feature ->
+                feature.providerId == NETEASE_PROVIDER_ID && feature.id == NETEASE_LEGACY_TOP_ARTISTS_FEATURE_ID
+            }
     }
 
     override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection =
@@ -558,6 +562,8 @@ private fun replacementArtistMatchTexts(value: String): List<String> {
         .distinct()
 }
 
+private const val NETEASE_PROVIDER_ID = "netease"
+private const val NETEASE_LEGACY_TOP_ARTISTS_FEATURE_ID = "netease_top_artists"
 private const val BILIBILI_PROVIDER_ID = "bilibili"
 private val BILIBILI_REPLACEMENT_BONUS_KEYWORDS = listOf("mv", "hires")
 private val BILIBILI_REPLACEMENT_PENALTY_KEYWORDS = listOf("cover", "翻唱", "remix")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryFeatureTest.kt
@@ -1,0 +1,32 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+
+class KotlinProviderRepositoryFeatureTest {
+    @Test
+    fun hidesRedundantNeteaseTopArtistsFeature() = runTest {
+        val client = ProviderHttpClient(
+            httpClient = HttpClient(MockEngine) {
+                engine { addHandler { respond("{\"code\":200}") } }
+            },
+        )
+        val repository = KotlinProviderRepository(
+            http = client,
+            credentials = InMemoryProviderCredentialStore(),
+        )
+
+        val features = repository.features()
+
+        assertTrue(features.any { it.id == "netease_artist_square" })
+        assertFalse(features.any { it.id == "netease_top_artists" })
+        client.close()
+    }
+}


### PR DESCRIPTION
## 变更

- 保留网易云音乐「歌手广场」作为唯一歌手发现入口。
- 在应用暴露给 UI 的功能列表中隐藏重复的 `netease_top_artists`「热门歌手」入口。
- 保留原 `netease_top_artists` 加载逻辑，兼容历史状态或旧入口。
- 新增回归测试，确保「歌手广场」存在且「热门歌手」不再重复展示。

## 原因

网易云歌手广场默认参数即 `area=-1 / type=-1 / initial=-1`，其中 `initial=-1` 对应「热门」。因此默认歌手广场与单独的热门歌手入口在产品层面重复。

## 影响

用户进入网易云音乐探索页时只会看到「歌手广场」。默认打开仍展示热门歌手，并可继续通过地区、类型、首字母筛选。