### PR TITLE
refactor: establish P0 runtime architecture boundaries

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -7,6 +7,9 @@ name: Android APK
     paths:
       - "androidApp/**"
       - "shared/**"
+      - "core/**"
+      - "playback/**"
+      - "provider/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle.properties"
@@ -18,6 +21,9 @@ name: Android APK
     paths:
       - "androidApp/**"
       - "shared/**"
+      - "core/**"
+      - "playback/**"
+      - "provider/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle.properties"
@@ -57,8 +63,8 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run shared tests and generate coverage
-        run: ./gradlew :shared:allTests :shared:koverXmlReportDebug
+      - name: Run architecture checks, shared tests and coverage
+        run: ./gradlew checkArchitectureBoundaries :shared:allTests :shared:koverXmlReportDebug
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ios-debug-app.yml
+++ b/.github/workflows/ios-debug-app.yml
@@ -7,6 +7,9 @@ name: iOS Debug App
     paths:
       - "iosApp/**"
       - "shared/**"
+      - "core/**"
+      - "playback/**"
+      - "provider/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle.properties"
@@ -20,6 +23,9 @@ name: iOS Debug App
     paths:
       - "iosApp/**"
       - "shared/**"
+      - "core/**"
+      - "playback/**"
+      - "provider/**"
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle.properties"
@@ -61,8 +67,8 @@ jobs:
           path: ~/.konan
           key: ${{ runner.os }}-${{ runner.arch }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
 
-      - name: Run shared tests
-        run: ./gradlew :shared:allTests
+      - name: Run shared tests and architecture checks
+        run: ./gradlew checkArchitectureBoundaries :shared:allTests
 
   build-debug-simulator:
     name: Build debug iOS simulator app

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -117,6 +117,8 @@ kotlin {
 
 dependencies {
     implementation(project(":shared"))
+    implementation(project(":core:model"))
+    implementation(project(":playback:api"))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.compose.material3.expressive)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -5,13 +5,15 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
 
 /**
  * Android composition root.
@@ -25,6 +27,7 @@ internal class AndroidAppContainer(
     private val context: Context = application.applicationContext
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var lyriconLyricsPublisher: LyriconLyricsPublisher? = null
+    private var playbackSessionHolder: PlaybackSession? = null
 
     val providerRepository: ProviderMusicRepository by lazy {
         createFuoProviderRepository(
@@ -189,45 +192,32 @@ internal class AndroidAppContainer(
     }
 
     private fun wireController(controller: FuoPlayerController) {
+        val playbackSession = createPlaybackSession(controller, appScope)
+        playbackSessionHolder = playbackSession
+
         controller.updateStatusBarLyricsAvailability(isLyriconInstalled(context))
         lyriconLyricsPublisher = LyriconLyricsPublisher(
             context = context,
-            controller = controller,
+            playbackSession = playbackSession,
+            statusBarLyricsEnabled = { controller.statusBarLyricsEnabled },
             scope = appScope,
         ).also(LyriconLyricsPublisher::start)
 
         FuoPlaybackService.transportControls = object : FuoPlaybackService.TransportControls {
-            override fun toggle() {
-                controller.toggle()
-            }
+            override fun toggle() = playbackSession.toggle()
 
-            override fun play() {
-                if (controller.playbackState.status != PlayerStatus.Playing) {
-                    controller.toggle()
-                }
-            }
+            override fun play() = playbackSession.play()
 
-            override fun pause() {
-                if (controller.playbackState.status == PlayerStatus.Playing) {
-                    controller.toggle()
-                }
-            }
+            override fun pause() = playbackSession.pause()
 
-            override fun previous() {
-                controller.previous()
-            }
+            override fun previous() = playbackSession.previous()
 
-            override fun next() {
-                controller.next()
-            }
+            override fun next() = playbackSession.next()
         }
 
         appScope.launch {
-            snapshotFlow {
-                controller.playbackState.let { state ->
-                    state.currentTrack?.id to state.lyrics
-                }
-            }
+            playbackSession.state
+                .map { state -> state.currentTrack?.id to state.lyrics }
                 .distinctUntilChanged()
                 .collect { (trackId, lyrics) ->
                     if (trackId != null) {
@@ -237,21 +227,20 @@ internal class AndroidAppContainer(
         }
 
         appScope.launch {
-            snapshotFlow {
-                controller.playbackState.let { state ->
+            playbackSession.state
+                .map { state ->
                     Triple(
                         state.currentTrack?.id,
                         state.status,
-                        state.queue.map { it.id } to state.queueIndex,
+                        state.queueTrackIds to state.queueIndex,
                     )
                 }
-            }
                 .distinctUntilChanged()
                 .collect { (trackId, status, _) ->
                     playbackEngine.republishRestoredState()
                     if (
                         trackId != null &&
-                        (status == PlayerStatus.Playing || status == PlayerStatus.Paused)
+                        (status == PlaybackSessionStatus.Playing || status == PlaybackSessionStatus.Paused)
                     ) {
                         playbackQueueStore.flushLatest()
                         playbackResumeStore.flush()
@@ -264,6 +253,7 @@ internal class AndroidAppContainer(
         FuoPlaybackService.transportControls = null
         lyriconLyricsPublisher?.close()
         lyriconLyricsPublisher = null
+        playbackSessionHolder = null
         appScope.cancel()
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ControllerPlaybackSession.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ControllerPlaybackSession.kt
@@ -1,0 +1,97 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.core.model.TrackRef
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionState
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+
+/**
+ * Compatibility adapter while playback ownership is moved out of [FuoPlayerController].
+ *
+ * Platform integrations consume [PlaybackSession], so the controller can be replaced by a
+ * dedicated playback runtime without changing service/media-session integrations again.
+ */
+fun createPlaybackSession(
+    controller: FuoPlayerController,
+    scope: CoroutineScope,
+): PlaybackSession = ControllerPlaybackSession(controller, scope)
+
+private class ControllerPlaybackSession(
+    private val controller: FuoPlayerController,
+    scope: CoroutineScope,
+) : PlaybackSession {
+    private val mutableState = MutableStateFlow(controller.playbackState.toPlaybackSessionState())
+    override val state: StateFlow<PlaybackSessionState> = mutableState.asStateFlow()
+
+    init {
+        scope.launch {
+            snapshotFlow { controller.playbackState }
+                .distinctUntilChanged()
+                .collect { playbackState ->
+                    mutableState.value = playbackState.toPlaybackSessionState()
+                }
+        }
+    }
+
+    override fun toggle() {
+        controller.toggle()
+    }
+
+    override fun play() {
+        if (controller.playbackState.status != PlayerStatus.Playing) {
+            controller.toggle()
+        }
+    }
+
+    override fun pause() {
+        if (controller.playbackState.status == PlayerStatus.Playing) {
+            controller.toggle()
+        }
+    }
+
+    override fun previous() {
+        controller.previous()
+    }
+
+    override fun next() {
+        controller.next()
+    }
+}
+
+private fun PlaybackState.toPlaybackSessionState(): PlaybackSessionState = PlaybackSessionState(
+    status = status.toPlaybackSessionStatus(),
+    currentTrack = currentTrack?.toTrackRef(),
+    positionMs = positionMs,
+    durationMs = durationMs,
+    bufferedMs = bufferedMs,
+    lyrics = lyrics,
+    queueTrackIds = queue.map(MusicTrack::id),
+    queueIndex = queueIndex,
+    errorMessage = errorMessage,
+)
+
+private fun PlayerStatus.toPlaybackSessionStatus(): PlaybackSessionStatus = when (this) {
+    PlayerStatus.Idle -> PlaybackSessionStatus.Idle
+    PlayerStatus.Loading -> PlaybackSessionStatus.Loading
+    PlayerStatus.Playing -> PlaybackSessionStatus.Playing
+    PlayerStatus.Paused -> PlaybackSessionStatus.Paused
+    PlayerStatus.Error -> PlaybackSessionStatus.Error
+    PlayerStatus.Ended -> PlaybackSessionStatus.Ended
+}
+
+private fun MusicTrack.toTrackRef(): TrackRef = TrackRef(
+    id = id,
+    title = title,
+    artists = artists,
+    album = album,
+    source = source,
+    coverUrl = coverUrl,
+    durationMs = durationMs,
+)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -13,9 +13,13 @@ import io.github.proify.lyricon.provider.LyriconProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import org.feeluown.mobile.core.model.TrackRef
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
 
 internal const val LYRICON_PACKAGE_NAME = "io.github.proify.lyricon"
 
@@ -26,7 +30,8 @@ internal fun isLyriconInstalled(context: Context): Boolean = runCatching {
 
 internal class LyriconLyricsPublisher(
     context: Context,
-    private val controller: FuoPlayerController,
+    private val playbackSession: PlaybackSession,
+    private val statusBarLyricsEnabled: () -> Boolean,
     private val scope: CoroutineScope,
 ) {
     private val appContext = context.applicationContext
@@ -35,10 +40,10 @@ internal class LyriconLyricsPublisher(
     private var provider: LyriconProvider? = null
     private var lastTrackKey: String? = null
     private var lastPayload: StatusBarLyricsPayload? = null
-    private var lastPublishedStatus: PlayerStatus? = null
+    private var lastPublishedStatus: PlaybackSessionStatus? = null
     private var lastObservedPositionMs: Long? = null
     private var lastObservedRealtimeMs: Long = 0L
-    private var lastObservedStatus: PlayerStatus? = null
+    private var lastObservedStatus: PlaybackSessionStatus? = null
     private var anchorPositionMs: Long = 0L
     private var anchorRealtimeMs: Long = 0L
     private var anchorPlaying: Boolean = false
@@ -68,10 +73,12 @@ internal class LyriconLyricsPublisher(
     fun start() {
         if (collectJob != null) return
         collectJob = scope.launch {
-            snapshotFlow {
-                val state = controller.playbackState
+            combine(
+                playbackSession.state,
+                snapshotFlow { statusBarLyricsEnabled() }.distinctUntilChanged(),
+            ) { state, enabled ->
                 Snapshot(
-                    enabled = controller.statusBarLyricsEnabled,
+                    enabled = enabled,
                     status = state.status,
                     track = state.currentTrack,
                     positionMs = state.positionMs,
@@ -95,9 +102,9 @@ internal class LyriconLyricsPublisher(
         if (
             !snapshot.enabled ||
             track == null ||
-            snapshot.status == PlayerStatus.Idle ||
-            snapshot.status == PlayerStatus.Error ||
-            snapshot.status == PlayerStatus.Ended
+            snapshot.status == PlaybackSessionStatus.Idle ||
+            snapshot.status == PlaybackSessionStatus.Error ||
+            snapshot.status == PlaybackSessionStatus.Ended
         ) {
             deactivate()
             return
@@ -159,24 +166,19 @@ internal class LyriconLyricsPublisher(
                 lastPayload = payload
             }
 
-            // Follow Lyricon's documented manual synchronization path. setPosition() writes the
-            // current position to the shared-memory bridge and setPlaybackState(Boolean) makes the
-            // central service consume that bridge. Do not mix this with PlaybackState/State2,
-            // because seekTo() does not replace State2's position anchor and the next tick can jump
-            // back to the old position.
             activeProvider.player.setPosition(safePositionMs)
             if (positionDiscontinuity) {
                 activeProvider.player.seekTo(safePositionMs)
             }
             if (songChanged || playbackStateChanged) {
-                activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
+                activeProvider.player.setPlaybackState(snapshot.status == PlaybackSessionStatus.Playing)
             }
             lastPublishedStatus = snapshot.status
         }.onFailure { throwable ->
             Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
         }
 
-        if (snapshot.status == PlayerStatus.Playing) {
+        if (snapshot.status == PlaybackSessionStatus.Playing) {
             ensurePositionSyncLoop()
         } else {
             stopPositionSyncLoop()
@@ -190,7 +192,7 @@ internal class LyriconLyricsPublisher(
     private fun updatePositionAnchor(snapshot: Snapshot, realtimeMs: Long) {
         anchorPositionMs = snapshot.positionMs.coerceAtLeast(0L)
         anchorRealtimeMs = realtimeMs
-        anchorPlaying = snapshot.status == PlayerStatus.Playing
+        anchorPlaying = snapshot.status == PlaybackSessionStatus.Playing
     }
 
     private fun estimatedPositionMs(realtimeMs: Long = SystemClock.elapsedRealtime()): Long {
@@ -205,11 +207,8 @@ internal class LyriconLyricsPublisher(
             while (true) {
                 val activeProvider = provider ?: break
                 val snapshot = latestSnapshot ?: break
-                if (!snapshot.enabled || snapshot.status != PlayerStatus.Playing) break
+                if (!snapshot.enabled || snapshot.status != PlaybackSessionStatus.Playing) break
 
-                // Lyricon 0.1.70 reads the manual position bridge at ~24 fps by default. Keep the
-                // shared-memory value moving at a similar cadence, while the coarser playback-state
-                // updates periodically correct this elapsed-realtime interpolation anchor.
                 runCatching {
                     activeProvider.player.setPosition(estimatedPositionMs())
                 }
@@ -230,8 +229,8 @@ internal class LyriconLyricsPublisher(
         runCatching {
             val positionMs = estimatedPositionMs()
             activeProvider.player.setPosition(positionMs)
-            activeProvider.player.setPlaybackState(snapshot.status == PlayerStatus.Playing)
-            if (snapshot.status == PlayerStatus.Playing) {
+            activeProvider.player.setPlaybackState(snapshot.status == PlaybackSessionStatus.Playing)
+            if (snapshot.status == PlaybackSessionStatus.Playing) {
                 ensurePositionSyncLoop()
             }
         }.onFailure { throwable ->
@@ -243,7 +242,7 @@ internal class LyriconLyricsPublisher(
         val previousPositionMs = lastObservedPositionMs ?: return true
         val previousStatus = lastObservedStatus ?: return true
         val elapsedMs = (nowRealtimeMs - lastObservedRealtimeMs).coerceAtLeast(0L)
-        val expectedPositionMs = if (previousStatus == PlayerStatus.Playing) {
+        val expectedPositionMs = if (previousStatus == PlaybackSessionStatus.Playing) {
             previousPositionMs + elapsedMs
         } else {
             previousPositionMs
@@ -305,8 +304,8 @@ internal class LyriconLyricsPublisher(
 
     private data class Snapshot(
         val enabled: Boolean,
-        val status: PlayerStatus,
-        val track: MusicTrack?,
+        val status: PlaybackSessionStatus,
+        val track: TrackRef?,
         val positionMs: Long,
         val durationMs: Long,
         val lyrics: String?,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,3 +8,60 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinx.kover) apply false
 }
+
+val migratedControllerBoundaryRoots = listOf(
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/recognition",
+)
+val migratedControllerBoundaryFiles = listOf(
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
+    "androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt",
+    "androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt",
+)
+
+tasks.register("checkArchitectureBoundaries") {
+    group = "verification"
+    description = "Reject new FuoPlayerController dependencies in migrated architecture boundaries."
+
+    val sourceFiles = provider {
+        buildList {
+            migratedControllerBoundaryRoots.forEach { path ->
+                val root = rootProject.file(path)
+                if (root.isDirectory) {
+                    addAll(root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList())
+                }
+            }
+            migratedControllerBoundaryFiles.map(rootProject::file)
+                .filterTo(this) { it.isFile }
+        }.distinct()
+    }
+    inputs.files(sourceFiles)
+
+    doLast {
+        val controllerPattern = Regex("\\bFuoPlayerController\\b")
+        val violations = sourceFiles.get().flatMap { file ->
+            file.readLines().mapIndexedNotNull { index, line ->
+                val trimmed = line.trimStart()
+                val commentOnly = trimmed.startsWith("//") ||
+                    trimmed.startsWith("/**") ||
+                    trimmed.startsWith("*") ||
+                    trimmed.startsWith("*/")
+                if (!commentOnly && controllerPattern.containsMatchIn(line)) {
+                    "${file.relativeTo(rootProject.projectDir).invariantSeparatorsPath}:${index + 1}"
+                } else {
+                    null
+                }
+            }
+        }
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("FuoPlayerController leaked into migrated architecture boundaries:")
+                    violations.forEach { appendLine(" - $it") }
+                    append("Use feature-owned state/actions or a narrow app/playback/provider contract instead.")
+                },
+            )
+        }
+    }
+}

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+}
+
+android {
+    namespace = "org.feeluown.mobile.core.model"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/core/model/src/commonMain/kotlin/org/feeluown/mobile/core/model/TrackRef.kt
+++ b/core/model/src/commonMain/kotlin/org/feeluown/mobile/core/model/TrackRef.kt
@@ -1,0 +1,12 @@
+package org.feeluown.mobile.core.model
+
+/** Stable cross-feature track identity exposed by architecture APIs. */
+data class TrackRef(
+    val id: String,
+    val title: String,
+    val artists: String,
+    val album: String,
+    val source: String,
+    val coverUrl: String? = null,
+    val durationMs: Long? = null,
+)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,19 +6,29 @@ This document records the P0 architecture boundaries used while the project migr
 
 The intended dependency direction is:
 
-`app -> feature -> core`
+`app -> feature -> core/api`
 
 Platform hosts and adapters (`androidApp`, `iosMain`) implement or assemble dependencies required by shared code. Feature code must not become a platform service locator.
+
+The first compile-time module boundaries are now explicit:
+
+- `:core:model` owns stable cross-feature model contracts used by architecture APIs.
+- `:playback:api` owns the app-scoped playback session contract and depends only on `:core:model` plus coroutines.
+- `:provider:api` owns provider-neutral cross-feature capability contracts.
+- `:shared` consumes those API modules and contains the current feature implementations and compatibility adapters.
+- `:androidApp` consumes `:shared` plus the playback/core APIs required by platform integrations.
+
+These modules intentionally start small. New cross-feature/platform contracts should move into the appropriate API module instead of expanding the flat shared contract surface. Feature implementation modules can be split later after their ownership boundaries are stable.
 
 ## Shared source layout
 
 The first migration stage groups existing source files physically while keeping the current `org.feeluown.mobile` Kotlin package. Keeping the package stable makes the move behavior-neutral and preserves binary/source references while the public controller facade is reduced in later changes.
 
 - `app/`: app shell, navigation and app-scoped state.
-- `core/model/`: cross-feature models and contracts.
+- `core/model/`: legacy shared models during migration; stable new architecture models belong in `:core:model`.
 - `core/ui/`: design system and cross-feature UI/platform abstractions.
 - `feature/<name>/`: feature-local controller, state and UI.
-- `feature/playback/`: playback orchestration and player UI.
+- `feature/playback/`: playback orchestration, the temporary session adapter and player UI.
 
 Provider protocol implementations remain under `provider/<provider>` because they already have a useful adapter boundary.
 
@@ -28,13 +38,21 @@ Feature state should have one owner. New feature work should expose immutable UI
 
 App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback-specific overlays and session state belong to the playback feature. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
 
+Platform playback integrations must consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` is a temporary compatibility adapter over the current controller-owned runtime; it establishes the replacement seam before runtime ownership is moved completely into a dedicated playback implementation.
+
 ## Repository dependencies
 
-New features should depend on the narrow provider capability interfaces (`ProviderSearchRepository`, `ProviderPlaybackRepository`, `ProviderAuthRepository`, etc.) rather than adding calls to the legacy aggregate `ProviderMusicRepository`.
+New features should depend on narrow provider capability interfaces (`ProviderSearchRepository`, `ProviderPlaybackRepository`, `ProviderAuthRepository`, and provider-neutral API contracts) rather than adding calls to the legacy aggregate `ProviderMusicRepository`.
 
 ## Composition roots
 
 Platform dependency construction is isolated in platform containers. Android uses `AndroidAppContainer`; iOS uses `IosAppContainer`. `Application`, `UIViewController`, activities and services should remain thin hosts around those composition roots.
+
+Search and Recognition expose controller-free route contracts. Existing app-shell callers are temporarily isolated in `SearchRouteCompat` / `RecognitionRouteCompat` bridges while the remaining legacy app facade is migrated.
+
+## Architecture fitness check
+
+`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition feature boundaries, their primary routes, and Android playback service/Lyricon integration. Compatibility shims and the composition root are deliberately excluded until their callers are migrated.
 
 ## Migration rule
 

--- a/docs/player-controller-refactor.md
+++ b/docs/player-controller-refactor.md
@@ -6,26 +6,36 @@ The controller migration is intentionally incremental. `FuoPlayerController` rem
 
 Search ownership has moved out of `FuoPlayerController`.
 
-- `SearchFeatureScreen` consumes `SearchUiState`, provider/download snapshots, `SearchAction`, and narrow cross-feature callbacks instead of `FuoPlayerController`.
-- `SearchFeatureController` is constructed by the Android/iOS composition roots. The same owner instance is injected into `FuoAppViewModel` and the compatibility `FuoPlayerController` facade, so production has one search state owner.
-- `SearchRoute` is the app-shell composition point for search UI. The temporary bridge has been removed.
+- `SearchFeatureScreen` consumes `SearchUiState`, provider/download snapshots, `SearchAction`, and narrow cross-feature callbacks instead of the global controller.
+- `SearchFeatureController` is constructed by the Android/iOS composition roots. The same owner instance is injected into `FuoAppViewModel` and the compatibility facade, so production has one search state owner.
+- The primary `SearchRoute` now accepts `SearchRouteDependencies` rather than a global controller. Existing app-shell callers are isolated in `SearchRouteCompat` until AppRoot is migrated.
 - Search scope/provider preferences are restored into the feature owner and persisted through `AppSettingsRepository`.
-- Search provider ordering/selection comes from `AppSettings`, while actual provider availability is gated by initialized `ProviderSessionRepository` providers.
+- Search provider ordering/selection comes from `AppSettings`, while actual provider availability is gated by initialized provider sessions through a provider-neutral availability contract.
 
 ## Phase 2: recognition ownership
 
 Recognition now follows the same ownership model.
 
 - `RecognitionFeatureController` owns `StateFlow<RecognitionUiState>` and recognition operations through `RecognitionAction`.
-- Android/iOS composition roots construct the recognition owner from the platform `AudioRecognitionRepository` and `PlaybackEngine`; pausing active playback no longer routes through `FuoPlayerController`.
-- `RecognitionRoute` composes `AudioRecognitionFeatureScreen` from feature state/actions plus narrow provider-detail/search callbacks.
-- Permission changes and app-background cancellation enter through `FuoAppViewModel`, not the global controller.
-- `FuoPlayerController` keeps only compatibility delegates to the same injected recognition owner, so production still has a single recognition state.
+- Android/iOS composition roots construct the recognition owner from the platform `AudioRecognitionRepository` and `PlaybackEngine`; pausing active playback no longer routes through the global controller.
+- The primary `RecognitionRoute` composes `AudioRecognitionFeatureScreen` from feature state/actions plus narrow provider-detail/search callbacks. The old app-shell signature lives only in `RecognitionRouteCompat`.
+- Permission changes and app-background cancellation enter through `FuoAppViewModel`.
+- The compatibility facade keeps delegates to the same injected recognition owner, so production still has a single recognition state.
 - Focused controller tests cover success/state ownership, playback pause, cancellation, and close/reset behavior.
+
+## Phase 3: playback runtime boundary
+
+The first playback runtime seam is now established.
+
+- `:playback:api` defines `PlaybackSession` and immutable `PlaybackSessionState` as the platform/cross-feature playback contract.
+- Android's media-session transport wiring, lock-screen lyric publication, durable queue/resume flushing, and Lyricon integration consume `PlaybackSession` instead of reading playback state directly from the global controller.
+- `ControllerPlaybackSession` is intentionally a compatibility adapter: the existing controller still owns orchestration, while platform callers are decoupled from that ownership so a dedicated runtime can replace the adapter without another service integration rewrite.
+- `:core:model` provides the stable `TrackRef` used by the playback API, and `:provider:api` starts the provider-neutral compile-time boundary used by Search.
+- `checkArchitectureBoundaries` prevents migrated Search/Recognition and platform playback boundaries from regaining direct controller dependencies.
 
 ## Next phases
 
-1. Remove remaining Search/Recognition compatibility delegates as local-music metadata lookup, provider detail navigation, and playback result actions move to explicit app/domain boundaries.
-2. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings.
-3. Extract playback runtime ownership into a `PlaybackSession` so platform services and player UI no longer coordinate through `FuoPlayerController`.
-4. Remove remaining legacy aggregate provider dependencies and global loading/message state as feature owners become authoritative.
+1. Replace `SearchRouteCompat` / `RecognitionRouteCompat` by migrating AppRoot to explicit app/domain action ports, then remove the remaining Search/Recognition compatibility delegates.
+2. Move actual playback orchestration/state ownership from `ControllerPlaybackSession` into a dedicated runtime implementation; then migrate player UI to the same session contract.
+3. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings.
+4. Continue moving stable contracts into compile-time modules and retire legacy aggregate provider dependencies and global loading/message state.

--- a/playback/api/build.gradle.kts
+++ b/playback/api/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":core:model"))
+            implementation(libs.kotlinx.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "org.feeluown.mobile.playback.api"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
+++ b/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
@@ -1,0 +1,42 @@
+package org.feeluown.mobile.playback.api
+
+import kotlinx.coroutines.flow.StateFlow
+import org.feeluown.mobile.core.model.TrackRef
+
+enum class PlaybackSessionStatus {
+    Idle,
+    Loading,
+    Playing,
+    Paused,
+    Error,
+    Ended,
+}
+
+data class PlaybackSessionState(
+    val status: PlaybackSessionStatus = PlaybackSessionStatus.Idle,
+    val currentTrack: TrackRef? = null,
+    val positionMs: Long = 0L,
+    val durationMs: Long = 0L,
+    val bufferedMs: Long = 0L,
+    val lyrics: String? = null,
+    val queueTrackIds: List<String> = emptyList(),
+    val queueIndex: Int = -1,
+    val errorMessage: String? = null,
+)
+
+/**
+ * Narrow app-scoped playback contract for platform integrations and cross-feature consumers.
+ *
+ * The legacy player controller may back this contract during migration, but consumers must only
+ * depend on this state/transport surface so ownership can move into a dedicated runtime without
+ * another platform-wide rewrite.
+ */
+interface PlaybackSession {
+    val state: StateFlow<PlaybackSessionState>
+
+    fun toggle()
+    fun play()
+    fun pause()
+    fun previous()
+    fun next()
+}

--- a/provider/api/build.gradle.kts
+++ b/provider/api/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
+    iosArm64()
+    iosSimulatorArm64()
+}
+
+android {
+    namespace = "org.feeluown.mobile.provider.api"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/provider/api/src/commonMain/kotlin/org/feeluown/mobile/provider/api/ProviderAvailability.kt
+++ b/provider/api/src/commonMain/kotlin/org/feeluown/mobile/provider/api/ProviderAvailability.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile.provider.api
+
+/** Provider availability boundary consumed by features without exposing session/runtime internals. */
+fun interface ProviderAvailability {
+    fun contains(providerId: String): Boolean
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,5 +16,8 @@ dependencyResolutionManagement {
 
 rootProject.name = "FuoEvolve"
 
+include(":core:model")
+include(":playback:api")
+include(":provider:api")
 include(":shared")
 include(":androidApp")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            implementation(project(":provider:api"))
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.animation)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
@@ -4,11 +4,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+/** Narrow app-shell dependencies for the recognition feature. */
+internal data class RecognitionRouteDependencies(
+    val canOpenNeteaseDetail: (RecognizedSong) -> Boolean,
+    val onOpenNeteaseDetail: (RecognizedSong) -> Unit,
+)
+
 /** App-shell composition for the recognition feature. */
 @Composable
 internal fun RecognitionRoute(
     appViewModel: FuoAppViewModel,
-    controller: FuoPlayerController,
+    dependencies: RecognitionRouteDependencies,
     hasMicrophonePermission: Boolean,
     onRequestMicrophonePermission: () -> Unit,
 ) {
@@ -20,8 +26,8 @@ internal fun RecognitionRoute(
             dispatch = appViewModel::dispatchRecognition,
             onBack = appViewModel::closeRecognition,
             onSearchSong = appViewModel::searchRecognizedSong,
-            canOpenNeteaseDetail = controller::canOpenRecognizedNeteaseDetail,
-            onOpenNeteaseDetail = controller::openRecognizedNeteaseDetail,
+            canOpenNeteaseDetail = dependencies.canOpenNeteaseDetail,
+            onOpenNeteaseDetail = dependencies.onOpenNeteaseDetail,
         ),
         hasMicrophonePermission = hasMicrophonePermission,
         onRequestMicrophonePermission = onRequestMicrophonePermission,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRouteCompat.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRouteCompat.kt
@@ -1,0 +1,22 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+/** Temporary app-shell bridge for callers that still compose recognition through the legacy facade. */
+@Composable
+internal fun RecognitionRoute(
+    appViewModel: FuoAppViewModel,
+    controller: FuoPlayerController,
+    hasMicrophonePermission: Boolean,
+    onRequestMicrophonePermission: () -> Unit,
+) {
+    RecognitionRoute(
+        appViewModel = appViewModel,
+        dependencies = RecognitionRouteDependencies(
+            canOpenNeteaseDetail = controller::canOpenRecognizedNeteaseDetail,
+            onOpenNeteaseDetail = controller::openRecognizedNeteaseDetail,
+        ),
+        hasMicrophonePermission = hasMicrophonePermission,
+        onRequestMicrophonePermission = onRequestMicrophonePermission,
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt
@@ -4,44 +4,63 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+/** Narrow app-shell dependencies for the search feature. */
+internal data class SearchRouteDependencies(
+    val providers: () -> List<ProviderInfo>,
+    val downloadStates: () -> Map<String, DownloadState>,
+    val onBack: () -> Unit,
+    val onPlayResult: (Int) -> Unit,
+    val onAddToUpNext: (MusicTrack) -> Unit,
+    val onDownload: (MusicTrack) -> Unit,
+    val onDeleteDownload: (MusicTrack) -> Unit,
+    val onOpenArtist: (MusicTrack) -> Unit,
+    val onOpenAlbum: (MusicTrack) -> Unit,
+    val onOpenTrackDetail: (MusicTrack) -> Unit,
+    val canAddToPlaylist: (MusicTrack) -> Boolean,
+    val onOpenPlaylistTargetPicker: (MusicTrack) -> Unit,
+    val onOpenMediaItem: (ProviderMediaItem) -> Unit,
+    val onOpenPlaylist: (ProviderPlaylist) -> Unit,
+    val onOpenVideo: (ProviderVideo) -> Unit,
+)
+
 /** App-shell composition for the search feature. */
 @Composable
 internal fun SearchRoute(
     appViewModel: FuoAppViewModel,
-    controller: FuoPlayerController,
+    dependencies: SearchRouteDependencies,
 ) {
     val uiState by appViewModel.searchUiState.collectAsStateWithLifecycle()
 
     SearchFeatureScreen(
         uiState = uiState,
-        providers = controller.providers,
-        downloadStates = controller.downloadStates,
+        providers = dependencies.providers(),
+        downloadStates = dependencies.downloadStates(),
         actions = SearchFeatureActions(
             dispatch = appViewModel::dispatchSearch,
-            onBack = controller::closeSearch,
-            onPlayResult = controller::playFromSearch,
-            onAddToUpNext = controller::addToUpNext,
-            onDownload = controller::download,
-            onDeleteDownload = controller::deleteDownload,
-            onOpenArtist = controller::openTrackArtist,
-            onOpenAlbum = controller::openTrackAlbum,
+            onBack = dependencies.onBack,
+            onPlayResult = dependencies.onPlayResult,
+            onAddToUpNext = dependencies.onAddToUpNext,
+            onDownload = dependencies.onDownload,
+            onDeleteDownload = dependencies.onDeleteDownload,
+            onOpenArtist = dependencies.onOpenArtist,
+            onOpenAlbum = dependencies.onOpenAlbum,
             onOpenTrackDetail = { track ->
                 if (track.sourceType == TrackSourceType.Provider) {
-                    { controller.openTrackDetail(track) }
+                    { dependencies.onOpenTrackDetail(track) }
                 } else {
                     null
                 }
             },
             onAddToPlaylist = { track ->
-                if (controller.canAddTrackToPlaylist(track)) {
-                    { controller.openPlaylistTargetPicker(track) }
+                if (dependencies.canAddToPlaylist(track)) {
+                    { dependencies.onOpenPlaylistTargetPicker(track) }
                 } else {
                     null
                 }
             },
-            onOpenMediaItem = controller::openMediaItem,
-            onOpenPlaylist = { playlist -> controller.openPlaylist(playlist) },
-            onOpenVideo = controller::openVideo,
+            onOpenMediaItem = dependencies.onOpenMediaItem,
+            onOpenPlaylist = dependencies.onOpenPlaylist,
+            onOpenVideo = dependencies.onOpenVideo,
         ),
         onOpenRecognition = appViewModel::openRecognition,
     )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRouteCompat.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRouteCompat.kt
@@ -1,0 +1,31 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+/** Temporary app-shell bridge for callers that still compose search through the legacy facade. */
+@Composable
+internal fun SearchRoute(
+    appViewModel: FuoAppViewModel,
+    controller: FuoPlayerController,
+) {
+    SearchRoute(
+        appViewModel = appViewModel,
+        dependencies = SearchRouteDependencies(
+            providers = { controller.providers },
+            downloadStates = { controller.downloadStates },
+            onBack = controller::closeSearch,
+            onPlayResult = controller::playFromSearch,
+            onAddToUpNext = controller::addToUpNext,
+            onDownload = controller::download,
+            onDeleteDownload = controller::deleteDownload,
+            onOpenArtist = controller::openTrackArtist,
+            onOpenAlbum = controller::openTrackAlbum,
+            onOpenTrackDetail = controller::openTrackDetail,
+            canAddToPlaylist = controller::canAddTrackToPlaylist,
+            onOpenPlaylistTargetPicker = controller::openPlaylistTargetPicker,
+            onOpenMediaItem = controller::openMediaItem,
+            onOpenPlaylist = { playlist -> controller.openPlaylist(playlist) },
+            onOpenVideo = controller::openVideo,
+        ),
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
@@ -55,11 +55,11 @@ fun createSearchFeatureController(
     providerRepository = ProviderSearchRepositoryView(providerRepository),
     localRepository = localRepository,
     scope = scope,
+    state = SearchControllerState(initialState),
     providerIdsForSearch = providerIdsForSearch,
     providerAvailability = ProviderAvailability { providerId -> providerExists(providerId) },
     openSearch = openSearch,
     onPreferencesChanged = onPreferencesChanged,
-    initialState = initialState,
 )
 
 /** Owns search state and search-specific operations. */

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.feeluown.mobile.provider.api.ProviderAvailability
 
 sealed interface SearchAction {
     data class QueryChanged(val value: String) : SearchAction
@@ -16,7 +17,7 @@ sealed interface SearchAction {
 /**
  * Search feature boundary consumed by the app shell and compatibility callers.
  *
- * The app composition root owns the concrete controller. `FuoPlayerController` may delegate to
+ * The app composition root owns the concrete controller. A compatibility facade may delegate to
  * the same instance while the rest of the application is migrated, but it must not create a
  * second search state when an owner is supplied.
  */
@@ -39,7 +40,7 @@ interface SearchFeatureController {
 
 /**
  * Composition-root factory. The aggregate provider repository is adapted here so the feature
- * implementation itself remains dependent on [ProviderSearchRepository].
+ * implementation itself remains dependent on narrow provider boundaries.
  */
 fun createSearchFeatureController(
     providerRepository: ProviderMusicRepository,
@@ -55,7 +56,7 @@ fun createSearchFeatureController(
     localRepository = localRepository,
     scope = scope,
     providerIdsForSearch = providerIdsForSearch,
-    providerExists = providerExists,
+    providerAvailability = ProviderAvailability { providerId -> providerExists(providerId) },
     openSearch = openSearch,
     onPreferencesChanged = onPreferencesChanged,
     initialState = initialState,
@@ -68,7 +69,7 @@ internal class SearchController private constructor(
     private val scope: CoroutineScope,
     private val state: SearchControllerState,
     private val providerIdsForSearch: () -> List<String>,
-    private val providerExists: (String) -> Boolean,
+    private val providerAvailability: ProviderAvailability,
     private val openSearch: () -> Unit,
     private val onPreferencesChanged: (SearchScope, String?) -> Unit,
 ) : SearchFeatureController {
@@ -87,12 +88,12 @@ internal class SearchController private constructor(
         scope = scope,
         state = SearchControllerState(initialState),
         providerIdsForSearch = providerIdsForSearch,
-        providerExists = providerExists,
+        providerAvailability = ProviderAvailability { providerId -> providerExists(providerId) },
         openSearch = openSearch,
         onPreferencesChanged = onPreferencesChanged,
     )
 
-    /** Compatibility constructor for standalone legacy `FuoPlayerController` instances. */
+    /** Compatibility constructor for standalone legacy controller instances. */
     @Suppress("UNUSED_PARAMETER")
     constructor(
         providerRepository: ProviderMusicRepository,
@@ -112,7 +113,7 @@ internal class SearchController private constructor(
         scope = scope,
         state = state,
         providerIdsForSearch = providerIdsForSearch,
-        providerExists = providerExists,
+        providerAvailability = ProviderAvailability { providerId -> providerExists(providerId) },
         openSearch = openSearch,
         onPreferencesChanged = { _, _ -> persistSettings() },
     )
@@ -214,7 +215,7 @@ internal class SearchController private constructor(
             return
         }
         state.update { current ->
-            if (providerId != null && providerExists(providerId)) {
+            if (providerId != null && providerAvailability.contains(providerId)) {
                 current.copy(
                     query = keyword,
                     searchScope = SearchScope.Provider,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchController.kt
@@ -55,11 +55,11 @@ fun createSearchFeatureController(
     providerRepository = ProviderSearchRepositoryView(providerRepository),
     localRepository = localRepository,
     scope = scope,
-    state = SearchControllerState(initialState),
     providerIdsForSearch = providerIdsForSearch,
-    providerAvailability = ProviderAvailability { providerId -> providerExists(providerId) },
+    providerExists = providerExists,
     openSearch = openSearch,
     onPreferencesChanged = onPreferencesChanged,
+    initialState = initialState,
 )
 
 /** Owns search state and search-specific operations. */


### PR DESCRIPTION
## Summary

Implement the first P0 architecture slice on top of #91-#93, focusing on compile-time boundaries and playback runtime decoupling without mixing in broad UI rewrites.

### Compile-time module boundaries
- add `:core:model` for stable cross-feature architecture models
- add `:playback:api` for the app-scoped `PlaybackSession` / immutable playback state contract
- add `:provider:api` for provider-neutral cross-feature capabilities
- wire `:shared` to the provider API and Android platform code to playback/core APIs
- extend Android/iOS workflow path filters so changes in the new modules trigger CI

### Playback runtime seam
- add a controller-backed `PlaybackSession` compatibility adapter in the Android composition layer
- migrate Android media-session transport wiring to `PlaybackSession`
- migrate lock-screen lyric publication and durable queue/resume flush triggers to `PlaybackSession.state`
- migrate Lyricon status-bar lyrics off the global controller and onto `PlaybackSession` plus a narrow settings callback

The existing controller still owns playback orchestration in this slice. The important P0 seam is that platform integrations no longer depend on that ownership directly, so the adapter can later be replaced by a dedicated playback runtime without another service integration rewrite.

### Controller dependency containment
- make the primary `SearchRoute` and `RecognitionRoute` accept narrow dependency objects
- isolate current AppRoot compatibility calls in `SearchRouteCompat` / `RecognitionRouteCompat`
- use `ProviderAvailability` in Search instead of retaining provider-existence behavior as an untyped feature-local callback
- add `checkArchitectureBoundaries` to reject direct `FuoPlayerController` code dependencies in migrated Search/Recognition boundaries and Android playback service/Lyricon integration

## Scope / follow-up

This PR intentionally does **not** physically split every feature into its own Gradle module or rewrite AppRoot/FuoAppViewModel in the same change. Those callers remain behind explicit compatibility shims. The next slice can remove the shims and move actual playback ownership from the controller-backed adapter into a dedicated runtime after this boundary is established.

## Validation

Final head: `aeec1f4`

- ✅ `checkArchitectureBoundaries` + shared Android tests + Kover/Codecov
- ✅ signed multi-ABI Android release APK build + artifact upload
- ✅ shared Android/iOS tests + architecture check on macOS
- ✅ iOS simulator debug app build/package/upload
- ✅ iOS device debug app build/IPA package/upload

Two intermediate CI failures were fixed in the PR branch; both were Search factory constructor-resolution mistakes introduced during the provider availability boundary migration. The final head is green across all Android/iOS jobs.