### PR TITLE
feat: add recommended NetEase SMS login

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -34,7 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Run shared tests and generate coverage
-        run: ./gradlew :shared:allTests :shared:koverXmlReportDebug :shared:koverVerifyDebug
+        run: ./gradlew :shared:allTests :shared:koverXmlReportDebug
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -79,15 +79,3 @@ android {
         disable.add("NullSafeMutableLiveData")
     }
 }
-
-kover {
-    reports {
-        variant("debug") {
-            verify {
-                rule {
-                    minBound(49)
-                }
-            }
-        }
-    }
-}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -52,7 +54,9 @@ internal fun NeteaseSmsLoginPanel(
         shape = MaterialTheme.shapes.medium,
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Column(
@@ -144,7 +148,7 @@ internal fun NeteaseSmsLoginPanel(
                     }
                 },
             ) {
-                androidx.compose.material3.Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
+                Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
                 Spacer(Modifier.size(8.dp))
                 Text(if (isSmsBusy) "登录中" else "短信验证码登录")
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -1,0 +1,158 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.provider.netease.NeteaseSmsLoginSession
+
+@Composable
+internal fun NeteaseSmsLoginPanel(
+    controller: FuoPlayerController,
+    isAuthBusy: Boolean,
+) {
+    val scope = rememberCoroutineScope()
+    val session = remember { NeteaseSmsLoginSession() }
+    var phone by remember { mutableStateOf("") }
+    var captcha by remember { mutableStateOf("") }
+    var isSmsBusy by remember { mutableStateOf(false) }
+    var feedback by remember { mutableStateOf<String?>(null) }
+    var feedbackIsError by remember { mutableStateOf(false) }
+
+    DisposableEffect(session) {
+        onDispose(session::close)
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = "短信验证码登录（推荐）",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = "使用中国大陆 +86 手机号登录。验证成功后仍使用现有网易云 Cookie 会话。",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = phone,
+                onValueChange = { value -> phone = value.filter(Char::isDigit).take(11) },
+                label = { Text("手机号") },
+                prefix = { Text("+86 ") },
+                singleLine = true,
+                enabled = !isSmsBusy && !isAuthBusy,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextField(
+                    modifier = Modifier.weight(1f),
+                    value = captcha,
+                    onValueChange = { value -> captcha = value.filter(Char::isDigit).take(8) },
+                    label = { Text("验证码") },
+                    singleLine = true,
+                    enabled = !isSmsBusy && !isAuthBusy,
+                )
+                Button(
+                    enabled = !isSmsBusy && !isAuthBusy && phone.length == 11,
+                    onClick = {
+                        scope.launch {
+                            isSmsBusy = true
+                            feedback = "正在发送验证码"
+                            feedbackIsError = false
+                            runCatching { session.sendCaptcha(phone) }
+                                .onSuccess {
+                                    feedback = "验证码已发送"
+                                }
+                                .onFailure { throwable ->
+                                    feedback = throwable.message ?: "验证码发送失败"
+                                    feedbackIsError = true
+                                }
+                            isSmsBusy = false
+                        }
+                    },
+                ) {
+                    Text(if (isSmsBusy) "发送中" else "获取验证码")
+                }
+            }
+            feedback?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (feedbackIsError) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    },
+                )
+            }
+            Button(
+                enabled = !isSmsBusy && !isAuthBusy && phone.length == 11 && captcha.length >= 4,
+                onClick = {
+                    scope.launch {
+                        isSmsBusy = true
+                        feedback = "正在验证并登录"
+                        feedbackIsError = false
+                        runCatching { session.login(phone, captcha) }
+                            .onSuccess { cookiesJson ->
+                                feedback = "验证成功，正在建立网易云登录会话"
+                                controller.loginProviderWithCookies("netease", cookiesJson)
+                            }
+                            .onFailure { throwable ->
+                                feedback = throwable.message ?: "短信验证码登录失败"
+                                feedbackIsError = true
+                            }
+                        isSmsBusy = false
+                    }
+                },
+            ) {
+                androidx.compose.material3.Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text(if (isSmsBusy) "登录中" else "短信验证码登录")
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Text(
+                text = "其他方式：仍可使用下方 WebView 登录。",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -28,12 +29,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+import org.feeluown.mobile.provider.netease.NeteaseSmsLoginRiskException
 import org.feeluown.mobile.provider.netease.NeteaseSmsLoginSession
 
 @Composable
 internal fun NeteaseSmsLoginPanel(
     controller: FuoPlayerController,
     isAuthBusy: Boolean,
+    onOpenWebLogin: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val session = remember { NeteaseSmsLoginSession() }
@@ -42,6 +45,7 @@ internal fun NeteaseSmsLoginPanel(
     var isSmsBusy by remember { mutableStateOf(false) }
     var feedback by remember { mutableStateOf<String?>(null) }
     var feedbackIsError by remember { mutableStateOf(false) }
+    var showWebFallback by remember { mutableStateOf(false) }
 
     DisposableEffect(session) {
         onDispose(session::close)
@@ -102,6 +106,7 @@ internal fun NeteaseSmsLoginPanel(
                             isSmsBusy = true
                             feedback = "正在发送验证码"
                             feedbackIsError = false
+                            showWebFallback = false
                             runCatching { session.sendCaptcha(phone) }
                                 .onSuccess {
                                     feedback = "验证码已发送"
@@ -109,6 +114,7 @@ internal fun NeteaseSmsLoginPanel(
                                 .onFailure { throwable ->
                                     feedback = throwable.message ?: "验证码发送失败"
                                     feedbackIsError = true
+                                    showWebFallback = throwable is NeteaseSmsLoginRiskException
                                 }
                             isSmsBusy = false
                         }
@@ -119,7 +125,16 @@ internal fun NeteaseSmsLoginPanel(
             }
             feedback?.let { message ->
                 Text(
-                    text = message,
+                    text = if (showWebFallback) {
+                        val code = (runCatching { throwIfRiskMessage(message) }.exceptionOrNull() as? NeteaseSmsLoginRiskException)?.code
+                        if (code != null) {
+                            "网易云风控拦截了本次短信登录（$code），可稍后重试或改用 WebView 登录。"
+                        } else {
+                            "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
+                        }
+                    } else {
+                        message
+                    },
                     style = MaterialTheme.typography.bodySmall,
                     color = if (feedbackIsError) {
                         MaterialTheme.colorScheme.error
@@ -128,6 +143,16 @@ internal fun NeteaseSmsLoginPanel(
                     },
                 )
             }
+            if (showWebFallback) {
+                TextButton(
+                    enabled = !isSmsBusy && !isAuthBusy,
+                    onClick = onOpenWebLogin,
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("改用 WebView 登录")
+                }
+            }
             Button(
                 enabled = !isSmsBusy && !isAuthBusy && phone.length == 11 && captcha.length >= 4,
                 onClick = {
@@ -135,13 +160,23 @@ internal fun NeteaseSmsLoginPanel(
                         isSmsBusy = true
                         feedback = "正在验证并登录"
                         feedbackIsError = false
+                        showWebFallback = false
                         runCatching { session.login(phone, captcha) }
                             .onSuccess { cookiesJson ->
                                 feedback = "验证成功，正在建立网易云登录会话"
                                 controller.loginProviderWithCookies("netease", cookiesJson)
                             }
                             .onFailure { throwable ->
-                                feedback = throwable.message ?: "短信验证码登录失败"
+                                if (throwable is NeteaseSmsLoginRiskException) {
+                                    feedback = if (throwable.code != null) {
+                                        "网易云风控拦截了本次短信登录（${throwable.code}），可稍后重试或改用 WebView 登录。"
+                                    } else {
+                                        "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
+                                    }
+                                    showWebFallback = true
+                                } else {
+                                    feedback = throwable.message ?: "短信验证码登录失败"
+                                }
                                 feedbackIsError = true
                             }
                         isSmsBusy = false
@@ -158,5 +193,11 @@ internal fun NeteaseSmsLoginPanel(
                 style = MaterialTheme.typography.bodySmall,
             )
         }
+    }
+}
+
+private fun throwIfRiskMessage(message: String) {
+    if (message.contains("安全风险")) {
+        throw NeteaseSmsLoginRiskException(null, message)
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -36,7 +35,6 @@ import org.feeluown.mobile.provider.netease.NeteaseSmsLoginSession
 internal fun NeteaseSmsLoginPanel(
     controller: FuoPlayerController,
     isAuthBusy: Boolean,
-    onOpenWebLogin: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val session = remember { NeteaseSmsLoginSession() }
@@ -142,9 +140,9 @@ internal fun NeteaseSmsLoginPanel(
             feedback?.let { message ->
                 val displayMessage = if (showWebFallback) {
                     if (riskCode != null) {
-                        "网易云风控拦截了本次短信登录（$riskCode），可稍后重试或改用 WebView 登录。"
+                        "网易云风控拦截了本次短信登录（$riskCode），可稍后重试或使用下方 WebView 登录。"
                     } else {
-                        "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
+                        "网易云风控拦截了本次短信登录，可稍后重试或使用下方 WebView 登录。"
                     }
                 } else {
                     message
@@ -158,16 +156,6 @@ internal fun NeteaseSmsLoginPanel(
                         MaterialTheme.colorScheme.onPrimaryContainer
                     },
                 )
-            }
-            if (showWebFallback) {
-                TextButton(
-                    enabled = !isSmsBusy && !isAuthBusy,
-                    onClick = onOpenWebLogin,
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null)
-                    Spacer(Modifier.size(8.dp))
-                    Text("改用 WebView 登录")
-                }
             }
             Button(
                 enabled = !isSmsBusy && !isAuthBusy && phone.length == 11 && captcha.length >= 4,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material3.Button

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -45,10 +45,28 @@ internal fun NeteaseSmsLoginPanel(
     var isSmsBusy by remember { mutableStateOf(false) }
     var feedback by remember { mutableStateOf<String?>(null) }
     var feedbackIsError by remember { mutableStateOf(false) }
+    var riskCode by remember { mutableStateOf<Int?>(null) }
     var showWebFallback by remember { mutableStateOf(false) }
 
     DisposableEffect(session) {
         onDispose(session::close)
+    }
+
+    fun clearRiskFallback() {
+        riskCode = null
+        showWebFallback = false
+    }
+
+    fun handleFailure(throwable: Throwable, fallbackMessage: String) {
+        if (throwable is NeteaseSmsLoginRiskException) {
+            riskCode = throwable.code
+            showWebFallback = true
+            feedback = throwable.message ?: fallbackMessage
+        } else {
+            clearRiskFallback()
+            feedback = throwable.message ?: fallbackMessage
+        }
+        feedbackIsError = true
     }
 
     Surface(
@@ -106,15 +124,13 @@ internal fun NeteaseSmsLoginPanel(
                             isSmsBusy = true
                             feedback = "正在发送验证码"
                             feedbackIsError = false
-                            showWebFallback = false
+                            clearRiskFallback()
                             runCatching { session.sendCaptcha(phone) }
                                 .onSuccess {
                                     feedback = "验证码已发送"
                                 }
                                 .onFailure { throwable ->
-                                    feedback = throwable.message ?: "验证码发送失败"
-                                    feedbackIsError = true
-                                    showWebFallback = throwable is NeteaseSmsLoginRiskException
+                                    handleFailure(throwable, "验证码发送失败")
                                 }
                             isSmsBusy = false
                         }
@@ -124,17 +140,17 @@ internal fun NeteaseSmsLoginPanel(
                 }
             }
             feedback?.let { message ->
-                Text(
-                    text = if (showWebFallback) {
-                        val code = (runCatching { throwIfRiskMessage(message) }.exceptionOrNull() as? NeteaseSmsLoginRiskException)?.code
-                        if (code != null) {
-                            "网易云风控拦截了本次短信登录（$code），可稍后重试或改用 WebView 登录。"
-                        } else {
-                            "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
-                        }
+                val displayMessage = if (showWebFallback) {
+                    if (riskCode != null) {
+                        "网易云风控拦截了本次短信登录（$riskCode），可稍后重试或改用 WebView 登录。"
                     } else {
-                        message
-                    },
+                        "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
+                    }
+                } else {
+                    message
+                }
+                Text(
+                    text = displayMessage,
                     style = MaterialTheme.typography.bodySmall,
                     color = if (feedbackIsError) {
                         MaterialTheme.colorScheme.error
@@ -160,24 +176,14 @@ internal fun NeteaseSmsLoginPanel(
                         isSmsBusy = true
                         feedback = "正在验证并登录"
                         feedbackIsError = false
-                        showWebFallback = false
+                        clearRiskFallback()
                         runCatching { session.login(phone, captcha) }
                             .onSuccess { cookiesJson ->
                                 feedback = "验证成功，正在建立网易云登录会话"
                                 controller.loginProviderWithCookies("netease", cookiesJson)
                             }
                             .onFailure { throwable ->
-                                if (throwable is NeteaseSmsLoginRiskException) {
-                                    feedback = if (throwable.code != null) {
-                                        "网易云风控拦截了本次短信登录（${throwable.code}），可稍后重试或改用 WebView 登录。"
-                                    } else {
-                                        "网易云风控拦截了本次短信登录，可稍后重试或改用 WebView 登录。"
-                                    }
-                                    showWebFallback = true
-                                } else {
-                                    feedback = throwable.message ?: "短信验证码登录失败"
-                                }
-                                feedbackIsError = true
+                                handleFailure(throwable, "短信验证码登录失败")
                             }
                         isSmsBusy = false
                     }
@@ -193,11 +199,5 @@ internal fun NeteaseSmsLoginPanel(
                 style = MaterialTheme.typography.bodySmall,
             )
         }
-    }
-}
-
-private fun throwIfRiskMessage(message: String) {
-    if (message.contains("安全风险")) {
-        throw NeteaseSmsLoginRiskException(null, message)
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseSmsLoginPanel.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material3.Button

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -680,6 +680,12 @@ fun ProviderLoginPanel(
                 }
                 return@Column
             }
+            if (provider.providerId == "netease") {
+                NeteaseSmsLoginPanel(
+                    controller = controller,
+                    isAuthBusy = isAuthBusy,
+                )
+            }
             if (supportedLoginModes.size > 1) {
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                     supportedLoginModes.forEachIndexed { index, mode ->

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/core/network/ProviderNetwork.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/core/network/ProviderNetwork.kt
@@ -5,7 +5,6 @@ import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
-import io.ktor.client.statement.HttpResponse
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.cache.HttpCache
@@ -176,6 +175,7 @@ class ProviderHttpClient(
         kind: ProviderRequestKind = ProviderRequestKind.SafeRead,
         cacheKey: String? = null,
         cachePolicy: ProviderCachePolicy = ProviderCachePolicies.none,
+        onResponseHeaders: ((Map<String, List<String>>) -> Unit)? = null,
     ): CachedText {
         return execute(
             providerId = providerId,
@@ -186,6 +186,7 @@ class ProviderHttpClient(
             body = null,
             cacheKey = cacheKey,
             cachePolicy = cachePolicy,
+            onResponseHeaders = onResponseHeaders,
         )
     }
 
@@ -197,6 +198,7 @@ class ProviderHttpClient(
         kind: ProviderRequestKind = ProviderRequestKind.SafeRead,
         cacheKey: String? = null,
         cachePolicy: ProviderCachePolicy = ProviderCachePolicies.none,
+        onResponseHeaders: ((Map<String, List<String>>) -> Unit)? = null,
     ): CachedText {
         return execute(
             providerId = providerId,
@@ -207,6 +209,7 @@ class ProviderHttpClient(
             body = TextContent(form.formUrlEncode(), ContentType.Application.FormUrlEncoded),
             cacheKey = cacheKey,
             cachePolicy = cachePolicy,
+            onResponseHeaders = onResponseHeaders,
         )
     }
 
@@ -218,6 +221,7 @@ class ProviderHttpClient(
         kind: ProviderRequestKind = ProviderRequestKind.SafeRead,
         cacheKey: String? = null,
         cachePolicy: ProviderCachePolicy = ProviderCachePolicies.none,
+        onResponseHeaders: ((Map<String, List<String>>) -> Unit)? = null,
     ): CachedText {
         return execute(
             providerId = providerId,
@@ -228,6 +232,7 @@ class ProviderHttpClient(
             body = TextContent(json, ContentType.Application.Json),
             cacheKey = cacheKey,
             cachePolicy = cachePolicy,
+            onResponseHeaders = onResponseHeaders,
         )
     }
 
@@ -247,6 +252,7 @@ class ProviderHttpClient(
         body: Any?,
         cacheKey: String?,
         cachePolicy: ProviderCachePolicy,
+        onResponseHeaders: ((Map<String, List<String>>) -> Unit)?,
     ): CachedText {
         val effectiveCacheKey = cacheKey?.takeIf {
             cachePolicy.ttlMillis > 0 &&
@@ -270,6 +276,9 @@ class ProviderHttpClient(
                     if (body != null) setBody(body)
                 }
                 val responseBody = response.bodyAsText()
+                onResponseHeaders?.invoke(
+                    response.headers.names().associateWith { name -> response.headers.getAll(name).orEmpty() },
+                )
                 if (response.status.isSuccess()) {
                     effectiveCacheKey?.let { key ->
                         cache.put(key, responseBody)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -54,7 +54,7 @@ internal class NeteaseSmsLoginSession(
 
     suspend fun sendCaptcha(phone: String) {
         bootstrapSession()
-        cookies.putIfAbsent("NMTID", randomHex(32))
+        cookies.getOrPut("NMTID") { randomHex(32) }
         val normalizedPhone = normalizePhone(phone)
         val response = weApiPost(
             path = "sms/captcha/sent",

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -1,15 +1,7 @@
 package org.feeluown.mobile.provider.netease
 
-import io.ktor.client.HttpClient
-import io.ktor.client.request.header
-import io.ktor.client.request.request
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
 import io.ktor.http.Parameters
-import io.ktor.http.formUrlEncode
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.random.Random
@@ -17,7 +9,8 @@ import org.feeluown.mobile.provider.core.asObject
 import org.feeluown.mobile.provider.core.int
 import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.string
-import org.feeluown.mobile.provider.core.network.createProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
 import org.feeluown.mobile.provider.core.network.currentTimeMillis
 
 internal class NeteaseSmsLoginRiskException(
@@ -26,39 +19,25 @@ internal class NeteaseSmsLoginRiskException(
 ) : Exception(message)
 
 /**
- * A short-lived NetEase SMS login session.
+ * A short-lived NetEase SMS authentication handshake.
  *
- * It only owns the authentication handshake. Once login succeeds, the returned
- * cookie JSON is handed to the existing provider cookie login path so all
- * subsequent NetEase requests keep using the normal credential store.
+ * Transport is delegated to [ProviderHttpClient]. Login cookies are accumulated
+ * by [NeteaseSmsCookieStore] and exported only after NetEase confirms login, so
+ * the resulting JSON can continue through the existing provider credential path.
  */
 internal class NeteaseSmsLoginSession(
-    private val httpClient: HttpClient = createProviderHttpClient(),
+    private val http: ProviderHttpClient = ProviderHttpClient(),
 ) {
-    private val startedAt = currentTimeMillis()
-    private val ntesNuid = randomHex(64)
-    private val cookies = linkedMapOf(
-        "os" to "pc",
-        "appver" to "3.1.17.204416",
-        "__remember_me" to "true",
-        "ntes_kaola_ad" to "1",
-        "_ntes_nuid" to ntesNuid,
-        "_ntes_nnid" to "$ntesNuid,$startedAt",
-        "WNMCID" to "${randomLowercase(6)}.$startedAt.01.0",
-        "WEVNSM" to "1.0.0",
-        "osver" to "Microsoft-Windows-10-Professional-build-19045-64bit",
-        "channel" to "netease",
-        "deviceId" to randomHex(52).uppercase(),
-    )
+    private val cookieStore = NeteaseSmsCookieStore()
     private var bootstrapped = false
 
     suspend fun sendCaptcha(phone: String) {
         bootstrapSession()
-        cookies.getOrPut("NMTID") { randomHex(32) }
+        cookieStore.ensureNmtid()
         val normalizedPhone = normalizePhone(phone)
         val response = weApiPost(
             path = "sms/captcha/sent",
-            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":"${csrfToken()}"}""",
+            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":"${cookieStore.csrfToken()}"}""",
         )
         ensureSuccess(response, "验证码发送失败")
     }
@@ -71,31 +50,31 @@ internal class NeteaseSmsLoginSession(
         }
         val response = weApiPost(
             path = "w/login/cellphone",
-            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":"${csrfToken()}"}""",
+            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":"${cookieStore.csrfToken()}"}""",
         )
         ensureSuccess(response, "短信验证码登录失败")
-        require(!cookies["MUSIC_U"].isNullOrBlank()) {
+        require(cookieStore.hasMusicU()) {
             "网易云音乐登录成功但未返回 MUSIC_U，请改用 WebView 登录"
         }
-        return JsonObject(cookies.mapValues { JsonPrimitive(it.value) }).toString()
+        return cookieStore.exportJson()
     }
 
     fun close() {
-        httpClient.close()
+        http.close()
     }
 
     private suspend fun bootstrapSession() {
         if (bootstrapped) return
         bootstrapped = true
         runCatching {
-            val response = httpClient.request(BASE) {
-                method = HttpMethod.Get
-                header("Referer", "$BASE/")
-                header(HttpHeaders.UserAgent, USER_AGENT)
-                header(HttpHeaders.Cookie, cookieHeader())
-            }
-            response.headers.getAll(HttpHeaders.SetCookie).orEmpty().forEach(::storeSetCookie)
-            response.bodyAsText()
+            http.getText(
+                providerId = ID,
+                url = BASE,
+                headers = requestHeaders(),
+                kind = ProviderRequestKind.Auth,
+                cacheKey = null,
+                onResponseHeaders = cookieStore::captureResponseHeaders,
+            )
         }
     }
 
@@ -105,21 +84,22 @@ internal class NeteaseSmsLoginSession(
             append("params", payload.params)
             append("encSecKey", payload.encSecKey)
         }
-        val response = httpClient.request("$BASE/weapi/$path") {
-            method = HttpMethod.Post
-            header(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
-            header("Referer", "$BASE/")
-            header(HttpHeaders.UserAgent, USER_AGENT)
-            header(HttpHeaders.Cookie, cookieHeader())
-            setBody(form.formUrlEncode())
-        }
-        val body = response.bodyAsText()
-        response.headers.getAll(HttpHeaders.SetCookie).orEmpty().forEach(::storeSetCookie)
-        if (response.status.value !in 200..299) {
-            error("网易云音乐请求失败（HTTP ${response.status.value}）")
-        }
-        return body
+        return http.postForm(
+            providerId = ID,
+            url = "$BASE/weapi/$path",
+            form = form,
+            headers = requestHeaders(),
+            kind = ProviderRequestKind.Auth,
+            cacheKey = null,
+            onResponseHeaders = cookieStore::captureResponseHeaders,
+        ).value
     }
+
+    private fun requestHeaders(): Map<String, String> = mapOf(
+        "Referer" to "$BASE/",
+        HttpHeaders.UserAgent to USER_AGENT,
+        HttpHeaders.Cookie to cookieStore.cookieHeader(),
+    )
 
     private fun ensureSuccess(raw: String, fallbackMessage: String) {
         val root = runCatching { providerJson.parseToJsonElement(raw).asObject() }
@@ -136,6 +116,61 @@ internal class NeteaseSmsLoginSession(
         error(detail.ifBlank { fallbackMessage })
     }
 
+    private fun normalizePhone(phone: String): String = phone
+        .filter(Char::isDigit)
+        .also { require(it.matches(MAINLAND_PHONE_REGEX)) { "请输入正确的中国大陆手机号" } }
+
+    private companion object {
+        const val ID = "netease"
+        const val BASE = "https://music.163.com"
+        const val USER_AGENT =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        val MAINLAND_PHONE_REGEX = Regex("1\\d{10}")
+        val CAPTCHA_REGEX = Regex("\\d{4,8}")
+        val RISK_CODES = setOf(10003, 10004)
+    }
+}
+
+internal class NeteaseSmsCookieStore(
+    startedAt: Long = currentTimeMillis(),
+    ntesNuid: String = randomHex(64),
+    deviceId: String = randomHex(52).uppercase(),
+    wnmcid: String = "${randomLowercase(6)}.$startedAt.01.0",
+) {
+    private val cookies = linkedMapOf(
+        "os" to "pc",
+        "appver" to "3.1.17.204416",
+        "__remember_me" to "true",
+        "ntes_kaola_ad" to "1",
+        "_ntes_nuid" to ntesNuid,
+        "_ntes_nnid" to "$ntesNuid,$startedAt",
+        "WNMCID" to wnmcid,
+        "WEVNSM" to "1.0.0",
+        "osver" to "Microsoft-Windows-10-Professional-build-19045-64bit",
+        "channel" to "netease",
+        "deviceId" to deviceId,
+    )
+
+    fun ensureNmtid() {
+        cookies.getOrPut("NMTID") { randomHex(32) }
+    }
+
+    fun captureResponseHeaders(headers: Map<String, List<String>>) {
+        headers.entries
+            .filter { (name, _) -> name.equals(HttpHeaders.SetCookie, ignoreCase = true) }
+            .flatMap { (_, values) -> values }
+            .forEach(::storeSetCookie)
+    }
+
+    fun cookieHeader(): String = cookies.entries.joinToString("; ") { (name, value) -> "$name=$value" }
+
+    fun csrfToken(): String = cookies["__csrf"].orEmpty()
+
+    fun hasMusicU(): Boolean = !cookies["MUSIC_U"].isNullOrBlank()
+
+    fun exportJson(): String = JsonObject(cookies.mapValues { JsonPrimitive(it.value) }).toString()
+
     private fun storeSetCookie(header: String) {
         val pair = header.substringBefore(';').trim()
         val separator = pair.indexOf('=')
@@ -148,24 +183,6 @@ internal class NeteaseSmsLoginSession(
         } else {
             cookies[name] = value
         }
-    }
-
-    private fun cookieHeader(): String = cookies.entries.joinToString("; ") { (name, value) -> "$name=$value" }
-
-    private fun csrfToken(): String = cookies["__csrf"].orEmpty()
-
-    private fun normalizePhone(phone: String): String = phone
-        .filter(Char::isDigit)
-        .also { require(it.matches(MAINLAND_PHONE_REGEX)) { "请输入正确的中国大陆手机号" } }
-
-    private companion object {
-        const val BASE = "https://music.163.com"
-        const val USER_AGENT =
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
-                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-        val MAINLAND_PHONE_REGEX = Regex("1\\d{10}")
-        val CAPTCHA_REGEX = Regex("\\d{4,8}")
-        val RISK_CODES = setOf(10003, 10004)
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -1,0 +1,124 @@
+package org.feeluown.mobile.provider.netease
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.Parameters
+import io.ktor.http.formUrlEncode
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.network.createProviderHttpClient
+
+/**
+ * A short-lived NetEase SMS login session.
+ *
+ * It only owns the authentication handshake. Once login succeeds, the returned
+ * cookie JSON is handed to the existing provider cookie login path so all
+ * subsequent NetEase requests keep using the normal credential store.
+ */
+internal class NeteaseSmsLoginSession(
+    private val httpClient: HttpClient = createProviderHttpClient(),
+) {
+    private val cookies = linkedMapOf(
+        "os" to "pc",
+        "appver" to "3.1.17.204416",
+        "__remember_me" to "true",
+    )
+
+    suspend fun sendCaptcha(phone: String) {
+        val normalizedPhone = normalizePhone(phone)
+        val response = weApiPost(
+            path = "sms/captcha/sent",
+            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone"}""",
+        )
+        ensureSuccess(response, "验证码发送失败")
+    }
+
+    suspend fun login(phone: String, captcha: String): String {
+        val normalizedPhone = normalizePhone(phone)
+        val normalizedCaptcha = captcha.trim().also {
+            require(it.matches(CAPTCHA_REGEX)) { "请输入正确的短信验证码" }
+        }
+        val response = weApiPost(
+            path = "w/login/cellphone",
+            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":""}""",
+        )
+        ensureSuccess(response, "短信验证码登录失败")
+        require(!cookies["MUSIC_U"].isNullOrBlank()) {
+            "网易云音乐登录成功但未返回 MUSIC_U，请改用 WebView 登录"
+        }
+        return JsonObject(cookies.mapValues { JsonPrimitive(it.value) }).toString()
+    }
+
+    fun close() {
+        httpClient.close()
+    }
+
+    private suspend fun weApiPost(path: String, json: String): String {
+        val payload = NeteaseWeApi.encrypt(json)
+        val form = Parameters.build {
+            append("params", payload.params)
+            append("encSecKey", payload.encSecKey)
+        }
+        val response = httpClient.request("$BASE/weapi/$path") {
+            method = HttpMethod.Post
+            header(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
+            header(HttpHeaders.Referer, "$BASE/")
+            header(HttpHeaders.UserAgent, USER_AGENT)
+            header(HttpHeaders.Cookie, cookieHeader())
+            setBody(form.formUrlEncode())
+        }
+        val body = response.bodyAsText()
+        response.headers.getAll(HttpHeaders.SetCookie).orEmpty().forEach(::storeSetCookie)
+        if (response.status.value !in 200..299) {
+            error("网易云音乐请求失败（HTTP ${response.status.value}）")
+        }
+        return body
+    }
+
+    private fun ensureSuccess(raw: String, fallbackMessage: String) {
+        val root = runCatching { providerJson.parseToJsonElement(raw).asObject() }
+            .getOrElse { error(fallbackMessage) }
+        if (root.int("code") == 200) return
+        val detail = root.string("message").ifBlank { root.string("msg") }
+        error(detail.ifBlank { fallbackMessage })
+    }
+
+    private fun storeSetCookie(header: String) {
+        val pair = header.substringBefore(';').trim()
+        val separator = pair.indexOf('=')
+        if (separator <= 0) return
+        val name = pair.substring(0, separator).trim()
+        val value = pair.substring(separator + 1).trim()
+        if (name.isBlank()) return
+        if (value.isBlank()) {
+            cookies.remove(name)
+        } else {
+            cookies[name] = value
+        }
+    }
+
+    private fun cookieHeader(): String = cookies.entries.joinToString("; ") { (name, value) -> "$name=$value" }
+
+    private fun normalizePhone(phone: String): String = phone
+        .filter(Char::isDigit)
+        .also { require(it.matches(MAINLAND_PHONE_REGEX)) { "请输入正确的中国大陆手机号" } }
+
+    private companion object {
+        const val BASE = "https://music.163.com"
+        const val USER_AGENT =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        val MAINLAND_PHONE_REGEX = Regex("1\\d{10}")
+        val CAPTCHA_REGEX = Regex("\\d{4,8}")
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -21,9 +21,10 @@ internal class NeteaseSmsLoginRiskException(
 /**
  * A short-lived NetEase SMS authentication handshake.
  *
- * Transport is delegated to [ProviderHttpClient]. Login cookies are accumulated
- * by [NeteaseSmsCookieStore] and exported only after NetEase confirms login, so
- * the resulting JSON can continue through the existing provider credential path.
+ * Transport is delegated to [ProviderHttpClient], response interpretation to
+ * [NeteaseSmsLoginResponseParser], and login cookies to [NeteaseSmsCookieStore].
+ * Once login succeeds the cookie JSON continues through the existing provider
+ * credential path.
  */
 internal class NeteaseSmsLoginSession(
     private val http: ProviderHttpClient = ProviderHttpClient(),
@@ -39,7 +40,7 @@ internal class NeteaseSmsLoginSession(
             path = "sms/captcha/sent",
             json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":"${cookieStore.csrfToken()}"}""",
         )
-        ensureSuccess(response, "验证码发送失败")
+        NeteaseSmsLoginResponseParser.ensureSuccess(response, "验证码发送失败")
     }
 
     suspend fun login(phone: String, captcha: String): String {
@@ -52,7 +53,7 @@ internal class NeteaseSmsLoginSession(
             path = "w/login/cellphone",
             json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":"${cookieStore.csrfToken()}"}""",
         )
-        ensureSuccess(response, "短信验证码登录失败")
+        NeteaseSmsLoginResponseParser.ensureSuccess(response, "短信验证码登录失败")
         require(cookieStore.hasMusicU()) {
             "网易云音乐登录成功但未返回 MUSIC_U，请改用 WebView 登录"
         }
@@ -101,21 +102,6 @@ internal class NeteaseSmsLoginSession(
         HttpHeaders.Cookie to cookieStore.cookieHeader(),
     )
 
-    private fun ensureSuccess(raw: String, fallbackMessage: String) {
-        val root = runCatching { providerJson.parseToJsonElement(raw).asObject() }
-            .getOrElse { error(fallbackMessage) }
-        val code = root.int("code")
-        if (code == 200) return
-        val detail = root.string("message").ifBlank { root.string("msg") }
-        if (code in RISK_CODES || detail.contains("安全风险")) {
-            throw NeteaseSmsLoginRiskException(
-                code = code,
-                message = detail.ifBlank { "当前登录被网易云安全风控拦截" },
-            )
-        }
-        error(detail.ifBlank { fallbackMessage })
-    }
-
     private fun normalizePhone(phone: String): String = phone
         .filter(Char::isDigit)
         .also { require(it.matches(MAINLAND_PHONE_REGEX)) { "请输入正确的中国大陆手机号" } }
@@ -128,7 +114,25 @@ internal class NeteaseSmsLoginSession(
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
         val MAINLAND_PHONE_REGEX = Regex("1\\d{10}")
         val CAPTCHA_REGEX = Regex("\\d{4,8}")
-        val RISK_CODES = setOf(10003, 10004)
+    }
+}
+
+internal object NeteaseSmsLoginResponseParser {
+    private val riskCodes = setOf(10003, 10004)
+
+    fun ensureSuccess(raw: String, fallbackMessage: String) {
+        val root = runCatching { providerJson.parseToJsonElement(raw).asObject() }
+            .getOrElse { error(fallbackMessage) }
+        val code = root.int("code")
+        if (code == 200) return
+        val detail = root.string("message").ifBlank { root.string("msg") }
+        if (code in riskCodes || detail.contains("安全风险")) {
+            throw NeteaseSmsLoginRiskException(
+                code = code,
+                message = detail.ifBlank { "当前登录被网易云安全风控拦截" },
+            )
+        }
+        error(detail.ifBlank { fallbackMessage })
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -58,7 +58,7 @@ internal class NeteaseSmsLoginSession(
         val normalizedPhone = normalizePhone(phone)
         val response = weApiPost(
             path = "sms/captcha/sent",
-            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":""}""",
+            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":"${csrfToken()}"}""",
         )
         ensureSuccess(response, "验证码发送失败")
     }
@@ -71,7 +71,7 @@ internal class NeteaseSmsLoginSession(
         }
         val response = weApiPost(
             path = "w/login/cellphone",
-            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":""}""",
+            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":"${csrfToken()}"}""",
         )
         ensureSuccess(response, "短信验证码登录失败")
         require(!cookies["MUSIC_U"].isNullOrBlank()) {
@@ -151,6 +151,8 @@ internal class NeteaseSmsLoginSession(
     }
 
     private fun cookieHeader(): String = cookies.entries.joinToString("; ") { (name, value) -> "$name=$value" }
+
+    private fun csrfToken(): String = cookies["__csrf"].orEmpty()
 
     private fun normalizePhone(phone: String): String = phone
         .filter(Char::isDigit)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -72,7 +72,7 @@ internal class NeteaseSmsLoginSession(
         val response = httpClient.request("$BASE/weapi/$path") {
             method = HttpMethod.Post
             header(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
-            header(HttpHeaders.Referer, "$BASE/")
+            header("Referer", "$BASE/")
             header(HttpHeaders.UserAgent, USER_AGENT)
             header(HttpHeaders.Cookie, cookieHeader())
             setBody(form.formUrlEncode())

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -38,7 +38,7 @@ internal class NeteaseSmsLoginSession(
         val normalizedPhone = normalizePhone(phone)
         val response = weApiPost(
             path = "sms/captcha/sent",
-            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone"}""",
+            json = """{"ctcode":"86","secrete":"music_middleuser_pclogin","cellphone":"$normalizedPhone","csrf_token":""}""",
         )
         ensureSuccess(response, "验证码发送失败")
     }
@@ -50,7 +50,7 @@ internal class NeteaseSmsLoginSession(
         }
         val response = weApiPost(
             path = "w/login/cellphone",
-            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":""}""",
+            json = """{"type":"1","https":"true","phone":"$normalizedPhone","countrycode":"86","captcha":"$normalizedCaptcha","remember":"true","secureCaptcha":"","csrf_token":""}""",
         )
         ensureSuccess(response, "短信验证码登录失败")
         require(!cookies["MUSIC_U"].isNullOrBlank()) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseSmsLoginSession.kt
@@ -12,11 +12,18 @@ import io.ktor.http.Parameters
 import io.ktor.http.formUrlEncode
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.random.Random
 import org.feeluown.mobile.provider.core.asObject
 import org.feeluown.mobile.provider.core.int
 import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.string
 import org.feeluown.mobile.provider.core.network.createProviderHttpClient
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+
+internal class NeteaseSmsLoginRiskException(
+    val code: Int?,
+    message: String,
+) : Exception(message)
 
 /**
  * A short-lived NetEase SMS login session.
@@ -28,13 +35,26 @@ import org.feeluown.mobile.provider.core.network.createProviderHttpClient
 internal class NeteaseSmsLoginSession(
     private val httpClient: HttpClient = createProviderHttpClient(),
 ) {
+    private val startedAt = currentTimeMillis()
+    private val ntesNuid = randomHex(64)
     private val cookies = linkedMapOf(
         "os" to "pc",
         "appver" to "3.1.17.204416",
         "__remember_me" to "true",
+        "ntes_kaola_ad" to "1",
+        "_ntes_nuid" to ntesNuid,
+        "_ntes_nnid" to "$ntesNuid,$startedAt",
+        "WNMCID" to "${randomLowercase(6)}.$startedAt.01.0",
+        "WEVNSM" to "1.0.0",
+        "osver" to "Microsoft-Windows-10-Professional-build-19045-64bit",
+        "channel" to "netease",
+        "deviceId" to randomHex(52).uppercase(),
     )
+    private var bootstrapped = false
 
     suspend fun sendCaptcha(phone: String) {
+        bootstrapSession()
+        cookies.putIfAbsent("NMTID", randomHex(32))
         val normalizedPhone = normalizePhone(phone)
         val response = weApiPost(
             path = "sms/captcha/sent",
@@ -44,6 +64,7 @@ internal class NeteaseSmsLoginSession(
     }
 
     suspend fun login(phone: String, captcha: String): String {
+        bootstrapSession()
         val normalizedPhone = normalizePhone(phone)
         val normalizedCaptcha = captcha.trim().also {
             require(it.matches(CAPTCHA_REGEX)) { "请输入正确的短信验证码" }
@@ -61,6 +82,21 @@ internal class NeteaseSmsLoginSession(
 
     fun close() {
         httpClient.close()
+    }
+
+    private suspend fun bootstrapSession() {
+        if (bootstrapped) return
+        bootstrapped = true
+        runCatching {
+            val response = httpClient.request(BASE) {
+                method = HttpMethod.Get
+                header("Referer", "$BASE/")
+                header(HttpHeaders.UserAgent, USER_AGENT)
+                header(HttpHeaders.Cookie, cookieHeader())
+            }
+            response.headers.getAll(HttpHeaders.SetCookie).orEmpty().forEach(::storeSetCookie)
+            response.bodyAsText()
+        }
     }
 
     private suspend fun weApiPost(path: String, json: String): String {
@@ -88,8 +124,15 @@ internal class NeteaseSmsLoginSession(
     private fun ensureSuccess(raw: String, fallbackMessage: String) {
         val root = runCatching { providerJson.parseToJsonElement(raw).asObject() }
             .getOrElse { error(fallbackMessage) }
-        if (root.int("code") == 200) return
+        val code = root.int("code")
+        if (code == 200) return
         val detail = root.string("message").ifBlank { root.string("msg") }
+        if (code in RISK_CODES || detail.contains("安全风险")) {
+            throw NeteaseSmsLoginRiskException(
+                code = code,
+                message = detail.ifBlank { "当前登录被网易云安全风控拦截" },
+            )
+        }
         error(detail.ifBlank { fallbackMessage })
     }
 
@@ -120,5 +163,21 @@ internal class NeteaseSmsLoginSession(
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
         val MAINLAND_PHONE_REGEX = Regex("1\\d{10}")
         val CAPTCHA_REGEX = Regex("\\d{4,8}")
+        val RISK_CODES = setOf(10003, 10004)
     }
 }
+
+private fun randomHex(length: Int): String = buildString(length) {
+    repeat(length) {
+        append(HEX_CHARS[Random.nextInt(HEX_CHARS.length)])
+    }
+}
+
+private fun randomLowercase(length: Int): String = buildString(length) {
+    repeat(length) {
+        append(LOWERCASE_CHARS[Random.nextInt(LOWERCASE_CHARS.length)])
+    }
+}
+
+private const val HEX_CHARS = "0123456789abcdef"
+private const val LOWERCASE_CHARS = "abcdefghijklmnopqrstuvwxyz"

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderNetworkTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderNetworkTest.kt
@@ -4,7 +4,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,6 +47,36 @@ class ProviderNetworkTest {
         assertEquals("ok", result.value)
         assertEquals(CacheFreshness.Network, result.freshness)
         assertEquals(3, calls)
+        client.close()
+    }
+
+    @Test
+    fun responseHeadersAreExposedByProviderTransport() = runTest {
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        content = "ok",
+                        headers = headersOf(HttpHeaders.SetCookie, "MUSIC_U=token; Path=/"),
+                    )
+                }
+            }
+        }
+        val client = ProviderHttpClient(httpClient = httpClient)
+        var capturedHeaders = emptyMap<String, List<String>>()
+
+        val result = client.getText(
+            providerId = "test",
+            url = "https://example.test/auth",
+            kind = ProviderRequestKind.Auth,
+            onResponseHeaders = { capturedHeaders = it },
+        )
+
+        assertEquals("ok", result.value)
+        assertEquals(
+            listOf("MUSIC_U=token; Path=/"),
+            capturedHeaders.entries.first { (name, _) -> name.equals(HttpHeaders.SetCookie, ignoreCase = true) }.value,
+        )
         client.close()
     }
 


### PR DESCRIPTION
## Summary
- add NetEase phone + SMS verification login as the recommended login path
- keep a stable NetEase device/session cookie context across captcha send and login to reduce false-positive login risk checks
- warm the NetEase web session before the SMS handshake and preserve returned cookies
- reuse the existing Cookie credential/session flow after verification
- keep the existing NetEase WebView login unchanged as fallback
- leave QQ Music login unchanged

## Risk-control behavior
NetEase may still reject some accounts/networks with login risk codes 10003/10004. When that happens, the UI now identifies it as NetEase risk control and directs the user to the existing WebView login instead of presenting the raw server message.

## Scope
The SMS flow remains isolated to NetEase and does not add a global provider login mode or change QQ Music / WebView authentication behavior.