### PR TITLE
[feat] Add sleep timer support to playback

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -290,6 +290,10 @@ class AndroidNativeAudioEngine(
         persistPlaybackState(forcePosition = true)
     }
 
+    override fun setStopAfterCurrentTrack(enabled: Boolean) {
+        FuoPlaybackService.setStopAfterCurrentTrack(context, enabled)
+    }
+
     internal fun republishRestoredState() {
         val session = restoredSession ?: return
         if (explicitStopRequested || startingPlayback) return

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -60,6 +60,8 @@ class FuoPlaybackService : MediaSessionService() {
     private var activePlayback: PreparedPlayback? = null
     private var activePlaybackHasReachedReady = false
     private var pendingPreloadError: String? = null
+    private var stopAfterCurrentTrack = false
+    private var holdAtCurrentEnd = false
     @Volatile
     private var activeGeneration: Long = 0L
     private var itemSerial: Long = 0L
@@ -99,9 +101,13 @@ class FuoPlaybackService : MediaSessionService() {
                 player.addListener(object : Player.Listener {
                     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                         val prepared = mediaItem?.mediaId?.let(preparedItems::get) ?: return
+                        if (activePlayback?.mediaItem?.mediaId != prepared.mediaItem.mediaId) {
+                            holdAtCurrentEnd = false
+                        }
                         activePlayback = prepared
                         activePlaybackHasReachedReady = player.playbackState == Player.STATE_READY
                         enqueueRemainingParts(prepared)
+                        applyStopAfterCurrentTrackGate()
                         publishPlaybackState()
                         preloadNext()
                     }
@@ -208,7 +214,25 @@ class FuoPlaybackService : MediaSessionService() {
             }
             ACTION_PAUSE -> player?.pause()
             ACTION_RESUME -> player?.play()
+            ACTION_SET_STOP_AFTER_CURRENT -> {
+                val enabled = intent.getBooleanExtra(EXTRA_STOP_AFTER_CURRENT, false)
+                val wasEnabled = stopAfterCurrentTrack
+                if (enabled) {
+                    holdAtCurrentEnd = false
+                } else if (
+                    wasEnabled &&
+                    player?.playbackState == Player.STATE_ENDED &&
+                    isFinalPlaybackPart(activePlayback)
+                ) {
+                    holdAtCurrentEnd = true
+                }
+                stopAfterCurrentTrack = enabled
+                applyStopAfterCurrentTrackGate()
+                publishPlaybackState()
+            }
             ACTION_STOP -> {
+                stopAfterCurrentTrack = false
+                holdAtCurrentEnd = false
                 player?.stop()
                 mutableAudioDecoderInfo.value = null
                 mutableAudioFormatInfo.value = null
@@ -254,6 +278,7 @@ class FuoPlaybackService : MediaSessionService() {
         activePlayback = null
         activePlaybackHasReachedReady = false
         pendingPreloadError = null
+        holdAtCurrentEnd = false
         activeGeneration = plan.generation
         mutableAudioFormatInfo.value = null
         mutablePlaybackState.value = PlaybackState(
@@ -272,6 +297,7 @@ class FuoPlaybackService : MediaSessionService() {
                     activePlayback = prepared
                     preparedItems[prepared.mediaItem.mediaId] = prepared
                     player?.run {
+                        applyStopAfterCurrentTrackGate()
                         setMediaSource(prepared.mediaSource)
                         prepare()
                         play()
@@ -294,6 +320,7 @@ class FuoPlaybackService : MediaSessionService() {
     }
 
     private fun preloadNext() {
+        if (shouldHoldAtCurrentEnd()) return
         val generation = activeGeneration
         val request = synchronized(pendingLock) {
             if (preloadingGeneration != null) {
@@ -313,7 +340,7 @@ class FuoPlaybackService : MediaSessionService() {
                     preparedItems[prepared.mediaItem.mediaId] = prepared
                     player?.run {
                         addMediaSource(prepared.mediaSource)
-                        if (playbackState == Player.STATE_ENDED) {
+                        if (playbackState == Player.STATE_ENDED && !shouldHoldAtCurrentEnd()) {
                             seekToNextMediaItem()
                             play()
                         }
@@ -571,7 +598,8 @@ class FuoPlaybackService : MediaSessionService() {
     private fun publishPlaybackState() {
         val prepared = activePlayback ?: return
         val currentPlayer = player ?: return
-        if (currentPlayer.playbackState == Player.STATE_ENDED && pendingPreloadError != null) {
+        val shouldHold = shouldHoldAtCurrentEnd()
+        if (currentPlayer.playbackState == Player.STATE_ENDED && pendingPreloadError != null && !shouldHold) {
             mutablePlaybackState.value = PlaybackState(
                 status = PlayerStatus.Error,
                 currentTrack = prepared.track,
@@ -588,7 +616,7 @@ class FuoPlaybackService : MediaSessionService() {
             return
         }
         val status = when {
-            currentPlayer.playbackState == Player.STATE_ENDED && hasPendingOrLoadingRequest() -> PlayerStatus.Loading
+            currentPlayer.playbackState == Player.STATE_ENDED && hasPendingOrLoadingRequest() && !shouldHold -> PlayerStatus.Loading
             currentPlayer.playbackState == Player.STATE_ENDED -> PlayerStatus.Ended
             currentPlayer.isPlaying -> PlayerStatus.Playing
             currentPlayer.playbackState == Player.STATE_BUFFERING &&
@@ -611,6 +639,22 @@ class FuoPlaybackService : MediaSessionService() {
             currentPartIndex = prepared.payload.currentPartIndex,
             playbackGeneration = activeGeneration,
         )
+    }
+
+    private fun applyStopAfterCurrentTrackGate() {
+        player?.setPauseAtEndOfMediaItems(
+            stopAfterCurrentTrack && isFinalPlaybackPart(activePlayback),
+        )
+    }
+
+    private fun shouldHoldAtCurrentEnd(): Boolean =
+        holdAtCurrentEnd || (stopAfterCurrentTrack && isFinalPlaybackPart(activePlayback))
+
+    private fun isFinalPlaybackPart(prepared: PreparedPlayback?): Boolean {
+        val payload = prepared?.payload ?: return false
+        if (payload.parts.isEmpty()) return true
+        val partIndex = payload.currentPartIndex
+        return partIndex !in payload.parts.indices || partIndex >= payload.parts.lastIndex
     }
 
     private fun hasPendingOrLoadingRequest(): Boolean = synchronized(pendingLock) {
@@ -769,8 +813,10 @@ class FuoPlaybackService : MediaSessionService() {
         private const val ACTION_PLAY = "org.feeluown.mobile.action.PLAY"
         private const val ACTION_PAUSE = "org.feeluown.mobile.action.PAUSE"
         private const val ACTION_RESUME = "org.feeluown.mobile.action.RESUME"
+        private const val ACTION_SET_STOP_AFTER_CURRENT = "org.feeluown.mobile.action.SET_STOP_AFTER_CURRENT"
         private const val ACTION_STOP = "org.feeluown.mobile.action.STOP"
         private const val EXTRA_PLAN = "plan"
+        private const val EXTRA_STOP_AFTER_CURRENT = "stop_after_current"
         private const val PLAYBACK_RESOLVE_TIMEOUT_MS = 30_000L
         private const val TAG = "FuoPlaybackService"
         private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
@@ -816,6 +862,16 @@ class FuoPlaybackService : MediaSessionService() {
 
         fun resume(context: Context) {
             start(context, Intent(context, FuoPlaybackService::class.java).setAction(ACTION_RESUME))
+        }
+
+        fun setStopAfterCurrentTrack(context: Context, enabled: Boolean) {
+            start(
+                context,
+                Intent(context, FuoPlaybackService::class.java).apply {
+                    action = ACTION_SET_STOP_AFTER_CURRENT
+                    putExtra(EXTRA_STOP_AFTER_CURRENT, enabled)
+                },
+            )
         }
 
         fun stop(context: Context) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppRoot.kt
@@ -247,6 +247,7 @@ fun AppRoot(
         val snackbarHostState = remember { SnackbarHostState() }
         val playlistOperationFeedback = controller.playlistOperationFeedback
         val downloadQueueFeedback = controller.downloadQueueFeedback
+        val playbackFeedback = controller.playbackFeedback
         LaunchedEffect(playlistOperationFeedback) {
             playlistOperationFeedback ?: return@LaunchedEffect
             snackbarHostState.showSnackbar(playlistOperationFeedback)
@@ -256,6 +257,11 @@ fun AppRoot(
             downloadQueueFeedback ?: return@LaunchedEffect
             snackbarHostState.showSnackbar(downloadQueueFeedback)
             controller.dismissDownloadQueueFeedback(downloadQueueFeedback)
+        }
+        LaunchedEffect(playbackFeedback) {
+            playbackFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(playbackFeedback)
+            controller.dismissPlaybackFeedback(playbackFeedback)
         }
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoContracts.kt
@@ -196,6 +196,9 @@ val DEFAULT_CELLULAR_AUDIO_QUALITY_POLICY = AudioQualityPolicy.Standard
 val DEFAULT_UNAVAILABLE_PLAYBACK_POLICY = UnavailablePlaybackPolicy.SmartReplace
 const val DEFAULT_SMART_REPLACEMENT_MIN_SCORE = 0.55
 const val PROVIDER_PAGE_SIZE = 50
+const val SLEEP_TIMER_MIN_MINUTES = 1
+const val SLEEP_TIMER_MAX_MINUTES = 1_440
+val SLEEP_TIMER_PRESET_MINUTES = listOf(15, 30, 45, 60, 90, 120)
 
 data class LocalMusicScanSettings(
     val excludedDirectoryIds: Set<String> = emptySet(),
@@ -353,6 +356,19 @@ enum class PlayerStatus {
     Error,
     Ended,
 }
+
+enum class SleepTimerMode {
+    Off,
+    Duration,
+    EndOfTrack,
+}
+
+data class SleepTimerState(
+    val mode: SleepTimerMode = SleepTimerMode.Off,
+    val deadlineMs: Long? = null,
+    val targetTrackId: String? = null,
+    val remainingMs: Long? = null,
+)
 
 enum class TrackChangeDirection {
     Next,
@@ -990,6 +1006,7 @@ interface PlaybackEngine {
     fun resume()
     fun stop()
     fun seekTo(positionMs: Long)
+    fun setStopAfterCurrentTrack(enabled: Boolean) = Unit
 }
 
 data class SettingsState(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/FuoPlayerController.kt
@@ -50,6 +50,7 @@ class FuoPlayerController(
     private val audioRecognitionRepository: AudioRecognitionRepository = UnsupportedAudioRecognitionRepository,
     private val oauthDeviceCodeAssistant: OAuthDeviceCodeAssistant = NoOpOAuthDeviceCodeAssistant,
     private val scope: CoroutineScope,
+    private val nowMillis: () -> Long = ::currentTimeMillis,
 ) {
     private val providerState = ProviderControllerState()
     private val localMusicState = LocalMusicControllerState()
@@ -178,6 +179,8 @@ class FuoPlayerController(
         private set
     var playlistOperationFeedback by mutableStateOf<String?>(null)
         private set
+    var playbackFeedback by mutableStateOf<String?>(null)
+        private set
     var localPlaylistOperationError by mutableStateOf<String?>(null)
         private set
     var localPlaylistImportPreview by mutableStateOf<LocalPlaylistImportPreview?>(null)
@@ -260,6 +263,8 @@ class FuoPlayerController(
     var downloadQueueFeedback by downloadState::queueFeedback
         private set
     var playbackState by mutableStateOf(PlaybackState())
+        private set
+    var sleepTimerState by mutableStateOf(SleepTimerState())
         private set
     var trackChangeDirection by mutableStateOf(TrackChangeDirection.Next)
         private set
@@ -359,6 +364,8 @@ class FuoPlayerController(
     private var suppressPlaybackRecoveryRequestSerial: Long? = null
     private var lyricsLoadJob: Job? = null
     private var lyricsLoadedForTrackId: String? = null
+    private var sleepTimerJob: Job? = null
+    private var sleepTimerSerial: Long = 0L
     private var localMusicRefreshSerial: Long = 0
     private var recommendContentRefreshSerial: Long = 0
     private var musicContentRefreshSerial: Long = 0
@@ -463,7 +470,11 @@ class FuoPlayerController(
             playbackEngine.state.collect { engineState ->
                 engineState.currentTrack?.let(::synchronizePlaybackTrack)
                 val queueTrackId = currentQueueTrack()?.id
+                if (queueTrackId != null) {
+                    clearEndOfTrackTimerIfTrackChanged(queueTrackId)
+                }
                 var shouldAutoAdvance = false
+                var shouldCompleteEndOfTrackTimer = false
                 when (engineState.status) {
                     PlayerStatus.Playing -> {
                         autoAdvanceEligibleTrackId = queueTrackId ?: engineState.currentTrack?.id
@@ -479,7 +490,22 @@ class FuoPlayerController(
                         ) {
                             autoAdvanceEligibleTrackId = null
                             lastEndedTrackId = endedTrackId
-                            shouldAutoAdvance = true
+                            val activeParts = engineState.playbackParts.ifEmpty { playbackParts }
+                            val activePartIndex = engineState.currentPartIndex
+                                .takeIf { it >= 0 }
+                                ?: currentPartIndex
+                            val isFinalPlaybackPart = activeParts.isEmpty() ||
+                                activePartIndex !in activeParts.indices ||
+                                activePartIndex >= activeParts.lastIndex
+                            if (
+                                sleepTimerState.mode == SleepTimerMode.EndOfTrack &&
+                                sleepTimerState.targetTrackId == endedTrackId &&
+                                isFinalPlaybackPart
+                            ) {
+                                shouldCompleteEndOfTrackTimer = true
+                            } else {
+                                shouldAutoAdvance = true
+                            }
                         }
                     }
                     else -> {
@@ -500,7 +526,10 @@ class FuoPlayerController(
                     currentPartIndex = engineState.currentPartIndex
                 }
                 isLoading = engineState.status == PlayerStatus.Loading
-                if (shouldAutoAdvance) {
+                if (shouldCompleteEndOfTrackTimer) {
+                    resetSleepTimer()
+                    playbackFeedback = "当前曲目已播放完，播放已暂停"
+                } else if (shouldAutoAdvance) {
                     next()
                 } else if (engineState.status == PlayerStatus.Error) {
                     if (!rollbackManualReplacement(playRequestSerial, engineState.errorMessage)) {
@@ -873,6 +902,90 @@ class FuoPlayerController(
 
     fun dismissDownloadQueueFeedback(feedback: String) {
         if (downloadQueueFeedback == feedback) downloadQueueFeedback = null
+    }
+
+    fun dismissPlaybackFeedback(feedback: String) {
+        if (playbackFeedback == feedback) playbackFeedback = null
+    }
+
+    fun setSleepTimerDurationMinutes(minutes: Int) {
+        if (currentSleepTimerTrackId() == null) {
+            playbackFeedback = "请先播放一首歌曲"
+            return
+        }
+        if (minutes !in SLEEP_TIMER_MIN_MINUTES..SLEEP_TIMER_MAX_MINUTES) {
+            playbackFeedback = "请输入 $SLEEP_TIMER_MIN_MINUTES–$SLEEP_TIMER_MAX_MINUTES 分钟"
+            return
+        }
+        val durationMs = minutes.toLong() * 60_000L
+        val deadlineMs = nowMillis() + durationMs
+        replaceSleepTimer(
+            SleepTimerState(
+                mode = SleepTimerMode.Duration,
+                deadlineMs = deadlineMs,
+                remainingMs = durationMs,
+            ),
+        )
+    }
+
+    fun setSleepTimerToEndOfTrack() {
+        val trackId = currentSleepTimerTrackId()
+        if (trackId == null) {
+            playbackFeedback = "请先播放一首歌曲"
+            return
+        }
+        replaceSleepTimer(
+            SleepTimerState(
+                mode = SleepTimerMode.EndOfTrack,
+                targetTrackId = trackId,
+            ),
+        )
+    }
+
+    fun clearSleepTimer() {
+        resetSleepTimer()
+    }
+
+    private fun currentSleepTimerTrackId(): String? = currentQueueTrack()?.id
+        ?: playbackState.currentTrack?.id
+
+    private fun replaceSleepTimer(state: SleepTimerState) {
+        resetSleepTimer()
+        sleepTimerState = state
+        playbackEngine.setStopAfterCurrentTrack(state.mode == SleepTimerMode.EndOfTrack)
+        if (state.mode != SleepTimerMode.Duration) return
+        val deadlineMs = state.deadlineMs ?: return
+        val serial = sleepTimerSerial
+        sleepTimerJob = scope.launch {
+            while (serial == sleepTimerSerial) {
+                val remainingMs = deadlineMs - nowMillis()
+                if (remainingMs <= 0L) {
+                    resetSleepTimer()
+                    playbackEngine.pause()
+                    playbackFeedback = "睡眠定时已结束，播放已暂停"
+                    break
+                }
+                sleepTimerState = sleepTimerState.copy(remainingMs = remainingMs)
+                delay(minOf(remainingMs, 1_000L))
+            }
+        }
+    }
+
+    private fun resetSleepTimer() {
+        sleepTimerSerial += 1L
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        sleepTimerState = SleepTimerState()
+        playbackEngine.setStopAfterCurrentTrack(false)
+    }
+
+    private fun clearEndOfTrackTimerIfTrackChanged(trackId: String?) {
+        if (
+            sleepTimerState.mode == SleepTimerMode.EndOfTrack &&
+            sleepTimerState.targetTrackId != trackId
+        ) {
+            resetSleepTimer()
+        }
     }
 
     fun onDownloadParallelismChange(value: Int) {
@@ -4069,6 +4182,13 @@ class FuoPlayerController(
         messageAfterStart: String? = null,
         suppressPlaybackRecovery: Boolean = false,
     ) {
+        clearEndOfTrackTimerIfTrackChanged(track.id)
+        if (
+            sleepTimerState.mode == SleepTimerMode.EndOfTrack &&
+            sleepTimerState.targetTrackId == track.id
+        ) {
+            playbackEngine.setStopAfterCurrentTrack(true)
+        }
         val requestSerial = ++playRequestSerial
         suppressPlaybackRecoveryRequestSerial = requestSerial.takeIf { suppressPlaybackRecovery }
         val playbackTrack = if (manualSelection != null) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/PlayerScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Delete
@@ -52,6 +53,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -71,6 +73,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
@@ -91,6 +94,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
@@ -389,6 +393,7 @@ private fun FullPlayerContent(controller: FuoPlayerController) {
                                     shuffleEnabled = controller.isShuffleEnabled,
                                     shuffleAvailable = !controller.isFmQueueActive,
                                     onShuffle = controller::toggleShuffle,
+                                    sleepTimerAction = { SleepTimerAction(controller) },
                                     extraAction = currentTrack?.let { track ->
                                         {
                                             NowPlayingTrackAction(controller = controller, track = track)
@@ -483,6 +488,7 @@ private fun FullPlayerContent(controller: FuoPlayerController) {
                     shuffleEnabled = controller.isShuffleEnabled,
                     shuffleAvailable = !controller.isFmQueueActive,
                     onShuffle = controller::toggleShuffle,
+                    sleepTimerAction = { SleepTimerAction(controller) },
                     extraAction = currentTrack?.let { track ->
                         {
                             NowPlayingTrackAction(controller = controller, track = track)
@@ -492,6 +498,187 @@ private fun FullPlayerContent(controller: FuoPlayerController) {
             }
             QueueBottomSheet(controller)
         }
+    }
+}
+
+@Composable
+private fun SleepTimerAction(controller: FuoPlayerController) {
+    var showSheet by remember { mutableStateOf(false) }
+    val timerState = controller.sleepTimerState
+    val isActive = timerState.mode != SleepTimerMode.Off
+    val contentDescription = when (timerState.mode) {
+        SleepTimerMode.Off -> "睡眠定时"
+        SleepTimerMode.Duration -> "睡眠定时，剩余 ${formatSleepTimerRemaining(timerState.remainingMs ?: 0L)}"
+        SleepTimerMode.EndOfTrack -> "当前曲目结束后暂停"
+    }
+    Box {
+        RoundControlButton(
+            imageVector = Icons.Filled.Timer,
+            contentDescription = contentDescription,
+            onClick = { showSheet = true },
+            selected = isActive,
+        )
+        if (showSheet) {
+            SleepTimerBottomSheet(
+                controller = controller,
+                onDismiss = { showSheet = false },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SleepTimerBottomSheet(
+    controller: FuoPlayerController,
+    onDismiss: () -> Unit,
+) {
+    val timerState = controller.sleepTimerState
+    var showCustomDurationDialog by remember { mutableStateOf(false) }
+    var customMinutesText by remember { mutableStateOf("") }
+    val customMinutes = customMinutesText.toIntOrNull()
+    val customMinutesValid = customMinutes?.let {
+        it in SLEEP_TIMER_MIN_MINUTES..SLEEP_TIMER_MAX_MINUTES
+    } == true
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "睡眠定时",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                if (timerState.mode != SleepTimerMode.Off) {
+                    TextButton(onClick = {
+                        controller.clearSleepTimer()
+                        onDismiss()
+                    }) {
+                        Text("关闭定时")
+                    }
+                }
+            }
+            when (timerState.mode) {
+                SleepTimerMode.Duration -> Text(
+                    text = "将在 ${formatSleepTimerRemaining(timerState.remainingMs ?: 0L)} 后暂停播放",
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                SleepTimerMode.EndOfTrack -> Text(
+                    text = "当前曲目（含全部多段内容）播放完后暂停",
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                SleepTimerMode.Off -> Text(
+                    text = "选择暂停播放的时机",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = "按时长",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SLEEP_TIMER_PRESET_MINUTES.chunked(3).forEach { rowMinutes ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    rowMinutes.forEach { minutes ->
+                        FilterChip(
+                            selected = false,
+                            onClick = {
+                                controller.setSleepTimerDurationMinutes(minutes)
+                                onDismiss()
+                            },
+                            modifier = Modifier.weight(1f),
+                            label = { Text("$minutes 分钟") },
+                        )
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    selected = timerState.mode == SleepTimerMode.EndOfTrack,
+                    onClick = {
+                        controller.setSleepTimerToEndOfTrack()
+                        onDismiss()
+                    },
+                    modifier = Modifier.weight(1f),
+                    label = { Text("当前曲目结束") },
+                )
+                FilterChip(
+                    selected = false,
+                    onClick = { showCustomDurationDialog = true },
+                    modifier = Modifier.weight(1f),
+                    label = { Text("自定义时长") },
+                )
+            }
+        }
+    }
+
+    if (showCustomDurationDialog) {
+        AlertDialog(
+            onDismissRequest = { showCustomDurationDialog = false },
+            title = { Text("自定义睡眠定时") },
+            text = {
+                TextField(
+                    value = customMinutesText,
+                    onValueChange = { value ->
+                        customMinutesText = value.filter(Char::isDigit)
+                    },
+                    singleLine = true,
+                    isError = customMinutesText.isNotBlank() && !customMinutesValid,
+                    label = { Text("分钟") },
+                    supportingText = {
+                        Text("请输入 $SLEEP_TIMER_MIN_MINUTES–$SLEEP_TIMER_MAX_MINUTES 分钟")
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = customMinutesValid,
+                    onClick = {
+                        customMinutes?.let(controller::setSleepTimerDurationMinutes)
+                        showCustomDurationDialog = false
+                        onDismiss()
+                    },
+                ) {
+                    Text("确定")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCustomDurationDialog = false }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+}
+
+private fun formatSleepTimerRemaining(remainingMs: Long): String {
+    val totalSeconds = (remainingMs.coerceAtLeast(0L) + 999L) / 1_000L
+    val minutes = totalSeconds / 60L
+    val seconds = totalSeconds % 60L
+    return when {
+        minutes >= 60L -> "${minutes / 60L}小时${minutes % 60L}分"
+        minutes > 0L -> "${minutes}分${seconds}秒"
+        else -> "${seconds}秒"
     }
 }
 
@@ -1174,6 +1361,7 @@ fun PlayerControls(
     shuffleAvailable: Boolean = true,
     onShuffle: (() -> Unit)? = null,
     onRepeat: (() -> Unit)? = null,
+    sleepTimerAction: (@Composable () -> Unit)? = null,
     extraAction: (@Composable () -> Unit)? = null,
 ) {
     Row(
@@ -1215,6 +1403,7 @@ fun PlayerControls(
             iconSize = if (compact) 24.dp else 26.dp,
         )
         when {
+            !compact && sleepTimerAction != null -> sleepTimerAction()
             !compact && extraAction != null -> extraAction()
             !compact && onRepeat != null -> RepeatModeTextButton(
                 repeatMode = repeatMode,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoPlayerControllerTest.kt
@@ -1020,6 +1020,268 @@ class FuoPlayerControllerTest {
     }
 
     @Test
+    fun durationSleepTimerPausesAfterDeadlineEvenWhenPlaybackIsPaused() = runTest {
+        var nowMillis = 0L
+        val track = providerTrack("provider:1", "First")
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(listOf(track)),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+                nowMillis = { nowMillis },
+            )
+
+            advanceUntilIdle()
+            controller.playLocalTrack(track, listOf(track))
+            advanceUntilIdle()
+            controller.setSleepTimerDurationMinutes(1)
+            runCurrent()
+
+            assertEquals(SleepTimerMode.Duration, controller.sleepTimerState.mode)
+            assertEquals(60_000L, controller.sleepTimerState.remainingMs)
+            controller.toggle()
+            runCurrent()
+            val pauseCountWhilePaused = engine.pauseCount
+
+            nowMillis += 59_000L
+            advanceTimeBy(59_000L)
+            runCurrent()
+            assertEquals(SleepTimerMode.Duration, controller.sleepTimerState.mode)
+            assertEquals(1_000L, controller.sleepTimerState.remainingMs)
+
+            nowMillis += 1_000L
+            advanceTimeBy(1_000L)
+            runCurrent()
+
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals(PlayerStatus.Paused, engine.state.value.status)
+            assertEquals(pauseCountWhilePaused + 1, engine.pauseCount)
+            assertEquals("睡眠定时已结束，播放已暂停", controller.playbackFeedback)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun replacingOrClearingSleepTimerCancelsThePreviousTimer() = runTest {
+        var nowMillis = 0L
+        val track = providerTrack("provider:1", "First")
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(listOf(track)),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+                nowMillis = { nowMillis },
+            )
+
+            advanceUntilIdle()
+            controller.playLocalTrack(track, listOf(track))
+            advanceUntilIdle()
+            controller.setSleepTimerDurationMinutes(1)
+            runCurrent()
+            controller.setSleepTimerToEndOfTrack()
+            runCurrent()
+
+            nowMillis += 60_000L
+            advanceTimeBy(60_000L)
+            runCurrent()
+            assertEquals(SleepTimerMode.EndOfTrack, controller.sleepTimerState.mode)
+            assertEquals(0, engine.pauseCount)
+
+            controller.clearSleepTimer()
+            runCurrent()
+            nowMillis += 60_000L
+            advanceTimeBy(60_000L)
+            runCurrent()
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals(0, engine.pauseCount)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun durationSleepTimerSurvivesManualTrackChange() = runTest {
+        var nowMillis = 0L
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(tracks),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+                nowMillis = { nowMillis },
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.setSleepTimerDurationMinutes(1)
+            runCurrent()
+            controller.next()
+            runCurrent()
+
+            assertEquals("provider:2", engine.lastTrack?.id)
+            assertEquals(SleepTimerMode.Duration, controller.sleepTimerState.mode)
+
+            nowMillis += 60_000L
+            advanceTimeBy(60_000L)
+            runCurrent()
+
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals("provider:2", engine.lastTrack?.id)
+            assertEquals(PlayerStatus.Paused, engine.state.value.status)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun endOfTrackSleepTimerTakesPriorityOverRepeatAndUpNext() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val upNext = providerTrack("provider:3", "Third")
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(tracks + upNext),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.toggleRepeat()
+            controller.addToUpNext(upNext)
+            controller.setSleepTimerToEndOfTrack()
+            runCurrent()
+            val firstTrackId = engine.lastTrack?.id
+
+            engine.emitEnded(engine.lastTrack ?: tracks.first())
+            advanceUntilIdle()
+
+            assertEquals(firstTrackId, engine.lastTrack?.id)
+            assertEquals(PlayerStatus.Ended, controller.playbackState.status)
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals("当前曲目已播放完，播放已暂停", controller.playbackFeedback)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun endOfTrackSleepTimerStopsAfterTheFinalMultipartPartAndResetsEngineFlag() = runTest {
+        val parent = providerTrack("bilibili:BV1xx", "Multi Part").copy(source = "bilibili")
+        val other = providerTrack("provider:2", "Second")
+        val parts = listOf(
+            PlaybackPart("bilibili:paged_BV1xx__1", "P1", 60_000),
+            PlaybackPart("bilibili:paged_BV1xx__2", "P2", 70_000),
+        )
+        val provider = FakeProviderRepository(
+            tracks = listOf(parent, other),
+            resolveHandler = { track, _, _, _, _, _ ->
+                val partIndex = parts.indexOfFirst { it.id == track.id }.takeIf { it >= 0 } ?: 0
+                PlaybackPayload(
+                    url = "https://example.com/${parts[partIndex].id}.m4s",
+                    title = parts[partIndex].title,
+                    artists = parent.artists,
+                    album = parent.album,
+                    source = parent.source,
+                    durationMs = parts[partIndex].durationMs,
+                    parts = parts,
+                    currentPartIndex = partIndex,
+                )
+            },
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = provider,
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playLocalTrack(parent, listOf(parent, other))
+            advanceUntilIdle()
+            controller.setSleepTimerToEndOfTrack()
+            runCurrent()
+
+            engine.emitEnded(engine.lastTrack ?: parent)
+            advanceUntilIdle()
+            assertEquals(1, controller.playbackState.currentPartIndex)
+            assertEquals(SleepTimerMode.EndOfTrack, controller.sleepTimerState.mode)
+            assertEquals(true, engine.stopAfterCurrentTrackValues.last())
+
+            engine.emitEnded(engine.lastTrack ?: parent)
+            advanceUntilIdle()
+
+            assertEquals(PlayerStatus.Ended, controller.playbackState.status)
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals(false, engine.stopAfterCurrentTrackValues.last())
+            assertEquals("当前曲目已播放完，播放已暂停", controller.playbackFeedback)
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
+    fun manualTrackChangeClearsEndOfTrackSleepTimer() = runTest {
+        val tracks = listOf(
+            providerTrack("provider:1", "First"),
+            providerTrack("provider:2", "Second"),
+        )
+        val engine = FakePlaybackEngine()
+        val controllerScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        try {
+            val controller = FuoPlayerController(
+                providerRepository = FakeProviderRepository(tracks),
+                localRepository = FakeLocalMusicRepository(),
+                downloadRepository = FakeDownloadRepository(emptyMap()),
+                playbackEngine = engine,
+                scope = controllerScope,
+            )
+
+            advanceUntilIdle()
+            controller.playAllLocalTracks(tracks)
+            advanceUntilIdle()
+            controller.setSleepTimerToEndOfTrack()
+            runCurrent()
+            controller.next()
+            advanceUntilIdle()
+
+            assertEquals("provider:2", engine.lastTrack?.id)
+            assertEquals(SleepTimerMode.Off, controller.sleepTimerState.mode)
+            assertEquals(false, engine.stopAfterCurrentTrackValues.last())
+        } finally {
+            controllerScope.cancel()
+        }
+    }
+
+    @Test
     fun multiPartTrackPlaysPartsInOrderBeforeMainQueueNextWhenShuffleIsEnabled() = runTest {
         val parent = providerTrack("bilibili:BV1xx", "Multi Part").copy(
             source = "bilibili",
@@ -4955,7 +5217,9 @@ class FuoPlayerControllerTest {
         var lastTrack: MusicTrack? = null
         var lastPayload: PlaybackPayload? = null
         var resumeCount = 0
+        var pauseCount = 0
         val seekPositions = mutableListOf<Long>()
+        val stopAfterCurrentTrackValues = mutableListOf<Boolean>()
 
         override fun prepareLoading(track: MusicTrack) {
             mutableState.value = PlaybackState(
@@ -4998,6 +5262,7 @@ class FuoPlayerControllerTest {
         }
 
         override fun pause() {
+            pauseCount += 1
             mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
         }
 
@@ -5013,6 +5278,10 @@ class FuoPlayerControllerTest {
         override fun seekTo(positionMs: Long) {
             seekPositions += positionMs
             mutableState.value = mutableState.value.copy(positionMs = positionMs)
+        }
+
+        override fun setStopAfterCurrentTrack(enabled: Boolean) {
+            stopAfterCurrentTrackValues += enabled
         }
     }
 


### PR DESCRIPTION
## Summary

- Add sleep-timer state and controls to the shared player contracts and controller.
- Expose sleep-timer UI in the player screen.
- Integrate timer expiry with Android playback service and native audio controls.
- Update controller unit-test coverage.

## Testing

- Not run (not requested).