### PR TITLE
Improve Bilibili smart replacement scoring

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -240,6 +240,7 @@ data class MusicTrack(
     val albumItemId: String? = null,
     val artistItems: List<ProviderMediaItem> = emptyList(),
     val providerUrl: String? = null,
+    val providerTags: List<String> = emptyList(),
 )
 
 data class ReplacementCandidate(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -611,7 +611,9 @@ internal fun bilibiliReplacementScore(origin: MusicTrack, candidate: MusicTrack)
     }
 
     val originVersions = replacementVersionKinds("${origin.title} ${origin.album}")
-    val candidateVersions = replacementVersionKinds(candidate.title)
+    val candidateTitleVersions = replacementVersionKinds(candidate.title)
+    val candidateTagVersions = replacementVersionKinds(candidate.providerTags.joinToString(" "))
+    val candidateVersions = candidateTitleVersions.ifEmpty { candidateTagVersions }
     score += BILIBILI_VERSION_SCORE * replacementVersionCompatibility(
         originVersions = originVersions,
         candidateVersions = candidateVersions,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/KotlinProviderRepository.kt
@@ -589,43 +589,130 @@ internal suspend fun <T> selectReplacementCandidate(
 }
 
 internal fun bilibiliReplacementScore(origin: MusicTrack, candidate: MusicTrack): Double {
-    val originTitle = normalizeReplacementText(origin.title)
-    val candidateTitle = normalizeReplacementText(candidate.title)
-    val candidateArtists = normalizeReplacementText(candidate.artists)
+    val originTitle = normalizeReplacementTitle(origin.title)
+    val candidateTitle = normalizeReplacementTitle(candidate.title)
     if (originTitle.isBlank() || candidateTitle.isBlank()) return 0.0
 
-    var score = 0.0
-    if (originTitle in candidateTitle) {
-        score += 0.40
+    var score = when {
+        originTitle == candidateTitle -> BILIBILI_TITLE_EXACT_SCORE
+        originTitle in candidateTitle || candidateTitle in originTitle -> BILIBILI_TITLE_CONTAINS_SCORE
+        else -> BILIBILI_TITLE_EXACT_SCORE * replacementTextSimilarity(originTitle, candidateTitle)
     }
-    if (
-        replacementArtistMatchTexts(origin.artists).any { artist ->
-            artist in candidateTitle || artist in candidateArtists
+
+    val originArtists = replacementArtistMatchTexts(origin.artists)
+    val candidateUploader = normalizeReplacementText(candidate.artists)
+    val candidateRawTitle = normalizeReplacementText(candidate.title)
+    val uploaderMatchesArtist = originArtists.any { artist -> replacementArtistMatches(artist, candidateUploader) }
+    val titleMentionsArtist = originArtists.any { artist -> replacementArtistMatches(artist, candidateRawTitle) }
+    score += when {
+        uploaderMatchesArtist -> BILIBILI_UPLOADER_ARTIST_SCORE
+        titleMentionsArtist -> BILIBILI_TITLE_ARTIST_SCORE
+        else -> 0.0
+    }
+
+    val originVersions = replacementVersionKinds("${origin.title} ${origin.album}")
+    val candidateVersions = replacementVersionKinds(candidate.title)
+    score += BILIBILI_VERSION_SCORE * replacementVersionCompatibility(
+        originVersions = originVersions,
+        candidateVersions = candidateVersions,
+        uploaderMatchesArtist = uploaderMatchesArtist,
+    )
+    if (hasReplacementVersionConflict(originVersions, candidateVersions, uploaderMatchesArtist)) {
+        score -= BILIBILI_VERSION_CONFLICT_PENALTY
+    }
+
+    if (uploaderMatchesArtist) {
+        score += when {
+            BILIBILI_OFFICIAL_MEDIA_KEYWORDS.any { keyword -> keyword in candidateRawTitle } ->
+                BILIBILI_OFFICIAL_MEDIA_SCORE
+            "musicvideo" in candidateRawTitle || "mv" in candidateRawTitle ->
+                BILIBILI_MV_SCORE
+            else -> 0.0
         }
-    ) {
-        score += 0.20
     }
-    if (BILIBILI_REPLACEMENT_BONUS_KEYWORDS.any { keyword -> keyword in candidateTitle }) {
-        score += 0.10
+    if (BILIBILI_QUALITY_KEYWORDS.any { keyword -> keyword in candidateRawTitle }) {
+        score += BILIBILI_QUALITY_SCORE
     }
-    if (
-        BILIBILI_REPLACEMENT_PENALTY_KEYWORDS.none { keyword -> keyword in originTitle } &&
-        BILIBILI_REPLACEMENT_PENALTY_KEYWORDS.any { keyword -> keyword in candidateTitle }
-    ) {
-        score -= 0.20
-    }
-    return applyReplacementDurationPenalty(score, origin, candidate)
+
+    score += replacementDurationScore(origin.durationMs, candidate.durationMs)
+    return score.coerceIn(0.0, 1.0)
 }
 
-private fun applyReplacementDurationPenalty(score: Double, origin: MusicTrack, candidate: MusicTrack): Double {
-    val originDuration = origin.durationMs
-    val candidateDuration = candidate.durationMs
-    if (originDuration != null && originDuration > 0 && candidateDuration != null && candidateDuration > 0) {
-        val diffRatio = kotlin.math.abs(originDuration - candidateDuration).toDouble() / originDuration.toDouble()
-        return (score - minOf(diffRatio * MAX_REPLACEMENT_DURATION_PENALTY, MAX_REPLACEMENT_DURATION_PENALTY))
-            .coerceAtLeast(0.0)
+private enum class ReplacementVersionKind {
+    COVER,
+    REMIX,
+    LIVE,
+    INSTRUMENTAL,
+}
+
+private fun normalizeReplacementTitle(value: String): String {
+    var title = value
+    REPLACEMENT_TITLE_DECORATION_PATTERNS.forEach { pattern ->
+        title = pattern.replace(title, " ")
     }
-    return score.coerceAtLeast(0.0)
+    return normalizeReplacementText(title)
+}
+
+private fun replacementVersionKinds(value: String): Set<ReplacementVersionKind> = buildSet {
+    if (REPLACEMENT_COVER_PATTERNS.any { pattern -> pattern.containsMatchIn(value) }) {
+        add(ReplacementVersionKind.COVER)
+    }
+    if (REPLACEMENT_REMIX_PATTERNS.any { pattern -> pattern.containsMatchIn(value) }) {
+        add(ReplacementVersionKind.REMIX)
+    }
+    if (REPLACEMENT_LIVE_PATTERNS.any { pattern -> pattern.containsMatchIn(value) }) {
+        add(ReplacementVersionKind.LIVE)
+    }
+    if (REPLACEMENT_INSTRUMENTAL_PATTERNS.any { pattern -> pattern.containsMatchIn(value) }) {
+        add(ReplacementVersionKind.INSTRUMENTAL)
+    }
+}
+
+private fun replacementVersionCompatibility(
+    originVersions: Set<ReplacementVersionKind>,
+    candidateVersions: Set<ReplacementVersionKind>,
+    uploaderMatchesArtist: Boolean,
+): Double = when {
+    originVersions == candidateVersions -> 1.0
+    originVersions.isEmpty() && candidateVersions.isNotEmpty() -> if (uploaderMatchesArtist) 0.5 else 0.0
+    originVersions.isNotEmpty() && candidateVersions.isEmpty() -> 0.5
+    originVersions.intersect(candidateVersions).isNotEmpty() -> 0.6
+    else -> 0.0
+}
+
+private fun hasReplacementVersionConflict(
+    originVersions: Set<ReplacementVersionKind>,
+    candidateVersions: Set<ReplacementVersionKind>,
+    uploaderMatchesArtist: Boolean,
+): Boolean = when {
+    originVersions.isNotEmpty() && candidateVersions.isNotEmpty() ->
+        originVersions.intersect(candidateVersions).isEmpty()
+    originVersions.isEmpty() && candidateVersions.isNotEmpty() -> !uploaderMatchesArtist
+    originVersions.isNotEmpty() && candidateVersions.isEmpty() -> !uploaderMatchesArtist
+    else -> false
+}
+
+private fun replacementDurationScore(originDurationMs: Long?, candidateDurationMs: Long?): Double {
+    val originDuration = originDurationMs?.takeIf { it > 0 } ?: return BILIBILI_UNKNOWN_DURATION_SCORE
+    val candidateDuration = candidateDurationMs?.takeIf { it > 0 } ?: return BILIBILI_UNKNOWN_DURATION_SCORE
+    return when (kotlin.math.abs(originDuration - candidateDuration)) {
+        in 0L..3_000L -> 0.10
+        in 3_001L..8_000L -> 0.095
+        in 8_001L..15_000L -> 0.08
+        in 15_001L..30_000L -> 0.04
+        else -> 0.0
+    }
+}
+
+private fun replacementTextSimilarity(left: String, right: String): Double {
+    if (left.isBlank() || right.isBlank()) return 0.0
+    val common = left.toSet().intersect(right.toSet()).size.toDouble()
+    return common / maxOf(left.toSet().size, right.toSet().size).toDouble()
+}
+
+private fun replacementArtistMatches(artist: String, value: String): Boolean {
+    if (artist.length < 2 || value.length < 2) return false
+    return artist in value || value in artist
 }
 
 private fun normalizeReplacementText(value: String): String =
@@ -645,10 +732,56 @@ private fun replacementArtistMatchTexts(value: String): List<String> {
 private const val NETEASE_PROVIDER_ID = "netease"
 private const val NETEASE_LEGACY_TOP_ARTISTS_FEATURE_ID = "netease_top_artists"
 private const val BILIBILI_PROVIDER_ID = "bilibili"
-private val BILIBILI_REPLACEMENT_BONUS_KEYWORDS = listOf("mv", "hires")
-private val BILIBILI_REPLACEMENT_PENALTY_KEYWORDS = listOf("cover", "翻唱", "remix")
+private const val BILIBILI_TITLE_EXACT_SCORE = 0.45
+private const val BILIBILI_TITLE_CONTAINS_SCORE = 0.42
+private const val BILIBILI_UPLOADER_ARTIST_SCORE = 0.25
+private const val BILIBILI_TITLE_ARTIST_SCORE = 0.10
+private const val BILIBILI_VERSION_SCORE = 0.10
+private const val BILIBILI_VERSION_CONFLICT_PENALTY = 0.15
+private const val BILIBILI_OFFICIAL_MEDIA_SCORE = 0.10
+private const val BILIBILI_MV_SCORE = 0.05
+private const val BILIBILI_QUALITY_SCORE = 0.02
+private const val BILIBILI_UNKNOWN_DURATION_SCORE = 0.05
+private val BILIBILI_OFFICIAL_MEDIA_KEYWORDS = listOf("officialmusicvideo", "officialvideo", "officialmv")
+private val BILIBILI_QUALITY_KEYWORDS = listOf("hires")
+private val REPLACEMENT_COVER_PATTERNS = listOf(
+    Regex("\\bcover\\b", RegexOption.IGNORE_CASE),
+    Regex("翻唱"),
+    Regex("歌ってみた"),
+    Regex("弾いてみた"),
+)
+private val REPLACEMENT_REMIX_PATTERNS = listOf(
+    Regex("\\bremix\\b", RegexOption.IGNORE_CASE),
+    Regex("重混"),
+)
+private val REPLACEMENT_LIVE_PATTERNS = listOf(
+    Regex("\\blive\\b", RegexOption.IGNORE_CASE),
+    Regex("现场"),
+    Regex("現場"),
+    Regex("ライブ"),
+)
+private val REPLACEMENT_INSTRUMENTAL_PATTERNS = listOf(
+    Regex("\\binstrumental\\b", RegexOption.IGNORE_CASE),
+    Regex("\\boff[ -]?vocal\\b", RegexOption.IGNORE_CASE),
+    Regex("\\bkaraoke\\b", RegexOption.IGNORE_CASE),
+    Regex("伴奏"),
+    Regex("纯音乐"),
+    Regex("純音樂"),
+)
+private val REPLACEMENT_MEDIA_DECORATION_PATTERNS = listOf(
+    Regex("\\bofficial[ -]?(?:music[ -]?)?video\\b", RegexOption.IGNORE_CASE),
+    Regex("\\bofficial[ -]?mv\\b", RegexOption.IGNORE_CASE),
+    Regex("\\bmusic[ -]?video\\b", RegexOption.IGNORE_CASE),
+    Regex("\\bmv\\b", RegexOption.IGNORE_CASE),
+    Regex("\\bhi[ -]?res\\b", RegexOption.IGNORE_CASE),
+)
+private val REPLACEMENT_TITLE_DECORATION_PATTERNS =
+    REPLACEMENT_COVER_PATTERNS +
+        REPLACEMENT_REMIX_PATTERNS +
+        REPLACEMENT_LIVE_PATTERNS +
+        REPLACEMENT_INSTRUMENTAL_PATTERNS +
+        REPLACEMENT_MEDIA_DECORATION_PATTERNS
 private val REPLACEMENT_ARTIST_SEPARATORS = listOf(" / ", "/", "、", ",", "，", ";", "；", "&", "+", "＋")
-private const val MAX_REPLACEMENT_DURATION_PENALTY = 0.30
 
 fun createKotlinProviderRepository(
     credentials: ProviderCredentialStore,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
@@ -76,7 +76,7 @@ class BilibiliProvider(
                 coverUrl = normalizeCover(item.stringOrNull("pic")),
                 durationMs = parseDurationMs(item.string("duration")),
                 providerUrl = "https://www.bilibili.com/video/$bvid",
-            )
+            ).copy(providerTags = parseSearchTags(item.stringOrNull("tag")))
         }
         return ProviderSearchResults(tracks = tracks)
     }
@@ -531,25 +531,7 @@ class BilibiliProvider(
             coverUrl = normalizeCover(item.stringOrNull("pic") ?: item.stringOrNull("cover")),
             durationMs = item.long("duration")?.times(1_000) ?: parseDurationMs(item.string("duration")),
             providerUrl = "https://www.bilibili.com/video/$bvid",
-        )
-    }
-
-    private fun kotlinx.serialization.json.JsonObject.toFavoritePlaylist(
-        isCollection: Boolean = false,
-    ): ProviderPlaylist? {
-        val rawIdentifier = stringOrNull("id") ?: stringOrNull("media_id") ?: return null
-        val identifier = if (isCollection) "$COLLECTION_PREFIX$rawIdentifier" else rawIdentifier
-        val title = stringOrNull("title") ?: return null
-        val ownerMid = stringOrNull("mid") ?: obj("upper")?.stringOrNull("mid")
-        return playlist(
-            identifier = identifier,
-            title = title,
-            coverUrl = normalizeCover(stringOrNull("cover")),
-            description = string("intro"),
-            playCount = obj("cnt_info")?.long("play"),
-            trackCount = int("media_count"),
-            providerUrl = ownerMid?.let { "https://space.bilibili.com/$it/favlist?fid=$rawIdentifier" },
-        )
+        ).copy(providerTags = parseSearchTags(item.stringOrNull("tag")))
     }
 
     private fun credentialsArePresent(credentials: org.feeluown.mobile.provider.core.ProviderCredentials): Boolean =
@@ -634,6 +616,13 @@ class BilibiliProvider(
         if (parts.isEmpty()) return null
         return parts.fold(0L) { total, part -> total * 60 + part } * 1_000
     }
+
+    private fun parseSearchTags(value: String?): List<String> = value
+        ?.split(',', '，')
+        ?.map { tag -> tag.trim() }
+        ?.filter { tag -> tag.isNotBlank() }
+        ?.distinct()
+        .orEmpty()
 
     private fun String.keyFromUrl(): String = substringAfterLast('/').substringBeforeLast('.')
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
@@ -534,6 +534,24 @@ class BilibiliProvider(
         ).copy(providerTags = parseSearchTags(item.stringOrNull("tag")))
     }
 
+    private fun kotlinx.serialization.json.JsonObject.toFavoritePlaylist(
+        isCollection: Boolean = false,
+    ): ProviderPlaylist? {
+        val rawIdentifier = stringOrNull("id") ?: stringOrNull("media_id") ?: return null
+        val identifier = if (isCollection) "$COLLECTION_PREFIX$rawIdentifier" else rawIdentifier
+        val title = stringOrNull("title") ?: return null
+        val ownerMid = stringOrNull("mid") ?: obj("upper")?.stringOrNull("mid")
+        return playlist(
+            identifier = identifier,
+            title = title,
+            coverUrl = normalizeCover(stringOrNull("cover")),
+            description = string("intro"),
+            playCount = obj("cnt_info")?.long("play"),
+            trackCount = int("media_count"),
+            providerUrl = ownerMid?.let { "https://space.bilibili.com/$it/favlist?fid=$rawIdentifier" },
+        )
+    }
+
     private fun credentialsArePresent(credentials: org.feeluown.mobile.provider.core.ProviderCredentials): Boolean =
         credentials.cookies.isNotEmpty() ||
             !credentials.cookieHeader.isNullOrBlank() ||

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
@@ -15,6 +15,30 @@ import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 
 class BilibiliProviderTest {
     @Test
+    fun searchPreservesBilibiliVideoTags() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        assertEquals("/x/web-interface/search/type", request.url.encodedPath)
+                        assertEquals("video", request.url.parameters["search_type"])
+                        assertEquals("ハルジオン YOASOBI", request.url.parameters["keyword"])
+                        respond(
+                            """{"code":0,"data":{"result":[{"bvid":"BVcover","title":"ハルジオン / YOASOBI","author":"七海Nana7mi","duration":"3:17","tag":"YOASOBI, ハルジオン,翻唱"}]}}""",
+                        )
+                    }
+                }
+            },
+        )
+        val provider = BilibiliProvider(client, InMemoryProviderCredentialStore())
+
+        val track = provider.search("ハルジオン YOASOBI").tracks.single()
+
+        assertEquals(listOf("YOASOBI", "ハルジオン", "翻唱"), track.providerTags)
+        client.close()
+    }
+
+    @Test
     fun resolveSelectsBilibiliAudioQualityAndPreservesPlayableParts() = runTest {
         val playUrlRequests = mutableListOf<Pair<String, String?>>()
         val client = ProviderHttpClient(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
@@ -99,7 +99,7 @@ class KotlinProviderRepositoryReplacementTest {
     }
 
     @Test
-    fun bilibiliScorePrefersYoasobiOfficialVideoOverTitleOnlyCover() {
+    fun bilibiliScorePrefersYoasobiOfficialVideoOverTaggedCover() {
         val origin = track(
             source = "netease",
             title = "ハルジオン",
@@ -117,11 +117,35 @@ class KotlinProviderRepositoryReplacementTest {
             title = "【七海】ハルジオン／春紫菀 【YOASOBI】（人声增强）",
             artists = "七海Nana7mi",
             durationMs = 197_000,
+            providerTags = listOf("YOASOBI", "ハルジオン", "翻唱"),
         )
 
         assertEquals(0.965, bilibiliReplacementScore(origin, official), 0.0001)
-        assertEquals(0.72, bilibiliReplacementScore(origin, cover), 0.0001)
+        assertEquals(0.47, bilibiliReplacementScore(origin, cover), 0.0001)
         assertTrue(bilibiliReplacementScore(origin, official) > bilibiliReplacementScore(origin, cover))
+    }
+
+    @Test
+    fun bilibiliScoreUsesTitleVersionBeforeConflictingTags() {
+        val origin = track(
+            source = "netease",
+            title = "Night Song Live",
+            artists = "Alice",
+            durationMs = 200_000,
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "Alice Night Song Live",
+            artists = "Alice Official",
+            durationMs = 201_000,
+        )
+        val candidateWithNoisyTags = candidate.copy(providerTags = listOf("翻唱", "音乐"))
+
+        assertEquals(
+            bilibiliReplacementScore(origin, candidate),
+            bilibiliReplacementScore(origin, candidateWithNoisyTags),
+            0.0001,
+        )
     }
 
     @Test
@@ -241,6 +265,7 @@ class KotlinProviderRepositoryReplacementTest {
         artists: String,
         durationMs: Long? = null,
         id: String = "$source:$title",
+        providerTags: List<String> = emptyList(),
     ): MusicTrack = MusicTrack(
         id = id,
         title = title,
@@ -250,5 +275,6 @@ class KotlinProviderRepositoryReplacementTest {
         sourceType = TrackSourceType.Provider,
         durationMs = durationMs,
         providerId = id,
+        providerTags = providerTags,
     )
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
@@ -4,10 +4,11 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class KotlinProviderRepositoryReplacementTest {
     @Test
-    fun bilibiliScoreMatchesTitleArtistAndBonusKeywords() {
+    fun bilibiliScoreStillMatchesTitleArtistAndQualityKeywords() {
         val origin = track(
             source = "netease",
             title = "Night Song",
@@ -19,27 +20,36 @@ class KotlinProviderRepositoryReplacementTest {
             artists = "Uploader",
         )
 
-        assertEquals(0.70, bilibiliReplacementScore(origin, candidate), 0.0001)
+        assertEquals(0.69, bilibiliReplacementScore(origin, candidate), 0.0001)
     }
 
     @Test
-    fun bilibiliScoreMatchesArtistMetadataWhenUploaderTitleOmitsArtist() {
+    fun bilibiliScoreRewardsUploaderArtistMatchMoreThanTitleMention() {
         val origin = track(
             source = "netease",
             title = "人间芳菲",
             artists = "音阙诗听",
         )
-        val candidate = track(
+        val officialUploader = track(
             source = "bilibili",
             title = "人间芳菲",
             artists = "音阙诗听",
         )
+        val titleMentionOnly = track(
+            source = "bilibili",
+            title = "音阙诗听 人间芳菲",
+            artists = "Uploader",
+        )
 
-        assertEquals(0.60, bilibiliReplacementScore(origin, candidate), 0.0001)
+        assertEquals(0.85, bilibiliReplacementScore(origin, officialUploader), 0.0001)
+        assertTrue(
+            bilibiliReplacementScore(origin, officialUploader) >
+                bilibiliReplacementScore(origin, titleMentionOnly),
+        )
     }
 
     @Test
-    fun bilibiliScorePenalizesCoverKeywords() {
+    fun bilibiliScorePenalizesCoverVersionConflict() {
         val origin = track(
             source = "netease",
             title = "晴天",
@@ -51,11 +61,11 @@ class KotlinProviderRepositoryReplacementTest {
             artists = "Uploader",
         )
 
-        assertEquals(0.40, bilibiliReplacementScore(origin, candidate), 0.0001)
+        assertEquals(0.42, bilibiliReplacementScore(origin, candidate), 0.0001)
     }
 
     @Test
-    fun bilibiliScoreKeepsOriginalKeywordVersions() {
+    fun bilibiliScoreKeepsMatchingRemixVersion() {
         val origin = track(
             source = "netease",
             title = "晴天 Remix",
@@ -67,11 +77,11 @@ class KotlinProviderRepositoryReplacementTest {
             artists = "Uploader",
         )
 
-        assertEquals(0.60, bilibiliReplacementScore(origin, candidate), 0.0001)
+        assertEquals(0.67, bilibiliReplacementScore(origin, candidate), 0.0001)
     }
 
     @Test
-    fun bilibiliScoreAppliesRelativeDurationPenalty() {
+    fun bilibiliScoreTreatsDurationAsSupportingEvidence() {
         val origin = track(
             source = "netease",
             title = "Night Song",
@@ -85,7 +95,62 @@ class KotlinProviderRepositoryReplacementTest {
             durationMs = 300_000,
         )
 
-        assertEquals(0.55, bilibiliReplacementScore(origin, candidate), 0.0001)
+        assertEquals(0.64, bilibiliReplacementScore(origin, candidate), 0.0001)
+    }
+
+    @Test
+    fun bilibiliScorePrefersYoasobiOfficialVideoOverTitleOnlyCover() {
+        val origin = track(
+            source = "netease",
+            title = "ハルジオン",
+            artists = "YOASOBI",
+            durationMs = 198_000,
+        )
+        val official = track(
+            source = "bilibili",
+            title = "YOASOBI ハルジオン(Halzion) Official Music Video",
+            artists = "Ayase-YOASOBI",
+            durationMs = 203_000,
+        )
+        val cover = track(
+            source = "bilibili",
+            title = "【七海】ハルジオン／春紫菀 【YOASOBI】（人声增强）",
+            artists = "七海Nana7mi",
+            durationMs = 197_000,
+        )
+
+        assertEquals(0.965, bilibiliReplacementScore(origin, official), 0.0001)
+        assertEquals(0.72, bilibiliReplacementScore(origin, cover), 0.0001)
+        assertTrue(bilibiliReplacementScore(origin, official) > bilibiliReplacementScore(origin, cover))
+    }
+
+    @Test
+    fun bilibiliScorePreservesCoverOriginVersion() {
+        val origin = track(
+            source = "netease",
+            title = "ハルジオン (Cover)",
+            artists = "Aimer",
+            durationMs = 198_000,
+        )
+        val matchingCover = track(
+            source = "bilibili",
+            title = "Aimer ハルジオン 歌ってみた",
+            artists = "Aimer Official",
+            durationMs = 199_000,
+        )
+        val originalArtistOfficial = track(
+            source = "bilibili",
+            title = "YOASOBI ハルジオン Official Music Video",
+            artists = "Ayase-YOASOBI",
+            durationMs = 203_000,
+        )
+
+        assertEquals(0.87, bilibiliReplacementScore(origin, matchingCover), 0.0001)
+        assertEquals(0.415, bilibiliReplacementScore(origin, originalArtistOfficial), 0.0001)
+        assertTrue(
+            bilibiliReplacementScore(origin, matchingCover) >
+                bilibiliReplacementScore(origin, originalArtistOfficial),
+        )
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Reworked Bilibili smart-replacement scoring around track identity, performer evidence, version compatibility, duration, and source confidence.
- Give uploader/artist matches more weight than merely mentioning the original artist in the video title.
- Recognize `Official Music Video` / `Official MV` as a strong signal only when the uploader also matches the target artist.
- Model `Cover`, `Remix`, `Live`, and instrumental/karaoke markers as version traits instead of applying an unconditional cover/remix penalty.
- Penalize version conflicts while preserving cases where the original track itself is a cover/remix/live version.
- Reduce duration from a large linear penalty to supporting evidence with tolerance for normal MV intro/outro differences.
- Preserve Bilibili's `tag` field from the existing video search response and use those tags as fallback version evidence, without adding per-candidate detail requests.
- Prefer explicit version markers in the video title over tags, so noisy/SEO tags cannot override a clearly identified `Live`, `Cover`, `Remix`, or instrumental version.
- Added regression coverage for YOASOBI `ハルジオン`, Bilibili search tag mapping, title-over-tag precedence, and cover-origin matching.

## Why

The previous Bilibili scorer treated an artist name in a video title almost the same as an uploader/artist match. A cover could therefore receive the same base score as an official upload and win solely because its duration was one or two seconds closer to the streaming track. It also only recognized literal `mv` and did not treat `Official Music Video` as an official-media signal.

Bilibili video search already returns a comma-separated `tag` field. That gives us useful version evidence such as `翻唱` without making extra network requests. Tags are deliberately used only for version classification and only when the title itself does not already identify a version.

The new scoring keeps the replacement target as the current recording (`work + performer + version`) rather than always preferring an original/official performance. This avoids breaking tracks whose source recording is itself a cover, remix, or live version.

## Validation

- Added/updated common tests for Bilibili search tag mapping and replacement scoring.
- The YOASOBI official `ハルジオン` fixture scores ~0.965, while the 七海 result with a `翻唱` search tag scores ~0.47.
- A matching Aimer cover scores ~0.87 vs ~0.415 for the YOASOBI original when the source track is explicitly a cover.
- Added a noisy-tag regression proving an explicit `Live` marker in the title takes precedence over a conflicting `翻唱` tag.
- Android APK and iOS Debug CI run on the PR branch; CI is the authoritative full compile/test check because a full local repository checkout is not available in this runtime.