### PR TITLE
fix: restore playback queue, part and progress after process loss

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -31,6 +31,7 @@ class AndroidNativeAudioEngine(
     private var pendingLockScreenLyrics: PendingLockScreenLyrics? = null
     private var activePlan: PlaybackPlan? = restoredSession?.plan
     private var pendingResumePositionMs: Long? = null
+    private var preparedRestoredSession: AndroidPlaybackResumeSnapshot? = null
     private var explicitStopRequested = false
     private var startingPlayback = false
     private var lastPersistedIdentity: String? = null
@@ -71,6 +72,7 @@ class AndroidNativeAudioEngine(
                     startingPlayback = false
                     if (serviceState.currentTrack != null) {
                         restoredSession = null
+                        preparedRestoredSession = null
                     }
                 }
 
@@ -110,6 +112,29 @@ class AndroidNativeAudioEngine(
     override fun prepareLoading(track: MusicTrack) {
         pendingLockScreenLyrics = null
         pendingResumePositionMs = null
+
+        // FuoPlayerController can briefly still expose Idle after process recreation even though
+        // this engine has already restored the same track as Paused. MiniPlayer becomes visible
+        // from the restored queue during that window, and its play button would otherwise call
+        // startPlayback(), clearing the saved position before resume() gets a chance to use it.
+        // Preserve the resumable session here and let play(plan) turn that stale restart into the
+        // same resume path used by FullPlayer.
+        val session = restoredSession ?: playbackResumeStore.load()
+        val shouldResumeRestoredSession = mutableState.value.status == PlayerStatus.Paused &&
+            session?.currentTrack?.id == track.id &&
+            session.resumePlan() != null
+        if (shouldResumeRestoredSession && session != null) {
+            preparedRestoredSession = session
+            restoredSession = session
+            activePlan = session.plan
+            explicitStopRequested = false
+            startingPlayback = false
+            connectController()
+            Log.d(TAG, "preserving restored session for prepared trackId=${track.id}")
+            return
+        }
+
+        preparedRestoredSession = null
         restoredSession = null
         explicitStopRequested = false
         startingPlayback = true
@@ -134,6 +159,20 @@ class AndroidNativeAudioEngine(
 
     override fun play(plan: PlaybackPlan) {
         val first = plan.requests.firstOrNull() ?: return
+        val preparedSession = preparedRestoredSession
+        if (preparedSession != null && preparedSession.currentTrack.id == first.track.id) {
+            preparedRestoredSession = null
+            restoredSession = preparedSession
+            activePlan = preparedSession.plan
+            Log.d(
+                TAG,
+                "converting stale restart to restored resume trackId=${first.track.id} positionMs=${preparedSession.positionMs}",
+            )
+            resume()
+            return
+        }
+
+        preparedRestoredSession = null
         explicitStopRequested = false
         startingPlayback = true
         restoredSession = null
@@ -178,6 +217,7 @@ class AndroidNativeAudioEngine(
 
     override fun resume() {
         explicitStopRequested = false
+        preparedRestoredSession = null
         val controller = mediaController
         val canResumeLiveSession = controller?.currentMediaItem != null &&
             controller.playbackState != Player.STATE_IDLE
@@ -224,6 +264,7 @@ class AndroidNativeAudioEngine(
     override fun stop() {
         pendingLockScreenLyrics = null
         pendingResumePositionMs = null
+        preparedRestoredSession = null
         restoredSession = null
         activePlan = null
         explicitStopRequested = true

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -16,16 +16,26 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import kotlin.math.abs
 
 class AndroidNativeAudioEngine(
     private val context: Context,
     private val scope: CoroutineScope,
 ) : PlaybackEngine {
-    private val mutableState = MutableStateFlow(PlaybackState())
+    private val playbackResumeStore = AndroidPlaybackResumeStore(context)
+    private var restoredSession: AndroidPlaybackResumeSnapshot? = playbackResumeStore.load()
+    private val mutableState = MutableStateFlow(restoredSession?.toPlaybackState() ?: PlaybackState())
     private var rawAudioQuality: String? = null
     private var mediaController: MediaController? = null
     private var controllerConnecting = false
     private var pendingLockScreenLyrics: PendingLockScreenLyrics? = null
+    private var activePlan: PlaybackPlan? = restoredSession?.plan
+    private var pendingResumePositionMs: Long? = null
+    private var explicitStopRequested = false
+    private var startingPlayback = false
+    private var lastPersistedIdentity: String? = null
+    private var lastPersistedPositionMs: Long = restoredSession?.positionMs ?: 0L
+    private var restoredRepublishSerial = 0L
 
     override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
     override val resolvesResourcesInternally: Boolean = true
@@ -47,13 +57,45 @@ class AndroidNativeAudioEngine(
         }
         scope.launch {
             FuoPlaybackService.playbackState.collect { serviceState ->
+                if (serviceState.isEmptyIdleState() && !explicitStopRequested && !startingPlayback) {
+                    val session = restoredSession ?: playbackResumeStore.load()
+                    if (session != null) {
+                        restoredSession = session
+                        activePlan = session.plan
+                        publishRestoredState(session)
+                        return@collect
+                    }
+                }
+
+                if (!serviceState.isEmptyIdleState()) {
+                    startingPlayback = false
+                    if (serviceState.currentTrack != null) {
+                        restoredSession = null
+                    }
+                }
+
                 rawAudioQuality = serviceState.audioQuality
-                val audioFormatInfo = mutableState.value.audioFormatInfo
+                val currentState = mutableState.value
+                val audioFormatInfo = currentState.audioFormatInfo
+                val pendingPosition = pendingResumePositionMs
                 mutableState.value = serviceState.copy(
+                    positionMs = pendingPosition ?: serviceState.positionMs,
+                    playbackParts = if (pendingPosition != null && serviceState.playbackParts.isEmpty()) {
+                        currentState.playbackParts
+                    } else {
+                        serviceState.playbackParts
+                    },
+                    currentPartIndex = if (pendingPosition != null && serviceState.currentPartIndex < 0) {
+                        currentState.currentPartIndex
+                    } else {
+                        serviceState.currentPartIndex
+                    },
                     audioQuality = normalizedAudioQualityLabel(rawAudioQuality, audioFormatInfo),
-                    audioDecoderInfo = mutableState.value.audioDecoderInfo,
+                    audioDecoderInfo = currentState.audioDecoderInfo,
                     audioFormatInfo = audioFormatInfo,
                 )
+                applyPendingResumeSeek()
+                persistPlaybackState()
                 applyPendingLockScreenLyrics()
             }
         }
@@ -67,6 +109,10 @@ class AndroidNativeAudioEngine(
 
     override fun prepareLoading(track: MusicTrack) {
         pendingLockScreenLyrics = null
+        pendingResumePositionMs = null
+        restoredSession = null
+        explicitStopRequested = false
+        startingPlayback = true
         rawAudioQuality = null
         mutableState.value = mutableState.value.copy(
             status = PlayerStatus.Loading,
@@ -88,6 +134,13 @@ class AndroidNativeAudioEngine(
 
     override fun play(plan: PlaybackPlan) {
         val first = plan.requests.firstOrNull() ?: return
+        explicitStopRequested = false
+        startingPlayback = true
+        restoredSession = null
+        pendingResumePositionMs = null
+        activePlan = plan
+        lastPersistedIdentity = null
+        lastPersistedPositionMs = 0L
         rawAudioQuality = null
         mutableState.value = mutableState.value.copy(
             status = PlayerStatus.Loading,
@@ -102,8 +155,10 @@ class AndroidNativeAudioEngine(
             playbackGeneration = plan.generation,
             errorMessage = null,
         )
+        persistPlaybackState(forceSession = true)
         runCatching { FuoPlaybackService.play(context, plan.toJson()) }
             .onFailure { throwable ->
+                startingPlayback = false
                 Log.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
                 mutableState.value = mutableState.value.copy(
                     status = PlayerStatus.Error,
@@ -118,16 +173,64 @@ class AndroidNativeAudioEngine(
         mediaController?.pause()
         FuoPlaybackService.pause(context)
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
+        persistPlaybackState(forcePosition = true)
     }
 
     override fun resume() {
-        mediaController?.play()
+        explicitStopRequested = false
+        val controller = mediaController
+        val canResumeLiveSession = controller?.currentMediaItem != null &&
+            controller.playbackState != Player.STATE_IDLE
+        if (canResumeLiveSession) {
+            controller.play()
+            FuoPlaybackService.resume(context)
+            mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
+            return
+        }
+
+        val session = restoredSession ?: playbackResumeStore.load()
+        val resumePlan = session?.resumePlan()
+        if (session != null && resumePlan != null) {
+            activePlan = resumePlan
+            restoredSession = session
+            pendingResumePositionMs = session.positionMs.coerceAtLeast(0L)
+            startingPlayback = true
+            lastPersistedIdentity = null
+            lastPersistedPositionMs = session.positionMs
+            mutableState.value = session.toPlaybackState().copy(
+                status = PlayerStatus.Loading,
+                playbackGeneration = resumePlan.generation,
+            )
+            persistPlaybackState(forceSession = true)
+            runCatching { FuoPlaybackService.play(context, resumePlan.toJson()) }
+                .onFailure { throwable ->
+                    startingPlayback = false
+                    Log.e(TAG, "restore playback service failed trackId=${session.currentTrack.id}", throwable)
+                    mutableState.value = session.toPlaybackState().copy(
+                        status = PlayerStatus.Error,
+                        errorMessage = throwable.message ?: "无法恢复播放进度",
+                    )
+                    return
+                }
+            connectController()
+            return
+        }
+
+        controller?.play()
         FuoPlaybackService.resume(context)
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
     }
 
     override fun stop() {
         pendingLockScreenLyrics = null
+        pendingResumePositionMs = null
+        restoredSession = null
+        activePlan = null
+        explicitStopRequested = true
+        startingPlayback = false
+        lastPersistedIdentity = null
+        lastPersistedPositionMs = 0L
+        playbackResumeStore.clear()
         rawAudioQuality = null
         clearCurrentLockScreenLyrics()
         mediaController?.stop()
@@ -140,8 +243,17 @@ class AndroidNativeAudioEngine(
         val normalizedPosition = positionMs.coerceAtLeast(0).let { position ->
             duration.takeIf { it > 0 }?.let(position::coerceAtMost) ?: position
         }
+        pendingResumePositionMs = null
         mediaController?.seekTo(normalizedPosition)
         mutableState.value = mutableState.value.copy(positionMs = normalizedPosition)
+        persistPlaybackState(forcePosition = true)
+    }
+
+    internal fun republishRestoredState() {
+        val session = restoredSession ?: return
+        if (explicitStopRequested || startingPlayback) return
+        restoredRepublishSerial += 1L
+        publishRestoredState(session, forceGeneration = true)
     }
 
     /**
@@ -172,6 +284,7 @@ class AndroidNativeAudioEngine(
                 runCatching { future.get() }
                     .onSuccess { controller ->
                         mediaController = controller
+                        applyPendingResumeSeek()
                         applyPendingLockScreenLyrics()
                     }
                     .onFailure { throwable ->
@@ -184,6 +297,70 @@ class AndroidNativeAudioEngine(
             },
             ContextCompat.getMainExecutor(context),
         )
+    }
+
+    private fun publishRestoredState(
+        session: AndroidPlaybackResumeSnapshot,
+        forceGeneration: Boolean = false,
+    ) {
+        val restoredState = session.toPlaybackState()
+        val audioFormatInfo = mutableState.value.audioFormatInfo
+        mutableState.value = restoredState.copy(
+            playbackGeneration = if (forceGeneration) {
+                restoredState.playbackGeneration + restoredRepublishSerial
+            } else {
+                restoredState.playbackGeneration
+            },
+            audioDecoderInfo = mutableState.value.audioDecoderInfo,
+            audioFormatInfo = audioFormatInfo,
+            audioQuality = normalizedAudioQualityLabel(rawAudioQuality, audioFormatInfo),
+        )
+    }
+
+    private fun applyPendingResumeSeek() {
+        val position = pendingResumePositionMs ?: return
+        val controller = mediaController ?: return
+        val currentItem = controller.currentMediaItem ?: return
+        val trackId = mutableState.value.currentTrack?.id ?: restoredSession?.currentTrack?.id
+        if (trackId != null && !currentItem.matchesTrack(trackId)) return
+        controller.seekTo(position)
+        pendingResumePositionMs = null
+        mutableState.value = mutableState.value.copy(positionMs = position)
+        persistPlaybackState(forcePosition = true)
+    }
+
+    private fun persistPlaybackState(
+        forceSession: Boolean = false,
+        forcePosition: Boolean = false,
+    ) {
+        val plan = activePlan ?: return
+        val state = mutableState.value
+        val track = state.currentTrack ?: return
+        if (state.status !in RESTORABLE_STATUSES) return
+
+        val identity = buildString {
+            append(plan.generation)
+            append('|')
+            append(track.id)
+            append('|')
+            append(state.currentPartIndex)
+            append('|')
+            state.playbackParts.forEach { part ->
+                append(part.id)
+                append(',')
+            }
+        }
+        if (forceSession || identity != lastPersistedIdentity) {
+            playbackResumeStore.saveSession(plan, state)
+            lastPersistedIdentity = identity
+            lastPersistedPositionMs = state.positionMs
+            return
+        }
+
+        if (forcePosition || abs(state.positionMs - lastPersistedPositionMs) >= POSITION_PERSIST_INTERVAL_MS) {
+            playbackResumeStore.savePosition(state.positionMs, state.durationMs)
+            lastPersistedPositionMs = state.positionMs
+        }
     }
 
     private fun applyPendingLockScreenLyrics() {
@@ -271,6 +448,7 @@ class AndroidNativeAudioEngine(
             .toString()
 
     private fun updatePosition() {
+        applyPendingResumeSeek()
         val controller = mediaController ?: return
         if (controller.playbackState == Player.STATE_IDLE) return
         val currentState = mutableState.value
@@ -288,6 +466,7 @@ class AndroidNativeAudioEngine(
             bufferedMs = controller.bufferedPosition.coerceAtLeast(0),
             lyrics = currentState.lyrics ?: sessionLyrics,
         )
+        persistPlaybackState()
     }
 
     private fun MediaItem.toMusicTrack(): MusicTrack? {
@@ -328,6 +507,9 @@ class AndroidNativeAudioEngine(
         )
     }
 
+    private fun PlaybackState.isEmptyIdleState(): Boolean =
+        status == PlayerStatus.Idle && currentTrack == null
+
     private data class PendingLockScreenLyrics(
         val trackId: String,
         val lyrics: String,
@@ -336,5 +518,7 @@ class AndroidNativeAudioEngine(
     private companion object {
         private const val TAG = "FuoAudioEngine"
         private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
+        private const val POSITION_PERSIST_INTERVAL_MS = 5_000L
+        private val RESTORABLE_STATUSES = setOf(PlayerStatus.Loading, PlayerStatus.Playing, PlayerStatus.Paused)
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -8,21 +8,44 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
     private val preferences = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
-        preferences.getString(KEY_QUEUE_SNAPSHOT, null)
-            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
-            ?: PlaybackQueueSnapshot()
+        val primaryRaw = preferences.getString(KEY_QUEUE_SNAPSHOT, null)
+        if (primaryRaw != null) {
+            return@withContext runCatching { PlaybackQueueCodec.decode(primaryRaw) }
+                .getOrElse { loadEmergencySnapshot() }
+        }
+        loadEmergencySnapshot()
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
         withContext(Dispatchers.IO) {
+            // Queue writes are relatively infrequent and must survive a process being killed
+            // immediately after playback is paused. commit() makes the disk write durable before
+            // this coroutine completes instead of leaving it queued behind SharedPreferences.apply().
             preferences.edit()
                 .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
-                .apply()
+                .commit()
         }
+    }
+
+    /**
+     * Stores a compact, last-resort queue checkpoint synchronously. This is only used if the
+     * normal queue snapshot was never written or cannot be decoded after an abrupt process kill.
+     */
+    fun saveEmergency(snapshot: PlaybackQueueSnapshot) {
+        preferences.edit()
+            .putString(KEY_EMERGENCY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
+            .commit()
+    }
+
+    private fun loadEmergencySnapshot(): PlaybackQueueSnapshot {
+        return preferences.getString(KEY_EMERGENCY_QUEUE_SNAPSHOT, null)
+            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
+            ?: PlaybackQueueSnapshot()
     }
 
     private companion object {
         private const val PREFS_NAME = "fuo_playback_queue"
         private const val KEY_QUEUE_SNAPSHOT = "queue_snapshot"
+        private const val KEY_EMERGENCY_QUEUE_SNAPSHOT = "emergency_queue_snapshot"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -7,45 +7,44 @@ import kotlinx.coroutines.withContext
 class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
     private val preferences = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+    @Volatile
+    private var latestSnapshot: PlaybackQueueSnapshot? = null
+
     override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
-        val primaryRaw = preferences.getString(KEY_QUEUE_SNAPSHOT, null)
-        if (primaryRaw != null) {
-            return@withContext runCatching { PlaybackQueueCodec.decode(primaryRaw) }
-                .getOrElse { loadEmergencySnapshot() }
-        }
-        loadEmergencySnapshot()
+        preferences.getString(KEY_QUEUE_SNAPSHOT, null)
+            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
+            ?.also { latestSnapshot = it }
+            ?: PlaybackQueueSnapshot()
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+        // FuoPlayerController launches save from its main-immediate scope. Capture the complete
+        // snapshot before the first suspension so a later pause can synchronously flush exactly
+        // this queue even if the asynchronous IO write has not finished yet.
+        latestSnapshot = snapshot
         withContext(Dispatchers.IO) {
-            // Queue writes are relatively infrequent and must survive a process being killed
-            // immediately after playback is paused. commit() makes the disk write durable before
-            // this coroutine completes instead of leaving it queued behind SharedPreferences.apply().
-            preferences.edit()
-                .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
-                .commit()
+            writeSnapshot(snapshot)
         }
     }
 
     /**
-     * Stores a compact, last-resort queue checkpoint synchronously. This is only used if the
-     * normal queue snapshot was never written or cannot be decoded after an abrupt process kill.
+     * Durably writes the most recent complete controller queue snapshot. This is intentionally
+     * synchronous and is only used at important playback lifecycle boundaries (playing/paused),
+     * where surviving an abrupt process kill is more important than deferring a small preference
+     * write.
      */
-    fun saveEmergency(snapshot: PlaybackQueueSnapshot) {
-        preferences.edit()
-            .putString(KEY_EMERGENCY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
-            .commit()
+    fun flushLatest() {
+        latestSnapshot?.let(::writeSnapshot)
     }
 
-    private fun loadEmergencySnapshot(): PlaybackQueueSnapshot {
-        return preferences.getString(KEY_EMERGENCY_QUEUE_SNAPSHOT, null)
-            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
-            ?: PlaybackQueueSnapshot()
+    private fun writeSnapshot(snapshot: PlaybackQueueSnapshot) {
+        preferences.edit()
+            .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
+            .commit()
     }
 
     private companion object {
         private const val PREFS_NAME = "fuo_playback_queue"
         private const val KEY_QUEUE_SNAPSHOT = "queue_snapshot"
-        private const val KEY_EMERGENCY_QUEUE_SNAPSHOT = "emergency_queue_snapshot"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
@@ -1,0 +1,150 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class AndroidPlaybackResumeSnapshot(
+    val plan: PlaybackPlan,
+    val currentTrack: MusicTrack,
+    val positionMs: Long,
+    val durationMs: Long,
+    val playbackParts: List<PlaybackPart>,
+    val currentPartIndex: Int,
+) {
+    fun toPlaybackState(): PlaybackState {
+        val normalizedDuration = durationMs.takeIf { it > 0L } ?: currentTrack.durationMs ?: 0L
+        val normalizedPosition = positionMs.coerceAtLeast(0L).let { position ->
+            normalizedDuration.takeIf { it > 0L }?.let(position::coerceAtMost) ?: position
+        }
+        val normalizedPartIndex = currentPartIndex.takeIf { it in playbackParts.indices } ?: -1
+        return PlaybackState(
+            status = PlayerStatus.Paused,
+            currentTrack = currentTrack,
+            positionMs = normalizedPosition,
+            durationMs = normalizedDuration,
+            playbackParts = playbackParts,
+            currentPartIndex = normalizedPartIndex,
+            playbackGeneration = plan.generation,
+            lyrics = currentTrack.lyrics,
+        )
+    }
+
+    fun resumePlan(): PlaybackPlan? {
+        val requestIndex = plan.requests.indexOfFirst { request ->
+            request.track.id == currentTrack.id
+        }
+        if (requestIndex < 0) return null
+
+        val remainingRequests = plan.requests.drop(requestIndex).toMutableList()
+        val currentRequest = remainingRequests.firstOrNull() ?: return null
+        val partIndex = currentPartIndex.takeIf { it in playbackParts.indices }
+        val part = partIndex?.let(playbackParts::get)
+        remainingRequests[0] = if (part != null) {
+            currentRequest.copy(
+                resolveTrack = part.toPlaybackTrack(currentRequest.resolveTrack),
+                requestedPartIndex = partIndex,
+            )
+        } else {
+            currentRequest
+        }
+        return plan.copy(requests = remainingRequests)
+    }
+}
+
+internal class AndroidPlaybackResumeStore(context: Context) {
+    private val preferences = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): AndroidPlaybackResumeSnapshot? {
+        if (preferences.getInt(KEY_VERSION, 0) != CURRENT_VERSION) return null
+        val planJson = preferences.getString(KEY_PLAN, null) ?: return null
+        val trackJson = preferences.getString(KEY_TRACK, null) ?: return null
+        return runCatching {
+            val plan = planJson.toPlaybackPlan()
+            if (plan.requests.isEmpty()) return@runCatching null
+            val currentTrack = JSONObject(trackJson).toMusicTrack()
+            val playbackParts = preferences.getString(KEY_PARTS, null)
+                ?.let(::decodeParts)
+                .orEmpty()
+            AndroidPlaybackResumeSnapshot(
+                plan = plan,
+                currentTrack = currentTrack,
+                positionMs = preferences.getLong(KEY_POSITION_MS, 0L),
+                durationMs = preferences.getLong(KEY_DURATION_MS, 0L),
+                playbackParts = playbackParts,
+                currentPartIndex = preferences.getInt(KEY_PART_INDEX, -1),
+            )
+        }.getOrNull()
+    }
+
+    fun saveSession(plan: PlaybackPlan, state: PlaybackState) {
+        val currentTrack = state.currentTrack ?: return
+        preferences.edit()
+            .putInt(KEY_VERSION, CURRENT_VERSION)
+            .putString(KEY_PLAN, plan.toJson())
+            .putString(KEY_TRACK, currentTrack.toJsonObject().toString())
+            .putString(KEY_PARTS, encodeParts(state.playbackParts))
+            .putInt(KEY_PART_INDEX, state.currentPartIndex)
+            .putLong(KEY_POSITION_MS, state.positionMs.coerceAtLeast(0L))
+            .putLong(KEY_DURATION_MS, state.durationMs.coerceAtLeast(0L))
+            .apply()
+    }
+
+    fun savePosition(positionMs: Long, durationMs: Long) {
+        if (!preferences.contains(KEY_PLAN)) return
+        preferences.edit()
+            .putLong(KEY_POSITION_MS, positionMs.coerceAtLeast(0L))
+            .putLong(KEY_DURATION_MS, durationMs.coerceAtLeast(0L))
+            .apply()
+    }
+
+    fun clear() {
+        preferences.edit().clear().apply()
+    }
+
+    private fun encodeParts(parts: List<PlaybackPart>): String = JSONArray().apply {
+        parts.forEach { part ->
+            put(
+                JSONObject()
+                    .put("id", part.id)
+                    .put("title", part.title)
+                    .put("duration_ms", part.durationMs),
+            )
+        }
+    }.toString()
+
+    private fun decodeParts(raw: String): List<PlaybackPart> {
+        val array = JSONArray(raw)
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.getJSONObject(index)
+                add(
+                    PlaybackPart(
+                        id = item.getString("id"),
+                        title = item.optString("title"),
+                        durationMs = item.optLong("duration_ms", 0L).takeIf { it > 0L },
+                    )
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private const val CURRENT_VERSION = 1
+        private const val PREFS_NAME = "fuo_playback_resume"
+        private const val KEY_VERSION = "version"
+        private const val KEY_PLAN = "plan"
+        private const val KEY_TRACK = "track"
+        private const val KEY_POSITION_MS = "position_ms"
+        private const val KEY_DURATION_MS = "duration_ms"
+        private const val KEY_PARTS = "parts"
+        private const val KEY_PART_INDEX = "part_index"
+    }
+}
+
+private fun PlaybackPart.toPlaybackTrack(parent: MusicTrack): MusicTrack = parent.copy(
+    id = id,
+    title = title.ifBlank { parent.title },
+    durationMs = durationMs ?: parent.durationMs,
+    providerId = id,
+)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
@@ -98,8 +98,22 @@ internal class AndroidPlaybackResumeStore(context: Context) {
             .apply()
     }
 
+    /**
+     * Forces pending apply() writes for the current resumable session to disk. A changing serial
+     * guarantees SharedPreferences performs a disk write even when all playback values are already
+     * present in memory. Call this at lifecycle boundaries such as pause before the process can be
+     * killed.
+     */
+    fun flush() {
+        if (!preferences.contains(KEY_PLAN)) return
+        val nextSerial = preferences.getLong(KEY_FLUSH_SERIAL, 0L) + 1L
+        preferences.edit()
+            .putLong(KEY_FLUSH_SERIAL, nextSerial)
+            .commit()
+    }
+
     fun clear() {
-        preferences.edit().clear().apply()
+        preferences.edit().clear().commit()
     }
 
     private fun encodeParts(parts: List<PlaybackPart>): String = JSONArray().apply {
@@ -139,6 +153,7 @@ internal class AndroidPlaybackResumeStore(context: Context) {
         private const val KEY_DURATION_MS = "duration_ms"
         private const val KEY_PARTS = "parts"
         private const val KEY_PART_INDEX = "part_index"
+        private const val KEY_FLUSH_SERIAL = "flush_serial"
     }
 }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -62,6 +62,10 @@ class FuoEvolveApplication : Application() {
         AndroidPlaybackQueueStore(applicationContext)
     }
 
+    private val playbackResumeStore: AndroidPlaybackResumeStore by lazy {
+        AndroidPlaybackResumeStore(applicationContext)
+    }
+
     private val resourceCacheRepository: AndroidResourceCacheRepository by lazy {
         AndroidResourceCacheRepository(applicationContext)
     }
@@ -132,13 +136,37 @@ class FuoEvolveApplication : Application() {
             appScope.launch {
                 snapshotFlow {
                     controller.playbackState.let { state ->
-                        state.queue.map { it.id } to state.queueIndex
+                        Triple(
+                            state.currentTrack?.id,
+                            state.status,
+                            state.queue.map { it.id } to state.queueIndex,
+                        )
                     }
                 }
                     .distinctUntilChanged()
-                    .collect { (queueIds, _) ->
-                        if (queueIds.isNotEmpty()) {
-                            playbackEngine.republishRestoredState()
+                    .collect { (_, status, _) ->
+                        // Queue restoration can briefly replace a valid restored currentTrack with
+                        // null. Re-publish the Android resume snapshot for that transition too, not
+                        // only when a non-empty queue appears, so the mini player remains visible.
+                        playbackEngine.republishRestoredState()
+
+                        if (status == PlayerStatus.Playing || status == PlayerStatus.Paused) {
+                            val state = controller.playbackState
+                            if (state.currentTrack != null && state.queue.isNotEmpty()) {
+                                // This is a last-resort checkpoint for an abrupt process kill. The
+                                // regular controller queue snapshot remains authoritative whenever
+                                // it is present and decodable.
+                                playbackQueueStore.saveEmergency(
+                                    PlaybackQueueSnapshot(
+                                        mainQueue = state.queue,
+                                        queueIndex = 0,
+                                        shuffleEnabled = controller.isShuffleEnabled,
+                                        repeatMode = controller.repeatMode,
+                                        isFmQueue = controller.isFmQueueActive,
+                                    ),
+                                )
+                                playbackResumeStore.flush()
+                            }
                         }
                     }
             }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -144,29 +144,21 @@ class FuoEvolveApplication : Application() {
                     }
                 }
                     .distinctUntilChanged()
-                    .collect { (_, status, _) ->
+                    .collect { (trackId, status, _) ->
                         // Queue restoration can briefly replace a valid restored currentTrack with
                         // null. Re-publish the Android resume snapshot for that transition too, not
                         // only when a non-empty queue appears, so the mini player remains visible.
                         playbackEngine.republishRestoredState()
 
-                        if (status == PlayerStatus.Playing || status == PlayerStatus.Paused) {
-                            val state = controller.playbackState
-                            if (state.currentTrack != null && state.queue.isNotEmpty()) {
-                                // This is a last-resort checkpoint for an abrupt process kill. The
-                                // regular controller queue snapshot remains authoritative whenever
-                                // it is present and decodable.
-                                playbackQueueStore.saveEmergency(
-                                    PlaybackQueueSnapshot(
-                                        mainQueue = state.queue,
-                                        queueIndex = 0,
-                                        shuffleEnabled = controller.isShuffleEnabled,
-                                        repeatMode = controller.repeatMode,
-                                        isFmQueue = controller.isFmQueueActive,
-                                    ),
-                                )
-                                playbackResumeStore.flush()
-                            }
+                        if (
+                            trackId != null &&
+                            (status == PlayerStatus.Playing || status == PlayerStatus.Paused)
+                        ) {
+                            // The store captured the controller's complete queue before its async IO
+                            // suspension. Flush that exact snapshot rather than reconstructing from
+                            // the UI display queue, which would lose already-played items.
+                            playbackQueueStore.flushLatest()
+                            playbackResumeStore.flush()
                         }
                     }
             }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -129,6 +129,19 @@ class FuoEvolveApplication : Application() {
                         }
                     }
             }
+            appScope.launch {
+                snapshotFlow {
+                    controller.playbackState.let { state ->
+                        state.queue.map { it.id } to state.queueIndex
+                    }
+                }
+                    .distinctUntilChanged()
+                    .collect { (queueIds, _) ->
+                        if (queueIds.isNotEmpty()) {
+                            playbackEngine.republishRestoredState()
+                        }
+                    }
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

- persist the current Android playback plan, logical track, multipart list/index, and playback position separately from the queue snapshot
- restore the app-facing playback state as paused when the MediaSession/service or app process is reclaimed
- rebuild the playback request for the saved multipart item and seek back to the saved position when playback resumes
- persist position every 5 seconds, and immediately on pause or manual seek
- capture the controller's complete queue snapshot before asynchronous IO and synchronously flush that exact snapshot when playback becomes active or paused
- explicitly flush the resumable playback snapshot at playback lifecycle boundaries
- re-publish a restored current track when queue restoration temporarily clears it, so the mini player remains visible after process recreation
- detect the startup race where MiniPlayer can call `startPlayback()` while the Android engine already owns a restored paused session; convert that stale restart into the same `resume()` path used by FullPlayer

## Why

The previous implementation restored the media session state, but process recreation exposed several timing races:

1. queue persistence could still be in asynchronous IO when the process was killed
2. startup queue restoration could temporarily overwrite the restored `currentTrack`, hiding MiniPlayer
3. after the queue made MiniPlayer visible, the controller could still briefly report `Idle` while `AndroidNativeAudioEngine` had already restored the same track as `Paused`; pressing MiniPlayer play during that window called `startPlayback()` and reset the position to zero, while opening FullPlayer first gave the paused state time to propagate and therefore resumed correctly

The Android engine now keeps the restored session authoritative for the current track. If a stale controller state attempts to prepare/start that same restored paused track, the engine preserves the saved session and converts the incoming start request into `resume()` instead of replacing it with a new zero-position plan.

## Expected behavior

After pausing playback and killing the app process, reopening the app should show the mini player with the previous current song and complete playback queue. Playback remains paused. Pressing play from either MiniPlayer or FullPlayer restores the same multipart item and seeks to the saved position instead of starting from the beginning.

## Validation

- reviewed both MiniPlayer and FullPlayer controls: both call `controller.toggle()`; the inconsistent behavior was caused by startup state propagation, not different UI handlers
- Android CI runs shared tests/coverage and builds the signed multi-ABI release APK
