### PR TITLE
fix: optimize detail page header layout

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ProviderHomeSection.kt
@@ -1,6 +1,7 @@
 package org.feeluown.mobile
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.LibraryMusic
@@ -31,6 +33,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -936,45 +939,76 @@ fun ProviderDetailHeader(
     placeholder: CoverPlaceholder = CoverPlaceholder.Song,
     action: (@Composable () -> Unit)? = null,
 ) {
-    Row(
+    val descriptionExpanded = remember(description) { mutableStateOf(false) }
+    val descriptionOverflows = remember(description) { mutableStateOf(false) }
+
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 8.dp, bottom = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        CoverBox(
-            track = track,
-            modifier = Modifier.size(112.dp),
-            placeholder = placeholder,
-        )
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.Top,
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
+            CoverBox(
+                track = track,
+                modifier = Modifier.size(112.dp),
+                placeholder = placeholder,
             )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (description.isNotBlank()) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (description.isNotBlank()) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 3,
+                    maxLines = if (descriptionExpanded.value) Int.MAX_VALUE else 4,
                     overflow = TextOverflow.Ellipsis,
+                    onTextLayout = { result ->
+                        if (!descriptionExpanded.value) {
+                            descriptionOverflows.value = result.hasVisualOverflow
+                        }
+                    },
                 )
+                if (descriptionOverflows.value || descriptionExpanded.value) {
+                    TextButton(
+                        onClick = { descriptionExpanded.value = !descriptionExpanded.value },
+                    ) {
+                        Text(if (descriptionExpanded.value) "收起简介" else "展开简介")
+                    }
+                }
             }
-            action?.invoke()
+        }
+        if (action != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+            ) {
+                action()
+            }
         }
     }
 }


### PR DESCRIPTION
## 改动
- 重构歌单、歌手、专辑、歌曲等详情页共用的 `ProviderDetailHeader`
- 将封面和核心标题信息保留在首行，简介与操作区移到独立的全宽区域
- 标题由 2 行提升到 3 行、副标题由 2 行提升到 4 行，减少关键信息被过早截断
- 长简介默认展示 4 行，并提供“展开简介 / 收起简介”以查看完整内容
- 顶部操作区改为独立横向可滚动区域，按钮按自身宽度布局，避免“添加到本地歌单”等文字在窄屏被压成多行

## 影响范围
共享 Header 被歌曲、歌单、歌手和专辑详情页复用，因此这些页面的手机布局会统一改善；未修改数据加载、播放、收藏或分享逻辑。

## 校验
- 分支基于当前 `master` 创建
- 对比确认仅修改 `ProviderHomeSection.kt`
- 需要由 PR CI 完成 Compose Multiplatform 编译与测试校验