### PR TITLE
fix: keep paused background playback resumable

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -108,6 +108,14 @@ class FuoPlaybackService : MediaSessionService() {
                         publishPlaybackState()
                     }
 
+                    override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                        publishPlaybackState()
+                    }
+
+                    override fun onPlaybackSuppressionReasonChanged(playbackSuppressionReason: Int) {
+                        publishPlaybackState()
+                    }
+
                     override fun onIsPlayingChanged(isPlaying: Boolean) {
                         publishPlaybackState()
                     }
@@ -576,10 +584,14 @@ class FuoPlaybackService : MediaSessionService() {
         val status = when {
             currentPlayer.playbackState == Player.STATE_ENDED && hasPendingOrLoadingRequest() -> PlayerStatus.Loading
             currentPlayer.playbackState == Player.STATE_ENDED -> PlayerStatus.Ended
-            currentPlayer.playbackState == Player.STATE_BUFFERING -> PlayerStatus.Loading
             currentPlayer.isPlaying -> PlayerStatus.Playing
-            currentPlayer.playbackState == Player.STATE_READY -> PlayerStatus.Paused
-            else -> PlayerStatus.Loading
+            currentPlayer.playbackState == Player.STATE_BUFFERING &&
+                currentPlayer.playWhenReady &&
+                currentPlayer.playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE -> PlayerStatus.Loading
+            currentPlayer.playbackState == Player.STATE_READY ||
+                currentPlayer.playbackState == Player.STATE_BUFFERING ||
+                currentPlayer.currentMediaItem != null -> PlayerStatus.Paused
+            else -> PlayerStatus.Idle
         }
         mutablePlaybackState.value = PlaybackState(
             status = status,

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -58,6 +58,7 @@ class FuoPlaybackService : MediaSessionService() {
     private var preloadingGeneration: Long? = null
     private val preparedItems = mutableMapOf<String, PreparedPlayback>()
     private var activePlayback: PreparedPlayback? = null
+    private var activePlaybackHasReachedReady = false
     private var pendingPreloadError: String? = null
     @Volatile
     private var activeGeneration: Long = 0L
@@ -99,12 +100,16 @@ class FuoPlaybackService : MediaSessionService() {
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                         val prepared = mediaItem?.mediaId?.let(preparedItems::get) ?: return
                         activePlayback = prepared
+                        activePlaybackHasReachedReady = player.playbackState == Player.STATE_READY
                         enqueueRemainingParts(prepared)
                         publishPlaybackState()
                         preloadNext()
                     }
 
                     override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_READY) {
+                            activePlaybackHasReachedReady = true
+                        }
                         publishPlaybackState()
                     }
 
@@ -247,6 +252,7 @@ class FuoPlaybackService : MediaSessionService() {
         }
         preparedItems.clear()
         activePlayback = null
+        activePlaybackHasReachedReady = false
         pendingPreloadError = null
         activeGeneration = plan.generation
         mutableAudioFormatInfo.value = null
@@ -588,9 +594,9 @@ class FuoPlaybackService : MediaSessionService() {
             currentPlayer.playbackState == Player.STATE_BUFFERING &&
                 currentPlayer.playWhenReady &&
                 currentPlayer.playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE -> PlayerStatus.Loading
-            currentPlayer.playbackState == Player.STATE_READY ||
-                currentPlayer.playbackState == Player.STATE_BUFFERING ||
-                currentPlayer.currentMediaItem != null -> PlayerStatus.Paused
+            currentPlayer.playbackState == Player.STATE_READY -> PlayerStatus.Paused
+            currentPlayer.playbackState == Player.STATE_BUFFERING && activePlaybackHasReachedReady -> PlayerStatus.Paused
+            currentPlayer.playbackState == Player.STATE_BUFFERING -> PlayerStatus.Loading
             else -> PlayerStatus.Idle
         }
         mutablePlaybackState.value = PlaybackState(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.2"
 compose = "1.11.1"
 kotlin = "2.3.20"
-media3 = "1.5.1"
+media3 = "1.6.1"
 activityCompose = "1.10.1"
 coreKtx = "1.15.0"
 coroutines = "1.10.2"
@@ -21,7 +21,7 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 androidx-media3-datasource = { module = "androidx.media3:media3-datasource", version.ref = "media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
-jellyfin-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-decoder", version = "1.5.0+1" }
+jellyfin-media3-ffmpeg-decoder = { module = "org.jellyfin.media3:media3-ffmpeg-decoder", version = "1.6.1+1" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
## What changed

- Upgrade AndroidX Media3 from 1.5.1 to 1.6.1 so paused/stopped playback keeps the media foreground-service state for the Media3 grace period instead of dropping the system media control immediately.
- Align the Jellyfin Media3 FFmpeg decoder with Media3 1.6.1 (`1.6.1+1`).
- Observe `playWhenReady` and playback-suppression changes in `FuoPlaybackService`.
- Treat buffering as `Loading` only when playback is actually expected to proceed; buffering while paused or suppressed by audio focus is exposed as `Paused` instead of leaving the UI spinner stuck.
- Avoid using `Loading` as the fallback for an idle player state.

## Root cause

The app was on Media3 1.5.1. When background playback was paused (including audio-focus interruptions), the media foreground-service/notification could be dropped immediately. At the same time, `FuoPlaybackService` mapped every `STATE_BUFFERING` state to `PlayerStatus.Loading` and did not publish state changes when only `playWhenReady` or the suppression reason changed. If the pause happened while buffering, the player UI could therefore remain in the loading state indefinitely even though playback had actually been paused.

## Impact

After a background pause, the system media control remains available during the Media3 pause grace period, and returning to FuoEvolve shows a normal paused/play control instead of an endless loading spinner.

## Validation

- Verified the branch diff is limited to `FuoPlaybackService.kt` and `gradle/libs.versions.toml`.
- Verified the added `Player.Listener` callback signatures against the AndroidX Media3 API reference.
- Verified Jellyfin publishes a Media3 1.6.1-compatible FFmpeg decoder artifact (`1.6.1+1`).
- CI will provide the full Android build/test validation for the dependency upgrade.