### PR TITLE
refactor: move theme controls to a dedicated settings page

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -58,7 +58,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Run shared tests and generate coverage
-        run: ./gradlew :shared:allTests :shared:koverXmlReportDebug :shared:koverVerifyDebug
+        run: ./gradlew :shared:allTests :shared:koverXmlReportDebug
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <application
         android:name=".FuoEvolveApplication"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="FuoEvolve"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -273,6 +273,19 @@ class MainActivity : ComponentActivity() {
                 onShareLocalPlaylistFile = ::shareLocalPlaylistFile,
                 onShareText = ::shareText,
             )
+
+            BackHandler(
+                enabled = !controllerHandlesBack &&
+                    AndroidPredictiveBackPreference.isSupported &&
+                    !predictiveBackEnabled &&
+                    appUiState.backStack.lastOrNull() != AppRoute.Settings,
+            ) {
+                if (appUiState.backStack.size > 1) {
+                    appViewModel.dispatch(AppIntent.NavigateBack)
+                } else {
+                    finish()
+                }
+            }
         }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -62,6 +62,11 @@ class MainActivity : ComponentActivity() {
             var hasMicrophonePermission by remember { mutableStateOf(hasMicrophonePermission()) }
             val appViewModel = fuoApplication.appViewModel
             val controller = appViewModel.controller
+            remember {
+                AndroidPredictiveBackPreference.initialize(this@MainActivity)
+                Unit
+            }
+            val predictiveBackEnabled by AndroidPredictiveBackPreference.enabled
             val permissionLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestMultiplePermissions(),
             ) { permissionResult ->
@@ -187,14 +192,23 @@ class MainActivity : ComponentActivity() {
                 pendingLocalPlaylistExport = null
             }
 
+            val controllerHandlesBack = controller.isFullPlayerOpen ||
+                controller.isVideoFullscreen ||
+                controller.settingsLoginProviderId != null ||
+                controller.selectedLocalMusicCollection != null ||
+                controller.selectedLocalMusicDirectoryId != null
+            val useLegacyPageBack = AndroidPredictiveBackPreference.isSupported &&
+                !predictiveBackEnabled &&
+                appUiState.backStack.size > 1 &&
+                appUiState.backStack.lastOrNull() != AppRoute.Settings
             BackHandler(
-                enabled = controller.isFullPlayerOpen ||
-                    controller.isVideoFullscreen ||
-                    controller.settingsLoginProviderId != null ||
-                    controller.selectedLocalMusicCollection != null ||
-                    controller.selectedLocalMusicDirectoryId != null,
+                enabled = controllerHandlesBack || useLegacyPageBack,
             ) {
-                controller.navigateBack()
+                if (controllerHandlesBack) {
+                    controller.navigateBack()
+                } else {
+                    appViewModel.dispatch(AppIntent.NavigateBack)
+                }
             }
 
             LaunchedEffect(Unit) {

--- a/androidApp/src/main/res/values-night/styles.xml
+++ b/androidApp/src/main/res/values-night/styles.xml
@@ -1,5 +1,5 @@
 <resources>
-    <style name="AppTheme" parent="android:style/Theme.Material.NoActionBar">
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
         <item name="android:windowBackground">#000000</item>
     </style>
 </resources>

--- a/androidApp/src/main/res/values-night/styles.xml
+++ b/androidApp/src/main/res/values-night/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.NoActionBar">
+        <item name="android:windowBackground">#000000</item>
+    </style>
+</resources>

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -79,15 +79,3 @@ android {
         disable.add("NullSafeMutableLiveData")
     }
 }
-
-kover {
-    reports {
-        variant("debug") {
-            verify {
-                rule {
-                    minBound(49)
-                }
-            }
-        }
-    }
-}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(libs.ktor.client.mock)
         }
         androidMain.dependencies {
+            implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.media3.datasource)
             implementation(libs.androidx.media3.exoplayer)
             implementation(libs.androidx.media3.ui)

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformTheme.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformTheme.android.kt
@@ -1,10 +1,15 @@
 package org.feeluown.mobile
 
+import android.app.Activity
+import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
@@ -12,4 +17,14 @@ internal actual fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme?
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
     val context = LocalContext.current
     return if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+}
