### PR TITLE
feat: safely refine smart replacement tie ordering

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -124,7 +124,7 @@ class KotlinProviderRepository : ProviderMusicRepository {
             minScore = smartReplacementMinScore,
             scoreOf = { candidate -> replacementScore(mediaTrack, candidate) },
         )
-        return ranked
+        return sortReplacementScoreTies(mediaTrack, ranked)
     }
 
     override suspend fun resolve(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
@@ -1,0 +1,100 @@
+package org.feeluown.mobile
+
+import kotlin.math.abs
+
+/**
+ * Refines only candidates that have exactly the same legacy replacement score.
+ * It never changes the score itself or which candidates pass the configured threshold.
+ */
+internal fun sortReplacementScoreTies(
+    origin: MusicTrack,
+    ranked: List<ReplacementCandidate>,
+): List<ReplacementCandidate> {
+    if (ranked.size < 2) return ranked
+    return ranked
+        .withIndex()
+        .sortedWith(
+            compareByDescending<IndexedValue<ReplacementCandidate>> { it.value.score }
+                .thenByDescending { replacementTieBreakConfidence(origin, it.value.track) }
+                .thenBy { it.index },
+        )
+        .map { it.value }
+}
+
+internal fun replacementTieBreakConfidence(origin: MusicTrack, candidate: MusicTrack): Double {
+    val titleScore = orderedTextSimilarity(origin.title, candidate.title)
+    val artistScore = artistSetSimilarity(origin.artists, candidate.artists)
+    val albumScore = exactMetadataMatch(origin.album, candidate.album)
+    val durationScore = durationCloseness(origin.durationMs, candidate.durationMs)
+    return titleScore * 0.45 + artistScore * 0.30 + albumScore * 0.15 + durationScore * 0.10
+}
+
+private fun orderedTextSimilarity(leftValue: String, rightValue: String): Double {
+    val left = normalizeTieBreakText(leftValue)
+    val right = normalizeTieBreakText(rightValue)
+    if (left.isBlank() || right.isBlank()) return 0.0
+    if (left == right) return 1.0
+    val longest = maxOf(left.length, right.length)
+    val distance = levenshteinDistance(left, right)
+    return (1.0 - distance.toDouble() / longest.toDouble()).coerceIn(0.0, 1.0)
+}
+
+private fun artistSetSimilarity(leftValue: String, rightValue: String): Double {
+    val left = splitArtists(leftValue)
+    val right = splitArtists(rightValue)
+    if (left.isEmpty() || right.isEmpty()) return 0.0
+    if (left == right) return 1.0
+    val intersection = left.intersect(right).size.toDouble()
+    val union = left.union(right).size.toDouble()
+    return if (union == 0.0) 0.0 else intersection / union
+}
+
+private fun exactMetadataMatch(leftValue: String, rightValue: String): Double {
+    val left = normalizeTieBreakText(leftValue)
+    val right = normalizeTieBreakText(rightValue)
+    if (left.isBlank() || right.isBlank()) return 0.0
+    return if (left == right) 1.0 else 0.0
+}
+
+private fun durationCloseness(left: Long?, right: Long?): Double {
+    val leftDuration = left?.takeIf { it > 0 } ?: return 0.0
+    val rightDuration = right?.takeIf { it > 0 } ?: return 0.0
+    val difference = abs(leftDuration - rightDuration)
+    return when {
+        difference <= 3_000L -> 1.0
+        difference <= 10_000L -> 0.5
+        else -> 0.0
+    }
+}
+
+private fun splitArtists(value: String): Set<String> {
+    val expanded = Regex("(?i)\\b(feat|featuring|ft|with)\\b\\.?").replace(value, "/")
+    return Regex("\\s*(?:/|、|,|，|;|；|&|\\+|＋|×)\\s*")
+        .split(expanded)
+        .map { normalizeTieBreakText(it) }
+        .filter { it.isNotBlank() }
+        .toSet()
+}
+
+private fun levenshteinDistance(left: String, right: String): Int {
+    if (left.isEmpty()) return right.length
+    if (right.isEmpty()) return left.length
+    var previous = IntArray(right.length + 1) { it }
+    var current = IntArray(right.length + 1)
+    left.forEachIndexed { leftIndex, leftChar ->
+        current[0] = leftIndex + 1
+        right.forEachIndexed { rightIndex, rightChar ->
+            val insertion = current[rightIndex] + 1
+            val deletion = previous[rightIndex + 1] + 1
+            val substitution = previous[rightIndex] + if (leftChar == rightChar) 0 else 1
+            current[rightIndex + 1] = minOf(insertion, deletion, substitution)
+        }
+        val swap = previous
+        previous = current
+        current = swap
+    }
+    return previous[right.length]
+}
+
+private fun normalizeTieBreakText(value: String): String =
+    value.lowercase().replace(Regex("[^\\p{L}\\p{N}]"), "")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
@@ -1,0 +1,75 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReplacementTieBreakTest {
+    @Test
+    fun tieBreakDoesNotChangeLegacyScoresOrCandidateCount() {
+        val original = track("netease", "Together", "Alice / Bob", album = "Album", durationMs = 180_000)
+        val lessCorroborated = ReplacementCandidate(
+            track("ytmusic", "Together", "Alice", album = "", durationMs = null, id = "less"),
+            0.80,
+        )
+        val corroborated = ReplacementCandidate(
+            track("qqmusic", "Together", "Bob & Alice", album = "Album", durationMs = 181_000, id = "better"),
+            0.80,
+        )
+
+        val ranked = listOf(lessCorroborated, corroborated)
+        val sorted = sortReplacementScoreTies(original, ranked)
+
+        assertEquals(ranked.size, sorted.size)
+        assertEquals(ranked.map { it.score }.sorted(), sorted.map { it.score }.sorted())
+        assertEquals("better", sorted.first().track.id)
+    }
+
+    @Test
+    fun higherLegacyScoreAlwaysWinsOverTieBreakConfidence() {
+        val original = track("netease", "Song", "Alice", album = "Album", durationMs = 180_000)
+        val higherLegacy = ReplacementCandidate(
+            track("ytmusic", "Different", "Other", id = "higher"),
+            0.81,
+        )
+        val lowerLegacyButPerfectMetadata = ReplacementCandidate(
+            track("qqmusic", "Song", "Alice", album = "Album", durationMs = 180_000, id = "lower"),
+            0.80,
+        )
+
+        val sorted = sortReplacementScoreTies(original, listOf(lowerLegacyButPerfectMetadata, higherLegacy))
+
+        assertEquals("higher", sorted.first().track.id)
+        assertEquals(0.81, sorted.first().score, 0.0001)
+    }
+
+    @Test
+    fun orderedTitleSimilarityDistinguishesReorderedTextForTies() {
+        val original = track("netease", "abc", "Artist")
+        val ordered = track("qqmusic", "abc", "Artist", id = "ordered")
+        val reordered = track("ytmusic", "cba", "Artist", id = "reordered")
+
+        assertTrue(
+            replacementTieBreakConfidence(original, ordered) >
+                replacementTieBreakConfidence(original, reordered),
+        )
+    }
+
+    private fun track(
+        source: String,
+        title: String,
+        artists: String,
+        album: String = "",
+        durationMs: Long? = null,
+        id: String = "$source:$title",
+    ): MusicTrack = MusicTrack(
+        id = id,
+        title = title,
+        artists = artists,
+        album = album,
+        source = source,
+        sourceType = TrackSourceType.Provider,
+        durationMs = durationMs,
+        providerId = id,
+    )
+}


### PR DESCRIPTION
Keep the existing smart replacement score formula and minScore filtering unchanged. Add secondary ordering only when legacy scores are exactly equal, using title order, normalized artist sets, exact album agreement, and close duration. No hard rejection, abstention, Bilibili rescaling, threshold change, or score change. Adds focused tests for score/count preservation and tie ordering.