### PR TITLE
fix: prioritize recording identity in smart replacement

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
@@ -44,9 +44,17 @@ internal fun replacementTieBreakConfidence(origin: MusicTrack, candidate: MusicT
 
 private fun replacementRecordingVersionRank(origin: MusicTrack, candidate: MusicTrack): Int {
     val originVersions = recordingVersionKinds("${origin.title} ${origin.album}")
-    val candidateTitleVersions = recordingVersionKinds(candidate.title)
-    val candidateTagVersions = recordingVersionKinds(candidate.providerTags.joinToString(" "))
-    val candidateVersions = candidateTitleVersions.ifEmpty { candidateTagVersions }
+    val candidateVersions = recordingVersionKinds(
+        buildString {
+            append(candidate.title)
+            append(' ')
+            append(candidate.album)
+            if (candidate.providerTags.isNotEmpty()) {
+                append(' ')
+                append(candidate.providerTags.joinToString(" "))
+            }
+        },
+    )
     return when {
         originVersions == candidateVersions -> 3
         originVersions.isEmpty() && candidateVersions.isNotEmpty() -> 0

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
@@ -3,8 +3,15 @@ package org.feeluown.mobile
 import kotlin.math.abs
 
 /**
- * Refines only candidates that have exactly the same legacy replacement score.
- * It never changes the score itself or which candidates pass the configured threshold.
+ * Re-ranks candidates that already passed the configured replacement score threshold.
+ *
+ * Recording identity is treated as a structural signal before the legacy score:
+ * 1. Prefer the same recording/version (studio, live, remix, cover, etc.).
+ * 2. For multi-artist originals, prefer candidates that preserve the full artist lineup.
+ * 3. Within the same recording profile, keep the legacy score and metadata confidence order.
+ *
+ * This keeps uploader/official provenance useful without allowing it to override a clearly
+ * different recording, such as an official live or solo version replacing the studio duet.
  */
 internal fun sortReplacementScoreTies(
     origin: MusicTrack,
@@ -14,7 +21,13 @@ internal fun sortReplacementScoreTies(
     return ranked
         .withIndex()
         .sortedWith(
-            compareByDescending<IndexedValue<ReplacementCandidate>> { it.value.score }
+            compareByDescending<IndexedValue<ReplacementCandidate>> {
+                replacementRecordingVersionRank(origin, it.value.track)
+            }
+                .thenByDescending {
+                    replacementCollaborationCoverage(origin, it.value.track)
+                }
+                .thenByDescending { it.value.score }
                 .thenByDescending { replacementTieBreakConfidence(origin, it.value.track) }
                 .thenBy { it.index },
         )
@@ -27,6 +40,61 @@ internal fun replacementTieBreakConfidence(origin: MusicTrack, candidate: MusicT
     val albumScore = exactMetadataMatch(origin.album, candidate.album)
     val durationScore = durationCloseness(origin.durationMs, candidate.durationMs)
     return titleScore * 0.45 + artistScore * 0.30 + albumScore * 0.15 + durationScore * 0.10
+}
+
+private fun replacementRecordingVersionRank(origin: MusicTrack, candidate: MusicTrack): Int {
+    val originVersions = recordingVersionKinds("${origin.title} ${origin.album}")
+    val candidateTitleVersions = recordingVersionKinds(candidate.title)
+    val candidateTagVersions = recordingVersionKinds(candidate.providerTags.joinToString(" "))
+    val candidateVersions = candidateTitleVersions.ifEmpty { candidateTagVersions }
+    return when {
+        originVersions == candidateVersions -> 3
+        originVersions.isEmpty() && candidateVersions.isNotEmpty() -> 0
+        originVersions.isNotEmpty() && candidateVersions.isEmpty() -> 1
+        originVersions.intersect(candidateVersions).isNotEmpty() -> 1
+        else -> 0
+    }
+}
+
+private fun replacementCollaborationCoverage(origin: MusicTrack, candidate: MusicTrack): Double {
+    val originArtists = splitArtists(origin.artists)
+    if (originArtists.size <= 1) return 1.0
+    val evidence = normalizeTieBreakText(
+        buildString {
+            append(candidate.title)
+            append(' ')
+            append(candidate.artists)
+            if (candidate.providerTags.isNotEmpty()) {
+                append(' ')
+                append(candidate.providerTags.joinToString(" "))
+            }
+        },
+    )
+    if (evidence.isBlank()) return 0.0
+    val matched = originArtists.count { artist ->
+        artist.length >= 2 && artist in evidence
+    }
+    return matched.toDouble() / originArtists.size.toDouble()
+}
+
+private enum class RecordingVersionKind {
+    COVER,
+    REMIX,
+    LIVE,
+    INSTRUMENTAL,
+    ACOUSTIC,
+    DEMO,
+    SOLO,
+}
+
+private fun recordingVersionKinds(value: String): Set<RecordingVersionKind> = buildSet {
+    if (RECORDING_COVER_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.COVER)
+    if (RECORDING_REMIX_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.REMIX)
+    if (RECORDING_LIVE_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.LIVE)
+    if (RECORDING_INSTRUMENTAL_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.INSTRUMENTAL)
+    if (RECORDING_ACOUSTIC_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.ACOUSTIC)
+    if (RECORDING_DEMO_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.DEMO)
+    if (RECORDING_SOLO_PATTERNS.any { it.containsMatchIn(value) }) add(RecordingVersionKind.SOLO)
 }
 
 private fun orderedTextSimilarity(leftValue: String, rightValue: String): Double {
@@ -98,3 +166,44 @@ private fun levenshteinDistance(left: String, right: String): Int {
 
 private fun normalizeTieBreakText(value: String): String =
     value.lowercase().replace(Regex("[^\\p{L}\\p{N}]"), "")
+
+private val RECORDING_COVER_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])cover(?:$|[^a-z0-9])"),
+    Regex("翻唱"),
+    Regex("歌ってみた"),
+    Regex("弾いてみた"),
+)
+private val RECORDING_REMIX_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])remix(?:$|[^a-z0-9])"),
+    Regex("重混"),
+)
+private val RECORDING_LIVE_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])live(?:$|[^a-z0-9])"),
+    Regex("现场"),
+    Regex("現場"),
+    Regex("ライブ"),
+)
+private val RECORDING_INSTRUMENTAL_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])instrumental(?:$|[^a-z0-9])"),
+    Regex("(?i)(?:^|[^a-z0-9])off[ -]?vocal(?:$|[^a-z0-9])"),
+    Regex("(?i)(?:^|[^a-z0-9])karaoke(?:$|[^a-z0-9])"),
+    Regex("伴奏"),
+    Regex("纯音乐"),
+    Regex("純音樂"),
+)
+private val RECORDING_ACOUSTIC_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])acoustic(?:$|[^a-z0-9])"),
+    Regex("(?i)(?:^|[^a-z0-9])unplugged(?:$|[^a-z0-9])"),
+    Regex("不插电"),
+    Regex("不插電"),
+)
+private val RECORDING_DEMO_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])demo(?:$|[^a-z0-9])"),
+    Regex("小样"),
+    Regex("小樣"),
+)
+private val RECORDING_SOLO_PATTERNS = listOf(
+    Regex("(?i)(?:^|[^a-z0-9])solo(?:$|[^a-z0-9])"),
+    Regex("独唱"),
+    Regex("獨唱"),
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/ReplacementTieBreak.kt
@@ -59,17 +59,7 @@ private fun replacementRecordingVersionRank(origin: MusicTrack, candidate: Music
 private fun replacementCollaborationCoverage(origin: MusicTrack, candidate: MusicTrack): Double {
     val originArtists = splitArtists(origin.artists)
     if (originArtists.size <= 1) return 1.0
-    val evidence = normalizeTieBreakText(
-        buildString {
-            append(candidate.title)
-            append(' ')
-            append(candidate.artists)
-            if (candidate.providerTags.isNotEmpty()) {
-                append(' ')
-                append(candidate.providerTags.joinToString(" "))
-            }
-        },
-    )
+    val evidence = normalizeTieBreakText("${candidate.title} ${candidate.artists}")
     if (evidence.isBlank()) return 0.0
     val matched = originArtists.count { artist ->
         artist.length >= 2 && artist in evidence

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
@@ -137,6 +137,52 @@ class ReplacementTieBreakTest {
     }
 
     @Test
+    fun candidateAlbumVersionMarkerPreventsFalseStudioMatch() {
+        val original = track("netease", "Song", "Alice")
+        val albumMarkedLive = ReplacementCandidate(
+            track(
+                source = "ytmusic",
+                title = "Song",
+                artists = "Alice",
+                album = "Live at Arena",
+                id = "album-live",
+            ),
+            0.90,
+        )
+        val studio = ReplacementCandidate(
+            track("qqmusic", "Song", "Alice", id = "studio"),
+            0.80,
+        )
+
+        val sorted = sortReplacementScoreTies(original, listOf(albumMarkedLive, studio))
+
+        assertEquals("studio", sorted.first().track.id)
+    }
+
+    @Test
+    fun candidateTagsAreCombinedWithTitleVersionMarkers() {
+        val original = track("netease", "Song Live", "Alice")
+        val liveCover = ReplacementCandidate(
+            track(
+                source = "bilibili",
+                title = "Song LIVE",
+                artists = "Alice",
+                id = "live-cover",
+                providerTags = listOf("翻唱"),
+            ),
+            0.90,
+        )
+        val matchingLive = ReplacementCandidate(
+            track("bilibili", "Song LIVE", "Alice", id = "live"),
+            0.80,
+        )
+
+        val sorted = sortReplacementScoreTies(original, listOf(liveCover, matchingLive))
+
+        assertEquals("live", sorted.first().track.id)
+    }
+
+    @Test
     fun yoasobiOfficialOriginalStillBeatsTaggedCover() {
         val original = track(
             source = "netease",

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ReplacementTieBreakTest.kt
@@ -26,7 +26,7 @@ class ReplacementTieBreakTest {
     }
 
     @Test
-    fun higherLegacyScoreAlwaysWinsOverTieBreakConfidence() {
+    fun higherLegacyScoreStillWinsWhenRecordingStructureIsEquivalent() {
         val original = track("netease", "Song", "Alice", album = "Album", durationMs = 180_000)
         val higherLegacy = ReplacementCandidate(
             track("ytmusic", "Different", "Other", id = "higher"),
@@ -41,6 +41,134 @@ class ReplacementTieBreakTest {
 
         assertEquals("higher", sorted.first().track.id)
         assertEquals(0.81, sorted.first().score, 0.0001)
+    }
+
+    @Test
+    fun studioVersionBeatsHigherScoredOfficialLiveUpload() {
+        val original = track(
+            source = "netease",
+            title = "学不会",
+            artists = "林俊杰",
+            durationMs = 240_000,
+        )
+        val officialLive = track(
+            source = "bilibili",
+            title = "学不会 LIVE",
+            artists = "林俊杰",
+            durationMs = 240_000,
+            id = "live",
+        )
+        val studioReupload = track(
+            source = "bilibili",
+            title = "林俊杰 - 学不会 Hi-Res",
+            artists = "音乐搬运",
+            durationMs = 240_000,
+            id = "studio",
+        )
+        val liveScore = bilibiliReplacementScore(original, officialLive)
+        val studioScore = bilibiliReplacementScore(original, studioReupload)
+
+        assertTrue(liveScore > studioScore)
+
+        val sorted = sortReplacementScoreTies(
+            original,
+            listOf(
+                ReplacementCandidate(officialLive, liveScore),
+                ReplacementCandidate(studioReupload, studioScore),
+            ),
+        )
+
+        assertEquals("studio", sorted.first().track.id)
+    }
+
+    @Test
+    fun fullCollaborationBeatsHigherScoredSingleArtistUpload() {
+        val original = track(
+            source = "netease",
+            title = "雀跃",
+            artists = "任然 / 小来",
+            durationMs = 215_000,
+        )
+        val officialSolo = track(
+            source = "bilibili",
+            title = "雀跃",
+            artists = "任然",
+            durationMs = 215_000,
+            id = "solo",
+        )
+        val duetReupload = track(
+            source = "bilibili",
+            title = "任然 / 小来 - 雀跃 Hi-Res",
+            artists = "音乐搬运",
+            durationMs = 215_000,
+            id = "duet",
+        )
+        val soloScore = bilibiliReplacementScore(original, officialSolo)
+        val duetScore = bilibiliReplacementScore(original, duetReupload)
+
+        assertTrue(soloScore > duetScore)
+
+        val sorted = sortReplacementScoreTies(
+            original,
+            listOf(
+                ReplacementCandidate(officialSolo, soloScore),
+                ReplacementCandidate(duetReupload, duetScore),
+            ),
+        )
+
+        assertEquals("duet", sorted.first().track.id)
+    }
+
+    @Test
+    fun explicitVersionOriginStillPrefersSameVersion() {
+        val original = track("netease", "学不会 Live", "林俊杰", durationMs = 240_000)
+        val matchingLive = ReplacementCandidate(
+            track("bilibili", "学不会 LIVE", "林俊杰", durationMs = 240_000, id = "live"),
+            0.75,
+        )
+        val studio = ReplacementCandidate(
+            track("bilibili", "林俊杰 - 学不会", "音乐搬运", durationMs = 240_000, id = "studio"),
+            0.90,
+        )
+
+        val sorted = sortReplacementScoreTies(original, listOf(studio, matchingLive))
+
+        assertEquals("live", sorted.first().track.id)
+    }
+
+    @Test
+    fun yoasobiOfficialOriginalStillBeatsTaggedCover() {
+        val original = track(
+            source = "netease",
+            title = "ハルジオン",
+            artists = "YOASOBI",
+            durationMs = 198_000,
+        )
+        val official = track(
+            source = "bilibili",
+            title = "YOASOBI ハルジオン(Halzion) Official Music Video",
+            artists = "Ayase-YOASOBI",
+            durationMs = 203_000,
+            id = "official",
+        )
+        val cover = track(
+            source = "bilibili",
+            title = "【七海】ハルジオン／春紫菀 【YOASOBI】（人声增强）",
+            artists = "七海Nana7mi",
+            durationMs = 197_000,
+            id = "cover",
+            providerTags = listOf("YOASOBI", "ハルジオン", "翻唱"),
+        )
+
+        val sorted = sortReplacementScoreTies(
+            original,
+            listOf(
+                ReplacementCandidate(cover, bilibiliReplacementScore(original, cover)),
+                ReplacementCandidate(official, bilibiliReplacementScore(original, official)),
+            ),
+        )
+
+        assertEquals("official", sorted.first().track.id)
     }
 
     @Test
@@ -62,6 +190,7 @@ class ReplacementTieBreakTest {
         album: String = "",
         durationMs: Long? = null,
         id: String = "$source:$title",
+        providerTags: List<String> = emptyList(),
     ): MusicTrack = MusicTrack(
         id = id,
         title = title,
@@ -71,5 +200,6 @@ class ReplacementTieBreakTest {
         sourceType = TrackSourceType.Provider,
         durationMs = durationMs,
         providerId = id,
+        providerTags = providerTags,
     )
 }


### PR DESCRIPTION
## What changed
- Re-rank already-qualified replacement candidates by recording/version compatibility before the legacy score.
- Treat an unmarked source track as the standard/studio recording, so Live/Remix/Cover/Instrumental/Acoustic/Demo/Solo variants cannot win solely because the uploader matches the artist.
- For multi-artist originals, prefer candidates whose title/uploader evidence preserves the full artist lineup before considering uploader provenance.
- Keep the existing score threshold, candidate search, score calculation, duration logic, and metadata tie-break unchanged.

## Regression coverage
- `学不会 - 林俊杰`: a lower-scored studio reupload now outranks a higher-scored official Live upload.
- `雀跃 - 任然 / 小来`: a lower-scored full duet reupload now outranks a higher-scored single-artist upload.
- Explicit Live origins still prefer Live candidates.
- `ハルジオン - YOASOBI`: official original remains preferred over a tagged cover.

## Rationale
The legacy Bilibili score gives strong weight to uploader/artist identity. That is useful provenance evidence, but it should not override structural recording mismatches. The rerank keeps provenance useful only after version and collaboration identity are compatible.