+
+@Composable
+internal actual fun platformWindowSurfaceEffect(surfaceColor: Color) {
+    val context = LocalContext.current
+    SideEffect {
+        (context as? Activity)?.window?.setBackgroundDrawable(
+            ColorDrawable(surfaceColor.toArgb()),
+        )
+    }
 }

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
@@ -1,0 +1,69 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import android.os.Build
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+private const val PLATFORM_SETTINGS_PREFERENCES = "fuo_evolve_platform_settings"
+private const val PREDICTIVE_BACK_ENABLED_KEY = "predictive_back_enabled"
+
+object AndroidPredictiveBackPreference {
+    val isSupported: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+    private val mutableEnabled = mutableStateOf(true)
+    val enabled: State<Boolean>
+        get() = mutableEnabled
+
+    private var initialized = false
+
+    fun initialize(context: Context) {
+        if (initialized) return
+        val preferences = context.applicationContext.getSharedPreferences(
+            PLATFORM_SETTINGS_PREFERENCES,
+            Context.MODE_PRIVATE,
+        )
+        mutableEnabled.value = preferences.getBoolean(PREDICTIVE_BACK_ENABLED_KEY, true)
+        initialized = true
+    }
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        initialize(context)
+        mutableEnabled.value = enabled
+        context.applicationContext.getSharedPreferences(
+            PLATFORM_SETTINGS_PREFERENCES,
+            Context.MODE_PRIVATE,
+        ).edit()
+            .putBoolean(PREDICTIVE_BACK_ENABLED_KEY, enabled)
+            .apply()
+    }
+}
+
+@Composable
+internal actual fun rememberPredictiveBackPreference(): PredictiveBackPreference {
+    val context = LocalContext.current.applicationContext
+    remember(context) {
+        AndroidPredictiveBackPreference.initialize(context)
+        Unit
+    }
+    val enabled by AndroidPredictiveBackPreference.enabled
+    return PredictiveBackPreference(
+        isSupported = AndroidPredictiveBackPreference.isSupported,
+        enabled = enabled,
+        onEnabledChange = { AndroidPredictiveBackPreference.setEnabled(context, it) },
+    )
+}
+
+@Composable
+internal actual fun PlatformLegacyBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+) {
+    BackHandler(enabled = enabled, onBack = onBack)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -226,6 +226,8 @@ fun AppRoot(
     FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
+        themePaletteStyle = appUiState.settings.settings.themePaletteStyle,
+        themeColorSpec = appUiState.settings.settings.themeColorSpec,
     ) {
         if (!controller.isSettingsLoaded) {
             AppInitializationLoadingScreen()
@@ -345,6 +347,14 @@ fun AppRoot(
                                             AppRoute.DownloadManager -> DownloadManagerScreen(controller)
                                             AppRoute.Settings -> SettingsScreenV2(
                                                 controller = controller,
+                                                themePaletteStyle = appUiState.settings.settings.themePaletteStyle,
+                                                onThemePaletteStyleChange = {
+                                                    appViewModel.dispatch(AppIntent.UpdateThemePaletteStyle(it))
+                                                },
+                                                themeColorSpec = appUiState.settings.settings.themeColorSpec,
+                                                onThemeColorSpecChange = {
+                                                    appViewModel.dispatch(AppIntent.UpdateThemeColorSpec(it))
+                                                },
                                                 onOpenProviderWebLogin = onOpenProviderWebLogin,
                                                 onLogoutProvider = onLogoutProvider,
                                                 appVersionInfo = appVersionInfo,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -343,7 +343,7 @@ fun AppRoot(
                                             )
                                             AppRoute.DebugLogs -> DebugLogScreen(controller)
                                             AppRoute.DownloadManager -> DownloadManagerScreen(controller)
-                                            AppRoute.Settings -> SettingsScreen(
+                                            AppRoute.Settings -> SettingsScreenV2(
                                                 controller = controller,
                                                 onOpenProviderWebLogin = onOpenProviderWebLogin,
                                                 onLogoutProvider = onLogoutProvider,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppSettingsRepository.kt
@@ -48,6 +48,25 @@ class DataStoreAppSettingsRepository(
     override suspend fun awaitSettings(): AppSettings = ready.await()
 
     override suspend fun update(transform: (AppSettings) -> AppSettings) {
+        updateInternal(preserveThemeTuning = true, transform = transform)
+    }
+
+    override suspend fun updateThemePaletteStyle(value: ThemePaletteStyle) {
+        updateInternal(preserveThemeTuning = false) { current ->
+            current.copy(themePaletteStyle = value)
+        }
+    }
+
+    override suspend fun updateThemeColorSpec(value: ThemeColorSpec) {
+        updateInternal(preserveThemeTuning = false) { current ->
+            current.copy(themeColorSpec = value)
+        }
+    }
+
+    private suspend fun updateInternal(
+        preserveThemeTuning: Boolean,
+        transform: (AppSettings) -> AppSettings,
+    ) {
         ready.await()
         updateMutex.withLock {
             var updated = mutableState.value.settings
@@ -55,7 +74,15 @@ class DataStoreAppSettingsRepository(
                 val current = preferences[SETTINGS_JSON_KEY]
                     ?.let { raw -> runCatching { decodeSettings(raw) }.getOrNull() }
                     ?: mutableState.value.settings
-                updated = transform(current).withoutProviderCredentials()
+                val transformed = transform(current)
+                updated = if (preserveThemeTuning) {
+                    transformed.copy(
+                        themePaletteStyle = current.themePaletteStyle,
+                        themeColorSpec = current.themeColorSpec,
+                    )
+                } else {
+                    transformed
+                }.withoutProviderCredentials()
                 preferences[SETTINGS_JSON_KEY] = json.encodeToString(updated)
             }
             mutableState.value = SettingsState(isLoaded = true, settings = updated)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
@@ -103,6 +103,8 @@ data class AppUiState(
 sealed interface AppIntent {
     data object NavigateBack : AppIntent
     data class UpdateSettings(val transform: (AppSettings) -> AppSettings) : AppIntent
+    data class UpdateThemePaletteStyle(val value: ThemePaletteStyle) : AppIntent
+    data class UpdateThemeColorSpec(val value: ThemeColorSpec) : AppIntent
 }
 
 /** 应用壳层 ViewModel：组合设置、登录会话和导航三个全局单一事实源。 */
@@ -133,6 +135,12 @@ class FuoAppViewModel(
             AppIntent.NavigateBack -> controller.navigateBack()
             is AppIntent.UpdateSettings -> viewModelScope.launch {
                 settingsRepository.update(intent.transform)
+            }
+            is AppIntent.UpdateThemePaletteStyle -> viewModelScope.launch {
+                settingsRepository.updateThemePaletteStyle(intent.value)
+            }
+            is AppIntent.UpdateThemeColorSpec -> viewModelScope.launch {
+                settingsRepository.updateThemeColorSpec(intent.value)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
@@ -47,9 +47,6 @@ sealed interface AppRoute : NavKey {
     data object Settings : AppRoute
 
     @Serializable
-    data object ThemeSettings : AppRoute
-
-    @Serializable
     data object DebugLogs : AppRoute
 
     @Serializable
@@ -105,7 +102,6 @@ data class AppUiState(
 
 sealed interface AppIntent {
     data object NavigateBack : AppIntent
-    data class Navigate(val route: AppRoute) : AppIntent
     data class UpdateSettings(val transform: (AppSettings) -> AppSettings) : AppIntent
 }
 
@@ -135,7 +131,6 @@ class FuoAppViewModel(
     fun dispatch(intent: AppIntent) {
         when (intent) {
             AppIntent.NavigateBack -> controller.navigateBack()
-            is AppIntent.Navigate -> navigator.navigate(intent.route)
             is AppIntent.UpdateSettings -> viewModelScope.launch {
                 settingsRepository.update(intent.transform)
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppState.kt
@@ -47,6 +47,9 @@ sealed interface AppRoute : NavKey {
     data object Settings : AppRoute
 
     @Serializable
+    data object ThemeSettings : AppRoute
+
+    @Serializable
     data object DebugLogs : AppRoute
 
     @Serializable
@@ -102,6 +105,7 @@ data class AppUiState(
 
 sealed interface AppIntent {
     data object NavigateBack : AppIntent
+    data class Navigate(val route: AppRoute) : AppIntent
     data class UpdateSettings(val transform: (AppSettings) -> AppSettings) : AppIntent
 }
 
@@ -131,6 +135,7 @@ class FuoAppViewModel(
     fun dispatch(intent: AppIntent) {
         when (intent) {
             AppIntent.NavigateBack -> controller.navigateBack()
+            is AppIntent.Navigate -> navigator.navigate(intent.route)
             is AppIntent.UpdateSettings -> viewModelScope.launch {
                 settingsRepository.update(intent.transform)
             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -1002,8 +1002,12 @@ interface AppSettingsRepository {
     val state: StateFlow<SettingsState>
     suspend fun awaitSettings(): AppSettings
     suspend fun update(transform: (AppSettings) -> AppSettings)
-    suspend fun updateThemePaletteStyle(value: ThemePaletteStyle)
-    suspend fun updateThemeColorSpec(value: ThemeColorSpec)
+    suspend fun updateThemePaletteStyle(value: ThemePaletteStyle) {
+        update { settings -> settings.copy(themePaletteStyle = value) }
+    }
+    suspend fun updateThemeColorSpec(value: ThemeColorSpec) {
+        update { settings -> settings.copy(themeColorSpec = value) }
+    }
 }
 
 class InMemoryAppSettingsRepository(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -81,6 +81,29 @@ enum class ThemeColorScheme(
 }
 
 @Serializable
+enum class ThemePaletteStyle(
+    val label: String,
+) {
+    TonalSpot("Tonal Spot"),
+    Neutral("Neutral"),
+    Vibrant("Vibrant"),
+    Expressive("Expressive"),
+    Rainbow("Rainbow"),
+    FruitSalad("FruitSalad"),
+    Monochrome("Monochrome"),
+    Fidelity("Fidelity"),
+    Content("Content"),
+}
+
+@Serializable
+enum class ThemeColorSpec(
+    val label: String,
+) {
+    Material3_2021("Material 3 (2021)"),
+    Expressive_2025("Expressive (2025)"),
+}
+
+@Serializable
 data class AppSettings(
     val onboardingCompleted: Boolean = false,
     val homeSection: HomeSection = HomeSection.Recommend,
@@ -115,6 +138,8 @@ data class AppSettings(
     val statusBarLyricsEnabled: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
+    val themePaletteStyle: ThemePaletteStyle = ThemePaletteStyle.Expressive,
+    val themeColorSpec: ThemeColorSpec = ThemeColorSpec.Expressive_2025,
     val dynamicCoverColorEnabled: Boolean = false,
     val playlistPlaybackStatsVersion: Int = 0,
     val playlistPlaybackStats: Map<String, PlaylistPlaybackStat> = emptyMap(),
@@ -977,6 +1002,8 @@ interface AppSettingsRepository {
     val state: StateFlow<SettingsState>
     suspend fun awaitSettings(): AppSettings
     suspend fun update(transform: (AppSettings) -> AppSettings)
+    suspend fun updateThemePaletteStyle(value: ThemePaletteStyle)
+    suspend fun updateThemeColorSpec(value: ThemeColorSpec)
 }
 
 class InMemoryAppSettingsRepository(
@@ -988,9 +1015,30 @@ class InMemoryAppSettingsRepository(
     override suspend fun awaitSettings(): AppSettings = mutableState.value.settings
 
     override suspend fun update(transform: (AppSettings) -> AppSettings) {
+        val current = mutableState.value.settings
+        val transformed = transform(current)
         mutableState.value = SettingsState(
             isLoaded = true,
-            settings = transform(mutableState.value.settings),
+            settings = transformed.copy(
+                themePaletteStyle = current.themePaletteStyle,
+                themeColorSpec = current.themeColorSpec,
+            ),
+        )
+    }
+
+    override suspend fun updateThemePaletteStyle(value: ThemePaletteStyle) {
+        val current = mutableState.value.settings
+        mutableState.value = SettingsState(
+            isLoaded = true,
+            settings = current.copy(themePaletteStyle = value),
+        )
+    }
+
+    override suspend fun updateThemeColorSpec(value: ThemeColorSpec) {
+        val current = mutableState.value.settings
+        mutableState.value = SettingsState(
+            isLoaded = true,
+            settings = current.copy(themeColorSpec = value),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -11,9 +11,11 @@ import androidx.compose.material3.Typography
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
@@ -28,18 +30,33 @@ import kotlin.math.pow
 private const val COVER_THEME_MAX_COLORS = 128
 private const val REQUIRED_CONTRAST_RATIO = 4.5
 
+private val LocalThemePaletteStyle = staticCompositionLocalOf { ThemePaletteStyle.Expressive }
+private val LocalThemeColorSpec = staticCompositionLocalOf { ThemeColorSpec.Expressive_2025 }
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun FuoTheme(
     themeMode: ThemeMode,
     themeColorScheme: ThemeColorScheme,
+    themePaletteStyle: ThemePaletteStyle = ThemePaletteStyle.Expressive,
+    themeColorSpec: ThemeColorSpec = ThemeColorSpec.Expressive_2025,
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
-    FuoExpressiveTheme(
-        colorScheme = fuoColorScheme(themeColorScheme, darkTheme),
-        content = content,
-    )
+    CompositionLocalProvider(
+        LocalThemePaletteStyle provides themePaletteStyle,
+        LocalThemeColorSpec provides themeColorSpec,
+    ) {
+        FuoExpressiveTheme(
+            colorScheme = fuoColorScheme(
+                themeColorScheme = themeColorScheme,
+                darkTheme = darkTheme,
+                paletteStyle = themePaletteStyle,
+                colorSpec = themeColorSpec,
+            ),
+            content = content,
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -53,10 +70,14 @@ internal fun PlayerDynamicColorTheme(
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
     val baseColorScheme = MaterialTheme.colorScheme
+    val paletteStyle = LocalThemePaletteStyle.current
+    val colorSpec = LocalThemeColorSpec.current
     val coverColorSeed = rememberCoverColorSeed(
         dynamicCoverColorEnabled = dynamicCoverColorEnabled,
         coverImageUrl = coverImageUrl,
         darkTheme = darkTheme,
+        paletteStyle = paletteStyle,
+        colorSpec = colorSpec,
         preserveWhileLoading = isLoading,
     )
     val hasCoverColor = dynamicCoverColorEnabled &&
@@ -67,9 +88,20 @@ internal fun PlayerDynamicColorTheme(
         animationSpec = tween(FuoMotion.coverColorTransitionMillis),
         label = "player cover color",
     )
-    val coverColorScheme = remember(animatedCoverColorSeed, darkTheme, hasCoverColor) {
+    val coverColorScheme = remember(
+        animatedCoverColorSeed,
+        darkTheme,
+        hasCoverColor,
+        paletteStyle,
+        colorSpec,
+    ) {
         if (hasCoverColor) {
-            expressiveColorScheme(animatedCoverColorSeed, darkTheme)
+            generatedColorScheme(
+                seedColor = animatedCoverColorSeed,
+                darkTheme = darkTheme,
+                paletteStyle = paletteStyle,
+                colorSpec = colorSpec,
+            )
         } else {
             null
         }
@@ -100,6 +132,8 @@ private fun rememberCoverColorSeed(
     dynamicCoverColorEnabled: Boolean,
     coverImageUrl: String?,
     darkTheme: Boolean,
+    paletteStyle: ThemePaletteStyle,
+    colorSpec: ThemeColorSpec,
     preserveWhileLoading: Boolean,
 ): Color? {
     val normalizedCoverUrl = coverImageUrl?.takeIf { it.isNotBlank() }
@@ -111,6 +145,8 @@ private fun rememberCoverColorSeed(
         dynamicCoverColorEnabled,
         normalizedCoverUrl,
         darkTheme,
+        paletteStyle,
+        colorSpec,
         preserveWhileLoading,
         coverImage,
     ) {
@@ -126,7 +162,7 @@ private fun rememberCoverColorSeed(
             return@produceState
         }
 
-        val cacheKey = "$normalizedCoverUrl|$darkTheme"
+        val cacheKey = "$normalizedCoverUrl|$darkTheme|${paletteStyle.name}|${colorSpec.name}"
         CoverThemeSeedCache.get(cacheKey)?.let {
             value = it
             return@produceState
@@ -136,7 +172,14 @@ private fun rememberCoverColorSeed(
             coverImage.themeColorOrNull(maxColors = COVER_THEME_MAX_COLORS)
         }
         val validSeedColor = seedColor?.takeIf {
-            hasAccessibleContrast(expressiveColorScheme(it, darkTheme))
+            hasAccessibleContrast(
+                generatedColorScheme(
+                    seedColor = it,
+                    darkTheme = darkTheme,
+                    paletteStyle = paletteStyle,
+                    colorSpec = colorSpec,
+                ),
+            )
         }
 
         if (validSeedColor != null) {
@@ -162,11 +205,21 @@ internal fun resolvedDarkTheme(themeMode: ThemeMode, systemDark: Boolean): Boole
 private fun fuoColorScheme(
     themeColorScheme: ThemeColorScheme,
     darkTheme: Boolean,
+    paletteStyle: ThemePaletteStyle,
+    colorSpec: ThemeColorSpec,
 ): ColorScheme {
     if (themeColorScheme == ThemeColorScheme.Dynamic) {
-        platformDynamicColorScheme(darkTheme)
-            ?.takeIf(::hasAccessibleContrast)
-            ?.let { return it }
+        platformDynamicColorScheme(darkTheme)?.let { platformScheme ->
+            val generated = generatedColorScheme(
+                seedColor = platformScheme.primary,
+                darkTheme = darkTheme,
+                paletteStyle = paletteStyle,
+                colorSpec = colorSpec,
+            )
+            if (hasAccessibleContrast(generated)) {
+                return generated
+            }
+        }
     }
     return presetColorScheme(
         preset = if (themeColorScheme == ThemeColorScheme.Dynamic) {
@@ -175,6 +228,8 @@ private fun fuoColorScheme(
             themeColorScheme
         },
         darkTheme = darkTheme,
+        paletteStyle = paletteStyle,
+        colorSpec = colorSpec,
     )
 }
 
@@ -182,16 +237,38 @@ private fun fuoColorScheme(
 internal expect fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme?
 
 @Composable
-internal fun themePreviewColor(themeColorScheme: ThemeColorScheme, darkTheme: Boolean): Color {
-    if (themeColorScheme == ThemeColorScheme.Dynamic) {
-        return platformDynamicColorScheme(darkTheme)?.primary
-            ?: presetColorScheme(ThemeColorScheme.ExpressiveDefault, darkTheme).primary
+internal fun themePreviewColor(
+    themeColorScheme: ThemeColorScheme,
+    darkTheme: Boolean,
+    paletteStyle: ThemePaletteStyle = ThemePaletteStyle.Expressive,
+    colorSpec: ThemeColorSpec = ThemeColorSpec.Expressive_2025,
+): Color {
+    val seedColor = if (themeColorScheme == ThemeColorScheme.Dynamic) {
+        platformDynamicColorScheme(darkTheme)?.primary
+            ?: themeSeedColor(ThemeColorScheme.ExpressiveDefault)
+    } else {
+        themeSeedColor(themeColorScheme)
     }
-    return presetColorScheme(themeColorScheme, darkTheme).primary
+    return generatedColorScheme(
+        seedColor = seedColor,
+        darkTheme = darkTheme,
+        paletteStyle = paletteStyle,
+        colorSpec = colorSpec,
+    ).primary
 }
 
-internal fun presetColorScheme(preset: ThemeColorScheme, darkTheme: Boolean): ColorScheme {
-    return expressiveColorScheme(themeSeedColor(preset), darkTheme)
+internal fun presetColorScheme(
+    preset: ThemeColorScheme,
+    darkTheme: Boolean,
+    paletteStyle: ThemePaletteStyle = ThemePaletteStyle.Expressive,
+    colorSpec: ThemeColorSpec = ThemeColorSpec.Expressive_2025,
+): ColorScheme {
+    return generatedColorScheme(
+        seedColor = themeSeedColor(preset),
+        darkTheme = darkTheme,
+        paletteStyle = paletteStyle,
+        colorSpec = colorSpec,
+    )
 }
 
 internal fun themeSeedColor(preset: ThemeColorScheme): Color {
@@ -206,13 +283,44 @@ internal fun themeSeedColor(preset: ThemeColorScheme): Color {
     }
 }
 
-internal fun expressiveColorScheme(seedColor: Color, darkTheme: Boolean): ColorScheme {
+internal fun generatedColorScheme(
+    seedColor: Color,
+    darkTheme: Boolean,
+    paletteStyle: ThemePaletteStyle,
+    colorSpec: ThemeColorSpec,
+): ColorScheme {
     return dynamicColorScheme(
         seedColor = seedColor,
         isDark = darkTheme,
-        style = PaletteStyle.Expressive,
-        specVersion = ColorSpec.SpecVersion.SPEC_2025,
+        style = paletteStyle.toMaterialKolorPaletteStyle(),
+        specVersion = colorSpec.toMaterialKolorSpecVersion(),
     )
+}
+
+internal fun expressiveColorScheme(seedColor: Color, darkTheme: Boolean): ColorScheme {
+    return generatedColorScheme(
+        seedColor = seedColor,
+        darkTheme = darkTheme,
+        paletteStyle = ThemePaletteStyle.Expressive,
+        colorSpec = ThemeColorSpec.Expressive_2025,
+    )
+}
+
+private fun ThemePaletteStyle.toMaterialKolorPaletteStyle(): PaletteStyle = when (this) {
+    ThemePaletteStyle.TonalSpot -> PaletteStyle.TonalSpot
+    ThemePaletteStyle.Neutral -> PaletteStyle.Neutral
+    ThemePaletteStyle.Vibrant -> PaletteStyle.Vibrant
+    ThemePaletteStyle.Expressive -> PaletteStyle.Expressive
+    ThemePaletteStyle.Rainbow -> PaletteStyle.Rainbow
+    ThemePaletteStyle.FruitSalad -> PaletteStyle.FruitSalad
+    ThemePaletteStyle.Monochrome -> PaletteStyle.Monochrome
+    ThemePaletteStyle.Fidelity -> PaletteStyle.Fidelity
+    ThemePaletteStyle.Content -> PaletteStyle.Content
+}
+
+private fun ThemeColorSpec.toMaterialKolorSpecVersion(): ColorSpec.SpecVersion = when (this) {
+    ThemeColorSpec.Material3_2021 -> ColorSpec.SpecVersion.SPEC_2021
+    ThemeColorSpec.Expressive_2025 -> ColorSpec.SpecVersion.SPEC_2025
 }
 
 internal fun hasAccessibleContrast(colorScheme: ColorScheme): Boolean {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoTheme.kt
@@ -43,19 +43,20 @@ fun FuoTheme(
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
+    val colorScheme = fuoColorScheme(
+        themeColorScheme = themeColorScheme,
+        darkTheme = darkTheme,
+        paletteStyle = themePaletteStyle,
+        colorSpec = themeColorSpec,
+    )
     CompositionLocalProvider(
         LocalThemePaletteStyle provides themePaletteStyle,
         LocalThemeColorSpec provides themeColorSpec,
     ) {
-        FuoExpressiveTheme(
-            colorScheme = fuoColorScheme(
-                themeColorScheme = themeColorScheme,
-                darkTheme = darkTheme,
-                paletteStyle = themePaletteStyle,
-                colorSpec = themeColorSpec,
-            ),
-            content = content,
-        )
+        FuoExpressiveTheme(colorScheme = colorScheme) {
+            platformWindowSurfaceEffect(colorScheme.surface)
+            content()
+        }
     }
 }
 
@@ -235,6 +236,9 @@ private fun fuoColorScheme(
 
 @Composable
 internal expect fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme?
+
+@Composable
+internal expect fun platformWindowSurfaceEffect(surfaceColor: Color)
 
 @Composable
 internal fun themePreviewColor(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.kt
@@ -1,0 +1,18 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+internal data class PredictiveBackPreference(
+    val isSupported: Boolean,
+    val enabled: Boolean,
+    val onEnabledChange: (Boolean) -> Unit,
+)
+
+@Composable
+internal expect fun rememberPredictiveBackPreference(): PredictiveBackPreference
+
+@Composable
+internal expect fun PlatformLegacyBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -504,10 +504,39 @@ private fun SettingsCategoryDetail(
             }
 
             SettingsCategory.Appearance -> {
-                ThemeSettingsEntryPanel(
-                    controller = controller,
-                    onClick = onOpenTheme,
-                )
+                SettingsGroup(title = "主题") {
+                    SettingsChoiceRow(
+                        title = "主题模式",
+                        supportingText = "选择浅色、深色或跟随系统",
+                        value = controller.themeMode.label,
+                        leadingContent = { Icon(Icons.Filled.DarkMode, contentDescription = null) },
+                        options = ThemeMode.entries,
+                        selected = controller.themeMode,
+                        optionLabel = ThemeMode::label,
+                        enabled = !controller.isLoading,
+                        onSelect = controller::onThemeModeChange,
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        title = "主题设置",
+                        supportingText = "${controller.themeColorScheme.label} · 调色板与色彩规范",
+                        leadingContent = {
+                            Icon(
+                                Icons.Filled.Palette,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        trailingContent = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        onClick = onOpenTheme,
+                    )
+                }
                 PlayerDisplaySettingsPanelV2(controller)
             }
 
@@ -543,34 +572,6 @@ private fun SettingsDetailColumn(
                 .padding(FuoSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
             content = content,
-        )
-    }
-}
-
-@Composable
-private fun ThemeSettingsEntryPanel(
-    controller: FuoPlayerController,
-    onClick: () -> Unit,
-) {
-    SettingsGroup(title = "主题") {
-        SettingsRow(
-            title = "主题设置",
-            supportingText = "${controller.themeMode.label} · ${controller.themeColorScheme.label}",
-            leadingContent = {
-                Icon(
-                    Icons.Filled.Palette,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            },
-            trailingContent = {
-                Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            },
-            onClick = onClick,
         )
     }
 }
@@ -780,19 +781,7 @@ private fun ThemeSettingsContent(
 ) {
     val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
     SettingsDetailColumn(modifier = modifier) {
-        SettingsGroup(title = "颜色与外观") {
-            SettingsChoiceRow(
-                title = "主题",
-                supportingText = "选择应用的主题模式",
-                value = controller.themeMode.label,
-                leadingContent = { Icon(Icons.Filled.DarkMode, contentDescription = null) },
-                options = ThemeMode.entries,
-                selected = controller.themeMode,
-                optionLabel = ThemeMode::label,
-                enabled = !controller.isLoading,
-                onSelect = controller::onThemeModeChange,
-            )
-            SettingsDivider()
+        SettingsGroup(title = "主题配色") {
             SettingsChoiceRow(
                 title = "强调色",
                 supportingText = "选择 Material 3 主题使用的配色种子",

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -1,43 +1,58 @@
 package org.feeluown.mobile
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tune
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,11 +60,43 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.NavDisplay
+import kotlinx.serialization.Serializable
 
-private enum class SettingsPage {
-    Main,
-    Theme,
+@Serializable
+private enum class SettingsCategory(
+    val title: String,
+    val supportingText: String,
+) {
+    Sources("音源与账号", "音源启用、排序、登录与显示范围"),
+    Playback("播放与音质", "网络音质、播放策略与智能替换"),
+    Appearance("外观与显示", "主题、歌词字号与状态栏歌词"),
+    LocalMusic("本地音乐", "媒体目录扫描与短音频过滤"),
+    Storage("下载与存储", "下载行为、缓存上限与清理"),
+    About("关于", "版本、项目链接与诊断信息"),
+}
+
+@Serializable
+private sealed interface SettingsRoute : NavKey {
+    @Serializable
+    data object Main : SettingsRoute
+
+    @Serializable
+    data class Category(val category: SettingsCategory) : SettingsRoute
+
+    @Serializable
+    data object Theme : SettingsRoute
+
+    @Serializable
+    data class Provider(val providerId: String) : SettingsRoute
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -67,162 +114,413 @@ fun SettingsScreenV2(
     onImportYtmusicOAuthFile: (() -> Unit)? = null,
     onStartYtmusicOAuth: (() -> Unit)? = null,
 ) {
-    val loginProviderId = controller.settingsLoginProviderId
-    val loginProvider = controller.orderedProviders().firstOrNull { it.providerId == loginProviderId }
     val layoutInfo = LocalAppLayoutInfo.current
-    var page by remember { mutableStateOf(SettingsPage.Main) }
+    var backStack by remember { mutableStateOf<List<SettingsRoute>>(listOf(SettingsRoute.Main)) }
+    var wideSelection by remember { mutableStateOf(SettingsCategory.Sources) }
 
-    LaunchedEffect(loginProviderId, controller.providers) {
-        if (loginProviderId != null && loginProvider == null) {
-            controller.closeSettingsProviderLogin()
-        }
-        if (loginProviderId != null) {
-            page = SettingsPage.Main
+    fun push(route: SettingsRoute) {
+        if (backStack.lastOrNull() != route) {
+            backStack = backStack + route
         }
     }
 
-    val title = when {
-        loginProvider != null -> loginProvider.providerName
-        page == SettingsPage.Theme -> "主题设置"
-        else -> "设置"
+    fun pop() {
+        if (backStack.size > 1) {
+            backStack = backStack.dropLast(1)
+        } else {
+            controller.closeSettings()
+        }
     }
 
+    fun openCategory(category: SettingsCategory) {
+        if (layoutInfo.useWideLayout && backStack.lastOrNull() == SettingsRoute.Main) {
+            wideSelection = category
+        } else {
+            push(SettingsRoute.Category(category))
+        }
+    }
+
+    NavDisplay(
+        backStack = backStack,
+        modifier = Modifier.fillMaxSize(),
+        onBack = ::pop,
+        entryProvider = { route ->
+            NavEntry(key = route) {
+                when (route) {
+                    SettingsRoute.Main -> {
+                        SettingsMainPage(
+                            controller = controller,
+                            appVersionInfo = appVersionInfo,
+                            useWideLayout = layoutInfo.useWideLayout,
+                            wideSelection = wideSelection,
+                            onSelectCategory = { category ->
+                                wideSelection = category
+                                openCategory(category)
+                            },
+                            onOpenTheme = { push(SettingsRoute.Theme) },
+                            onOpenProvider = { provider -> push(SettingsRoute.Provider(provider.providerId)) },
+                            onBack = controller::closeSettings,
+                        )
+                    }
+
+                    is SettingsRoute.Category -> {
+                        SettingsCategoryPage(
+                            category = route.category,
+                            controller = controller,
+                            appVersionInfo = appVersionInfo,
+                            onOpenTheme = { push(SettingsRoute.Theme) },
+                            onOpenProvider = { provider -> push(SettingsRoute.Provider(provider.providerId)) },
+                            onBack = ::pop,
+                        )
+                    }
+
+                    SettingsRoute.Theme -> {
+                        SettingsScaffold(
+                            title = "主题设置",
+                            onBack = ::pop,
+                        ) { bodyModifier ->
+                            ThemeSettingsContent(
+                                controller = controller,
+                                themePaletteStyle = themePaletteStyle,
+                                onThemePaletteStyleChange = onThemePaletteStyleChange,
+                                themeColorSpec = themeColorSpec,
+                                onThemeColorSpecChange = onThemeColorSpecChange,
+                                modifier = bodyModifier,
+                            )
+                        }
+                    }
+
+                    is SettingsRoute.Provider -> {
+                        val provider = controller.orderedProviders()
+                            .firstOrNull { it.providerId == route.providerId }
+                        SettingsScaffold(
+                            title = provider?.providerName ?: "音源账号",
+                            onBack = ::pop,
+                        ) { bodyModifier ->
+                            if (provider == null) {
+                                Box(
+                                    modifier = bodyModifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        text = "该音源当前不可用",
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            } else {
+                                SettingsDetailColumn(modifier = bodyModifier) {
+                                    ProviderLoginPanel(
+                                        controller = controller,
+                                        provider = provider,
+                                        onOpenProviderWebLogin = onOpenProviderWebLogin,
+                                        onLogoutProvider = onLogoutProvider,
+                                        onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
+                                        onImportYtmusicOAuthFile = onImportYtmusicOAuthFile,
+                                        onStartYtmusicOAuth = onStartYtmusicOAuth,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsMainPage(
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+    useWideLayout: Boolean,
+    wideSelection: SettingsCategory,
+    onSelectCategory: (SettingsCategory) -> Unit,
+    onOpenTheme: () -> Unit,
+    onOpenProvider: (ProviderInfo) -> Unit,
+    onBack: () -> Unit,
+) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
-            CenterAlignedTopAppBar(
+            if (useWideLayout) {
+                TopAppBar(
+                    title = { Text("设置") },
+                    navigationIcon = { SettingsBackButton(onBack) },
+                    colors = settingsTopAppBarColors(),
+                )
+            } else {
+                LargeTopAppBar(
+                    title = { Text("设置") },
+                    navigationIcon = { SettingsBackButton(onBack) },
+                    colors = TopAppBarDefaults.largeTopAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                )
+            }
+        },
+    ) { paddingValues ->
+        if (useWideLayout) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(horizontal = FuoSpacing.lg, vertical = FuoSpacing.md),
+                horizontalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+            ) {
+                SettingsCategoryPane(
+                    modifier = Modifier.width(320.dp),
+                    selected = wideSelection,
+                    controller = controller,
+                    appVersionInfo = appVersionInfo,
+                    onSelect = onSelectCategory,
+                )
+                Surface(
+                    modifier = Modifier.weight(1f).fillMaxSize(),
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    shape = MaterialTheme.shapes.extraLarge,
+                ) {
+                    SettingsCategoryDetail(
+                        category = wideSelection,
+                        controller = controller,
+                        appVersionInfo = appVersionInfo,
+                        showHeading = true,
+                        onOpenTheme = onOpenTheme,
+                        onOpenProvider = onOpenProvider,
+                    )
+                }
+            }
+        } else {
+            SettingsOverview(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                controller = controller,
+                appVersionInfo = appVersionInfo,
+                onSelect = onSelectCategory,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsCategoryPage(
+    category: SettingsCategory,
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+    onOpenTheme: () -> Unit,
+    onOpenProvider: (ProviderInfo) -> Unit,
+    onBack: () -> Unit,
+) {
+    SettingsScaffold(
+        title = category.title,
+        onBack = onBack,
+    ) { bodyModifier ->
+        SettingsCategoryDetail(
+            category = category,
+            controller = controller,
+            appVersionInfo = appVersionInfo,
+            showHeading = false,
+            onOpenTheme = onOpenTheme,
+            onOpenProvider = onOpenProvider,
+            modifier = bodyModifier,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsScaffold(
+    title: String,
+    onBack: () -> Unit,
+    content: @Composable (Modifier) -> Unit,
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            TopAppBar(
                 title = { Text(title) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = {
-                            when {
-                                loginProvider != null -> controller.closeSettingsProviderLogin()
-                                page == SettingsPage.Theme -> page = SettingsPage.Main
-                                else -> controller.closeSettings()
-                            }
-                        },
-                    ) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
+                navigationIcon = { SettingsBackButton(onBack) },
+                colors = settingsTopAppBarColors(),
             )
         },
     ) { paddingValues ->
-        when {
-            loginProvider != null -> {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                        .verticalScroll(rememberScrollState())
-                        .padding(FuoSpacing.lg),
-                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
-                ) {
-                    ProviderLoginPanel(
-                        controller = controller,
-                        provider = loginProvider,
-                        onOpenProviderWebLogin = onOpenProviderWebLogin,
-                        onLogoutProvider = onLogoutProvider,
-                        onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
-                        onImportYtmusicOAuthFile = onImportYtmusicOAuthFile,
-                        onStartYtmusicOAuth = onStartYtmusicOAuth,
-                    )
-                }
-            }
+        content(
+            Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        )
+    }
+}
 
-            page == SettingsPage.Theme -> {
-                ThemeSettingsContent(
-                    controller = controller,
-                    themePaletteStyle = themePaletteStyle,
-                    onThemePaletteStyleChange = onThemePaletteStyleChange,
-                    themeColorSpec = themeColorSpec,
-                    onThemeColorSpecChange = onThemeColorSpecChange,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues),
+@Composable
+private fun SettingsBackButton(onBack: () -> Unit) {
+    IconButton(onClick = onBack) {
+        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun settingsTopAppBarColors() = TopAppBarDefaults.topAppBarColors(
+    containerColor = MaterialTheme.colorScheme.surface,
+)
+
+@Composable
+private fun SettingsOverview(
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+    onSelect: (SettingsCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsDetailColumn(modifier = modifier) {
+        SettingsGroup {
+            SettingsCategory.entries.forEachIndexed { index, category ->
+                SettingsRow(
+                    title = category.title,
+                    supportingText = categorySummary(category, controller, appVersionInfo),
+                    leadingContent = {
+                        Icon(
+                            imageVector = categoryIcon(category),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    onClick = { onSelect(category) },
                 )
-            }
-
-            layoutInfo.useWideLayout -> {
-                val wideScrollState = rememberScrollState()
-                Row(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                        .padding(FuoSpacing.lg)
-                        .verticalScroll(wideScrollState),
-                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
-                    ) {
-                        ProviderSwitchPanel(
-                            controller = controller,
-                            onOpenProviderLogin = { provider ->
-                                controller.openSettingsProviderLogin(provider.providerId)
-                            },
-                        )
-                        AudioQualitySettingsPanel(controller)
-                        PlaybackPolicySettingsPanel(controller)
-                        SmartReplacementSettingsPanel(controller)
-                    }
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
-                    ) {
-                        ThemeSettingsEntryPanel(
-                            controller = controller,
-                            onClick = { page = SettingsPage.Theme },
-                        )
-                        PlayerDisplaySettingsPanelV2(controller)
-                        LocalMusicScanSettingsPanel(controller)
-                        DownloadSettingsPanel(controller)
-                        CacheSettingsPanel(controller)
-                        if (controller.isDebugLogViewerAvailable) {
-                            DebugSettingsPanel(controller)
-                        }
-                        AppInfoPanel(appVersionInfo)
-                    }
-                }
-            }
-
-            else -> {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                        .verticalScroll(rememberScrollState())
-                        .padding(FuoSpacing.lg),
-                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
-                ) {
-                    ProviderSwitchPanel(
-                        controller = controller,
-                        onOpenProviderLogin = { provider ->
-                            controller.openSettingsProviderLogin(provider.providerId)
-                        },
-                    )
-                    AudioQualitySettingsPanel(controller)
-                    PlaybackPolicySettingsPanel(controller)
-                    SmartReplacementSettingsPanel(controller)
-                    ThemeSettingsEntryPanel(
-                        controller = controller,
-                        onClick = { page = SettingsPage.Theme },
-                    )
-                    PlayerDisplaySettingsPanelV2(controller)
-                    LocalMusicScanSettingsPanel(controller)
-                    DownloadSettingsPanel(controller)
-                    CacheSettingsPanel(controller)
-                    if (controller.isDebugLogViewerAvailable) {
-                        DebugSettingsPanel(controller)
-                    }
-                    AppInfoPanel(appVersionInfo)
+                if (index < SettingsCategory.entries.lastIndex) {
+                    SettingsDivider()
                 }
             }
         }
+        Text(
+            modifier = Modifier.padding(horizontal = FuoSpacing.md),
+            text = "设置会自动保存，并在支持的平台间保持一致的 Material 3 交互结构。",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SettingsCategoryPane(
+    selected: SettingsCategory,
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+    onSelect: (SettingsCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.extraLarge,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = FuoSpacing.sm),
+        ) {
+            SettingsCategory.entries.forEach { category ->
+                SettingsRow(
+                    title = category.title,
+                    supportingText = categorySummary(category, controller, appVersionInfo),
+                    selected = selected == category,
+                    leadingContent = {
+                        Icon(categoryIcon(category), contentDescription = null)
+                    },
+                    onClick = { onSelect(category) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsCategoryDetail(
+    category: SettingsCategory,
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+    showHeading: Boolean,
+    onOpenTheme: () -> Unit,
+    onOpenProvider: (ProviderInfo) -> Unit,
+    modifier: Modifier = Modifier.fillMaxSize(),
+) {
+    SettingsDetailColumn(modifier = modifier) {
+        if (showHeading) {
+            Column(verticalArrangement = Arrangement.spacedBy(FuoSpacing.xs)) {
+                Text(
+                    text = category.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Text(
+                    text = category.supportingText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        when (category) {
+            SettingsCategory.Sources -> ProviderSwitchPanel(
+                controller = controller,
+                onOpenProviderLogin = onOpenProvider,
+            )
+
+            SettingsCategory.Playback -> {
+                AudioQualitySettingsPanelV2(controller)
+                PlaybackPolicySettingsPanelV2(controller)
+                SmartReplacementSettingsPanel(controller)
+            }
+
+            SettingsCategory.Appearance -> {
+                ThemeSettingsEntryPanel(
+                    controller = controller,
+                    onClick = onOpenTheme,
+                )
+                PlayerDisplaySettingsPanelV2(controller)
+            }
+
+            SettingsCategory.LocalMusic -> LocalMusicScanSettingsPanel(controller)
+
+            SettingsCategory.Storage -> {
+                DownloadSettingsPanelV2(controller)
+                CacheSettingsPanel(controller)
+            }
+
+            SettingsCategory.About -> AboutSettingsPanelV2(
+                controller = controller,
+                appVersionInfo = appVersionInfo,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsDetailColumn(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .widthIn(max = 760.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+            content = content,
+        )
     }
 }
 
@@ -231,16 +529,10 @@ private fun ThemeSettingsEntryPanel(
     controller: FuoPlayerController,
     onClick: () -> Unit,
 ) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = MaterialTheme.shapes.medium,
-    ) {
-        FuoSettingRow(
-            modifier = Modifier.fillMaxWidth(),
+    SettingsGroup(title = "主题") {
+        SettingsRow(
             title = "主题设置",
             supportingText = "${controller.themeMode.label} · ${controller.themeColorScheme.label}",
-            onClick = onClick,
             leadingContent = {
                 Icon(
                     Icons.Filled.Palette,
@@ -255,25 +547,18 @@ private fun ThemeSettingsEntryPanel(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             },
+            onClick = onClick,
         )
     }
 }
 
 @Composable
 private fun PlayerDisplaySettingsPanelV2(controller: FuoPlayerController) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = MaterialTheme.shapes.medium,
-    ) {
+    SettingsGroup(title = "播放显示") {
         Column(
-            modifier = Modifier.padding(FuoSpacing.lg),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.padding(horizontal = FuoSpacing.lg, vertical = FuoSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
         ) {
-            Text(
-                text = "播放显示",
-                style = MaterialTheme.typography.titleMedium,
-            )
             Text(
                 text = "歌词字号",
                 style = MaterialTheme.typography.bodyMedium,
@@ -288,30 +573,175 @@ private fun PlayerDisplaySettingsPanelV2(controller: FuoPlayerController) {
                             index = index,
                             count = LyricFontSize.entries.size,
                         ),
-                        colors = settingsSegmentedButtonColors(),
                     ) {
                         Text(size.label)
                     }
                 }
             }
-            if (controller.isStatusBarLyricsAvailable) {
-                FuoSettingRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    title = "开启状态栏歌词",
-                    supportingText = "通过词幕在系统状态栏显示当前歌词",
-                    enabled = !controller.isLoading,
-                    onClick = {
-                        controller.onStatusBarLyricsEnabledChange(!controller.statusBarLyricsEnabled)
-                    },
-                    trailingContent = {
-                        Switch(
-                            checked = controller.statusBarLyricsEnabled,
-                            enabled = !controller.isLoading,
-                            onCheckedChange = controller::onStatusBarLyricsEnabledChange,
-                        )
-                    },
-                )
+        }
+        if (controller.isStatusBarLyricsAvailable) {
+            SettingsDivider(startPadding = FuoSpacing.lg)
+            SettingsToggleRow(
+                title = "状态栏歌词",
+                supportingText = "通过词幕在系统状态栏显示当前歌词",
+                checked = controller.statusBarLyricsEnabled,
+                enabled = !controller.isLoading,
+                onCheckedChange = controller::onStatusBarLyricsEnabledChange,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioQualitySettingsPanelV2(controller: FuoPlayerController) {
+    SettingsGroup(title = "音质") {
+        SettingsChoiceRow(
+            title = "Wi‑Fi",
+            supportingText = "连接 Wi‑Fi 时优先使用的音质",
+            value = controller.wifiAudioQualityPolicy.label,
+            options = AudioQualityPolicy.entries,
+            selected = controller.wifiAudioQualityPolicy,
+            optionLabel = AudioQualityPolicy::label,
+            enabled = !controller.isLoading,
+            onSelect = controller::onWifiAudioQualityPolicyChange,
+        )
+        SettingsDivider()
+        SettingsChoiceRow(
+            title = "蜂窝网络",
+            supportingText = "使用移动数据时优先使用的音质",
+            value = controller.cellularAudioQualityPolicy.label,
+            options = AudioQualityPolicy.entries,
+            selected = controller.cellularAudioQualityPolicy,
+            optionLabel = AudioQualityPolicy::label,
+            enabled = !controller.isLoading,
+            onSelect = controller::onCellularAudioQualityPolicyChange,
+        )
+    }
+}
+
+@Composable
+private fun PlaybackPolicySettingsPanelV2(controller: FuoPlayerController) {
+    SettingsGroup(title = "播放策略") {
+        SettingsToggleRow(
+            title = "其他应用播放时自动暂停",
+            supportingText = "检测到其他应用开始播放时暂停当前播放",
+            checked = controller.pauseOnOtherAppPlayback,
+            enabled = !controller.isLoading,
+            onCheckedChange = controller::onPauseOnOtherAppPlaybackChange,
+        )
+        SettingsDivider(startPadding = FuoSpacing.lg)
+        Column(
+            modifier = Modifier.padding(FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+        ) {
+            Text(
+                text = "资源不可用时",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                UnavailablePlaybackPolicy.entries.forEachIndexed { index, policy ->
+                    SegmentedButton(
+                        selected = controller.unavailablePlaybackPolicy == policy,
+                        onClick = { controller.onUnavailablePlaybackPolicyChange(policy) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = UnavailablePlaybackPolicy.entries.size,
+                        ),
+                    ) {
+                        Text(policy.label)
+                    }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun DownloadSettingsPanelV2(controller: FuoPlayerController) {
+    SettingsGroup(title = "下载") {
+        SettingsRow(
+            title = "下载管理",
+            supportingText = "${controller.downloadTasks.count { it.status == DownloadTaskStatus.Downloading }} 个下载中",
+            leadingContent = {
+                Icon(Icons.Filled.Download, contentDescription = null)
+            },
+            trailingContent = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            onClick = controller::openDownloadManager,
+        )
+        SettingsDivider()
+        SettingsChoiceRow(
+            title = "并行下载数量",
+            supportingText = "同时进行的下载任务数量",
+            value = controller.downloadParallelism.toString(),
+            options = (1..5).toList(),
+            selected = controller.downloadParallelism,
+            optionLabel = Int::toString,
+            enabled = !controller.isLoading,
+            onSelect = controller::onDownloadParallelismChange,
+        )
+    }
+}
+
+@Composable
+private fun AboutSettingsPanelV2(
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+) {
+    val uriHandler = LocalUriHandler.current
+    SettingsGroup(title = "应用信息") {
+        appVersionInfo?.takeIf { it.isNotBlank() }?.let { versionInfo ->
+            SettingsRow(
+                title = "版本",
+                trailingContent = {
+                    Text(
+                        text = versionInfo.removePrefix("版本 "),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+            )
+            SettingsDivider()
+        }
+        SettingsRow(
+            title = "FuoEvolve 源代码",
+            supportingText = "GitHub 项目主页",
+            leadingContent = { Icon(Icons.Filled.Code, contentDescription = null) },
+            trailingContent = { Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null) },
+            onClick = { uriHandler.openUri(FUO_EVOLVE_SOURCE_URL) },
+        )
+        SettingsDivider()
+        SettingsRow(
+            title = "FeelUOwn 主项目",
+            supportingText = "上游项目主页",
+            leadingContent = { Icon(Icons.Filled.Code, contentDescription = null) },
+            trailingContent = { Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null) },
+            onClick = { uriHandler.openUri(FEELUOWN_SOURCE_URL) },
+        )
+    }
+    if (controller.isDebugLogViewerAvailable) {
+        SettingsGroup(title = "诊断") {
+            SettingsRow(
+                title = "应用日志",
+                supportingText = "查看、筛选和导出调试日志",
+                leadingContent = { Icon(Icons.Filled.BugReport, contentDescription = null) },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                onClick = controller::openDebugLogs,
+            )
         }
     }
 }
@@ -326,81 +756,83 @@ private fun ThemeSettingsContent(
     modifier: Modifier = Modifier,
 ) {
     val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .padding(FuoSpacing.lg),
-        verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
-    ) {
-        ThemeSelectorCard(
-            title = "主题",
-            supportingText = "选择应用的主题模式",
-            value = controller.themeMode.label,
-            icon = { Icon(Icons.Filled.DarkMode, contentDescription = null) },
-            options = ThemeMode.entries,
-            selected = controller.themeMode,
-            optionLabel = ThemeMode::label,
-            enabled = !controller.isLoading,
-            onSelect = controller::onThemeModeChange,
-        )
-        ThemeSelectorCard(
-            title = "强调色",
-            supportingText = "选择 Material 3 主题使用的配色种子",
-            value = controller.themeColorScheme.label,
-            icon = { Icon(Icons.Filled.Palette, contentDescription = null) },
-            options = ThemeColorScheme.entries,
-            selected = controller.themeColorScheme,
-            optionLabel = ThemeColorScheme::label,
-            enabled = !controller.isLoading,
-            optionLeading = { scheme ->
-                Box(
-                    modifier = Modifier
-                        .size(18.dp)
-                        .clip(CircleShape)
-                        .background(
-                            themePreviewColor(
-                                themeColorScheme = scheme,
-                                darkTheme = darkTheme,
-                                paletteStyle = themePaletteStyle,
-                                colorSpec = themeColorSpec,
+    SettingsDetailColumn(modifier = modifier) {
+        SettingsGroup(title = "颜色与外观") {
+            SettingsChoiceRow(
+                title = "主题",
+                supportingText = "选择应用的主题模式",
+                value = controller.themeMode.label,
+                leadingContent = { Icon(Icons.Filled.DarkMode, contentDescription = null) },
+                options = ThemeMode.entries,
+                selected = controller.themeMode,
+                optionLabel = ThemeMode::label,
+                enabled = !controller.isLoading,
+                onSelect = controller::onThemeModeChange,
+            )
+            SettingsDivider()
+            SettingsChoiceRow(
+                title = "强调色",
+                supportingText = "选择 Material 3 主题使用的配色种子",
+                value = controller.themeColorScheme.label,
+                leadingContent = { Icon(Icons.Filled.Palette, contentDescription = null) },
+                options = ThemeColorScheme.entries,
+                selected = controller.themeColorScheme,
+                optionLabel = ThemeColorScheme::label,
+                enabled = !controller.isLoading,
+                optionLeading = { scheme ->
+                    Box(
+                        modifier = Modifier
+                            .size(18.dp)
+                            .clip(CircleShape)
+                            .background(
+                                themePreviewColor(
+                                    themeColorScheme = scheme,
+                                    darkTheme = darkTheme,
+                                    paletteStyle = themePaletteStyle,
+                                    colorSpec = themeColorSpec,
+                                ),
                             ),
-                        ),
-                )
-            },
-            onSelect = controller::onThemeColorSchemeChange,
-        )
-        ThemeSelectorCard(
-            title = "调色板风格",
-            supportingText = "用于推导 Material 3 调色板的色调算法",
-            value = themePaletteStyle.label,
-            icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
-            options = ThemePaletteStyle.entries,
-            selected = themePaletteStyle,
-            optionLabel = ThemePaletteStyle::label,
-            enabled = !controller.isLoading,
-            onSelect = onThemePaletteStyleChange,
-        )
-        ThemeSelectorCard(
-            title = "色彩规范",
-            supportingText = "Material 3 色彩规范版本",
-            value = themeColorSpec.label,
-            icon = { Icon(Icons.Filled.Tune, contentDescription = null) },
-            options = ThemeColorSpec.entries,
-            selected = themeColorSpec,
-            optionLabel = ThemeColorSpec::label,
-            enabled = !controller.isLoading,
-            onSelect = onThemeColorSpecChange,
-        )
-        ThemeSwitchCard(
-            title = "封面动态取色",
-            supportingText = "根据当前播放封面生成播放器主题色",
-            icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
-            checked = controller.dynamicCoverColorEnabled,
-            enabled = !controller.isLoading,
-            onCheckedChange = controller::onDynamicCoverColorEnabledChange,
-        )
+                    )
+                },
+                onSelect = controller::onThemeColorSchemeChange,
+            )
+            SettingsDivider()
+            SettingsChoiceRow(
+                title = "调色板风格",
+                supportingText = "用于推导 Material 3 调色板的色调算法",
+                value = themePaletteStyle.label,
+                leadingContent = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
+                options = ThemePaletteStyle.entries,
+                selected = themePaletteStyle,
+                optionLabel = ThemePaletteStyle::label,
+                enabled = !controller.isLoading,
+                onSelect = onThemePaletteStyleChange,
+            )
+            SettingsDivider()
+            SettingsChoiceRow(
+                title = "色彩规范",
+                supportingText = "Material 3 色彩规范版本",
+                value = themeColorSpec.label,
+                leadingContent = { Icon(Icons.Filled.Tune, contentDescription = null) },
+                options = ThemeColorSpec.entries,
+                selected = themeColorSpec,
+                optionLabel = ThemeColorSpec::label,
+                enabled = !controller.isLoading,
+                onSelect = onThemeColorSpecChange,
+            )
+        }
+        SettingsGroup(title = "播放器") {
+            SettingsToggleRow(
+                title = "封面动态取色",
+                supportingText = "根据当前播放封面生成播放器主题色",
+                checked = controller.dynamicCoverColorEnabled,
+                enabled = !controller.isLoading,
+                leadingContent = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
+                onCheckedChange = controller::onDynamicCoverColorEnabledChange,
+            )
+        }
         Text(
-            modifier = Modifier.padding(horizontal = FuoSpacing.md, vertical = FuoSpacing.sm),
+            modifier = Modifier.padding(horizontal = FuoSpacing.md),
             text = "动态取色只影响播放页；封面不可用时自动回退到上方选择的强调色。",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -409,48 +841,159 @@ private fun ThemeSettingsContent(
 }
 
 @Composable
-private fun <T> ThemeSelectorCard(
-    title: String,
-    supportingText: String,
-    value: String,
-    icon: @Composable () -> Unit,
-    options: List<T>,
-    selected: T,
-    optionLabel: (T) -> String,
-    enabled: Boolean,
-    onSelect: (T) -> Unit,
-    optionLeading: (@Composable (T) -> Unit)? = null,
+private fun SettingsGroup(
+    title: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
-    var expanded by remember { mutableStateOf(false) }
-    Box(modifier = Modifier.fillMaxWidth()) {
+    Column(verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm)) {
+        title?.let {
+            Text(
+                modifier = Modifier.padding(horizontal = FuoSpacing.md),
+                text = it,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         Surface(
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colorScheme.surfaceContainer,
             shape = MaterialTheme.shapes.large,
         ) {
-            FuoSettingRow(
-                modifier = Modifier.fillMaxWidth(),
-                title = title,
-                supportingText = supportingText,
+            Column(content = content)
+        }
+    }
+}
+
+@Composable
+private fun SettingsRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    leadingContent: (@Composable () -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+    enabled: Boolean = true,
+    selected: Boolean = false,
+    onClick: (() -> Unit)? = null,
+) {
+    val interactiveModifier = if (onClick == null) {
+        modifier
+    } else {
+        modifier
+            .fuoInteractive()
+            .clickable(
                 enabled = enabled,
-                onClick = { expanded = true },
-                leadingContent = {
-                    Box(
-                        modifier = Modifier.size(40.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        icon()
-                    }
-                },
-                trailingContent = {
+                role = Role.Button,
+                onClick = onClick,
+            )
+    }
+    ListItem(
+        modifier = interactiveModifier,
+        colors = if (selected) {
+            ListItemDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                headlineColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                supportingColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                leadingIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                trailingIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        } else {
+            ListItemDefaults.colors(containerColor = Color.Transparent)
+        },
+        headlineContent = { Text(title) },
+        supportingContent = supportingText?.let { text ->
+            {
+                Text(
+                    text = text,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        leadingContent = leadingContent,
+        trailingContent = trailingContent,
+    )
+}
+
+@Composable
+private fun SettingsToggleRow(
+    title: String,
+    supportingText: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    leadingContent: (@Composable () -> Unit)? = null,
+) {
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fuoInteractive()
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            ),
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        headlineContent = { Text(title) },
+        supportingContent = {
+            Text(
+                text = supportingText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        leadingContent = leadingContent,
+        trailingContent = {
+            Switch(
+                checked = checked,
+                enabled = enabled,
+                onCheckedChange = null,
+            )
+        },
+    )
+}
+
+@Composable
+private fun <T> SettingsChoiceRow(
+    title: String,
+    supportingText: String,
+    value: String,
+    options: List<T>,
+    selected: T,
+    optionLabel: (T) -> String,
+    enabled: Boolean,
+    onSelect: (T) -> Unit,
+    leadingContent: (@Composable () -> Unit)? = null,
+    optionLeading: (@Composable (T) -> Unit)? = null,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        SettingsRow(
+            modifier = Modifier.fillMaxWidth(),
+            title = title,
+            supportingText = supportingText,
+            enabled = enabled,
+            onClick = { expanded = true },
+            leadingContent = leadingContent,
+            trailingContent = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.xs),
+                ) {
                     Text(
                         text = value,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
-                },
-            )
-        }
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+        )
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
@@ -474,16 +1017,14 @@ private fun <T> ThemeSelectorCard(
                         )
                     },
                     leadingIcon = {
-                        if (isSelected) {
-                            Icon(
+                        when {
+                            isSelected -> Icon(
                                 Icons.Filled.Check,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onSecondaryContainer,
                             )
-                        } else if (optionLeading != null) {
-                            optionLeading(option)
-                        } else {
-                            Box(Modifier.size(24.dp))
+                            optionLeading != null -> optionLeading(option)
+                            else -> Spacer(Modifier.size(24.dp))
                         }
                     },
                     onClick = {
@@ -497,40 +1038,36 @@ private fun <T> ThemeSelectorCard(
 }
 
 @Composable
-private fun ThemeSwitchCard(
-    title: String,
-    supportingText: String,
-    icon: @Composable () -> Unit,
-    checked: Boolean,
-    enabled: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = MaterialTheme.shapes.large,
-    ) {
-        FuoSettingRow(
-            modifier = Modifier.fillMaxWidth(),
-            title = title,
-            supportingText = supportingText,
-            enabled = enabled,
-            onClick = { onCheckedChange(!checked) },
-            leadingContent = {
-                Box(
-                    modifier = Modifier.size(40.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    icon()
-                }
-            },
-            trailingContent = {
-                Switch(
-                    checked = checked,
-                    enabled = enabled,
-                    onCheckedChange = onCheckedChange,
-                )
-            },
-        )
+private fun SettingsDivider(startPadding: androidx.compose.ui.unit.Dp = 64.dp) {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = startPadding, end = FuoSpacing.lg),
+        color = MaterialTheme.colorScheme.outlineVariant,
+    )
+}
+
+private fun categoryIcon(category: SettingsCategory): ImageVector = when (category) {
+    SettingsCategory.Sources -> Icons.Filled.ManageAccounts
+    SettingsCategory.Playback -> Icons.Filled.Settings
+    SettingsCategory.Appearance -> Icons.Filled.Palette
+    SettingsCategory.LocalMusic -> Icons.Filled.AutoAwesome
+    SettingsCategory.Storage -> Icons.Filled.Download
+    SettingsCategory.About -> Icons.Filled.Code
+}
+
+private fun categorySummary(
+    category: SettingsCategory,
+    controller: FuoPlayerController,
+    appVersionInfo: String?,
+): String = when (category) {
+    SettingsCategory.Sources -> "${controller.enabledProviderIds.size} 个音源已启用"
+    SettingsCategory.Playback ->
+        "Wi‑Fi ${controller.wifiAudioQualityPolicy.label} · ${controller.unavailablePlaybackPolicy.label}"
+    SettingsCategory.Appearance -> "${controller.themeMode.label} · ${controller.themeColorScheme.label}"
+    SettingsCategory.LocalMusic -> if (controller.localMusicDirectories.isEmpty()) {
+        "媒体库扫描与过滤"
+    } else {
+        "${controller.localMusicDirectories.size} 个媒体目录"
     }
+    SettingsCategory.Storage -> "并行下载 ${controller.downloadParallelism} · 缓存与清理"
+    SettingsCategory.About -> appVersionInfo?.takeIf { it.isNotBlank() } ?: "FuoEvolve"
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -682,7 +682,7 @@ private fun DownloadSettingsPanelV2(controller: FuoPlayerController) {
             value = controller.downloadParallelism.toString(),
             options = (1..5).toList(),
             selected = controller.downloadParallelism,
-            optionLabel = Int::toString,
+            optionLabel = { it.toString() },
             enabled = !controller.isLoading,
             onSelect = controller::onDownloadParallelismChange,
         )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -1,5 +1,12 @@
 package org.feeluown.mobile
 
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -99,6 +106,27 @@ private sealed interface SettingsRoute : NavKey {
     data class Provider(val providerId: String) : SettingsRoute
 }
 
+private fun settingsPageTransition(
+    initialOffsetX: (Int) -> Int,
+    targetOffsetX: (Int) -> Int,
+): ContentTransform = (
+    slideInHorizontally(
+        initialOffsetX = initialOffsetX,
+        animationSpec = tween(FuoMotion.pageTransitionMillis),
+    ) + fadeIn(animationSpec = tween(FuoMotion.pageFadeMillis))
+    ) togetherWith (
+    slideOutHorizontally(
+        targetOffsetX = targetOffsetX,
+        animationSpec = tween(FuoMotion.pageTransitionMillis),
+    ) + fadeOut(animationSpec = tween(FuoMotion.pageFadeMillis))
+    )
+
+private fun settingsForwardPageTransition(): ContentTransform =
+    settingsPageTransition(initialOffsetX = { it }, targetOffsetX = { -it })
+
+private fun settingsPopPageTransition(): ContentTransform =
+    settingsPageTransition(initialOffsetX = { -it }, targetOffsetX = { it })
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreenV2(
@@ -144,6 +172,9 @@ fun SettingsScreenV2(
         backStack = backStack,
         modifier = Modifier.fillMaxSize(),
         onBack = ::pop,
+        transitionSpec = { settingsForwardPageTransition() },
+        popTransitionSpec = { settingsPopPageTransition() },
+        predictivePopTransitionSpec = { settingsPopPageTransition() },
         entryProvider = { route ->
             NavEntry(key = route) {
                 when (route) {
@@ -253,9 +284,7 @@ private fun SettingsMainPage(
                 LargeTopAppBar(
                     title = { Text("设置") },
                     navigationIcon = { SettingsBackButton(onBack) },
-                    colors = TopAppBarDefaults.largeTopAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                    ),
+                    colors = settingsTopAppBarColors(),
                 )
             }
         },
@@ -401,12 +430,6 @@ private fun SettingsOverview(
                 }
             }
         }
-        Text(
-            modifier = Modifier.padding(horizontal = FuoSpacing.md),
-            text = "设置会自动保存，并在支持的平台间保持一致的 Material 3 交互结构。",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }
 
@@ -966,21 +989,24 @@ private fun <T> SettingsChoiceRow(
     optionLeading: (@Composable (T) -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Box(modifier = Modifier.fillMaxWidth()) {
-        SettingsRow(
-            modifier = Modifier.fillMaxWidth(),
-            title = title,
-            supportingText = supportingText,
-            enabled = enabled,
-            onClick = { expanded = true },
-            leadingContent = leadingContent,
-            trailingContent = {
+    var displayedValue by remember(value) { mutableStateOf(value) }
+    var displayedSelected by remember(selected) { mutableStateOf(selected) }
+
+    SettingsRow(
+        modifier = Modifier.fillMaxWidth(),
+        title = title,
+        supportingText = supportingText,
+        enabled = enabled,
+        onClick = { expanded = true },
+        leadingContent = leadingContent,
+        trailingContent = {
+            Box {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(FuoSpacing.xs),
                 ) {
                     Text(
-                        text = value,
+                        text = displayedValue,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
@@ -992,49 +1018,51 @@ private fun <T> SettingsChoiceRow(
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-            },
-        )
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            options.forEach { option ->
-                val isSelected = option == selected
-                DropdownMenuItem(
-                    modifier = if (isSelected) {
-                        Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
-                    } else {
-                        Modifier
-                    },
-                    text = {
-                        Text(
-                            text = optionLabel(option),
-                            color = if (isSelected) {
-                                MaterialTheme.colorScheme.onSecondaryContainer
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                ) {
+                    options.forEach { option ->
+                        val isSelected = option == displayedSelected
+                        DropdownMenuItem(
+                            modifier = if (isSelected) {
+                                Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
                             } else {
-                                MaterialTheme.colorScheme.onSurface
+                                Modifier
+                            },
+                            text = {
+                                Text(
+                                    text = optionLabel(option),
+                                    color = if (isSelected) {
+                                        MaterialTheme.colorScheme.onSecondaryContainer
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurface
+                                    },
+                                )
+                            },
+                            leadingIcon = {
+                                when {
+                                    isSelected -> Icon(
+                                        Icons.Filled.Check,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                    optionLeading != null -> optionLeading(option)
+                                    else -> Spacer(Modifier.size(24.dp))
+                                }
+                            },
+                            onClick = {
+                                displayedSelected = option
+                                displayedValue = optionLabel(option)
+                                expanded = false
+                                onSelect(option)
                             },
                         )
-                    },
-                    leadingIcon = {
-                        when {
-                            isSelected -> Icon(
-                                Icons.Filled.Check,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                            optionLeading != null -> optionLeading(option)
-                            else -> Spacer(Modifier.size(24.dp))
-                        }
-                    },
-                    onClick = {
-                        expanded = false
-                        onSelect(option)
-                    },
-                )
+                    }
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -55,6 +56,10 @@ private enum class SettingsPage {
 @Composable
 fun SettingsScreenV2(
     controller: FuoPlayerController,
+    themePaletteStyle: ThemePaletteStyle,
+    onThemePaletteStyleChange: (ThemePaletteStyle) -> Unit,
+    themeColorSpec: ThemeColorSpec,
+    onThemeColorSpecChange: (ThemeColorSpec) -> Unit,
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
     onLogoutProvider: (ProviderInfo) -> Unit,
     appVersionInfo: String?,
@@ -131,6 +136,10 @@ fun SettingsScreenV2(
             page == SettingsPage.Theme -> {
                 ThemeSettingsContent(
                     controller = controller,
+                    themePaletteStyle = themePaletteStyle,
+                    onThemePaletteStyleChange = onThemePaletteStyleChange,
+                    themeColorSpec = themeColorSpec,
+                    onThemeColorSpecChange = onThemeColorSpecChange,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
@@ -310,6 +319,10 @@ private fun PlayerDisplaySettingsPanelV2(controller: FuoPlayerController) {
 @Composable
 private fun ThemeSettingsContent(
     controller: FuoPlayerController,
+    themePaletteStyle: ThemePaletteStyle,
+    onThemePaletteStyleChange: (ThemePaletteStyle) -> Unit,
+    themeColorSpec: ThemeColorSpec,
+    onThemeColorSpecChange: (ThemeColorSpec) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
@@ -344,10 +357,39 @@ private fun ThemeSettingsContent(
                     modifier = Modifier
                         .size(18.dp)
                         .clip(CircleShape)
-                        .background(themePreviewColor(scheme, darkTheme)),
+                        .background(
+                            themePreviewColor(
+                                themeColorScheme = scheme,
+                                darkTheme = darkTheme,
+                                paletteStyle = themePaletteStyle,
+                                colorSpec = themeColorSpec,
+                            ),
+                        ),
                 )
             },
             onSelect = controller::onThemeColorSchemeChange,
+        )
+        ThemeSelectorCard(
+            title = "调色板风格",
+            supportingText = "用于推导 Material 3 调色板的色调算法",
+            value = themePaletteStyle.label,
+            icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
+            options = ThemePaletteStyle.entries,
+            selected = themePaletteStyle,
+            optionLabel = ThemePaletteStyle::label,
+            enabled = !controller.isLoading,
+            onSelect = onThemePaletteStyleChange,
+        )
+        ThemeSelectorCard(
+            title = "色彩规范",
+            supportingText = "Material 3 色彩规范版本",
+            value = themeColorSpec.label,
+            icon = { Icon(Icons.Filled.Tune, contentDescription = null) },
+            options = ThemeColorSpec.entries,
+            selected = themeColorSpec,
+            optionLabel = ThemeColorSpec::label,
+            enabled = !controller.isLoading,
+            onSelect = onThemeColorSpecChange,
         )
         ThemeSwitchCard(
             title = "封面动态取色",

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -143,6 +143,7 @@ fun SettingsScreenV2(
     onStartYtmusicOAuth: (() -> Unit)? = null,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
+    val predictiveBackPreference = rememberPredictiveBackPreference()
     var backStack by remember { mutableStateOf<List<SettingsRoute>>(listOf(SettingsRoute.Main)) }
     var wideSelection by remember { mutableStateOf(SettingsCategory.Sources) }
 
@@ -216,6 +217,7 @@ fun SettingsScreenV2(
                                 onThemePaletteStyleChange = onThemePaletteStyleChange,
                                 themeColorSpec = themeColorSpec,
                                 onThemeColorSpecChange = onThemeColorSpecChange,
+                                predictiveBackPreference = predictiveBackPreference,
                                 modifier = bodyModifier,
                             )
                         }
@@ -256,6 +258,10 @@ fun SettingsScreenV2(
                 }
             }
         },
+    )
+    PlatformLegacyBackHandler(
+        enabled = predictiveBackPreference.isSupported && !predictiveBackPreference.enabled,
+        onBack = ::pop,
     )
 }
 
@@ -777,6 +783,7 @@ private fun ThemeSettingsContent(
     onThemePaletteStyleChange: (ThemePaletteStyle) -> Unit,
     themeColorSpec: ThemeColorSpec,
     onThemeColorSpecChange: (ThemeColorSpec) -> Unit,
+    predictiveBackPreference: PredictiveBackPreference,
     modifier: Modifier = Modifier,
 ) {
     val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
@@ -832,6 +839,20 @@ private fun ThemeSettingsContent(
                 enabled = !controller.isLoading,
                 onSelect = onThemeColorSpecChange,
             )
+        }
+        if (predictiveBackPreference.isSupported) {
+            SettingsGroup(title = "导航") {
+                SettingsToggleRow(
+                    title = "预测性返回手势",
+                    supportingText = "返回手势过程中预览上一页",
+                    checked = predictiveBackPreference.enabled,
+                    enabled = !controller.isLoading,
+                    leadingContent = {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    },
+                    onCheckedChange = predictiveBackPreference.onEnabledChange,
+                )
+            }
         }
         SettingsGroup(title = "播放器") {
             SettingsToggleRow(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -28,9 +28,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -46,6 +46,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
+private enum class SettingsPage {
+    Main,
+    Theme,
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreenV2(
@@ -53,7 +58,6 @@ fun SettingsScreenV2(
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
     onLogoutProvider: (ProviderInfo) -> Unit,
     appVersionInfo: String?,
-    onOpenThemeSettings: () -> Unit,
     onImportYtmusicHeaderFile: (() -> Unit)? = null,
     onImportYtmusicOAuthFile: (() -> Unit)? = null,
     onStartYtmusicOAuth: (() -> Unit)? = null,
@@ -61,25 +65,35 @@ fun SettingsScreenV2(
     val loginProviderId = controller.settingsLoginProviderId
     val loginProvider = controller.orderedProviders().firstOrNull { it.providerId == loginProviderId }
     val layoutInfo = LocalAppLayoutInfo.current
+    var page by remember { mutableStateOf(SettingsPage.Main) }
 
     LaunchedEffect(loginProviderId, controller.providers) {
         if (loginProviderId != null && loginProvider == null) {
             controller.closeSettingsProviderLogin()
         }
+        if (loginProviderId != null) {
+            page = SettingsPage.Main
+        }
+    }
+
+    val title = when {
+        loginProvider != null -> loginProvider.providerName
+        page == SettingsPage.Theme -> "主题设置"
+        else -> "设置"
     }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(loginProvider?.providerName ?: "设置") },
+                title = { Text(title) },
                 navigationIcon = {
                     IconButton(
                         onClick = {
-                            if (loginProvider != null) {
-                                controller.closeSettingsProviderLogin()
-                            } else {
-                                controller.closeSettings()
+                            when {
+                                loginProvider != null -> controller.closeSettingsProviderLogin()
+                                page == SettingsPage.Theme -> page = SettingsPage.Main
+                                else -> controller.closeSettings()
                             }
                         },
                     ) {
@@ -114,6 +128,15 @@ fun SettingsScreenV2(
                 }
             }
 
+            page == SettingsPage.Theme -> {
+                ThemeSettingsContent(
+                    controller = controller,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                )
+            }
+
             layoutInfo.useWideLayout -> {
                 val wideScrollState = rememberScrollState()
                 Row(
@@ -144,7 +167,7 @@ fun SettingsScreenV2(
                     ) {
                         ThemeSettingsEntryPanel(
                             controller = controller,
-                            onClick = onOpenThemeSettings,
+                            onClick = { page = SettingsPage.Theme },
                         )
                         PlayerDisplaySettingsPanelV2(controller)
                         LocalMusicScanSettingsPanel(controller)
@@ -178,7 +201,7 @@ fun SettingsScreenV2(
                     SmartReplacementSettingsPanel(controller)
                     ThemeSettingsEntryPanel(
                         controller = controller,
-                        onClick = onOpenThemeSettings,
+                        onClick = { page = SettingsPage.Theme },
                     )
                     PlayerDisplaySettingsPanelV2(controller)
                     LocalMusicScanSettingsPanel(controller)
@@ -191,37 +214,6 @@ fun SettingsScreenV2(
                 }
             }
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ThemeSettingsScreen(
-    controller: FuoPlayerController,
-    onBack: () -> Unit,
-) {
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.surface,
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("主题设置") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
-            )
-        },
-    ) { paddingValues ->
-        ThemeSettingsContent(
-            controller = controller,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -1,0 +1,496 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+
+private enum class SettingsPage {
+    Main,
+    Theme,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreenV2(
+    controller: FuoPlayerController,
+    onOpenProviderWebLogin: (ProviderInfo) -> Unit,
+    onLogoutProvider: (ProviderInfo) -> Unit,
+    appVersionInfo: String?,
+    onImportYtmusicHeaderFile: (() -> Unit)? = null,
+    onImportYtmusicOAuthFile: (() -> Unit)? = null,
+    onStartYtmusicOAuth: (() -> Unit)? = null,
+) {
+    val loginProviderId = controller.settingsLoginProviderId
+    val loginProvider = controller.orderedProviders().firstOrNull { it.providerId == loginProviderId }
+    val layoutInfo = LocalAppLayoutInfo.current
+    var page by remember { mutableStateOf(SettingsPage.Main) }
+
+    LaunchedEffect(loginProviderId, controller.providers) {
+        if (loginProviderId != null && loginProvider == null) {
+            controller.closeSettingsProviderLogin()
+        }
+        if (loginProviderId != null) {
+            page = SettingsPage.Main
+        }
+    }
+
+    val title = when {
+        loginProvider != null -> loginProvider.providerName
+        page == SettingsPage.Theme -> "主题设置"
+        else -> "设置"
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            when {
+                                loginProvider != null -> controller.closeSettingsProviderLogin()
+                                page == SettingsPage.Theme -> page = SettingsPage.Main
+                                else -> controller.closeSettings()
+                            }
+                        },
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+    ) { paddingValues ->
+        when {
+            loginProvider != null -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .verticalScroll(rememberScrollState())
+                        .padding(FuoSpacing.lg),
+                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+                ) {
+                    ProviderLoginPanel(
+                        controller = controller,
+                        provider = loginProvider,
+                        onOpenProviderWebLogin = onOpenProviderWebLogin,
+                        onLogoutProvider = onLogoutProvider,
+                        onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
+                        onImportYtmusicOAuthFile = onImportYtmusicOAuthFile,
+                        onStartYtmusicOAuth = onStartYtmusicOAuth,
+                    )
+                }
+            }
+
+            page == SettingsPage.Theme -> {
+                ThemeSettingsContent(
+                    controller = controller,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                )
+            }
+
+            layoutInfo.useWideLayout -> {
+                val wideScrollState = rememberScrollState()
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .padding(FuoSpacing.lg)
+                        .verticalScroll(wideScrollState),
+                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+                    ) {
+                        ProviderSwitchPanel(
+                            controller = controller,
+                            onOpenProviderLogin = { provider ->
+                                controller.openSettingsProviderLogin(provider.providerId)
+                            },
+                        )
+                        AudioQualitySettingsPanel(controller)
+                        PlaybackPolicySettingsPanel(controller)
+                        SmartReplacementSettingsPanel(controller)
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+                    ) {
+                        ThemeSettingsEntryPanel(
+                            controller = controller,
+                            onClick = { page = SettingsPage.Theme },
+                        )
+                        PlayerDisplaySettingsPanelV2(controller)
+                        LocalMusicScanSettingsPanel(controller)
+                        DownloadSettingsPanel(controller)
+                        CacheSettingsPanel(controller)
+                        if (controller.isDebugLogViewerAvailable) {
+                            DebugSettingsPanel(controller)
+                        }
+                        AppInfoPanel(appVersionInfo)
+                    }
+                }
+            }
+
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .verticalScroll(rememberScrollState())
+                        .padding(FuoSpacing.lg),
+                    verticalArrangement = Arrangement.spacedBy(FuoSpacing.lg),
+                ) {
+                    ProviderSwitchPanel(
+                        controller = controller,
+                        onOpenProviderLogin = { provider ->
+                            controller.openSettingsProviderLogin(provider.providerId)
+                        },
+                    )
+                    AudioQualitySettingsPanel(controller)
+                    PlaybackPolicySettingsPanel(controller)
+                    SmartReplacementSettingsPanel(controller)
+                    ThemeSettingsEntryPanel(
+                        controller = controller,
+                        onClick = { page = SettingsPage.Theme },
+                    )
+                    PlayerDisplaySettingsPanelV2(controller)
+                    LocalMusicScanSettingsPanel(controller)
+                    DownloadSettingsPanel(controller)
+                    CacheSettingsPanel(controller)
+                    if (controller.isDebugLogViewerAvailable) {
+                        DebugSettingsPanel(controller)
+                    }
+                    AppInfoPanel(appVersionInfo)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeSettingsEntryPanel(
+    controller: FuoPlayerController,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        FuoSettingRow(
+            modifier = Modifier.fillMaxWidth(),
+            title = "主题设置",
+            supportingText = "${controller.themeMode.label} · ${controller.themeColorScheme.label}",
+            onClick = onClick,
+            leadingContent = {
+                Icon(
+                    Icons.Filled.Palette,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            trailingContent = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun PlayerDisplaySettingsPanelV2(controller: FuoPlayerController) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier.padding(FuoSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "播放显示",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = "歌词字号",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                LyricFontSize.entries.forEachIndexed { index, size ->
+                    SegmentedButton(
+                        selected = controller.lyricFontSize == size,
+                        onClick = { controller.onLyricFontSizeChange(size) },
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = LyricFontSize.entries.size,
+                        ),
+                        colors = settingsSegmentedButtonColors(),
+                    ) {
+                        Text(size.label)
+                    }
+                }
+            }
+            if (controller.isStatusBarLyricsAvailable) {
+                FuoSettingRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    title = "开启状态栏歌词",
+                    supportingText = "通过词幕在系统状态栏显示当前歌词",
+                    enabled = !controller.isLoading,
+                    onClick = {
+                        controller.onStatusBarLyricsEnabledChange(!controller.statusBarLyricsEnabled)
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = controller.statusBarLyricsEnabled,
+                            enabled = !controller.isLoading,
+                            onCheckedChange = controller::onStatusBarLyricsEnabledChange,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeSettingsContent(
+    controller: FuoPlayerController,
+    modifier: Modifier = Modifier,
+) {
+    val darkTheme = resolvedDarkTheme(controller.themeMode, isSystemInDarkTheme())
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(FuoSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+    ) {
+        ThemeSelectorCard(
+            title = "主题",
+            supportingText = "选择应用的主题模式",
+            value = controller.themeMode.label,
+            icon = { Icon(Icons.Filled.DarkMode, contentDescription = null) },
+            options = ThemeMode.entries,
+            selected = controller.themeMode,
+            optionLabel = ThemeMode::label,
+            enabled = !controller.isLoading,
+            onSelect = controller::onThemeModeChange,
+        )
+        ThemeSelectorCard(
+            title = "强调色",
+            supportingText = "选择 Material 3 主题使用的配色种子",
+            value = controller.themeColorScheme.label,
+            icon = { Icon(Icons.Filled.Palette, contentDescription = null) },
+            options = ThemeColorScheme.entries,
+            selected = controller.themeColorScheme,
+            optionLabel = ThemeColorScheme::label,
+            enabled = !controller.isLoading,
+            optionLeading = { scheme ->
+                Box(
+                    modifier = Modifier
+                        .size(18.dp)
+                        .clip(CircleShape)
+                        .background(themePreviewColor(scheme, darkTheme)),
+                )
+            },
+            onSelect = controller::onThemeColorSchemeChange,
+        )
+        ThemeSwitchCard(
+            title = "封面动态取色",
+            supportingText = "根据当前播放封面生成播放器主题色",
+            icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
+            checked = controller.dynamicCoverColorEnabled,
+            enabled = !controller.isLoading,
+            onCheckedChange = controller::onDynamicCoverColorEnabledChange,
+        )
+        Text(
+            modifier = Modifier.padding(horizontal = FuoSpacing.md, vertical = FuoSpacing.sm),
+            text = "动态取色只影响播放页；封面不可用时自动回退到上方选择的强调色。",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun <T> ThemeSelectorCard(
+    title: String,
+    supportingText: String,
+    value: String,
+    icon: @Composable () -> Unit,
+    options: List<T>,
+    selected: T,
+    optionLabel: (T) -> String,
+    enabled: Boolean,
+    onSelect: (T) -> Unit,
+    optionLeading: (@Composable (T) -> Unit)? = null,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            shape = MaterialTheme.shapes.large,
+        ) {
+            FuoSettingRow(
+                modifier = Modifier.fillMaxWidth(),
+                title = title,
+                supportingText = supportingText,
+                enabled = enabled,
+                onClick = { expanded = true },
+                leadingContent = {
+                    Box(
+                        modifier = Modifier.size(40.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        icon()
+                    }
+                },
+                trailingContent = {
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { option ->
+                val isSelected = option == selected
+                DropdownMenuItem(
+                    modifier = if (isSelected) {
+                        Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
+                    } else {
+                        Modifier
+                    },
+                    text = {
+                        Text(
+                            text = optionLabel(option),
+                            color = if (isSelected) {
+                                MaterialTheme.colorScheme.onSecondaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
+                        )
+                    },
+                    leadingIcon = {
+                        if (isSelected) {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                            )
+                        } else if (optionLeading != null) {
+                            optionLeading(option)
+                        } else {
+                            Box(Modifier.size(24.dp))
+                        }
+                    },
+                    onClick = {
+                        expanded = false
+                        onSelect(option)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeSwitchCard(
+    title: String,
+    supportingText: String,
+    icon: @Composable () -> Unit,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.large,
+    ) {
+        FuoSettingRow(
+            modifier = Modifier.fillMaxWidth(),
+            title = title,
+            supportingText = supportingText,
+            enabled = enabled,
+            onClick = { onCheckedChange(!checked) },
+            leadingContent = {
+                Box(
+                    modifier = Modifier.size(40.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    icon()
+                }
+            },
+            trailingContent = {
+                Switch(
+                    checked = checked,
+                    enabled = enabled,
+                    onCheckedChange = onCheckedChange,
+                )
+            },
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/SettingsScreenV2.kt
@@ -28,9 +28,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -44,14 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-
-private enum class SettingsPage {
-    Main,
-    Theme,
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,6 +53,7 @@ fun SettingsScreenV2(
     onOpenProviderWebLogin: (ProviderInfo) -> Unit,
     onLogoutProvider: (ProviderInfo) -> Unit,
     appVersionInfo: String?,
+    onOpenThemeSettings: () -> Unit,
     onImportYtmusicHeaderFile: (() -> Unit)? = null,
     onImportYtmusicOAuthFile: (() -> Unit)? = null,
     onStartYtmusicOAuth: (() -> Unit)? = null,
@@ -67,35 +61,25 @@ fun SettingsScreenV2(
     val loginProviderId = controller.settingsLoginProviderId
     val loginProvider = controller.orderedProviders().firstOrNull { it.providerId == loginProviderId }
     val layoutInfo = LocalAppLayoutInfo.current
-    var page by remember { mutableStateOf(SettingsPage.Main) }
 
     LaunchedEffect(loginProviderId, controller.providers) {
         if (loginProviderId != null && loginProvider == null) {
             controller.closeSettingsProviderLogin()
         }
-        if (loginProviderId != null) {
-            page = SettingsPage.Main
-        }
-    }
-
-    val title = when {
-        loginProvider != null -> loginProvider.providerName
-        page == SettingsPage.Theme -> "主题设置"
-        else -> "设置"
     }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(title) },
+                title = { Text(loginProvider?.providerName ?: "设置") },
                 navigationIcon = {
                     IconButton(
                         onClick = {
-                            when {
-                                loginProvider != null -> controller.closeSettingsProviderLogin()
-                                page == SettingsPage.Theme -> page = SettingsPage.Main
-                                else -> controller.closeSettings()
+                            if (loginProvider != null) {
+                                controller.closeSettingsProviderLogin()
+                            } else {
+                                controller.closeSettings()
                             }
                         },
                     ) {
@@ -130,15 +114,6 @@ fun SettingsScreenV2(
                 }
             }
 
-            page == SettingsPage.Theme -> {
-                ThemeSettingsContent(
-                    controller = controller,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues),
-                )
-            }
-
             layoutInfo.useWideLayout -> {
                 val wideScrollState = rememberScrollState()
                 Row(
@@ -169,7 +144,7 @@ fun SettingsScreenV2(
                     ) {
                         ThemeSettingsEntryPanel(
                             controller = controller,
-                            onClick = { page = SettingsPage.Theme },
+                            onClick = onOpenThemeSettings,
                         )
                         PlayerDisplaySettingsPanelV2(controller)
                         LocalMusicScanSettingsPanel(controller)
@@ -203,7 +178,7 @@ fun SettingsScreenV2(
                     SmartReplacementSettingsPanel(controller)
                     ThemeSettingsEntryPanel(
                         controller = controller,
-                        onClick = { page = SettingsPage.Theme },
+                        onClick = onOpenThemeSettings,
                     )
                     PlayerDisplaySettingsPanelV2(controller)
                     LocalMusicScanSettingsPanel(controller)
@@ -216,6 +191,37 @@ fun SettingsScreenV2(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemeSettingsScreen(
+    controller: FuoPlayerController,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("主题设置") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+    ) { paddingValues ->
+        ThemeSettingsContent(
+            controller = controller,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        )
     }
 }
 

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformTheme.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PlatformTheme.ios.kt
@@ -2,6 +2,10 @@ package org.feeluown.mobile
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 @Composable
 internal actual fun platformDynamicColorScheme(darkTheme: Boolean): ColorScheme? = null
+
+@Composable
+internal actual fun platformWindowSurfaceEffect(surfaceColor: Color) = Unit

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
@@ -1,0 +1,17 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun rememberPredictiveBackPreference(): PredictiveBackPreference =
+    PredictiveBackPreference(
+        isSupported = false,
+        enabled = false,
+        onEnabledChange = {},
+    )
+
+@Composable
+internal actual fun PlatformLegacyBackHandler(
+    enabled: Boolean,
+    onBack: () -> Unit,
+) = Unit


### PR DESCRIPTION
## 变更
- 将主题相关配置从“播放显示”中拆出，集中到“主题设置”二级页
- “外观与显示”一级详情直接提供主题模式选择；强调色、调色板风格、色彩规范等高级选项保留在主题设置下级页
- 实现“调色板风格”设置，支持 Tonal Spot、Neutral、Vibrant、Expressive、Rainbow、FruitSalad、Monochrome、Fidelity、Content，并实际接入 MaterialKolor `PaletteStyle`
- 实现“色彩规范”设置，支持 Material 3 (2021) 与 Expressive (2025)，分别映射 MaterialKolor `SPEC_2021` / `SPEC_2025`
- 调色板风格与色彩规范会作用于预设强调色、系统动态色重新生成的主题，以及播放页封面动态取色
- 新增配置持久化，默认保持原有 Expressive + 2025 行为，兼容已有设置数据

## 设置页结构重构
- 一级设置页改为概览式信息架构，收敛为 6 个分类：音源与账号、播放与音质、外观与显示、本地音乐、下载与存储、关于
- 手机端点击分类进入二级设置页，不再在一级页直接铺满全部高级控件
- 使用 Settings 内部 Navigation3 back stack 管理分类页、主题页和音源账号页，系统返回与顶部返回保持同一层级语义
- 设置页进入/返回使用与应用其他详情页一致的左右滑动动画
- 宽屏布局改为 list-detail：左侧分类列表，右侧显示当前分类详情；详情内容限制最大宽度，避免平板上控件无限拉伸
- 一级设置页使用 LargeTopAppBar，详情页使用标准 TopAppBar，替换此前所有页面统一居中的标题样式

## Material 3 一致性
- 主题设置页按分组式设置列表组织强调色、调色板风格、色彩规范、导航和播放器相关选项
- 下拉单选菜单锚定当前值所在的尾部区域，并在选择后立即更新当前值与选中状态
- Wi‑Fi / 蜂窝网络音质、并行下载数量改为标准设置行 + 单选菜单，避免四到五段 SegmentedButton 在窄屏拥挤
- 保留适合快速比较的 SegmentedButton：歌词字号、资源不可用策略
- 新增统一 SettingsRow / SettingsChoiceRow / SettingsToggleRow，使用 `surfaceContainer`、透明 ListItem 容器、`secondaryContainer` 选中态和标准分隔线
- Switch 设置改为整行 `toggleable(role = Role.Switch)`，内部 Switch 不再单独响应点击，减少重复交互目标和无障碍语义冲突
- 应用信息、源码、日志统一收口到“关于”；下载行为与缓存统一收口到“下载与存储”

## 预测性返回
- Android 14（API 34）及以上设备在“主题设置”中显示“预测性返回手势”开关；不支持的系统和 iOS 不显示该设置
- 默认开启并持久化保存；开启时由 Navigation3 使用 predictive back progress 和 `predictivePopTransitionSpec` 预览上一页
- 关闭时改用普通 BackHandler 完成页级返回，不使用预测性返回进度
- Android Manifest 显式启用 OnBackInvoked callback，以便支持系统预测性返回分发
- 预测性返回期间的 Window 背景会同步当前 Material 主题 `surface`，避免暗色模式下页面淡出时透出亮色 Activity 背景；系统夜间启动背景也改为黑色兜底

## 说明
“界面缩放”暂未新增；主题配色、设置页信息架构以及预测性返回开关已经接入实际行为。

## 验证
- Android / iOS CI 已重新触发
- 建议重点验证：Android 14+ 开关显示与持久化、暗色模式预测性返回亮度、开启/关闭后的返回手势差异、手机端分类进入/返回、宽屏 list-detail 切换、主题设置即时生效、音源账号页、下载管理和应用日志跳转