### PR TITLE
feat: improve offline downloads and local library

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidCoalescingLocalMusicRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidCoalescingLocalMusicRepository.kt
@@ -1,0 +1,59 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class AndroidCoalescingLocalMusicRepository(
+    private val delegate: LocalMusicRepository,
+    private val assetStore: AndroidOfflineAssetStore,
+) : LocalMusicRepository {
+    private val refreshMutex = Mutex()
+    private var lastSuccessfulRefreshAt = 0L
+
+    override val mediaChangeEvents: Flow<Unit> = delegate.mediaChangeEvents
+
+    override suspend fun updateScanSettings(settings: LocalMusicScanSettings) =
+        delegate.updateScanSettings(settings)
+
+    override suspend fun isDatabaseReady(): Boolean = delegate.isDatabaseReady()
+
+    override suspend fun isDatabaseStale(): Boolean {
+        if (delegate.isDatabaseStale()) return true
+        val assetsByUri = assetStore.all().associateBy { it.localUri }
+        if (assetsByUri.isEmpty()) return false
+        return delegate.tracks().any { track ->
+            val localUri = track.localUri ?: return@any false
+            val asset = assetsByUri[localUri] ?: return@any false
+            track.sourceType != TrackSourceType.Downloaded ||
+                track.id != asset.providerTrackId ||
+                track.source != asset.source ||
+                track.providerId != asset.providerId
+        }
+    }
+
+    override suspend fun directories(): List<LocalMusicDirectory> = delegate.directories()
+
+    override suspend fun tracks(): List<MusicTrack> = delegate.tracks()
+
+    override suspend fun refreshDatabase(): List<MusicTrack> = refreshMutex.withLock {
+        val now = System.currentTimeMillis()
+        if (lastSuccessfulRefreshAt > 0L &&
+            now - lastSuccessfulRefreshAt < LocalLibraryRefreshPolicy.duplicateEventWindowMs &&
+            delegate.isDatabaseReady() &&
+            !isDatabaseStale()
+        ) {
+            return@withLock delegate.tracks()
+        }
+        delegate.refreshDatabase().also {
+            lastSuccessfulRefreshAt = System.currentTimeMillis()
+        }
+    }
+
+    override suspend fun search(keyword: String): List<MusicTrack> = delegate.search(keyword)
+
+    override suspend fun updateMetadata(track: MusicTrack, metadata: LocalTrackMetadata) =
+        delegate.updateMetadata(track, metadata)
+
+    override suspend fun saveLyrics(track: MusicTrack, lyrics: String) = delegate.saveLyrics(track, lyrics)
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -8,18 +8,18 @@ import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -28,8 +28,8 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.RandomAccessFile
-import java.net.URL
 import java.net.HttpURLConnection
+import java.net.URL
 import kotlin.coroutines.coroutineContext
 
 class AndroidDownloadRepository(
@@ -39,6 +39,7 @@ class AndroidDownloadRepository(
 ) : DownloadRepository {
     private val records = linkedMapOf<String, DownloadRecord>()
     private val taskRecords = linkedMapOf<String, DownloadTask>()
+    private val resumeMetadata = linkedMapOf<String, DownloadResumeMetadata>()
     private val mutableStates = MutableStateFlow<Map<String, DownloadState>>(emptyMap())
     private val mutableTasks = MutableStateFlow<List<DownloadTask>>(emptyList())
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -55,6 +56,7 @@ class AndroidDownloadRepository(
         withContext(Dispatchers.IO) {
             records.clear()
             taskRecords.clear()
+            resumeMetadata.clear()
             val file = indexFile()
             if (file.exists()) {
                 val array = JSONArray(file.readText())
@@ -78,8 +80,12 @@ class AndroidDownloadRepository(
                 records.values.forEach { record ->
                     taskRecords[record.trackId] = record.toCompletedTask()
                 }
-                saveTasks()
             }
+            loadResumeMetadata()
+            reconcileStorage()
+            saveRecords()
+            saveTasks()
+            saveResumeMetadata()
             publishStates()
             publishTasks()
             schedule()
@@ -142,11 +148,13 @@ class AndroidDownloadRepository(
             taskConnections.remove(taskId)?.disconnect()
             taskJobs.remove(taskId)?.cancel()
             val task = taskRecords.remove(taskId) ?: return
-            temporaryFile(task.id).delete()
+            deleteTemporaryFiles(task.id)
+            resumeMetadata.remove(task.id)
             val record = records.remove(task.id)
             if (deleteFile) record?.uri?.let(::deleteUri)
             saveRecords()
             saveTasks()
+            saveResumeMetadata()
             publishTasks()
             publishStates()
         }
@@ -165,9 +173,13 @@ class AndroidDownloadRepository(
                     runCatching { File(requireNotNull(Uri.parse(uri).path)).delete() }
                 }
             }
+            val taskKey = recordKey ?: key
+            taskRecords.remove(taskKey)
+            resumeMetadata.remove(taskKey)
+            deleteTemporaryFiles(taskKey)
             saveRecords()
-            taskRecords.remove(recordKey ?: key)
             saveTasks()
+            saveResumeMetadata()
             publishTasks()
             publishStates()
         }
@@ -224,11 +236,13 @@ class AndroidDownloadRepository(
             )
             taskMutex.withLock {
                 records[task.id] = record
+                resumeMetadata.remove(task.id)
                 updateTask(taskRecords.getValue(task.id).copy(
                     status = DownloadTaskStatus.Completed, completedUri = finalUri.toString(), downloadedBytes = bytes,
                     totalBytes = bytes, failureMessage = null, updatedAt = System.currentTimeMillis(),
                 ))
                 saveRecords()
+                saveResumeMetadata()
             }
             tempFile.delete()
         } catch (cancelled: CancellationException) {
@@ -258,12 +272,34 @@ class AndroidDownloadRepository(
             coroutineContext.ensureActive()
             payload.headers.forEach { (key, value) -> connection.setRequestProperty(key, value) }
             val existing = targetFile.length()
-            if (existing > 0) connection.setRequestProperty("Range", "bytes=$existing-")
+            val resourceKey = resumeResourceKey(payload.url)
+            val storedResume = taskMutex.withLock { resumeMetadata[taskId] }
+            val canResume = existing > 0L && storedResume?.resourceKey == resourceKey
+            if (canResume) {
+                connection.setRequestProperty("Range", "bytes=$existing-")
+                (storedResume?.etag ?: storedResume?.lastModified)?.let { validator ->
+                    connection.setRequestProperty("If-Range", validator)
+                }
+            }
             val responseCode = httpConnection?.responseCode
-            val append = existing > 0 && responseCode == HttpURLConnection.HTTP_PARTIAL
+            val append = canResume && responseCode == HttpURLConnection.HTTP_PARTIAL
             val start = if (append) existing else 0L
             val total = connection.contentLengthLong.takeIf { it > 0 }?.plus(start)
+            val nextResume = DownloadResumeMetadata(
+                resourceKey = resourceKey,
+                etag = httpConnection?.getHeaderField("ETag")?.takeIf { it.isNotBlank() }
+                    ?: storedResume?.etag.takeIf { append },
+                lastModified = httpConnection?.getHeaderField("Last-Modified")?.takeIf { it.isNotBlank() }
+                    ?: storedResume?.lastModified.takeIf { append },
+            )
+            taskMutex.withLock {
+                resumeMetadata[taskId] = nextResume
+                saveResumeMetadata()
+            }
+
             var written = start
+            var lastPublishedAt = 0L
+            var lastPersistedAt = 0L
             connection.getInputStream().use { input ->
                 FileOutputStream(targetFile, append).use { output ->
                     val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
@@ -274,13 +310,32 @@ class AndroidDownloadRepository(
                         output.write(buffer, 0, read)
                         written += read
                         if (total != null) {
-                            val progress = (written.toFloat() / total.toFloat()).coerceIn(0f, 1f)
-                            scope.launch { taskMutex.withLock {
-                                taskRecords[taskId]?.let { updateTask(it.copy(downloadedBytes = written, totalBytes = total, updatedAt = System.currentTimeMillis())) }
-                            } }
+                            val now = System.currentTimeMillis()
+                            val publish = now - lastPublishedAt >= DownloadCheckpointPolicy.progressPublishIntervalMs
+                            val persist = now - lastPersistedAt >= DownloadCheckpointPolicy.persistenceIntervalMs
+                            if (publish || persist) {
+                                checkpointProgress(
+                                    taskId = taskId,
+                                    downloadedBytes = written,
+                                    totalBytes = total,
+                                    publish = publish,
+                                    persist = persist,
+                                )
+                                if (publish) lastPublishedAt = now
+                                if (persist) lastPersistedAt = now
+                            }
                         }
                     }
                 }
+            }
+            if (total != null) {
+                checkpointProgress(
+                    taskId = taskId,
+                    downloadedBytes = written,
+                    totalBytes = total,
+                    publish = true,
+                    persist = true,
+                )
             }
             return written
         } catch (throwable: Throwable) {
@@ -289,6 +344,29 @@ class AndroidDownloadRepository(
         } finally {
             taskMutex.withLock { taskConnections.remove(taskId) }
             httpConnection?.disconnect()
+        }
+    }
+
+    private suspend fun checkpointProgress(
+        taskId: String,
+        downloadedBytes: Long,
+        totalBytes: Long,
+        publish: Boolean,
+        persist: Boolean,
+    ) {
+        taskMutex.withLock {
+            val task = taskRecords[taskId] ?: return@withLock
+            if (task.status != DownloadTaskStatus.Downloading) return@withLock
+            taskRecords[taskId] = task.copy(
+                downloadedBytes = downloadedBytes,
+                totalBytes = totalBytes,
+                updatedAt = System.currentTimeMillis(),
+            )
+            if (persist) saveTasks()
+            if (publish) {
+                publishTasks()
+                publishStates()
+            }
         }
     }
 
@@ -423,11 +501,25 @@ class AndroidDownloadRepository(
 
     private fun indexFile(): File = File(context.filesDir, "downloads.json")
     private fun taskIndexFile(): File = File(context.filesDir, "download_tasks.json")
+    private fun resumeIndexFile(): File = File(context.filesDir, "download_resume.json")
 
     private fun temporaryFile(taskId: String, extension: String = "part"): File {
         val directory = File(context.filesDir, "download_parts")
         if (!directory.exists()) directory.mkdirs()
-        return File(directory, "${taskId.hashCode().toUInt().toString(16)}.$extension.part")
+        return File(directory, "${temporaryFilePrefix(taskId)}.$extension.part")
+    }
+
+    private fun temporaryFilePrefix(taskId: String): String = taskId.hashCode().toUInt().toString(16)
+
+    private fun deleteTemporaryFiles(taskId: String) {
+        val directory = File(context.filesDir, "download_parts")
+        if (!directory.isDirectory) return
+        val prefix = "${temporaryFilePrefix(taskId)}."
+        directory.listFiles()?.forEach { file ->
+            if (file.isFile && file.name.startsWith(prefix) && file.name.endsWith(".part")) {
+                runCatching { file.delete() }
+            }
+        }
     }
 
     private fun deleteUri(uri: String) {
@@ -440,6 +532,112 @@ class AndroidDownloadRepository(
         taskRecords.values.forEach { array.put(it.toJson()) }
         taskIndexFile().writeText(array.toString())
     }
+
+    private fun loadResumeMetadata() {
+        val file = resumeIndexFile()
+        if (!file.isFile) return
+        runCatching {
+            val array = JSONArray(file.readText())
+            for (index in 0 until array.length()) {
+                val item = array.getJSONObject(index)
+                val taskId = item.optString("taskId").takeIf { it.isNotBlank() } ?: continue
+                val resourceKey = item.optString("resourceKey").takeIf { it.isNotBlank() } ?: continue
+                resumeMetadata[taskId] = DownloadResumeMetadata(
+                    resourceKey = resourceKey,
+                    etag = item.optString("etag").takeIf { it.isNotBlank() },
+                    lastModified = item.optString("lastModified").takeIf { it.isNotBlank() },
+                )
+            }
+        }.onFailure { throwable ->
+            Log.w(TAG, "load download resume metadata failed", throwable)
+        }
+    }
+
+    private fun saveResumeMetadata() {
+        val array = JSONArray()
+        resumeMetadata.forEach { (taskId, metadata) ->
+            array.put(
+                JSONObject()
+                    .put("taskId", taskId)
+                    .put("resourceKey", metadata.resourceKey)
+                    .put("etag", metadata.etag ?: "")
+                    .put("lastModified", metadata.lastModified ?: ""),
+            )
+        }
+        resumeIndexFile().writeText(array.toString())
+    }
+
+    private fun reconcileStorage() {
+        val now = System.currentTimeMillis()
+        val invalidCompletedIds = taskRecords.values
+            .filter { task ->
+                task.status == DownloadTaskStatus.Completed &&
+                    task.completedUri?.takeIf { it.isNotBlank() }?.let(::downloadedUriExists) != true
+            }
+            .map { it.id }
+            .toSet()
+        invalidCompletedIds.forEach { taskId ->
+            val task = taskRecords[taskId] ?: return@forEach
+            records.remove(taskId)
+            resumeMetadata.remove(taskId)
+            taskRecords[taskId] = task.copy(
+                status = DownloadTaskStatus.Failed,
+                downloadedBytes = 0L,
+                totalBytes = null,
+                completedUri = null,
+                failureMessage = "下载文件不存在，请重试",
+                updatedAt = now,
+            )
+        }
+
+        records.entries.toList().forEach { (taskId, record) ->
+            if (!downloadedUriExists(record.uri)) {
+                records.remove(taskId)
+                resumeMetadata.remove(taskId)
+                taskRecords[taskId]?.let { task ->
+                    taskRecords[taskId] = task.copy(
+                        status = DownloadTaskStatus.Failed,
+                        downloadedBytes = 0L,
+                        totalBytes = null,
+                        completedUri = null,
+                        failureMessage = "下载文件不存在，请重试",
+                        updatedAt = now,
+                    )
+                }
+            } else if (taskId !in taskRecords) {
+                taskRecords[taskId] = record.toCompletedTask()
+            }
+        }
+
+        val activePrefixes = taskRecords.values
+            .filter { it.status != DownloadTaskStatus.Completed }
+            .mapTo(hashSetOf()) { temporaryFilePrefix(it.id) }
+        val partsDirectory = File(context.filesDir, "download_parts")
+        partsDirectory.listFiles()?.forEach { file ->
+            if (!file.isFile || !file.name.endsWith(".part")) return@forEach
+            val prefix = file.name.substringBefore('.')
+            if (prefix !in activePrefixes) runCatching { file.delete() }
+        }
+    }
+
+    private fun downloadedUriExists(uriString: String): Boolean {
+        val uri = runCatching { Uri.parse(uriString) }.getOrNull() ?: return false
+        return when (uri.scheme) {
+            "file" -> uri.path?.let(::File)?.isFile == true
+            "content" -> runCatching {
+                context.contentResolver.query(
+            uri,
+            arrayOf(MediaStore.MediaColumns._ID),
+            null,
+            null,
+            null,
+        )?.use { cursor -> cursor.moveToFirst() } ?: false
+            }.getOrDefault(false)
+            else -> false
+        }
+    }
+
+    private fun resumeResourceKey(url: String): String = url.substringBefore('?').substringBefore('#')
 
     private fun JSONObject.toRecord(): DownloadRecord = DownloadRecord(
         trackId = getString("trackId"),

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidIndexedLocalMusicRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidIndexedLocalMusicRepository.kt
@@ -1,0 +1,726 @@
+package org.feeluown.mobile
+
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import java.io.File
+import java.util.Locale
+
+/**
+ * Incremental MediaStore index used by the Android local library.
+ *
+ * The legacy repository is retained for media observation and write operations (metadata / lyrics)
+ * so this migration changes indexing only. Track rows are upserted when MediaStore's modification
+ * timestamp or the associated offline asset identity changes; missing media ids are removed.
+ */
+internal class AndroidIndexedLocalMusicRepository(
+    context: Context,
+    private val assetStore: AndroidOfflineAssetStore,
+) : LocalMusicRepository {
+    private val appContext = context.applicationContext
+    private val legacy = AndroidLocalMusicRepository(appContext)
+    private val database = IndexedLocalMusicDatabase(appContext)
+
+    @Volatile
+    private var scanSettings = LocalMusicScanSettings()
+
+    override val mediaChangeEvents: Flow<Unit> = legacy.mediaChangeEvents
+
+    override suspend fun updateScanSettings(settings: LocalMusicScanSettings) {
+        scanSettings = settings
+        legacy.updateScanSettings(settings)
+    }
+
+    override suspend fun isDatabaseReady(): Boolean = withContext(Dispatchers.IO) {
+        database.readableDatabase.indexMeta(INDEX_KEY_INITIALIZED) == "1"
+    }
+
+    override suspend fun isDatabaseStale(): Boolean = withContext(Dispatchers.IO) {
+        val db = database.readableDatabase
+        if (db.indexMeta(INDEX_KEY_LAYOUT_VERSION) != INDEX_LAYOUT_VERSION) return@withContext true
+        val rows = queryAudioRows()
+        if (db.indexMeta(INDEX_KEY_FINGERPRINT) != mediaFingerprint(rows)) return@withContext true
+        val stored = db.readStoredSignatures()
+        val assetsByUri = assetStore.all().associateBy { it.localUri }
+        val folderLyrics = queryLyrics()
+        val appLyrics = queryAppLyrics()
+        rows.any { row ->
+            val uri = row.uri.toString()
+            val signature = stored[row.mediaId] ?: return@any true
+            signature.localUri != uri ||
+                signature.assetId != assetsByUri[uri]?.id ||
+                signature.lyrics != row.indexedLyrics(folderLyrics, appLyrics)
+        }
+    }
+
+    override suspend fun directories(): List<LocalMusicDirectory> = withContext(Dispatchers.IO) {
+        database.readableDatabase.readDirectories()
+    }
+
+    override suspend fun tracks(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        database.readableDatabase.readIndexedTracks(scanSettings)
+    }
+
+    override suspend fun refreshDatabase(): List<MusicTrack> = withContext(Dispatchers.IO) {
+        val rows = queryAudioRows()
+        val fingerprint = mediaFingerprint(rows)
+        val imageCovers = queryImageCovers()
+        val fallbackCovers = rows
+            .groupBy { it.directory.id }
+            .mapValues { (_, directoryRows) ->
+                directoryRows
+                    .sortedWith(
+                        compareBy<IndexedAudioRow> { it.displayName.lowercase(Locale.ROOT) }
+                            .thenBy { it.mediaId },
+                    )
+                    .firstOrNull()
+                    ?.let { indexedLocalCoverUri(it.uri, it.albumId) }
+            }
+        val directories = rows
+            .map { it.directory }
+            .distinctBy { it.id }
+            .map { directory ->
+                directory.copy(coverUrl = imageCovers[directory.id] ?: fallbackCovers[directory.id])
+            }
+
+        val assetsByUri = assetStore.all().associateBy { it.localUri }
+        val metadataOverrides = metadataOverrides()
+        val folderLyrics = queryLyrics()
+        val appLyrics = queryAppLyrics()
+        val db = database.writableDatabase
+        val stored = db.readStoredSignatures()
+        val currentIds = rows.mapTo(linkedSetOf()) { it.mediaId }
+        val changed = rows.mapNotNull { row ->
+        val uri = row.uri.toString()
+        val asset = assetsByUri[uri]
+        val signature = stored[row.mediaId]
+        val lyrics = row.indexedLyrics(folderLyrics, appLyrics)
+        if (signature != null &&
+            signature.dateModified == row.dateModified &&
+            signature.localUri == uri &&
+            signature.assetId == asset?.id &&
+            signature.lyrics == lyrics
+        ) {
+            return@mapNotNull null
+        }
+        row.toRecord(
+            asset = asset,
+            metadataOverride = metadataOverrides[uri],
+            lyrics = lyrics,
+        )
+    }
+            db.syncIndex(
+            changedRecords = changed,
+            currentMediaIds = currentIds,
+            directories = directories,
+            fingerprint = fingerprint,
+        )
+        db.readIndexedTracks(scanSettings)
+    }
+
+    override suspend fun search(keyword: String): List<MusicTrack> = withContext(Dispatchers.IO) {
+        val normalized = keyword.trim()
+        if (normalized.isEmpty()) emptyList()
+        else database.readableDatabase.readIndexedTracks(scanSettings, normalized)
+    }
+
+    override suspend fun updateMetadata(track: MusicTrack, metadata: LocalTrackMetadata) {
+        legacy.updateMetadata(track, metadata)
+        val localUri = track.localUri ?: return
+        database.writableDatabase.updateIndexedMetadata(
+            localUri = localUri,
+            metadata = LocalTrackMetadata(
+                title = metadata.title.ifBlank { track.title },
+                artists = metadata.artists,
+                album = metadata.album,
+            ),
+        )
+    }
+
+    override suspend fun saveLyrics(track: MusicTrack, lyrics: String) {
+        legacy.saveLyrics(track, lyrics)
+        val localUri = track.localUri ?: return
+        val text = lyrics.takeIf { it.isNotBlank() } ?: return
+        database.writableDatabase.updateIndexedLyrics(localUri, text)
+    }
+
+    private fun queryAudioRows(): List<IndexedAudioRow> {
+        val rows = mutableListOf<IndexedAudioRow>()
+        val collection = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+        val projection = mutableListOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.ALBUM_ID,
+            MediaStore.Audio.Media.DURATION,
+            MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.DATE_ADDED,
+            MediaStore.Audio.Media.DATE_MODIFIED,
+        ).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                add(MediaStore.Audio.Media.RELATIVE_PATH)
+            } else {
+                @Suppress("DEPRECATION")
+                add(MediaStore.Audio.Media.DATA)
+            }
+        }.toTypedArray()
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+        val sortOrder = "${MediaStore.Audio.Media.DATE_ADDED} DESC"
+        try {
+            appContext.contentResolver.query(collection, projection, selection, null, sortOrder)
+        } catch (_: SecurityException) {
+            null
+        }?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val titleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val albumIdColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
+            val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val displayNameColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            val dateModifiedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED)
+            val relativePathColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
+            } else {
+                -1
+            }
+            val dataColumn = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                @Suppress("DEPRECATION")
+                cursor.getColumnIndex(MediaStore.Audio.Media.DATA)
+            } else {
+                -1
+            }
+            while (cursor.moveToNext()) {
+                val relativePath = if (relativePathColumn >= 0) cursor.getString(relativePathColumn).orEmpty() else ""
+                val filePath = if (dataColumn >= 0) cursor.getString(dataColumn).orEmpty() else ""
+                val directory = indexedDirectoryInfo(relativePath, filePath) ?: continue
+                val mediaId = cursor.getLong(idColumn)
+                rows += IndexedAudioRow(
+                    uri = ContentUris.withAppendedId(collection, mediaId),
+                    title = cursor.getString(titleColumn).orEmpty(),
+                    artist = cursor.getString(artistColumn).orEmpty(),
+                    album = cursor.getString(albumColumn).orEmpty(),
+                    albumId = cursor.getLong(albumIdColumn),
+                    durationMs = cursor.getLong(durationColumn),
+                    displayName = cursor.getString(displayNameColumn).orEmpty(),
+                    relativePath = relativePath,
+                    filePath = filePath,
+                    directory = directory,
+                    mediaId = mediaId,
+                    dateAdded = cursor.getLong(dateAddedColumn),
+                    dateModified = cursor.getLong(dateModifiedColumn),
+                )
+            }
+        }
+        return rows
+    }
+
+    private fun queryImageCovers(): Map<String, String> {
+        val collection = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+        val projection = mutableListOf(
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.DISPLAY_NAME,
+        ).apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(MediaStore.Images.Media.RELATIVE_PATH)
+            else {
+                @Suppress("DEPRECATION")
+                add(MediaStore.Images.Media.DATA)
+            }
+        }.toTypedArray()
+        val rows = mutableListOf<IndexedImageRow>()
+        try {
+            appContext.contentResolver.query(collection, projection, null, null, null)
+        } catch (_: SecurityException) {
+            null
+        }?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            val nameColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME)
+            val relativePathColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                cursor.getColumnIndex(MediaStore.Images.Media.RELATIVE_PATH)
+            } else -1
+            val dataColumn = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                @Suppress("DEPRECATION")
+                cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+            } else -1
+            while (cursor.moveToNext()) {
+                val relativePath = if (relativePathColumn >= 0) cursor.getString(relativePathColumn).orEmpty() else ""
+                val filePath = if (dataColumn >= 0) cursor.getString(dataColumn).orEmpty() else ""
+                val directory = indexedDirectoryInfo(relativePath, filePath) ?: continue
+                rows += IndexedImageRow(
+                    directoryId = directory.id,
+                    displayName = cursor.getString(nameColumn).orEmpty(),
+                    uri = ContentUris.withAppendedId(collection, cursor.getLong(idColumn)),
+                )
+            }
+        }
+        return rows
+            .sortedWith(compareBy<IndexedImageRow> { it.directoryId }.thenBy { it.displayName.lowercase(Locale.ROOT) })
+            .distinctBy { it.directoryId }
+            .associate { it.directoryId to it.uri.toString() }
+    }
+
+    private fun queryLyrics(): Map<String, String> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return emptyMap()
+        val collection = MediaStore.Files.getContentUri("external")
+        val projection = arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            MediaStore.MediaColumns.DISPLAY_NAME,
+            MediaStore.MediaColumns.RELATIVE_PATH,
+        )
+        val result = linkedMapOf<String, String>()
+        try {
+            appContext.contentResolver.query(
+                collection,
+                projection,
+                "${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ?",
+                arrayOf("%.lrc"),
+                null,
+            )
+        } catch (_: SecurityException) {
+            null
+        }?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
+            val nameColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+            val pathColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.RELATIVE_PATH)
+            while (cursor.moveToNext()) {
+                val displayName = cursor.getString(nameColumn).orEmpty()
+                if (!displayName.endsWith(".lrc", ignoreCase = true)) continue
+                val key = indexedLyricKey(cursor.getString(pathColumn).orEmpty(), displayName) ?: continue
+                val uri = ContentUris.withAppendedId(collection, cursor.getLong(idColumn))
+                val text = runCatching {
+                    appContext.contentResolver.openInputStream(uri)
+                        ?.bufferedReader(Charsets.UTF_8)
+                        ?.use { it.readText() }
+                }.getOrNull()?.takeIf { it.isNotBlank() } ?: continue
+                result[key] = text
+            }
+        }
+        return result
+    }
+
+    private fun queryAppLyrics(): Map<String, String> {
+        val directory = File(appContext.filesDir, INDEX_LYRICS_FOLDER)
+        if (!directory.isDirectory) return emptyMap()
+        return buildMap {
+            directory.listFiles { file -> file.isFile && file.name.endsWith(".lrc", ignoreCase = true) }
+                ?.forEach { file ->
+                    val key = indexedLyricBaseName(file.name)?.lowercase(Locale.ROOT) ?: return@forEach
+                    val text = runCatching { file.readText() }.getOrNull()?.takeIf { it.isNotBlank() } ?: return@forEach
+                    put(key, text)
+                }
+        }
+    }
+
+    private fun metadataOverrides(): Map<String, LocalTrackMetadata> {
+        val file = File(appContext.filesDir, INDEX_METADATA_OVERRIDE_FILE)
+        if (!file.isFile) return emptyMap()
+        return runCatching {
+            val array = JSONArray(file.readText())
+            buildMap {
+                for (index in 0 until array.length()) {
+                    val item = array.getJSONObject(index)
+                    val uri = item.optString("uri").takeIf { it.isNotBlank() } ?: continue
+                    put(
+                        uri,
+                        LocalTrackMetadata(
+                            title = item.optString("title"),
+                            artists = item.optString("artists"),
+                            album = item.optString("album"),
+                        ),
+                    )
+                }
+            }
+        }.getOrDefault(emptyMap())
+    }
+}
+
+private class IndexedLocalMusicDatabase(context: Context) :
+    SQLiteOpenHelper(context, INDEX_DATABASE_NAME, null, INDEX_DATABASE_VERSION) {
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE tracks (
+                row_id TEXT PRIMARY KEY NOT NULL,
+                id TEXT NOT NULL,
+                local_uri TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL,
+                artists TEXT NOT NULL,
+                album TEXT NOT NULL,
+                source TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                provider_id TEXT,
+                provider_name TEXT,
+                cover_url TEXT,
+                duration_ms INTEGER NOT NULL,
+                lyrics TEXT,
+                directory_id TEXT NOT NULL,
+                directory_name TEXT NOT NULL,
+                media_id INTEGER NOT NULL UNIQUE,
+                date_added INTEGER NOT NULL,
+                date_modified INTEGER NOT NULL,
+                asset_id TEXT
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX tracks_directory_idx ON tracks(directory_id)")
+        db.execSQL("CREATE INDEX tracks_title_idx ON tracks(title)")
+        db.execSQL("CREATE TABLE directories (id TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL, cover_url TEXT)")
+        db.execSQL("CREATE TABLE meta (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL)")
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        db.execSQL("DROP TABLE IF EXISTS tracks")
+        db.execSQL("DROP TABLE IF EXISTS directories")
+        db.execSQL("DROP TABLE IF EXISTS meta")
+        onCreate(db)
+    }
+}
+
+private data class IndexedAudioRow(
+    val uri: Uri,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val albumId: Long,
+    val durationMs: Long,
+    val displayName: String,
+    val relativePath: String,
+    val filePath: String,
+    val directory: LocalMusicDirectory,
+    val mediaId: Long,
+    val dateAdded: Long,
+    val dateModified: Long,
+)
+
+private data class IndexedImageRow(
+    val directoryId: String,
+    val displayName: String,
+    val uri: Uri,
+)
+
+private data class IndexedTrackRecord(
+    val track: MusicTrack,
+    val directory: LocalMusicDirectory,
+    val mediaId: Long,
+    val dateAdded: Long,
+    val dateModified: Long,
+    val assetId: String?,
+)
+
+private data class StoredIndexedSignature(
+        val dateModified: Long,
+        val localUri: String,
+        val assetId: String?,
+        val lyrics: String?,
+    )
+
+    private fun IndexedAudioRow.toRecord(
+        asset: OfflineAsset?,
+        metadataOverride: LocalTrackMetadata?,
+        lyrics: String?,
+    ): IndexedTrackRecord {
+        val legacyDownloaded = directory.id == INDEX_FEELUOWN_DIRECTORY_ID
+        val sourceType = if (asset != null || legacyDownloaded) TrackSourceType.Downloaded else TrackSourceType.LocalMediaStore
+        val uriString = uri.toString()
+        val title = metadataOverride?.title ?: asset?.title ?: this.title
+        val artists = metadataOverride?.artists ?: asset?.artists ?: artist
+        val album = metadataOverride?.album ?: asset?.album ?: this.album
+        val track = MusicTrack(
+            id = asset?.providerTrackId ?: if (sourceType == TrackSourceType.Downloaded) "downloaded:$uriString" else "local:$uriString",
+            title = title,
+            artists = artists,
+            album = album,
+            source = asset?.source ?: "local",
+            sourceType = sourceType,
+            coverUrl = indexedLocalCoverUri(uri, albumId),
+            durationMs = (asset?.durationMs ?: durationMs).takeIf { it > 0 },
+            localUri = uriString,
+            localDirectoryId = directory.id,
+            lyrics = lyrics,
+            providerId = asset?.providerId,
+            providerName = asset?.providerName,
+        )
+        return IndexedTrackRecord(
+            track = track,
+            directory = directory,
+            mediaId = mediaId,
+            dateAdded = dateAdded,
+            dateModified = dateModified,
+            assetId = asset?.id,
+        )
+    }
+
+private fun SQLiteDatabase.syncIndex(
+    changedRecords: List<IndexedTrackRecord>,
+    currentMediaIds: Set<Long>,
+    directories: List<LocalMusicDirectory>,
+    fingerprint: String,
+) {
+    beginTransaction()
+    try {
+        val existingIds = mutableListOf<Long>()
+        rawQuery("SELECT media_id FROM tracks", null).use { cursor ->
+            while (cursor.moveToNext()) existingIds += cursor.getLong(0)
+        }
+        existingIds.asSequence()
+            .filterNot(currentMediaIds::contains)
+            .forEach { mediaId -> delete("tracks", "media_id = ?", arrayOf(mediaId.toString())) }
+        changedRecords.forEach { record -> replace("tracks", null, record.toContentValues()) }
+        delete("directories", null, null)
+        directories.forEach { directory ->
+            replace(
+                "directories",
+                null,
+                ContentValues().apply {
+                    put("id", directory.id)
+                    put("name", directory.name)
+                    put("cover_url", directory.coverUrl)
+                },
+            )
+        }
+        putIndexMeta(INDEX_KEY_INITIALIZED, "1")
+        putIndexMeta(INDEX_KEY_LAYOUT_VERSION, INDEX_LAYOUT_VERSION)
+        putIndexMeta(INDEX_KEY_FINGERPRINT, fingerprint)
+        setTransactionSuccessful()
+    } finally {
+        endTransaction()
+    }
+}
+
+private fun SQLiteDatabase.readStoredSignatures(): Map<Long, StoredIndexedSignature> {
+        val result = linkedMapOf<Long, StoredIndexedSignature>()
+        rawQuery("SELECT media_id, date_modified, local_uri, asset_id, lyrics FROM tracks", null).use { cursor ->
+            while (cursor.moveToNext()) {
+                result[cursor.getLong(0)] = StoredIndexedSignature(
+                    dateModified = cursor.getLong(1),
+                    localUri = cursor.getString(2).orEmpty(),
+                    assetId = cursor.getString(3)?.takeIf { it.isNotBlank() },
+                    lyrics = cursor.getString(4)?.takeIf { it.isNotBlank() },
+                )
+            }
+        }
+        return result
+    }
+
+private fun SQLiteDatabase.readDirectories(): List<LocalMusicDirectory> {
+    val counts = linkedMapOf<String, Int>()
+    rawQuery("SELECT directory_id, COUNT(*) FROM tracks GROUP BY directory_id", null).use { cursor ->
+        while (cursor.moveToNext()) counts[cursor.getString(0).orEmpty()] = cursor.getInt(1)
+    }
+    val result = mutableListOf<LocalMusicDirectory>()
+    rawQuery("SELECT id, name, cover_url FROM directories ORDER BY name COLLATE NOCASE", null).use { cursor ->
+        while (cursor.moveToNext()) {
+            val id = cursor.getString(0).orEmpty()
+            result += LocalMusicDirectory(
+                id = id,
+                name = cursor.getString(1).orEmpty(),
+                trackCount = counts[id] ?: 0,
+                coverUrl = cursor.getString(2)?.takeIf { it.isNotBlank() },
+            )
+        }
+    }
+    return result
+}
+
+private fun SQLiteDatabase.readIndexedTracks(
+    settings: LocalMusicScanSettings,
+    keyword: String? = null,
+): List<MusicTrack> {
+    val where = mutableListOf<String>()
+    val args = mutableListOf<String>()
+    val excluded = settings.excludedDirectoryIds.flatMap(::localMusicDirectoryIdAliases).toSet()
+    if (excluded.isNotEmpty()) {
+        where += "directory_id NOT IN (${excluded.joinToString(",") { "?" }})"
+        args += excluded
+    }
+    if (settings.minDurationSeconds > 0) {
+        where += "duration_ms >= ?"
+        args += (settings.minDurationSeconds * 1000L).toString()
+    }
+    keyword?.takeIf { it.isNotBlank() }?.let { value ->
+        where += "(title LIKE ? COLLATE NOCASE OR artists LIKE ? COLLATE NOCASE OR album LIKE ? COLLATE NOCASE)"
+        val pattern = "%$value%"
+        repeat(3) { args += pattern }
+    }
+    val selection = where.takeIf { it.isNotEmpty() }?.joinToString(" AND ")?.let { "WHERE $it" }.orEmpty()
+    val result = mutableListOf<MusicTrack>()
+    rawQuery(
+        """
+        SELECT id, title, artists, album, source, source_type, provider_id, provider_name,
+               cover_url, duration_ms, local_uri, lyrics, directory_id
+        FROM tracks
+        $selection
+        ORDER BY date_added DESC, title COLLATE NOCASE ASC
+        """.trimIndent(),
+        args.toTypedArray(),
+    ).use { cursor ->
+        while (cursor.moveToNext()) {
+            result += MusicTrack(
+                id = cursor.getString(0).orEmpty(),
+                title = cursor.getString(1).orEmpty(),
+                artists = cursor.getString(2).orEmpty(),
+                album = cursor.getString(3).orEmpty(),
+                source = cursor.getString(4).orEmpty(),
+                sourceType = runCatching { TrackSourceType.valueOf(cursor.getString(5).orEmpty()) }
+                    .getOrDefault(TrackSourceType.LocalMediaStore),
+                providerId = cursor.getString(6)?.takeIf { it.isNotBlank() },
+                providerName = cursor.getString(7)?.takeIf { it.isNotBlank() },
+                coverUrl = cursor.getString(8)?.takeIf { it.isNotBlank() },
+                durationMs = cursor.getLong(9).takeIf { it > 0 },
+                localUri = cursor.getString(10).orEmpty(),
+                lyrics = cursor.getString(11)?.takeIf { it.isNotBlank() },
+                localDirectoryId = cursor.getString(12).orEmpty(),
+            )
+        }
+    }
+    return result
+}
+
+private fun IndexedTrackRecord.toContentValues(): ContentValues = ContentValues().apply {
+    put("row_id", assetId ?: track.localUri.orEmpty())
+    put("id", track.id)
+    put("local_uri", track.localUri.orEmpty())
+    put("title", track.title)
+    put("artists", track.artists)
+    put("album", track.album)
+    put("source", track.source)
+    put("source_type", track.sourceType.name)
+    put("provider_id", track.providerId)
+    put("provider_name", track.providerName)
+    put("cover_url", track.coverUrl)
+    put("duration_ms", track.durationMs ?: 0)
+    put("lyrics", track.lyrics)
+    put("directory_id", directory.id)
+    put("directory_name", directory.name)
+    put("media_id", mediaId)
+    put("date_added", dateAdded)
+    put("date_modified", dateModified)
+    put("asset_id", assetId)
+}
+
+private fun SQLiteDatabase.updateIndexedMetadata(localUri: String, metadata: LocalTrackMetadata) {
+    update(
+        "tracks",
+        ContentValues().apply {
+            put("title", metadata.title)
+            put("artists", metadata.artists)
+            put("album", metadata.album)
+        },
+        "local_uri = ?",
+        arrayOf(localUri),
+    )
+}
+
+private fun SQLiteDatabase.updateIndexedLyrics(localUri: String, lyrics: String) {
+    update("tracks", ContentValues().apply { put("lyrics", lyrics) }, "local_uri = ?", arrayOf(localUri))
+}
+
+private fun SQLiteDatabase.indexMeta(key: String): String? {
+    query("meta", arrayOf("value"), "key = ?", arrayOf(key), null, null, null).use { cursor ->
+        return if (cursor.moveToFirst()) cursor.getString(0) else null
+    }
+}
+
+private fun SQLiteDatabase.putIndexMeta(key: String, value: String) {
+    replace("meta", null, ContentValues().apply { put("key", key); put("value", value) })
+}
+
+private fun indexedDirectoryInfo(relativePath: String, filePath: String): LocalMusicDirectory? {
+    val firstLevelName = if (relativePath.isNotBlank()) {
+        val segments = relativePath.replace('\\', '/').split('/').filter { it.isNotBlank() }
+        if (segments.firstOrNull()?.equals(INDEX_MUSIC_DIRECTORY_NAME, ignoreCase = true) != true) return null
+        segments.getOrNull(1)
+    } else {
+        val musicRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC)
+            .path.replace('\\', '/').trimEnd('/')
+        val directoryPath = filePath.replace('\\', '/').substringBeforeLast('/', "").trimEnd('/')
+        if (directoryPath != musicRoot && !directoryPath.startsWith("$musicRoot/")) return null
+        if (directoryPath == musicRoot) null
+        else directoryPath.removePrefix("$musicRoot/").substringBefore('/').takeIf { it.isNotBlank() }
+    }
+    return if (firstLevelName.isNullOrBlank()) {
+        LocalMusicDirectory(id = INDEX_MUSIC_ROOT_DIRECTORY_ID, name = "歌曲", trackCount = 0)
+    } else {
+        LocalMusicDirectory(id = "$INDEX_MUSIC_DIRECTORY_NAME/$firstLevelName/", name = firstLevelName, trackCount = 0)
+    }
+}
+
+private fun IndexedAudioRow.indexedLyrics(
+    folderLyrics: Map<String, String>,
+    appLyrics: Map<String, String>,
+): String? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        val audioFile = filePath.takeIf { it.isNotBlank() }?.let(::File)
+        audioFile?.resolveSibling("${audioFile.nameWithoutExtension}.lrc")
+            ?.takeIf { it.isFile }
+            ?.let { runCatching { it.readText() }.getOrNull()?.takeIf(String::isNotBlank) }
+            ?.let { return it }
+        val base = audioFile?.nameWithoutExtension ?: indexedLyricBaseName(displayName) ?: return null
+        return appLyrics[base.lowercase(Locale.ROOT)]
+    }
+    indexedLyricKey(relativePath, displayName)?.let(folderLyrics::get)?.let { return it }
+    val base = indexedLyricBaseName(displayName)?.lowercase(Locale.ROOT) ?: return null
+    return appLyrics[base]
+}
+
+private fun mediaFingerprint(rows: List<IndexedAudioRow>): String {
+    var maxAdded = 0L
+    var maxModified = 0L
+    var hash = 1125899906842597L
+    rows.forEach { row ->
+        maxAdded = maxOf(maxAdded, row.dateAdded)
+        maxModified = maxOf(maxModified, row.dateModified)
+        hash = hash * 31 + row.mediaId
+        hash = hash * 31 + row.dateModified
+        hash = hash * 31 + row.durationMs
+    }
+    return "${rows.size}:$maxAdded:$maxModified:$hash"
+}
+
+private fun indexedLyricKey(relativePath: String, fileName: String): String? {
+    val base = indexedLyricBaseName(fileName) ?: return null
+    return "${relativePath.trim('/').lowercase(Locale.ROOT)}/${base.lowercase(Locale.ROOT)}"
+}
+
+private fun indexedLyricBaseName(fileName: String): String? =
+    fileName.substringBeforeLast('.', "").ifBlank { null }
+
+private fun indexedAlbumArtUri(albumId: Long): String? {
+    if (albumId <= 0) return null
+    return Uri.parse("content://media/external/audio/albumart")
+        .buildUpon()
+        .appendPath(albumId.toString())
+        .build()
+        .toString()
+}
+
+private fun indexedLocalCoverUri(audioUri: Uri, albumId: Long): String = Uri.Builder()
+    .scheme("fuo-cover")
+    .appendQueryParameter("albumArt", indexedAlbumArtUri(albumId).orEmpty())
+    .appendQueryParameter("audio", audioUri.toString())
+    .build()
+    .toString()
+
+private const val INDEX_DATABASE_NAME = "local_music_index_v3.db"
+private const val INDEX_DATABASE_VERSION = 2
+private const val INDEX_LAYOUT_VERSION = "music-first-level-v3-incremental"
+private const val INDEX_KEY_INITIALIZED = "initialized"
+private const val INDEX_KEY_LAYOUT_VERSION = "layout_version"
+private const val INDEX_KEY_FINGERPRINT = "media_fingerprint"
+private const val INDEX_MUSIC_DIRECTORY_NAME = "Music"
+private const val INDEX_MUSIC_ROOT_DIRECTORY_ID = "Music/"
+private const val INDEX_FEELUOWN_DIRECTORY_ID = "Music/FeelUOwn/"
+private const val INDEX_METADATA_OVERRIDE_FILE = "local_music_metadata.json"
+private const val INDEX_LYRICS_FOLDER = "lyrics"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidOfflineAssetStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidOfflineAssetStore.kt
@@ -1,0 +1,97 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import org.json.JSONObject
+
+internal class AndroidOfflineAssetStore(context: Context) {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    fun all(): List<OfflineAsset> {
+        return preferences.all.entries.mapNotNull { (key, value) ->
+            if (!key.startsWith(ASSET_KEY_PREFIX)) return@mapNotNull null
+            (value as? String)?.let { raw -> runCatching { JSONObject(raw).toOfflineAsset() }.getOrNull() }
+        }
+    }
+
+    fun findById(assetId: String): OfflineAsset? {
+        return read(assetId)
+    }
+
+    fun findByLocalUri(localUri: String): OfflineAsset? {
+        return all().firstOrNull { it.localUri == localUri }
+    }
+
+    fun findByTrack(track: MusicTrack): OfflineAsset? {
+        track.localUri?.let(::findByLocalUri)?.let { return it }
+        return read(offlineAssetId(track))
+            ?: all().firstOrNull { it.providerTrackId == track.id && it.source == track.source }
+    }
+
+    fun upsert(asset: OfflineAsset) {
+        preferences.edit()
+            .putString(assetKey(asset.id), asset.toJson().toString())
+            .apply()
+    }
+
+    fun remove(assetId: String) {
+        preferences.edit().remove(assetKey(assetId)).apply()
+    }
+
+    fun removeByLocalUri(localUri: String) {
+        val editor = preferences.edit()
+        var changed = false
+        all().filter { it.localUri == localUri }.forEach { asset ->
+            editor.remove(assetKey(asset.id))
+            changed = true
+        }
+        if (changed) editor.apply()
+    }
+
+    private fun read(assetId: String): OfflineAsset? {
+        val raw = preferences.getString(assetKey(assetId), null) ?: return null
+        return runCatching { JSONObject(raw).toOfflineAsset() }.getOrNull()
+    }
+
+    private fun assetKey(assetId: String): String = "$ASSET_KEY_PREFIX$assetId"
+
+    private companion object {
+        private const val PREFERENCES_NAME = "offline_assets"
+        private const val ASSET_KEY_PREFIX = "asset:"
+    }
+}
+
+private fun OfflineAsset.toJson(): JSONObject = JSONObject()
+    .put("id", id)
+    .put("providerTrackId", providerTrackId)
+    .put("providerId", providerId ?: "")
+    .put("providerName", providerName ?: "")
+    .put("source", source)
+    .put("title", title)
+    .put("artists", artists)
+    .put("album", album)
+    .put("localUri", localUri)
+    .put("coverUrl", coverUrl ?: "")
+    .put("durationMs", durationMs ?: 0)
+    .put("fileSize", fileSize)
+    .put("audioQuality", audioQuality ?: "")
+    .put("createdAt", createdAt)
+
+private fun JSONObject.toOfflineAsset(): OfflineAsset = OfflineAsset(
+    id = getString("id"),
+    providerTrackId = getString("providerTrackId"),
+    providerId = optString("providerId").takeIf { it.isNotBlank() },
+    providerName = optString("providerName").takeIf { it.isNotBlank() },
+    source = optString("source"),
+    title = optString("title"),
+    artists = optString("artists"),
+    album = optString("album"),
+    localUri = getString("localUri"),
+    coverUrl = optString("coverUrl").takeIf { it.isNotBlank() },
+    durationMs = optLong("durationMs").takeIf { it > 0 },
+    fileSize = optLong("fileSize"),
+    audioQuality = optString("audioQuality").takeIf { it.isNotBlank() },
+    createdAt = optLong("createdAt"),
+)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidOfflineAwareDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidOfflineAwareDownloadRepository.kt
@@ -1,0 +1,91 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+internal class AndroidOfflineAwareDownloadRepository(
+    private val delegate: DownloadRepository,
+    private val assetStore: AndroidOfflineAssetStore,
+    scope: CoroutineScope,
+) : DownloadRepository {
+    private val mutableTasks = MutableStateFlow(delegate.tasks.value)
+
+    override val states: StateFlow<Map<String, DownloadState>> = delegate.states
+    override val tasks: StateFlow<List<DownloadTask>> = mutableTasks.asStateFlow()
+
+    init {
+        scope.launch {
+            delegate.tasks.collect { tasks ->
+                syncCompletedAssets(tasks)
+                mutableTasks.value = tasks
+            }
+        }
+    }
+
+    override suspend fun load() {
+        delegate.load()
+        val loadedTasks = delegate.tasks.value
+        syncCompletedAssets(loadedTasks)
+        mutableTasks.value = loadedTasks
+    }
+
+    override suspend fun download(track: MusicTrack) = delegate.download(track)
+
+    override suspend fun download(track: MusicTrack, payload: PlaybackPayload) =
+        delegate.download(track, payload)
+
+    override suspend fun updateParallelism(parallelism: Int) =
+        delegate.updateParallelism(parallelism)
+
+    override suspend fun pause(taskId: String) = delegate.pause(taskId)
+
+    override suspend fun resume(taskId: String) = delegate.resume(taskId)
+
+    override suspend fun retry(taskId: String) = delegate.retry(taskId)
+
+    override suspend fun deleteTask(taskId: String, deleteFile: Boolean) {
+        val completedUri = delegate.tasks.value.firstOrNull { it.id == taskId }?.completedUri
+        delegate.deleteTask(taskId, deleteFile)
+        if (deleteFile && completedUri != null) {
+            assetStore.removeByLocalUri(completedUri)
+        }
+    }
+
+    override suspend fun deleteDownloaded(track: MusicTrack) {
+        val asset = assetStore.findByTrack(track)
+        delegate.deleteDownloaded(track)
+        asset?.let { assetStore.remove(it.id) }
+        track.localUri?.let(assetStore::removeByLocalUri)
+    }
+
+    private fun syncCompletedAssets(tasks: List<DownloadTask>) {
+        tasks.asSequence()
+            .filter { it.status == DownloadTaskStatus.Completed }
+            .forEach { task ->
+                val localUri = task.completedUri?.takeIf { it.isNotBlank() } ?: return@forEach
+                val asset = task.toOfflineAsset(localUri)
+                if (assetStore.findById(asset.id) != asset) {
+                    assetStore.upsert(asset)
+                }
+            }
+    }
+
+    private fun DownloadTask.toOfflineAsset(localUri: String): OfflineAsset = OfflineAsset(
+        id = offlineAssetId(track),
+        providerTrackId = track.id,
+        providerId = track.providerId,
+        providerName = track.providerName,
+        source = track.source,
+        title = track.title,
+        artists = track.artists,
+        album = track.album,
+        localUri = localUri,
+        coverUrl = track.coverUrl,
+        durationMs = track.durationMs,
+        fileSize = totalBytes ?: downloadedBytes,
+        createdAt = updatedAt,
+    )
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -30,18 +30,40 @@ class FuoEvolveApplication : Application() {
         return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
     }
 
-    private val localRepository: AndroidLocalMusicRepository by lazy {
-        AndroidLocalMusicRepository(applicationContext)
+    private val offlineAssetStore: AndroidOfflineAssetStore by lazy {
+        AndroidOfflineAssetStore(applicationContext)
+    }
+
+    private val indexedLocalRepository: LocalMusicRepository by lazy {
+        AndroidIndexedLocalMusicRepository(
+            context = applicationContext,
+            assetStore = offlineAssetStore,
+        )
+    }
+
+    private val localRepository: LocalMusicRepository by lazy {
+        AndroidCoalescingLocalMusicRepository(
+            delegate = indexedLocalRepository,
+            assetStore = offlineAssetStore,
+        )
     }
 
     private val localPlaylistRepository: AndroidLocalPlaylistRepository by lazy {
         AndroidLocalPlaylistRepository(applicationContext)
     }
 
-    private val downloadRepository: AndroidDownloadRepository by lazy {
+    private val rawDownloadRepository: AndroidDownloadRepository by lazy {
         AndroidDownloadRepository(applicationContext, providerRepository) { tasks ->
             FuoDownloadService.update(applicationContext, tasks)
         }
+    }
+
+    private val downloadRepository: DownloadRepository by lazy {
+        AndroidOfflineAwareDownloadRepository(
+            delegate = rawDownloadRepository,
+            assetStore = offlineAssetStore,
+            scope = appScope,
+        )
     }
 
     private val playbackEngine: AndroidNativeAudioEngine by lazy {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadCheckpointPolicy.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadCheckpointPolicy.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile
+
+object DownloadCheckpointPolicy {
+    const val progressPublishIntervalMs: Long = 500L
+    const val persistenceIntervalMs: Long = 3_000L
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadControllerState.kt
@@ -1,0 +1,12 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+internal class DownloadControllerState {
+    var states by mutableStateOf<Map<String, DownloadState>>(emptyMap())
+    var tasks by mutableStateOf<List<DownloadTask>>(emptyList())
+    var queueFeedback by mutableStateOf<String?>(null)
+    var parallelism by mutableStateOf(DEFAULT_DOWNLOAD_PARALLELISM)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadResumeMetadata.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/DownloadResumeMetadata.kt
@@ -1,0 +1,7 @@
+package org.feeluown.mobile
+
+data class DownloadResumeMetadata(
+    val resourceKey: String,
+    val etag: String? = null,
+    val lastModified: String? = null,
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -52,6 +52,9 @@ class FuoPlayerController(
     private val scope: CoroutineScope,
 ) {
     private val providerState = ProviderControllerState()
+    private val localMusicState = LocalMusicControllerState()
+    private val downloadState = DownloadControllerState()
+    private val settingsUiState = SettingsControllerState()
 
     var isSettingsLoaded by mutableStateOf(false)
         private set
@@ -183,7 +186,7 @@ class FuoPlayerController(
         private set
     var artistTargets by mutableStateOf<List<TrackArtistTarget>>(emptyList())
         private set
-    var localTracks by mutableStateOf<List<MusicTrack>>(emptyList())
+    var localTracks by localMusicState::tracks
         private set
     var query by mutableStateOf("")
         private set
@@ -209,17 +212,17 @@ class FuoPlayerController(
         private set
     var playlistFilter by mutableStateOf(PlaylistFilter.All)
         private set
-    var localMusicViewMode by mutableStateOf(LocalMusicViewMode.All)
+    var localMusicViewMode by localMusicState::viewMode
         private set
-    var localMusicDirectories by mutableStateOf<List<LocalMusicDirectory>>(emptyList())
+    var localMusicDirectories by localMusicState::directories
         private set
-    var selectedLocalMusicDirectoryId by mutableStateOf<String?>(null)
+    var selectedLocalMusicDirectoryId by localMusicState::selectedDirectoryId
         private set
-    var selectedLocalMusicCollection by mutableStateOf<LocalMusicCollectionSelection?>(null)
+    var selectedLocalMusicCollection by localMusicState::selectedCollection
         private set
-    var excludedLocalMusicDirectoryIds by mutableStateOf<Set<String>>(emptySet())
+    var excludedLocalMusicDirectoryIds by localMusicState::excludedDirectoryIds
         private set
-    var localMusicMinDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
+    var localMusicMinDurationSeconds by localMusicState::minDurationSeconds
         private set
     val isSearchOpen: Boolean
         get() = navigator.contains(AppRoute.Search)
@@ -247,59 +250,59 @@ class FuoPlayerController(
     fun showMessage(text: String) {
         message = text
     }
-    var downloadStates by mutableStateOf<Map<String, DownloadState>>(emptyMap())
+    var downloadStates by downloadState::states
         private set
-    var downloadTasks by mutableStateOf<List<DownloadTask>>(emptyList())
+    var downloadTasks by downloadState::tasks
         private set
-    var downloadQueueFeedback by mutableStateOf<String?>(null)
+    var downloadQueueFeedback by downloadState::queueFeedback
         private set
     var playbackState by mutableStateOf(PlaybackState())
         private set
     var trackChangeDirection by mutableStateOf(TrackChangeDirection.Next)
         private set
-    var cacheUsage by mutableStateOf(CacheUsage())
+    var cacheUsage by settingsUiState::cacheUsage
         private set
-    var audioCacheLimitMb by mutableStateOf(DEFAULT_AUDIO_CACHE_LIMIT_MB)
+    var audioCacheLimitMb by settingsUiState::audioCacheLimitMb
         private set
-    var imageCacheLimitMb by mutableStateOf(DEFAULT_IMAGE_CACHE_LIMIT_MB)
+    var imageCacheLimitMb by settingsUiState::imageCacheLimitMb
         private set
-    var downloadParallelism by mutableStateOf(DEFAULT_DOWNLOAD_PARALLELISM)
+    var downloadParallelism by downloadState::parallelism
         private set
-    var wifiAudioQualityPolicy by mutableStateOf(DEFAULT_WIFI_AUDIO_QUALITY_POLICY)
+    var wifiAudioQualityPolicy by settingsUiState::wifiAudioQualityPolicy
         private set
-    var cellularAudioQualityPolicy by mutableStateOf(DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY)
+    var cellularAudioQualityPolicy by settingsUiState::cellularAudioQualityPolicy
         private set
-    var unavailablePlaybackPolicy by mutableStateOf(DEFAULT_UNAVAILABLE_PLAYBACK_POLICY)
+    var unavailablePlaybackPolicy by settingsUiState::unavailablePlaybackPolicy
         private set
-    var smartReplacementProviderIds by mutableStateOf<Set<String>>(emptySet())
+    var smartReplacementProviderIds by settingsUiState::smartReplacementProviderIds
         private set
-    var smartReplacementMinScore by mutableStateOf(DEFAULT_SMART_REPLACEMENT_MIN_SCORE)
+    var smartReplacementMinScore by settingsUiState::smartReplacementMinScore
         private set
     var replacementCandidateState by mutableStateOf(ReplacementCandidateState())
         private set
-    var lyricFontSize by mutableStateOf(LyricFontSize.Small)
+    var lyricFontSize by settingsUiState::lyricFontSize
         private set
-    var themeMode by mutableStateOf(ThemeMode.System)
+    var themeMode by settingsUiState::themeMode
         private set
-    var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
+    var themeColorScheme by settingsUiState::themeColorScheme
         private set
-    var dynamicCoverColorEnabled by mutableStateOf(false)
+    var dynamicCoverColorEnabled by settingsUiState::dynamicCoverColorEnabled
         private set
-    var pauseOnOtherAppPlayback by mutableStateOf(DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK)
+    var pauseOnOtherAppPlayback by settingsUiState::pauseOnOtherAppPlayback
         private set
-    var debugLogLines by mutableStateOf<List<String>>(emptyList())
+    var debugLogLines by settingsUiState::debugLogLines
         private set
-    var debugLogLevelFilters by mutableStateOf(DEFAULT_DEBUG_LOG_LEVEL_FILTERS)
+    var debugLogLevelFilters by settingsUiState::debugLogLevelFilters
         private set
-    var debugLogError by mutableStateOf<String?>(null)
+    var debugLogError by settingsUiState::debugLogError
         private set
-    var localMetadataEditorTrack by mutableStateOf<MusicTrack?>(null)
+    var localMetadataEditorTrack by localMusicState::metadataEditorTrack
         private set
-    var selectedLocalMetadataProviderId by mutableStateOf<String?>(null)
+    var selectedLocalMetadataProviderId by localMusicState::selectedMetadataProviderId
         private set
-    var localMetadataSearchResults by mutableStateOf<List<MusicTrack>>(emptyList())
+    var localMetadataSearchResults by localMusicState::metadataSearchResults
         private set
-    var localMetadataSearchMessage by mutableStateOf<String?>(null)
+    var localMetadataSearchMessage by localMusicState::metadataSearchMessage
         private set
     val isDebugLogViewerAvailable: Boolean
         get() = debugLogRepository.isAvailable
@@ -355,13 +358,23 @@ class FuoPlayerController(
     private var minePlaylistRefreshSerial: Long = 0
     private var mineContentRefreshSerial: Long = 0
     private var hasLocalMusicPermission: Boolean = false
-    private var observedCompletedDownloadTaskIds = emptySet<String>()
-    private var pendingLocalMusicMediaRefresh: Job? = null
     private var audioRecognitionJob: Job? = null
     private var audioRecognitionSerial: Long = 0
     private var playbackParts: List<PlaybackPart> = emptyList()
     private var currentPartIndex: Int = -1
     private val settingsUpdates = Channel<AppSettings>(capacity = Channel.UNLIMITED)
+    private val offlineLibraryCoordinator = OfflineLibraryControllerCoordinator(
+        scope = scope,
+        downloadRepository = downloadRepository,
+        localRepository = localRepository,
+        onDownloadStates = { downloadStates = it },
+        onDownloadTasks = { downloadTasks = it },
+        hasLocalMusicPermission = { hasLocalMusicPermission },
+        shouldShowLocalMusicLoading = { homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic },
+        refreshLocalMusic = { forceRefresh, showLoading ->
+            refreshLocalMusic(forceRefresh = forceRefresh, showLoading = showLoading)
+        },
+    )
 
     init {
         scope.launch {
@@ -416,25 +429,7 @@ class FuoPlayerController(
                 }
             }
         }
-        scope.launch {
-            downloadRepository.states.collect {
-                downloadStates = it
-            }
-        }
-        scope.launch {
-            downloadRepository.tasks.collect {
-                downloadTasks = it
-                val completedIds = it.filter { task -> task.status == DownloadTaskStatus.Completed }.map { task -> task.id }.toSet()
-                val newlyCompleted = completedIds - observedCompletedDownloadTaskIds
-                observedCompletedDownloadTaskIds = completedIds
-                if (newlyCompleted.isNotEmpty() && hasLocalMusicPermission) {
-                    refreshLocalMusic(
-                        forceRefresh = true,
-                        showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic,
-                    )
-                }
-            }
-        }
+        offlineLibraryCoordinator.start()
         scope.launch {
             resourceCacheRepository.usage.collect {
                 cacheUsage = it
@@ -497,18 +492,6 @@ class FuoPlayerController(
                         suppressPlaybackRecoveryRequestSerial = null
                     }
                     commitManualReplacementIfReady(engineState)
-                }
-            }
-        }
-        scope.launch {
-            localRepository.mediaChangeEvents.collect {
-                pendingLocalMusicMediaRefresh?.cancel()
-                pendingLocalMusicMediaRefresh = launch {
-                    delay(750)
-                    if (hasLocalMusicPermission && localRepository.isDatabaseReady()) {
-                        val showLoading = homeSection == HomeSection.Mine && mineSection == MineSection.LocalMusic
-                        refreshLocalMusic(forceRefresh = true, showLoading = showLoading)
-                    }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalLibraryRefreshPolicy.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalLibraryRefreshPolicy.kt
@@ -1,0 +1,5 @@
+package org.feeluown.mobile
+
+object LocalLibraryRefreshPolicy {
+    const val duplicateEventWindowMs: Long = 1_500L
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/LocalMusicControllerState.kt
@@ -1,0 +1,19 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+internal class LocalMusicControllerState {
+    var tracks by mutableStateOf<List<MusicTrack>>(emptyList())
+    var viewMode by mutableStateOf(LocalMusicViewMode.All)
+    var directories by mutableStateOf<List<LocalMusicDirectory>>(emptyList())
+    var selectedDirectoryId by mutableStateOf<String?>(null)
+    var selectedCollection by mutableStateOf<LocalMusicCollectionSelection?>(null)
+    var excludedDirectoryIds by mutableStateOf<Set<String>>(emptySet())
+    var minDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
+    var metadataEditorTrack by mutableStateOf<MusicTrack?>(null)
+    var selectedMetadataProviderId by mutableStateOf<String?>(null)
+    var metadataSearchResults by mutableStateOf<List<MusicTrack>>(emptyList())
+    var metadataSearchMessage by mutableStateOf<String?>(null)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/OfflineAsset.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/OfflineAsset.kt
@@ -1,0 +1,53 @@
+package org.feeluown.mobile
+
+/**
+ * Stable identity and provenance for a provider track that has been materialized locally.
+ *
+ * Download task ids intentionally remain unchanged for UI/backward compatibility. Offline assets
+ * use a provider-aware id so tracks from different providers cannot overwrite each other in the
+ * local asset index.
+ */
+data class OfflineAsset(
+    val id: String,
+    val providerTrackId: String,
+    val providerId: String?,
+    val providerName: String?,
+    val source: String,
+    val title: String,
+    val artists: String,
+    val album: String,
+    val localUri: String,
+    val coverUrl: String? = null,
+    val durationMs: Long? = null,
+    val fileSize: Long = 0,
+    val audioQuality: String? = null,
+    val createdAt: Long = 0,
+)
+
+fun offlineAssetId(track: MusicTrack): String = offlineAssetId(
+    providerId = track.providerId,
+    source = track.source,
+    providerTrackId = track.id,
+)
+
+fun offlineAssetId(
+    providerId: String?,
+    source: String,
+    providerTrackId: String,
+): String {
+    val providerKey = providerId?.trim().takeUnless { it.isNullOrBlank() }
+        ?: source.trim().ifBlank { "provider" }
+    return "${encodeOfflineAssetIdPart(providerKey)}:${encodeOfflineAssetIdPart(providerTrackId)}"
+}
+
+private fun encodeOfflineAssetIdPart(value: String): String = buildString {
+    value.forEach { character ->
+        when (character) {
+            '%' -> append("%25")
+            ':' -> append("%3A")
+            '\n' -> append("%0A")
+            '\r' -> append("%0D")
+            else -> append(character)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/OfflineLibraryControllerCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/OfflineLibraryControllerCoordinator.kt
@@ -1,0 +1,62 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/** Coordinates download state and local-media invalidation without owning UI state. */
+internal class OfflineLibraryControllerCoordinator(
+    private val scope: CoroutineScope,
+    private val downloadRepository: DownloadRepository,
+    private val localRepository: LocalMusicRepository,
+    private val onDownloadStates: (Map<String, DownloadState>) -> Unit,
+    private val onDownloadTasks: (List<DownloadTask>) -> Unit,
+    private val hasLocalMusicPermission: () -> Boolean,
+    private val shouldShowLocalMusicLoading: () -> Boolean,
+    private val refreshLocalMusic: suspend (forceRefresh: Boolean, showLoading: Boolean) -> Unit,
+) {
+    private var started = false
+    private var observedCompletedDownloadTaskIds = emptySet<String>()
+    private var pendingLocalMusicMediaRefresh: Job? = null
+
+    fun start() {
+        if (started) return
+        started = true
+        scope.launch {
+            downloadRepository.states.collect { states ->
+                onDownloadStates(states)
+            }
+        }
+        scope.launch {
+            downloadRepository.tasks.collect { tasks ->
+                onDownloadTasks(tasks)
+                val completedIds = tasks
+                    .asSequence()
+                    .filter { it.status == DownloadTaskStatus.Completed }
+                    .map { it.id }
+                    .toSet()
+                val newlyCompleted = completedIds - observedCompletedDownloadTaskIds
+                observedCompletedDownloadTaskIds = completedIds
+                if (newlyCompleted.isNotEmpty() && hasLocalMusicPermission()) {
+                    refreshLocalMusic(true, shouldShowLocalMusicLoading())
+                }
+            }
+        }
+        scope.launch {
+            localRepository.mediaChangeEvents.collect {
+                pendingLocalMusicMediaRefresh?.cancel()
+                pendingLocalMusicMediaRefresh = launch {
+                    delay(MEDIA_CHANGE_DEBOUNCE_MS)
+                    if (hasLocalMusicPermission() && localRepository.isDatabaseReady()) {
+                        refreshLocalMusic(true, shouldShowLocalMusicLoading())
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val MEDIA_CHANGE_DEBOUNCE_MS = 750L
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsControllerState.kt
@@ -1,0 +1,24 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+internal class SettingsControllerState {
+    var cacheUsage by mutableStateOf(CacheUsage())
+    var audioCacheLimitMb by mutableStateOf(DEFAULT_AUDIO_CACHE_LIMIT_MB)
+    var imageCacheLimitMb by mutableStateOf(DEFAULT_IMAGE_CACHE_LIMIT_MB)
+    var wifiAudioQualityPolicy by mutableStateOf(DEFAULT_WIFI_AUDIO_QUALITY_POLICY)
+    var cellularAudioQualityPolicy by mutableStateOf(DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY)
+    var unavailablePlaybackPolicy by mutableStateOf(DEFAULT_UNAVAILABLE_PLAYBACK_POLICY)
+    var smartReplacementProviderIds by mutableStateOf<Set<String>>(emptySet())
+    var smartReplacementMinScore by mutableStateOf(DEFAULT_SMART_REPLACEMENT_MIN_SCORE)
+    var lyricFontSize by mutableStateOf(LyricFontSize.Small)
+    var themeMode by mutableStateOf(ThemeMode.System)
+    var themeColorScheme by mutableStateOf(ThemeColorScheme.Dynamic)
+    var dynamicCoverColorEnabled by mutableStateOf(false)
+    var pauseOnOtherAppPlayback by mutableStateOf(DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK)
+    var debugLogLines by mutableStateOf<List<String>>(emptyList())
+    var debugLogLevelFilters by mutableStateOf(setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error))
+    var debugLogError by mutableStateOf<String?>(null)
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/OfflineAssetTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/OfflineAssetTest.kt
@@ -1,0 +1,20 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class OfflineAssetTest {
+    @Test
+    fun providerIdentityKeepsAssetsDistinct() {
+        val first = offlineAssetId(providerId = "netease", source = "netease", providerTrackId = "42")
+        val second = offlineAssetId(providerId = "qqmusic", source = "qqmusic", providerTrackId = "42")
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun identityEscapesSeparators() {
+        assertEquals("provider%3Aid:track%3Aid", offlineAssetId("provider:id", "ignored", "track:id"))
+    }
+}


### PR DESCRIPTION
## What changed

### 1. Download reliability
- Throttle download progress publication to roughly 500 ms and persist checkpoints roughly every 3 seconds instead of rewriting task JSON on every buffer read.
- Persist resume metadata (`ETag` / `Last-Modified`) and use `If-Range` when resuming partial downloads.
- Reconcile completed records with actual MediaStore/files on startup and clean orphan `.part` files.
- Query MediaStore to verify downloaded content instead of opening asset descriptors, avoiding false negatives on vendor Android implementations.

### 2. Incremental local music index
- Add an isolated `local_music_index_v3.db` index; the existing local-music database remains untouched.
- Upsert only new/modified MediaStore rows and delete missing rows rather than rebuilding the entire track table on every refresh.
- Move search, minimum-duration filtering and excluded-directory filtering into SQLite queries.
- Coalesce duplicate download-completion / MediaStore refresh events.

### 3. Unified offline identity
- Add `OfflineAsset` as the stable provider-track ↔ local-file identity/provenance model.
- Persist Android offline assets and write the mapping before publishing a completed download task to the controller.
- Restore provider id/name/source/track id when downloaded files enter the local library.
- Keep `Music/FeelUOwn/` location detection only as a compatibility fallback for older downloads.

### FuoPlayerController modularization
- Extract download, local-music and settings state into dedicated state modules.
- Move download/local-library Flow coordination and refresh debounce into `OfflineLibraryControllerCoordinator`.
- Keep existing `FuoPlayerController` public properties/method signatures and playback/provider behavior unchanged.

## Compatibility
- No UI behavior changes in this PR.
- Existing `DownloadRepository`, `LocalMusicRepository` and `FuoPlayerController` public contracts remain unchanged.
- Existing download directory, MediaStore publishing, embedded ID3/M4A metadata and lyrics behavior remain unchanged.

## Validation
- `./gradlew :shared:allTests :androidApp:assembleDebug --stacktrace` passed before squash.
- Official Android APK CI passed, including shared tests/coverage and signed multi-ABI release APK build.
- Official iOS CI passed: simulator app, device app/IPA, and shared Android+iOS tests.
- Added focused tests for provider-aware `OfflineAsset` identity.
