### PR TITLE
feat: add Lyricon status bar lyrics

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -130,4 +130,5 @@ dependencies {
     implementation(libs.jellyfin.media3.ffmpeg.decoder)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.lyricon.provider)
 }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
+    <queries>
+        <package android:name="io.github.proify.lyricon" />
+    </queries>
+
     <application
         android:name=".FuoEvolveApplication"
         android:allowBackup="true"
@@ -21,6 +25,10 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <meta-data android:name="lyricon_module" android:value="true" />
+        <meta-data android:name="lyricon_module_author" android:value="FeelUOwn" />
+        <meta-data android:name="lyricon_module_description" android:value="FuoEvolve 状态栏歌词" />
+        <meta-data android:name="lyricon_module_tags" android:resource="@array/lyricon_module_tags" />
         <activity
             android:name=".MainActivity"
             android:configChanges="uiMode|orientation|screenSize"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 
 class FuoEvolveApplication : Application() {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var lyriconLyricsPublisher: LyriconLyricsPublisher? = null
 
     internal val providerRepository: ProviderMusicRepository by lazy {
         createFuoProviderRepository(
@@ -117,6 +118,12 @@ class FuoEvolveApplication : Application() {
             oauthDeviceCodeAssistant = AndroidOAuthDeviceCodeAssistant(applicationContext),
             scope = appScope,
         ).also { controller ->
+            controller.updateStatusBarLyricsAvailability(isLyriconInstalled(applicationContext))
+            lyriconLyricsPublisher = LyriconLyricsPublisher(
+                context = applicationContext,
+                controller = controller,
+                scope = appScope,
+            ).also(LyriconLyricsPublisher::start)
             FuoPlaybackService.transportControls = object : FuoPlaybackService.TransportControls {
                 override fun toggle() {
                     controller.toggle()
@@ -198,6 +205,8 @@ class FuoEvolveApplication : Application() {
 
     override fun onTerminate() {
         FuoPlaybackService.transportControls = null
+        lyriconLyricsPublisher?.close()
+        lyriconLyricsPublisher = null
         appScope.cancel()
         super.onTerminate()
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -1,0 +1,197 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.runtime.snapshotFlow
+import io.github.proify.lyricon.lyric.model.LyricWord as LyriconLyricWord
+import io.github.proify.lyricon.lyric.model.RichLyricLine as LyriconRichLyricLine
+import io.github.proify.lyricon.lyric.model.Song as LyriconSong
+import io.github.proify.lyricon.provider.ConnectionListener
+import io.github.proify.lyricon.provider.LyriconFactory
+import io.github.proify.lyricon.provider.LyriconProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+internal const val LYRICON_PACKAGE_NAME = "io.github.proify.lyricon"
+
+@Suppress("DEPRECATION")
+internal fun isLyriconInstalled(context: Context): Boolean = runCatching {
+    context.packageManager.getPackageInfo(LYRICON_PACKAGE_NAME, 0)
+}.isSuccess
+
+internal class LyriconLyricsPublisher(
+    context: Context,
+    private val controller: FuoPlayerController,
+    private val scope: CoroutineScope,
+) {
+    private val appContext = context.applicationContext
+    private var collectJob: Job? = null
+    private var provider: LyriconProvider? = null
+    private var lastTrackKey: String? = null
+    private var lastPayload: StatusBarLyricsPayload? = null
+
+    private val connectionListener = object : ConnectionListener {
+        override fun onConnected(provider: LyriconProvider) {
+            Log.d(TAG, "Lyricon connected")
+        }
+
+        override fun onReconnected(provider: LyriconProvider) {
+            Log.d(TAG, "Lyricon reconnected")
+        }
+
+        override fun onDisconnected(provider: LyriconProvider) {
+            Log.w(TAG, "Lyricon disconnected")
+        }
+
+        override fun onConnectTimeout(provider: LyriconProvider) {
+            Log.w(TAG, "Lyricon connection timed out; playback continues normally")
+        }
+    }
+
+    fun start() {
+        if (collectJob != null) return
+        collectJob = scope.launch {
+            snapshotFlow {
+                val state = controller.playbackState
+                Snapshot(
+                    enabled = controller.statusBarLyricsEnabled,
+                    status = state.status,
+                    track = state.currentTrack,
+                    positionMs = state.positionMs,
+                    durationMs = state.durationMs,
+                    lyrics = state.lyrics,
+                )
+            }
+                .distinctUntilChanged()
+                .collect(::publish)
+        }
+    }
+
+    fun close() {
+        collectJob?.cancel()
+        collectJob = null
+        deactivate()
+    }
+
+    private fun publish(snapshot: Snapshot) {
+        val track = snapshot.track
+        if (
+            !snapshot.enabled ||
+            track == null ||
+            snapshot.status == PlayerStatus.Idle ||
+            snapshot.status == PlayerStatus.Error ||
+            snapshot.status == PlayerStatus.Ended
+        ) {
+            deactivate()
+            return
+        }
+
+        val payload = buildStatusBarLyricsPayload(
+            rawLyrics = snapshot.lyrics,
+            durationMs = snapshot.durationMs.takeIf { it > 0L } ?: track.durationMs,
+        )
+        if (payload == StatusBarLyricsPayload.Empty) {
+            deactivate()
+            return
+        }
+
+        val activeProvider = ensureProvider() ?: return
+        val trackKey = listOf(track.source, track.id, track.title, track.artists).joinToString("\u0000")
+        runCatching {
+            if (trackKey != lastTrackKey || payload != lastPayload) {
+                when (payload) {
+                    StatusBarLyricsPayload.Empty -> Unit
+                    is StatusBarLyricsPayload.Text -> activeProvider.player.sendText(payload.text)
+                    is StatusBarLyricsPayload.Timed -> activeProvider.player.setSong(
+                        LyriconSong(
+                            id = "${track.source}:${track.id}",
+                            name = track.title,
+                            artist = track.artists,
+                            duration = snapshot.durationMs.takeIf { it > 0L } ?: track.durationMs ?: 0L,
+                            lyrics = payload.lines.map { line ->
+                                LyriconRichLyricLine(
+                                    begin = line.beginMs,
+                                    end = line.endMs,
+                                    text = line.text,
+                                    words = line.words?.map { word ->
+                                        LyriconLyricWord(
+                                            begin = word.beginMs,
+                                            end = word.endMs,
+                                            text = word.text,
+                                        )
+                                    },
+                                    translation = line.translation,
+                                    roma = line.romanization,
+                                )
+                            },
+                        ),
+                    )
+                }
+                lastTrackKey = trackKey
+                lastPayload = payload
+            }
+            activeProvider.player.setPosition(snapshot.positionMs.coerceAtLeast(0L))
+            activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
+        }.onFailure { throwable ->
+            Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
+        }
+    }
+
+    private fun ensureProvider(): LyriconProvider? {
+        provider?.let { return it }
+        if (!isLyriconInstalled(appContext)) {
+            Log.d(TAG, "Lyricon is not installed; skip status bar lyrics")
+            return null
+        }
+        return runCatching {
+            LyriconFactory.createProvider(appContext).also { created ->
+                created.autoSync = true
+                created.player.setDisplayTranslation(true)
+                created.player.setDisplayRoma(true)
+                created.service.addConnectionListener(connectionListener)
+                if (!created.register()) {
+                    Log.w(TAG, "Lyricon provider registration was not started; playback is unaffected")
+                }
+                provider = created
+            }
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to initialize Lyricon; playback is unaffected", throwable)
+        }.getOrNull()
+    }
+
+    private fun deactivate() {
+        val activeProvider = provider ?: return
+        runCatching {
+            activeProvider.player.setPlaybackState(false)
+            activeProvider.player.setSong(null)
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to clear Lyricon song", throwable)
+        }
+        runCatching { activeProvider.unregister() }
+            .onFailure { throwable -> Log.w(TAG, "Unable to unregister Lyricon", throwable) }
+        runCatching {
+            activeProvider.service.removeConnectionListener(connectionListener)
+            activeProvider.destroy()
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to destroy Lyricon provider", throwable)
+        }
+        provider = null
+        lastTrackKey = null
+        lastPayload = null
+    }
+
+    private data class Snapshot(
+        val enabled: Boolean,
+        val status: PlayerStatus,
+        val track: MusicTrack?,
+        val positionMs: Long,
+        val durationMs: Long,
+        val lyrics: String?,
+    )
+
+    private companion object {
+        const val TAG = "LyriconLyricsPublisher"
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -1,7 +1,6 @@
 package org.feeluown.mobile
 
 import android.content.Context
-import android.media.session.PlaybackState as AndroidPlaybackState
 import android.os.SystemClock
 import android.util.Log
 import androidx.compose.runtime.snapshotFlow
@@ -13,6 +12,7 @@ import io.github.proify.lyricon.provider.LyriconFactory
 import io.github.proify.lyricon.provider.LyriconProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -31,6 +31,7 @@ internal class LyriconLyricsPublisher(
 ) {
     private val appContext = context.applicationContext
     private var collectJob: Job? = null
+    private var positionSyncJob: Job? = null
     private var provider: LyriconProvider? = null
     private var lastTrackKey: String? = null
     private var lastPayload: StatusBarLyricsPayload? = null
@@ -38,14 +39,21 @@ internal class LyriconLyricsPublisher(
     private var lastObservedPositionMs: Long? = null
     private var lastObservedRealtimeMs: Long = 0L
     private var lastObservedStatus: PlayerStatus? = null
+    private var anchorPositionMs: Long = 0L
+    private var anchorRealtimeMs: Long = 0L
+    private var anchorPlaying: Boolean = false
+    @Volatile
+    private var latestSnapshot: Snapshot? = null
 
     private val connectionListener = object : ConnectionListener {
         override fun onConnected(provider: LyriconProvider) {
             Log.d(TAG, "Lyricon connected")
+            syncManualPlaybackState(provider)
         }
 
         override fun onReconnected(provider: LyriconProvider) {
             Log.d(TAG, "Lyricon reconnected")
+            syncManualPlaybackState(provider)
         }
 
         override fun onDisconnected(provider: LyriconProvider) {
@@ -110,6 +118,10 @@ internal class LyriconLyricsPublisher(
         val songChanged = trackKey != lastTrackKey || payload != lastPayload
         val positionDiscontinuity = songChanged || isPositionDiscontinuity(snapshot, nowRealtimeMs)
         val playbackStateChanged = snapshot.status != lastPublishedStatus
+        val safePositionMs = snapshot.positionMs.coerceAtLeast(0L)
+
+        latestSnapshot = snapshot
+        updatePositionAnchor(snapshot, nowRealtimeMs)
 
         runCatching {
             if (songChanged) {
@@ -147,26 +159,84 @@ internal class LyriconLyricsPublisher(
                 lastPayload = payload
             }
 
-            // Lyricon has two distinct position paths. PlaybackState supplies a monotonic anchor
-            // from which the central service advances position at its own update rate; seekTo()
-            // explicitly tells subscribers that playback jumped. Re-sending a fresh PlaybackState
-            // for every coarse FuoEvolve position poll can repeatedly re-anchor lyric progress and
-            // makes word-synced lyrics appear stuck. Keep the anchor stable during ordinary playback
-            // and only replace it when the song/state changes or a real discontinuity is observed.
+            // Follow Lyricon's documented manual synchronization path. setPosition() writes the
+            // current position to the shared-memory bridge and setPlaybackState(Boolean) makes the
+            // central service consume that bridge. Do not mix this with PlaybackState/State2,
+            // because seekTo() does not replace State2's position anchor and the next tick can jump
+            // back to the old position.
+            activeProvider.player.setPosition(safePositionMs)
             if (positionDiscontinuity) {
-                activeProvider.player.seekTo(snapshot.positionMs.coerceAtLeast(0L))
+                activeProvider.player.seekTo(safePositionMs)
             }
-            if (songChanged || playbackStateChanged || positionDiscontinuity) {
-                activeProvider.player.setPlaybackState(snapshot.toAndroidPlaybackState(nowRealtimeMs))
-                lastPublishedStatus = snapshot.status
+            if (songChanged || playbackStateChanged) {
+                activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
             }
+            lastPublishedStatus = snapshot.status
         }.onFailure { throwable ->
             Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
         }
 
-        lastObservedPositionMs = snapshot.positionMs.coerceAtLeast(0L)
+        if (snapshot.status == PlayerStatus.Playing) {
+            ensurePositionSyncLoop()
+        } else {
+            stopPositionSyncLoop()
+        }
+
+        lastObservedPositionMs = safePositionMs
         lastObservedRealtimeMs = nowRealtimeMs
         lastObservedStatus = snapshot.status
+    }
+
+    private fun updatePositionAnchor(snapshot: Snapshot, realtimeMs: Long) {
+        anchorPositionMs = snapshot.positionMs.coerceAtLeast(0L)
+        anchorRealtimeMs = realtimeMs
+        anchorPlaying = snapshot.status == PlayerStatus.Playing
+    }
+
+    private fun estimatedPositionMs(realtimeMs: Long = SystemClock.elapsedRealtime()): Long {
+        val base = anchorPositionMs
+        if (!anchorPlaying) return base
+        return (base + (realtimeMs - anchorRealtimeMs).coerceAtLeast(0L)).coerceAtLeast(0L)
+    }
+
+    private fun ensurePositionSyncLoop() {
+        if (positionSyncJob?.isActive == true) return
+        positionSyncJob = scope.launch {
+            while (true) {
+                val activeProvider = provider ?: break
+                val snapshot = latestSnapshot ?: break
+                if (!snapshot.enabled || snapshot.status != PlayerStatus.Playing) break
+
+                // Lyricon 0.1.70 reads the manual position bridge at ~24 fps by default. Keep the
+                // shared-memory value moving at a similar cadence, while the coarser playback-state
+                // updates periodically correct this elapsed-realtime interpolation anchor.
+                runCatching {
+                    activeProvider.player.setPosition(estimatedPositionMs())
+                }
+                delay(POSITION_SYNC_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopPositionSyncLoop() {
+        positionSyncJob?.cancel()
+        positionSyncJob = null
+    }
+
+    private fun syncManualPlaybackState(activeProvider: LyriconProvider) {
+        val snapshot = latestSnapshot ?: return
+        if (!snapshot.enabled) return
+
+        runCatching {
+            val positionMs = estimatedPositionMs()
+            activeProvider.player.setPosition(positionMs)
+            activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
+            if (snapshot.status == PlayerStatus.Playing) {
+                ensurePositionSyncLoop()
+            }
+        }.onFailure { throwable ->
+            Log.w(TAG, "Unable to resync Lyricon playback state", throwable)
+        }
     }
 
     private fun isPositionDiscontinuity(snapshot: Snapshot, nowRealtimeMs: Long): Boolean {
@@ -179,18 +249,6 @@ internal class LyriconLyricsPublisher(
             previousPositionMs
         }
         return abs(snapshot.positionMs.coerceAtLeast(0L) - expectedPositionMs) > POSITION_DISCONTINUITY_THRESHOLD_MS
-    }
-
-    private fun Snapshot.toAndroidPlaybackState(updateRealtimeMs: Long): AndroidPlaybackState {
-        val isPlaying = status == PlayerStatus.Playing
-        return AndroidPlaybackState.Builder()
-            .setState(
-                if (isPlaying) AndroidPlaybackState.STATE_PLAYING else AndroidPlaybackState.STATE_PAUSED,
-                positionMs.coerceAtLeast(0L),
-                if (isPlaying) 1f else 0f,
-                updateRealtimeMs,
-            )
-            .build()
     }
 
     private fun ensureProvider(): LyriconProvider? {
@@ -216,6 +274,8 @@ internal class LyriconLyricsPublisher(
     }
 
     private fun deactivate() {
+        stopPositionSyncLoop()
+        latestSnapshot = null
         val activeProvider = provider ?: return
         runCatching {
             activeProvider.player.setPlaybackState(false)
@@ -238,6 +298,9 @@ internal class LyriconLyricsPublisher(
         lastObservedPositionMs = null
         lastObservedRealtimeMs = 0L
         lastObservedStatus = null
+        anchorPositionMs = 0L
+        anchorRealtimeMs = 0L
+        anchorPlaying = false
     }
 
     private data class Snapshot(
@@ -252,5 +315,6 @@ internal class LyriconLyricsPublisher(
     private companion object {
         const val TAG = "LyriconLyricsPublisher"
         const val POSITION_DISCONTINUITY_THRESHOLD_MS = 750L
+        const val POSITION_SYNC_INTERVAL_MS = 40L
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 internal const val LYRICON_PACKAGE_NAME = "io.github.proify.lyricon"
 
@@ -33,6 +34,10 @@ internal class LyriconLyricsPublisher(
     private var provider: LyriconProvider? = null
     private var lastTrackKey: String? = null
     private var lastPayload: StatusBarLyricsPayload? = null
+    private var lastPublishedStatus: PlayerStatus? = null
+    private var lastObservedPositionMs: Long? = null
+    private var lastObservedRealtimeMs: Long = 0L
+    private var lastObservedStatus: PlayerStatus? = null
 
     private val connectionListener = object : ConnectionListener {
         override fun onConnected(provider: LyriconProvider) {
@@ -101,8 +106,13 @@ internal class LyriconLyricsPublisher(
 
         val activeProvider = ensureProvider() ?: return
         val trackKey = listOf(track.source, track.id, track.title, track.artists).joinToString("\u0000")
+        val nowRealtimeMs = SystemClock.elapsedRealtime()
+        val songChanged = trackKey != lastTrackKey || payload != lastPayload
+        val positionDiscontinuity = songChanged || isPositionDiscontinuity(snapshot, nowRealtimeMs)
+        val playbackStateChanged = snapshot.status != lastPublishedStatus
+
         runCatching {
-            if (trackKey != lastTrackKey || payload != lastPayload) {
+            if (songChanged) {
                 when (payload) {
                     StatusBarLyricsPayload.Empty -> Unit
                     is StatusBarLyricsPayload.Text -> activeProvider.player.sendText(payload.text)
@@ -116,11 +126,13 @@ internal class LyriconLyricsPublisher(
                                 LyriconRichLyricLine(
                                     begin = line.beginMs,
                                     end = line.endMs,
+                                    duration = line.endMs - line.beginMs,
                                     text = line.text,
                                     words = line.words?.map { word ->
                                         LyriconLyricWord(
                                             begin = word.beginMs,
                                             end = word.endMs,
+                                            duration = word.endMs - word.beginMs,
                                             text = word.text,
                                         )
                                     },
@@ -135,25 +147,48 @@ internal class LyriconLyricsPublisher(
                 lastPayload = payload
             }
 
-            // Lyricon's setPosition() writes through an optional SharedMemory bridge. If that
-            // bridge cannot be mapped on a device, the call can succeed without advancing the
-            // central player's position, leaving the generated title placeholder visible forever.
-            // PlaybackState synchronization goes through Binder and lets Lyricon advance the
-            // position from elapsedRealtime, while also preserving the state for autoSync.
-            activeProvider.player.setPlaybackState(snapshot.toAndroidPlaybackState())
+            // Lyricon has two distinct position paths. PlaybackState supplies a monotonic anchor
+            // from which the central service advances position at its own update rate; seekTo()
+            // explicitly tells subscribers that playback jumped. Re-sending a fresh PlaybackState
+            // for every coarse FuoEvolve position poll can repeatedly re-anchor lyric progress and
+            // makes word-synced lyrics appear stuck. Keep the anchor stable during ordinary playback
+            // and only replace it when the song/state changes or a real discontinuity is observed.
+            if (positionDiscontinuity) {
+                activeProvider.player.seekTo(snapshot.positionMs.coerceAtLeast(0L))
+            }
+            if (songChanged || playbackStateChanged || positionDiscontinuity) {
+                activeProvider.player.setPlaybackState(snapshot.toAndroidPlaybackState(nowRealtimeMs))
+                lastPublishedStatus = snapshot.status
+            }
         }.onFailure { throwable ->
             Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
         }
+
+        lastObservedPositionMs = snapshot.positionMs.coerceAtLeast(0L)
+        lastObservedRealtimeMs = nowRealtimeMs
+        lastObservedStatus = snapshot.status
     }
 
-    private fun Snapshot.toAndroidPlaybackState(): AndroidPlaybackState {
+    private fun isPositionDiscontinuity(snapshot: Snapshot, nowRealtimeMs: Long): Boolean {
+        val previousPositionMs = lastObservedPositionMs ?: return true
+        val previousStatus = lastObservedStatus ?: return true
+        val elapsedMs = (nowRealtimeMs - lastObservedRealtimeMs).coerceAtLeast(0L)
+        val expectedPositionMs = if (previousStatus == PlayerStatus.Playing) {
+            previousPositionMs + elapsedMs
+        } else {
+            previousPositionMs
+        }
+        return abs(snapshot.positionMs.coerceAtLeast(0L) - expectedPositionMs) > POSITION_DISCONTINUITY_THRESHOLD_MS
+    }
+
+    private fun Snapshot.toAndroidPlaybackState(updateRealtimeMs: Long): AndroidPlaybackState {
         val isPlaying = status == PlayerStatus.Playing
         return AndroidPlaybackState.Builder()
             .setState(
                 if (isPlaying) AndroidPlaybackState.STATE_PLAYING else AndroidPlaybackState.STATE_PAUSED,
                 positionMs.coerceAtLeast(0L),
                 if (isPlaying) 1f else 0f,
-                SystemClock.elapsedRealtime(),
+                updateRealtimeMs,
             )
             .build()
     }
@@ -199,6 +234,10 @@ internal class LyriconLyricsPublisher(
         provider = null
         lastTrackKey = null
         lastPayload = null
+        lastPublishedStatus = null
+        lastObservedPositionMs = null
+        lastObservedRealtimeMs = 0L
+        lastObservedStatus = null
     }
 
     private data class Snapshot(
@@ -212,5 +251,6 @@ internal class LyriconLyricsPublisher(
 
     private companion object {
         const val TAG = "LyriconLyricsPublisher"
+        const val POSITION_DISCONTINUITY_THRESHOLD_MS = 750L
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -1,6 +1,8 @@
 package org.feeluown.mobile
 
 import android.content.Context
+import android.media.session.PlaybackState as AndroidPlaybackState
+import android.os.SystemClock
 import android.util.Log
 import androidx.compose.runtime.snapshotFlow
 import io.github.proify.lyricon.lyric.model.LyricWord as LyriconLyricWord
@@ -132,11 +134,28 @@ internal class LyriconLyricsPublisher(
                 lastTrackKey = trackKey
                 lastPayload = payload
             }
-            activeProvider.player.setPosition(snapshot.positionMs.coerceAtLeast(0L))
-            activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
+
+            // Lyricon's setPosition() writes through an optional SharedMemory bridge. If that
+            // bridge cannot be mapped on a device, the call can succeed without advancing the
+            // central player's position, leaving the generated title placeholder visible forever.
+            // PlaybackState synchronization goes through Binder and lets Lyricon advance the
+            // position from elapsedRealtime, while also preserving the state for autoSync.
+            activeProvider.player.setPlaybackState(snapshot.toAndroidPlaybackState())
         }.onFailure { throwable ->
             Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
         }
+    }
+
+    private fun Snapshot.toAndroidPlaybackState(): AndroidPlaybackState {
+        val isPlaying = status == PlayerStatus.Playing
+        return AndroidPlaybackState.Builder()
+            .setState(
+                if (isPlaying) AndroidPlaybackState.STATE_PLAYING else AndroidPlaybackState.STATE_PAUSED,
+                positionMs.coerceAtLeast(0L),
+                if (isPlaying) 1f else 0f,
+                SystemClock.elapsedRealtime(),
+            )
+            .build()
     }
 
     private fun ensureProvider(): LyriconProvider? {

--- a/androidApp/src/main/res/values/arrays.xml
+++ b/androidApp/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="lyricon_module_tags">
+        <item>$syllable</item>
+        <item>$translation</item>
+    </string-array>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ datastore = "1.2.1"
 materialKolor = "5.0.0-alpha07"
 ktor = "3.5.1"
 kover = "0.9.8"
+lyriconProvider = "0.1.70"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -42,6 +43,7 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+lyricon-provider = { module = "io.github.proify.lyricon:provider", version.ref = "lyriconProvider" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -112,6 +112,7 @@ data class AppSettings(
     val smartReplacementSelections: Map<String, SmartReplacementSelection> = emptyMap(),
     val pauseOnOtherAppPlayback: Boolean = DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
+    val statusBarLyricsEnabled: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
     val dynamicCoverColorEnabled: Boolean = false,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -282,6 +282,10 @@ class FuoPlayerController(
         private set
     var lyricFontSize by settingsUiState::lyricFontSize
         private set
+    var statusBarLyricsEnabled by mutableStateOf(false)
+        private set
+    var isStatusBarLyricsAvailable by mutableStateOf(false)
+        private set
     var themeMode by settingsUiState::themeMode
         private set
     var themeColorScheme by settingsUiState::themeColorScheme
@@ -1545,6 +1549,15 @@ class FuoPlayerController(
     fun onLyricFontSizeChange(value: LyricFontSize) {
         lyricFontSize = value
         persistSettings()
+    }
+
+    fun onStatusBarLyricsEnabledChange(value: Boolean) {
+        statusBarLyricsEnabled = value
+        persistSettings()
+    }
+
+    fun updateStatusBarLyricsAvailability(value: Boolean) {
+        isStatusBarLyricsAvailable = value
     }
 
     fun onThemeModeChange(value: ThemeMode) {
@@ -4969,6 +4982,7 @@ class FuoPlayerController(
         smartReplacementMinScore = settings.smartReplacementMinScore.coerceIn(0.0, 1.0)
         smartReplacementSelections = settings.smartReplacementSelections
         lyricFontSize = settings.lyricFontSize
+        statusBarLyricsEnabled = settings.statusBarLyricsEnabled
         themeMode = settings.themeMode
         themeColorScheme = settings.themeColorScheme
         dynamicCoverColorEnabled = settings.dynamicCoverColorEnabled
@@ -5012,6 +5026,7 @@ class FuoPlayerController(
             smartReplacementMinScore = smartReplacementMinScore,
             smartReplacementSelections = smartReplacementSelections,
             lyricFontSize = lyricFontSize,
+            statusBarLyricsEnabled = statusBarLyricsEnabled,
             themeMode = themeMode,
             themeColorScheme = themeColorScheme,
             dynamicCoverColorEnabled = dynamicCoverColorEnabled,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreen.kt
@@ -1169,6 +1169,24 @@ fun PlayerDisplaySettingsPanel(controller: FuoPlayerController) {
                     }
                 }
             }
+            if (controller.isStatusBarLyricsAvailable) {
+                FuoSettingRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    title = "开启状态栏歌词",
+                    supportingText = "通过词幕在系统状态栏显示当前歌词",
+                    enabled = !controller.isLoading,
+                    onClick = {
+                        controller.onStatusBarLyricsEnabledChange(!controller.statusBarLyricsEnabled)
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = controller.statusBarLyricsEnabled,
+                            enabled = !controller.isLoading,
+                            onCheckedChange = controller::onStatusBarLyricsEnabledChange,
+                        )
+                    },
+                )
+            }
             Text(
                 text = "外观模式",
                 style = MaterialTheme.typography.bodyMedium,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/StatusBarLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/StatusBarLyrics.kt
@@ -1,0 +1,87 @@
+package org.feeluown.mobile
+
+sealed interface StatusBarLyricsPayload {
+    data object Empty : StatusBarLyricsPayload
+
+    data class Text(
+        val text: String,
+    ) : StatusBarLyricsPayload
+
+    data class Timed(
+        val lines: List<StatusBarLyricLine>,
+    ) : StatusBarLyricsPayload
+}
+
+data class StatusBarLyricLine(
+    val beginMs: Long,
+    val endMs: Long,
+    val text: String,
+    val translation: String? = null,
+    val romanization: String? = null,
+    val words: List<StatusBarLyricWord>? = null,
+)
+
+data class StatusBarLyricWord(
+    val beginMs: Long,
+    val endMs: Long,
+    val text: String,
+)
+
+fun buildStatusBarLyricsPayload(
+    rawLyrics: String?,
+    durationMs: Long?,
+): StatusBarLyricsPayload {
+    val parsed = parseLyrics(rawLyrics)
+        .filter { it.text.isNotBlank() }
+    if (parsed.isEmpty()) return StatusBarLyricsPayload.Empty
+
+    val timed = parsed.filter { it.timeMs != Long.MAX_VALUE }
+    if (timed.isEmpty()) {
+        val text = parsed
+            .map { it.text.trim() }
+            .filter(String::isNotBlank)
+            .joinToString("\n")
+        return if (text.isBlank()) StatusBarLyricsPayload.Empty else StatusBarLyricsPayload.Text(text)
+    }
+
+    val lines = timed.mapIndexed { index, line ->
+        val begin = line.timeMs.coerceAtLeast(0L)
+        val nextBegin = timed.getOrNull(index + 1)
+            ?.timeMs
+            ?.takeIf { it > begin }
+        val durationEnd = durationMs
+            ?.takeIf { it > begin }
+        val end = nextBegin ?: durationEnd ?: (begin + MIN_VALID_LYRIC_DURATION_MS)
+        val words = line.words
+            ?.mapNotNull { word ->
+                val wordBegin = word.startMs.coerceAtLeast(begin)
+                if (wordBegin >= end || word.text.isBlank()) return@mapNotNull null
+                val requestedEnd = word.startMs + word.durationMs.coerceAtLeast(MIN_VALID_LYRIC_DURATION_MS)
+                val wordEnd = requestedEnd
+                    .coerceAtMost(end)
+                    .coerceAtLeast(wordBegin + MIN_VALID_LYRIC_DURATION_MS)
+                    .coerceAtMost(end)
+                if (wordEnd <= wordBegin) {
+                    null
+                } else {
+                    StatusBarLyricWord(
+                        beginMs = wordBegin,
+                        endMs = wordEnd,
+                        text = word.text,
+                    )
+                }
+            }
+            ?.takeIf { it.isNotEmpty() }
+        StatusBarLyricLine(
+            beginMs = begin,
+            endMs = end,
+            text = line.text,
+            translation = line.translation?.takeIf(String::isNotBlank),
+            romanization = line.romanization?.takeIf(String::isNotBlank),
+            words = words,
+        )
+    }
+    return StatusBarLyricsPayload.Timed(lines)
+}
+
+private const val MIN_VALID_LYRIC_DURATION_MS = 1L

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -112,8 +112,29 @@ class AppSettingsRepositoryTest {
 
         assertTrue(settings.onboardingCompleted)
         assertFalse(settings.dynamicCoverColorEnabled)
+        assertFalse(settings.statusBarLyricsEnabled)
         assertTrue(settings.pauseOnOtherAppPlayback)
         assertTrue(settings.smartReplacementSelections.isEmpty())
+    }
+
+    @Test
+    fun statusBarLyricsSettingDefaultsOffAndRoundTrips() = runTest {
+        val dataStore = FakePreferencesDataStore()
+        val first = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+
+        assertFalse(first.awaitSettings().statusBarLyricsEnabled)
+        first.update { it.copy(statusBarLyricsEnabled = true) }
+
+        val restored = DataStoreAppSettingsRepository(
+            dataStore = dataStore,
+            legacyLoader = null,
+            scope = backgroundScope,
+        ).awaitSettings()
+        assertTrue(restored.statusBarLyricsEnabled)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/StatusBarLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/StatusBarLyricsTest.kt
@@ -1,0 +1,82 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class StatusBarLyricsTest {
+    @Test
+    fun lrcUsesNextLineAndSongDurationAsEnds() {
+        val payload = assertIs<StatusBarLyricsPayload.Timed>(
+            buildStatusBarLyricsPayload(
+                rawLyrics = "[00:01.000]第一行\n[00:02.500]第二行",
+                durationMs = 5_000,
+            ),
+        )
+
+        assertEquals(1_000, payload.lines[0].beginMs)
+        assertEquals(2_500, payload.lines[0].endMs)
+        assertEquals(2_500, payload.lines[1].beginMs)
+        assertEquals(5_000, payload.lines[1].endMs)
+    }
+
+    @Test
+    fun translationAndRomanizationArePreserved() {
+        val raw = composeLyricsWithRichTracks(
+            main = "[00:01.000]春",
+            translation = "[00:01.000]Spring",
+            romanization = "[00:01.000]haru",
+        )
+        val payload = assertIs<StatusBarLyricsPayload.Timed>(
+            buildStatusBarLyricsPayload(raw, durationMs = 2_000),
+        )
+
+        assertEquals("春", payload.lines.single().text)
+        assertEquals("Spring", payload.lines.single().translation)
+        assertEquals("haru", payload.lines.single().romanization)
+    }
+
+    @Test
+    fun yrcWordTimingIsPreserved() {
+        val payload = assertIs<StatusBarLyricsPayload.Timed>(
+            buildStatusBarLyricsPayload(
+                rawLyrics = "[1000,800](1000,300,0)你(1300,500,0)好",
+                durationMs = 3_000,
+            ),
+        )
+        val line = payload.lines.single()
+
+        assertEquals("你好", line.text)
+        assertEquals(1_000, line.beginMs)
+        assertEquals(3_000, line.endMs)
+        assertEquals(2, line.words?.size)
+        assertEquals(StatusBarLyricWord(1_000, 1_300, "你"), line.words?.get(0))
+        assertEquals(StatusBarLyricWord(1_300, 1_800, "好"), line.words?.get(1))
+    }
+
+    @Test
+    fun untimedLyricsUseTextPayload() {
+        val payload = assertIs<StatusBarLyricsPayload.Text>(
+            buildStatusBarLyricsPayload("第一行\n第二行", durationMs = null),
+        )
+        assertEquals("第一行\n第二行", payload.text)
+    }
+
+    @Test
+    fun emptyLyricsProduceEmptyPayload() {
+        assertIs<StatusBarLyricsPayload.Empty>(buildStatusBarLyricsPayload(null, durationMs = 2_000))
+        assertIs<StatusBarLyricsPayload.Empty>(buildStatusBarLyricsPayload("   ", durationMs = 2_000))
+    }
+
+    @Test
+    fun lastLineWithoutDurationStillHasValidEnd() {
+        val payload = assertIs<StatusBarLyricsPayload.Timed>(
+            buildStatusBarLyricsPayload("[00:01.000]最后一行", durationMs = null),
+        )
+        val line = payload.lines.single()
+        assertEquals(1_000, line.beginMs)
+        assertEquals(1_001, line.endMs)
+        assertNull(line.words)
+    }
+}


### PR DESCRIPTION
## Summary

- 新增“开启状态栏歌词”设置，仅 Android 且检测到已安装 `io.github.proify.lyricon` 时显示，默认关闭。
- 接入 `io.github.proify.lyricon:provider:0.1.70`，由 Android Application 持有 `LyriconLyricsPublisher`，同步歌曲、歌词、播放状态和进度。
- 复用现有 `parseLyrics`，支持 LRC、翻译/罗马音、YRC 逐字歌词；无时间轴歌词通过 `sendText` 发送。
- 无歌词、停止/结束播放或关闭设置时清理远端歌曲并注销 Provider；连接异常仅记录日志，不影响正常播放。
- 增加 Lyricon 包可见性、Provider 元数据及 `$syllable` / `$translation` 标签，并补充设置持久化与歌词转换测试。

## Validation

- `./gradlew :shared:allTests :androidApp:compileDebugKotlin :androidApp:lint` ✅

## Manual verification

- CI 环境无法验证词幕 APK、LSPosed/System UI 激活状态；仍需真机确认安装检测、切歌、播放/暂停、拖动进度及停止后的歌词清理。