### PR TITLE
refactor: migrate player UI to playback session

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -28,6 +28,8 @@ internal class AndroidAppContainer(
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var lyriconLyricsPublisher: LyriconLyricsPublisher? = null
     private var playbackSessionHolder: PlaybackSession? = null
+    private val playbackSession: PlaybackSession
+        get() = checkNotNull(playbackSessionHolder) { "Playback runtime is not wired" }
 
     val providerRepository: ProviderMusicRepository by lazy {
         createFuoProviderRepository(
@@ -230,8 +232,10 @@ internal class AndroidAppContainer(
     }
 
     val appViewModel: FuoAppViewModel by lazy {
+        val wiredController = controller
         FuoAppViewModel(
-            controller = controller,
+            controller = wiredController,
+            playbackSession = playbackSession,
             searchController = searchController,
             recognitionController = recognitionController,
             searchAppPort = searchAppPort,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,10 @@ val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeFullPlayer.kt",
     "androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt",
     "androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt",
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,8 @@ val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePorts.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt",
     "androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt",
     "androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt",
 )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ The first compile-time module boundaries are now explicit:
 - `:playback:api` owns the app-scoped playback session contract and depends only on `:core:model` plus coroutines.
 - `:playback:runtime` owns the default `PlaybackSession` state/transport implementation and depends only on `:playback:api` plus coroutines.
 - `:provider:api` owns provider-neutral cross-feature capability contracts.
-- `:shared` contains the current feature implementations and legacy playback/provider contracts that are still being migrated.
+- `:shared` consumes the playback/provider API contracts and contains the current feature implementations and legacy playback/provider contracts that are still being migrated.
 - `:androidApp` consumes `:shared` plus playback/core APIs and adapts the existing platform engine/queue coordinator into `:playback:runtime`.
 
 These modules intentionally start small. New cross-feature/platform contracts should move into the appropriate API/runtime module instead of expanding the flat shared contract surface. Feature implementation modules can be split later after their ownership boundaries are stable.
@@ -39,7 +39,9 @@ Feature state should have one owner. New feature work should expose immutable UI
 
 App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback-specific platform/session state now belongs to `DefaultPlaybackRuntime`. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
 
-Platform playback integrations must consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` has been retired. `DefaultPlaybackRuntime` now owns the published session state and play/pause/toggle policy. The Android composition edge still supplies the current queue/lyrics presentation and three temporary queue-transition callbacks (`startCurrent`, `previous`, `next`) while queue selection and resource-resolution policy are extracted from the legacy coordinator.
+Platform playback integrations and migrated playback UI must consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` has been retired. `DefaultPlaybackRuntime` now owns the published session state and play/pause/toggle policy. Android and iOS both adapt their existing engine/queue coordinator into the same runtime contract. The composition edge still supplies the current queue/lyrics presentation and three temporary queue-transition callbacks (`startCurrent`, `previous`, `next`) while queue selection and resource-resolution policy are extracted from the legacy coordinator.
+
+MiniPlayer is the first common playback UI consumer migrated to `PlaybackSessionState` and session transport controls. Its remaining full-player visibility/transition bridge is presentation-only and is scheduled for removal with the FullPlayer/queue/lyrics migration.
 
 ## Repository dependencies
 
@@ -51,11 +53,11 @@ Platform dependency construction is isolated in platform containers. Android use
 
 Search and Recognition are composed through explicit `SearchAppPort` / `RecognitionAppPort` contracts. Their routes and feature UI no longer accept `FuoPlayerController`. During the remaining migration, platform composition roots may adapt still-centralized controller operations to those ports; the dependency must not leak back into the feature or app route contract.
 
-Android playback uses `AndroidPlaybackRuntime.kt` as a composition-edge adapter. The shared runtime module remains controller-free; only the adapter may bridge the remaining queue coordinator until that policy is moved into playback-owned components.
+Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. The shared runtime module remains controller-free; only these adapters may bridge the remaining queue coordinator until that policy is moved into playback-owned components. `FuoAppViewModel` exposes the resulting app-scoped `PlaybackSession`, and `AppRoot` supplies it to playback UI through `LocalPlaybackSession`.
 
 ## Architecture fitness check
 
-`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter.
+`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, the controller-free MiniPlayer implementation/composition contract, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter.
 
 ## Migration rule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ The first migration stage groups existing source files physically while keeping 
 - `core/model/`: legacy shared models during migration; stable new architecture models belong in `:core:model`.
 - `core/ui/`: design system and cross-feature UI/platform abstractions.
 - `feature/<name>/`: feature-local controller, state and UI.
-- `feature/playback/`: the remaining legacy playback coordinator and player UI while they migrate onto the runtime contract.
+- `feature/playback/`: playback session composition plus the remaining legacy coordinator/presentation helpers during migration.
 
 Provider protocol implementations remain under `provider/<provider>` because they already have a useful adapter boundary.
 
@@ -37,11 +37,13 @@ Provider protocol implementations remain under `provider/<provider>` because the
 
 Feature state should have one owner. New feature work should expose immutable UI state (preferably `StateFlow`) instead of adding new delegated properties to `FuoPlayerController`.
 
-App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback-specific platform/session state now belongs to `DefaultPlaybackRuntime`. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
+App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback status, timing, current stable track reference, lyrics, queue identity/index, errors, and transport policy belong to `PlaybackSession` / `DefaultPlaybackRuntime`. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
 
-Platform playback integrations and migrated playback UI must consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` has been retired. `DefaultPlaybackRuntime` now owns the published session state and play/pause/toggle policy. Android and iOS both adapt their existing engine/queue coordinator into the same runtime contract. The composition edge still supplies the current queue/lyrics presentation and three temporary queue-transition callbacks (`startCurrent`, `previous`, `next`) while queue selection and resource-resolution policy are extracted from the legacy coordinator.
+Platform playback integrations and migrated playback UI consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` has been retired. Android and iOS both adapt their existing engine/queue coordinator into the same runtime contract. The composition edge still supplies three temporary queue-transition callbacks (`startCurrent`, `previous`, `next`) while queue selection and resource-resolution policy are extracted from the legacy coordinator.
 
-MiniPlayer is the first common playback UI consumer migrated to `PlaybackSessionState` and session transport controls. Its remaining full-player visibility/transition bridge is presentation-only and is scheduled for removal with the FullPlayer/queue/lyrics migration.
+MiniPlayer and FullPlayer now read authoritative playback state/transport from `PlaybackSession`. FullPlayer-specific rich presentation and feature operations that do not belong in the narrow session contract—queue editing, seek/shuffle/repeat, sleep timer, rich `MusicTrack` metadata, downloads and replacement actions—flow through `PlaybackUiPort`. `ControllerPlaybackUiPort` is an app-shell compatibility adapter only; migrated playback UI does not depend on `FuoPlayerController` directly.
+
+Legacy feature screens that still call the old `MiniPlayer(controller)` signature are outside the playback UI boundary. That signature remains only as a feature-shell compatibility call site while those screens are migrated; playback state and transport themselves remain session-owned.
 
 ## Repository dependencies
 
@@ -53,11 +55,11 @@ Platform dependency construction is isolated in platform containers. Android use
 
 Search and Recognition are composed through explicit `SearchAppPort` / `RecognitionAppPort` contracts. Their routes and feature UI no longer accept `FuoPlayerController`. During the remaining migration, platform composition roots may adapt still-centralized controller operations to those ports; the dependency must not leak back into the feature or app route contract.
 
-Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. The shared runtime module remains controller-free; only these adapters may bridge the remaining queue coordinator until that policy is moved into playback-owned components. `FuoAppViewModel` exposes the resulting app-scoped `PlaybackSession`, and `AppRoot` supplies it to playback UI through `LocalPlaybackSession`.
+Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. The shared runtime module remains controller-free. `FuoAppViewModel` exposes the resulting app-scoped `PlaybackSession`, and `AppRoot` supplies it to playback UI through `LocalPlaybackSession`. `AppRoot` also supplies the temporary `PlaybackUiPort` adapter separately so the stable runtime API does not expand into app-specific UI operations.
 
 ## Architecture fitness check
 
-`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, the controller-free MiniPlayer implementation/composition contract, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter.
+`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, `PlaybackUiPort`, playback composition contracts, controller-free MiniPlayer/FullPlayer implementations, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter.
 
 ## Migration rule
 

--- a/docs/player-controller-refactor.md
+++ b/docs/player-controller-refactor.md
@@ -53,21 +53,33 @@ Playback platform state and transport policy now have a dedicated owner.
 - Focused runtime tests cover state composition and transport dispatch, and CI runs `:playback:runtime:allTests` on both Android and iOS workflows.
 - Architecture fitness rules scan the runtime module and reject reintroduction of `ControllerPlaybackSession`.
 
-## Phase 6: playback UI migration C1
+## Phase 6: playback UI migration
 
-The MiniPlayer rendering/transport path now consumes the dedicated playback session on both platforms.
+### C1: MiniPlayer
 
-- iOS now has `IosPlaybackRuntime.kt`, mirroring the Android composition-edge adapter and constructing the same `DefaultPlaybackRuntime` contract.
+The MiniPlayer rendering/transport path consumes the dedicated playback session on both platforms.
+
+- iOS has `IosPlaybackRuntime.kt`, mirroring the Android composition-edge adapter and constructing the same `DefaultPlaybackRuntime` contract.
 - `FuoAppViewModel` receives the app-scoped `PlaybackSession`; `AppRoot` provides it to playback UI through `LocalPlaybackSession`.
 - `RuntimeMiniPlayer` renders `PlaybackSessionState`, cover metadata from `TrackRef`, progress, lyrics, and previous/toggle/next transport without reading `FuoPlayerController`.
-- The existing `MiniPlayer(controller)` entry point is intentionally kept as a C1-only presentation bridge for current screen call sites. It forwards only full-player visibility, transition direction, and the open-full-player action while all playback state/transport comes from `PlaybackSession`.
-- `checkArchitectureBoundaries` scans the new MiniPlayer implementation and playback composition contract so controller dependencies cannot leak into the migrated path.
-- FullPlayer, queue, lyrics presentation state, seek, shuffle/repeat, sleep timer, replacement actions, and removal of the temporary MiniPlayer entry bridge are deliberately deferred to C2 on the same PR after C1 review.
+- Review feedback exposed an iOS pre-engine resource-resolution failure path. `IosPlaybackRuntime` now bridges only the same-track `Loading -> coordinator Error` transition until resource resolution becomes runtime-owned, with focused iOS regression tests.
+
+### C2: FullPlayer, queue and lyrics
+
+The active FullPlayer path is now controller-free.
+
+- `RuntimeFullPlayer` consumes authoritative status, timing, lyrics, error, queue index, and previous/toggle/next transport from `PlaybackSession`.
+- `PlaybackUiPort` carries only richer UI/application concerns that do not belong in the narrow runtime API: rich `MusicTrack` metadata, queue edits, seek/shuffle/repeat, sleep timer, audio/replacement information, downloads and now-playing actions.
+- `ControllerPlaybackUiPort` is a temporary app-shell adapter over the remaining centralized owners. The playback UI itself has no `FuoPlayerController` dependency.
+- Existing pure rendering helpers for cover transitions, progress, karaoke lyrics, controls and detail dialogs are reused through a render-only `PlaybackState` snapshot; session-owned fields remain sourced from `PlaybackSession`.
+- `AppRoot` supplies both `LocalPlaybackSession` and `LocalPlaybackUiPort`, and the active full-player overlay renders `RuntimeFullPlayer`.
+- Home and local-playlist MiniPlayer call sites now use the controller-free `PlaybackMiniPlayer` host. Other legacy feature screens can keep their old call signature until their own feature migration; that compatibility call does not change playback state/transport ownership.
+- Architecture fitness rules scan `PlaybackUiPort`, playback composition contracts, `RuntimeMiniPlayer`, and `RuntimeFullPlayer` to prevent direct controller dependencies from returning.
 
 ## Next phases
 
-1. C2: migrate FullPlayer/queue/lyrics and playback-specific presentation actions to runtime-owned state/narrow playback UI ports, then remove the temporary `MiniPlayer(controller)` bridge.
-2. Move the remaining `startCurrent` / `previous` / `next` queue-transition policy and resource-start orchestration out of `FuoPlayerController`, removing the final runtime queue bridge.
+1. Move the remaining `startCurrent` / `previous` / `next` queue-transition policy and resource-start orchestration out of `FuoPlayerController`, removing the final runtime queue bridge and the iOS pre-engine error compatibility bridge.
+2. Replace `ControllerPlaybackUiPort` responsibilities with explicit playback/download/provider-detail owners as those feature boundaries become available.
 3. Replace controller-backed Search/Recognition app-port operations as their sibling playback/download/provider-detail owners become explicit domain/feature ports.
-4. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings.
+4. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings; remove their legacy MiniPlayer call signatures during those migrations.
 5. Continue moving stable contracts into compile-time modules and retire legacy aggregate provider dependencies and global loading/message state.

--- a/docs/player-controller-refactor.md
+++ b/docs/player-controller-refactor.md
@@ -53,9 +53,20 @@ Playback platform state and transport policy now have a dedicated owner.
 - Focused runtime tests cover state composition and transport dispatch, and CI runs `:playback:runtime:allTests` on both Android and iOS workflows.
 - Architecture fitness rules scan the runtime module and reject reintroduction of `ControllerPlaybackSession`.
 
+## Phase 6: playback UI migration C1
+
+The MiniPlayer rendering/transport path now consumes the dedicated playback session on both platforms.
+
+- iOS now has `IosPlaybackRuntime.kt`, mirroring the Android composition-edge adapter and constructing the same `DefaultPlaybackRuntime` contract.
+- `FuoAppViewModel` receives the app-scoped `PlaybackSession`; `AppRoot` provides it to playback UI through `LocalPlaybackSession`.
+- `RuntimeMiniPlayer` renders `PlaybackSessionState`, cover metadata from `TrackRef`, progress, lyrics, and previous/toggle/next transport without reading `FuoPlayerController`.
+- The existing `MiniPlayer(controller)` entry point is intentionally kept as a C1-only presentation bridge for current screen call sites. It forwards only full-player visibility, transition direction, and the open-full-player action while all playback state/transport comes from `PlaybackSession`.
+- `checkArchitectureBoundaries` scans the new MiniPlayer implementation and playback composition contract so controller dependencies cannot leak into the migrated path.
+- FullPlayer, queue, lyrics presentation state, seek, shuffle/repeat, sleep timer, replacement actions, and removal of the temporary MiniPlayer entry bridge are deliberately deferred to C2 on the same PR after C1 review.
+
 ## Next phases
 
-1. Migrate mini/full player UI and playback overlays to `PlaybackSession`/runtime-owned UI state, expanding the playback action contract only for UI capabilities that are actually needed.
+1. C2: migrate FullPlayer/queue/lyrics and playback-specific presentation actions to runtime-owned state/narrow playback UI ports, then remove the temporary `MiniPlayer(controller)` bridge.
 2. Move the remaining `startCurrent` / `previous` / `next` queue-transition policy and resource-start orchestration out of `FuoPlayerController`, removing the final runtime queue bridge.
 3. Replace controller-backed Search/Recognition app-port operations as their sibling playback/download/provider-detail owners become explicit domain/feature ports.
 4. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            api(project(":playback:api"))
             implementation(project(":provider:api"))
             implementation(compose.runtime)
             implementation(compose.foundation)
@@ -59,6 +60,7 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
         }
         iosMain.dependencies {
+            implementation(project(":playback:runtime"))
             implementation(libs.ktor.client.darwin)
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -223,6 +223,7 @@ fun AppRoot(
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
     val controller = appViewModel.controller
+    val playbackUiPort = remember(controller) { ControllerPlaybackUiPort(controller) }
     FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
@@ -314,6 +315,7 @@ fun AppRoot(
 
             CompositionLocalProvider(
                 LocalPlaybackSession provides appViewModel.playbackSession,
+                LocalPlaybackUiPort provides playbackUiPort,
                 LocalShareHandler provides { onShareText(it.text) },
                 LocalLocalPlaylistFileActions provides LocalPlaylistFileActions(
                     importFile = onImportLocalPlaylistFile,
@@ -417,14 +419,14 @@ fun AppRoot(
                                 },
                             )
                             AnimatedVisibility(
-                                visible = controller.isFullPlayerOpen,
+                                visible = playbackUiPort.isFullPlayerOpen,
                                 modifier = Modifier.fillMaxSize(),
                                 enter = slideInVertically(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it / 2 } +
                                     fadeIn(tween(FuoMotion.overlayFadeMillis)),
                                 exit = slideOutVertically(animationSpec = tween(FuoMotion.overlayExitMillis)) { it / 2 } +
                                     fadeOut(tween(FuoMotion.overlayFadeMillis)),
                             ) {
-                                FullPlayer(controller)
+                                RuntimeFullPlayer()
                             }
                             controller.localMetadataEditorTrack?.let { track ->
                                 LocalMetadataDialog(controller = controller, track = track)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -313,6 +313,7 @@ fun AppRoot(
             }
 
             CompositionLocalProvider(
+                LocalPlaybackSession provides appViewModel.playbackSession,
                 LocalShareHandler provides { onShareText(it.text) },
                 LocalLocalPlaylistFileActions provides LocalPlaylistFileActions(
                     importFile = onImportLocalPlaylistFile,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import org.feeluown.mobile.playback.api.PlaybackSession
 
 @Serializable
 sealed interface AppRoute : NavKey {
@@ -165,6 +166,7 @@ sealed interface AppIntent {
 /** 应用壳层 ViewModel：组合设置、登录会话、导航和 feature owner。 */
 class FuoAppViewModel(
     val controller: FuoPlayerController,
+    val playbackSession: PlaybackSession,
     private val searchController: SearchFeatureController,
     private val recognitionController: RecognitionFeatureController,
     internal val searchAppPort: SearchAppPort,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/ControllerPlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/ControllerPlaybackUiPort.kt
@@ -1,0 +1,63 @@
+package org.feeluown.mobile
+
+/** App-shell compatibility adapter while playback presentation ownership is extracted. */
+internal class ControllerPlaybackUiPort(
+    private val controller: FuoPlayerController,
+) : PlaybackUiPort {
+    override val isFullPlayerOpen: Boolean get() = controller.isFullPlayerOpen
+    override val isQueueOpen: Boolean get() = controller.isQueueOpen
+    override val trackChangeDirection: TrackChangeDirection get() = controller.trackChangeDirection
+    override val currentTrack: MusicTrack? get() = controller.playbackState.currentTrack
+    override val queue: List<MusicTrack> get() = controller.playbackState.queue
+    override val playbackParts: List<PlaybackPart> get() = controller.playbackState.playbackParts
+    override val currentPartIndex: Int get() = controller.playbackState.currentPartIndex
+    override val displayUpNextCount: Int get() = controller.displayUpNextCount
+    override val isShuffleEnabled: Boolean get() = controller.isShuffleEnabled
+    override val repeatMode: RepeatMode get() = controller.repeatMode
+    override val isFmQueueActive: Boolean get() = controller.isFmQueueActive
+    override val sleepTimerState: SleepTimerState get() = controller.sleepTimerState
+    override val lyricFontSize: LyricFontSize get() = controller.lyricFontSize
+    override val themeMode: ThemeMode get() = controller.themeMode
+    override val dynamicCoverColorEnabled: Boolean get() = controller.dynamicCoverColorEnabled
+    override val audioQuality: String? get() = controller.playbackState.audioQuality
+    override val audioFormatInfo: AudioFormatInfo? get() = controller.playbackState.audioFormatInfo
+    override val audioDecoderInfo: AudioDecoderInfo? get() = controller.playbackState.audioDecoderInfo
+    override val replacementCandidateState: ReplacementCandidateState get() = controller.replacementCandidateState
+    override val downloadStates: Map<String, DownloadState> get() = controller.downloadStates
+
+    override fun openFullPlayer() = controller.openFullPlayer()
+    override fun closeFullPlayer() = controller.closeFullPlayer()
+    override fun toggleQueue() = controller.toggleQueue()
+    override fun seekTo(positionMs: Long) = controller.seekTo(positionMs)
+    override fun toggleShuffle() = controller.toggleShuffle()
+    override fun toggleRepeat() = controller.toggleRepeat()
+
+    override fun clearQueue() = controller.clearQueue()
+    override fun playQueueIndex(index: Int) = controller.playQueueIndex(index)
+    override fun removeFromQueue(track: MusicTrack) = controller.removeFromQueue(track)
+    override fun playPlaybackPart(index: Int) = controller.playPlaybackPart(index)
+
+    override fun setSleepTimerDurationMinutes(minutes: Int) = controller.setSleepTimerDurationMinutes(minutes)
+    override fun clearSleepTimer() = controller.clearSleepTimer()
+    override fun setSleepTimerToEndOfTrack() = controller.setSleepTimerToEndOfTrack()
+
+    override fun addToUpNext(track: MusicTrack) = controller.addToUpNext(track)
+    override fun download(track: MusicTrack) = controller.download(track)
+    override fun deleteDownload(track: MusicTrack) = controller.deleteDownload(track)
+    override fun openTrackArtist(track: MusicTrack) = controller.openTrackArtist(track)
+    override fun openTrackAlbum(track: MusicTrack) = controller.openTrackAlbum(track)
+    override fun openOriginalTrackDetail(track: MusicTrack) = controller.openOriginalTrackDetail(track)
+    override fun openLocalMetadataEditor(track: MusicTrack) = controller.openLocalMetadataEditor(track)
+    override fun canAddTrackToPlaylist(track: MusicTrack): Boolean = controller.canAddTrackToPlaylist(track)
+    override fun openPlaylistTargetPicker(track: MusicTrack) = controller.openPlaylistTargetPicker(track)
+    override fun canRemoveTrackFromSelectedPlaylist(track: MusicTrack): Boolean =
+        controller.canRemoveTrackFromSelectedPlaylist(track)
+    override fun removeTrackFromSelectedPlaylist(track: MusicTrack) = controller.removeTrackFromSelectedPlaylist(track)
+    override fun canSetSongDisliked(track: MusicTrack): Boolean = controller.canSetSongDisliked(track, true)
+    override fun setSongDisliked(track: MusicTrack) = controller.setSongDisliked(track, true)
+
+    override fun loadReplacementCandidates(track: MusicTrack) = controller.loadReplacementCandidates(track)
+    override fun selectReplacementCandidate(track: MusicTrack, candidate: ReplacementCandidate) =
+        controller.selectReplacementCandidate(track, candidate)
+    override fun openReplacementTrackDetail(track: MusicTrack) = controller.openReplacementTrackDetail(track)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -72,6 +72,7 @@ fun HomeScreen(
     onOpenRecognition: () -> Unit,
 ) {
     val layoutInfo = LocalAppLayoutInfo.current
+    val playbackUiPort = LocalPlaybackUiPort.current
     Scaffold(
         topBar = {
             if (!layoutInfo.useWideLayout) {
@@ -97,8 +98,8 @@ fun HomeScreen(
             }
         },
         bottomBar = {
-            if (controller.playbackState.currentTrack != null) {
-                MiniPlayer(controller)
+            if (playbackUiPort.currentTrack != null) {
+                PlaybackMiniPlayer()
             }
         },
     ) { paddingValues ->

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/LocalPlaylistScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/LocalPlaylistScreen.kt
@@ -59,6 +59,7 @@ fun LocalPlaylistScreen(
 ) {
     val displayPlaylist = controller.selectedLocalPlaylist ?: playlist ?: return
     val fileActions = LocalLocalPlaylistFileActions.current
+    val playbackUiPort = LocalPlaybackUiPort.current
     var showDeleteDialog by remember(displayPlaylist.id) { mutableStateOf(false) }
 
     Scaffold(
@@ -106,7 +107,7 @@ fun LocalPlaylistScreen(
             )
         },
         bottomBar = {
-            if (controller.playbackState.currentTrack != null) MiniPlayer(controller)
+            if (playbackUiPort.currentTrack != null) PlaybackMiniPlayer()
         },
     ) { paddingValues ->
         Column(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt
@@ -1,0 +1,9 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import org.feeluown.mobile.playback.api.PlaybackSession
+
+/** App-scoped playback session supplied by the platform composition root. */
+internal val LocalPlaybackSession = staticCompositionLocalOf<PlaybackSession> {
+    error("PlaybackSession is not provided")
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -1,0 +1,20 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalPlaybackUiPort = staticCompositionLocalOf<PlaybackUiPort> {
+    error("PlaybackUiPort is not provided")
+}
+
+/** Controller-free MiniPlayer entry point used by migrated app screens. */
+@Composable
+fun PlaybackMiniPlayer() {
+    val uiPort = LocalPlaybackUiPort.current
+    RuntimeMiniPlayer(
+        playbackSession = LocalPlaybackSession.current,
+        isFullPlayerOpen = uiPort.isFullPlayerOpen,
+        transitionDirection = uiPort.trackChangeDirection,
+        onOpenFullPlayer = uiPort::openFullPlayer,
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -1,0 +1,65 @@
+package org.feeluown.mobile
+
+/**
+ * UI-specific playback presentation/actions that intentionally stay outside [PlaybackSession].
+ *
+ * [PlaybackSession] remains the authoritative transport/timing/status contract. This port carries
+ * richer app models and presentation operations needed by FullPlayer/queue/replacement UI while
+ * those owners are still being extracted from the legacy coordinator.
+ */
+interface PlaybackUiPort {
+    val isFullPlayerOpen: Boolean
+    val isQueueOpen: Boolean
+    val trackChangeDirection: TrackChangeDirection
+    val currentTrack: MusicTrack?
+    val queue: List<MusicTrack>
+    val playbackParts: List<PlaybackPart>
+    val currentPartIndex: Int
+    val displayUpNextCount: Int
+    val isShuffleEnabled: Boolean
+    val repeatMode: RepeatMode
+    val isFmQueueActive: Boolean
+    val sleepTimerState: SleepTimerState
+    val lyricFontSize: LyricFontSize
+    val themeMode: ThemeMode
+    val dynamicCoverColorEnabled: Boolean
+    val audioQuality: String?
+    val audioFormatInfo: AudioFormatInfo?
+    val audioDecoderInfo: AudioDecoderInfo?
+    val replacementCandidateState: ReplacementCandidateState
+    val downloadStates: Map<String, DownloadState>
+
+    fun openFullPlayer()
+    fun closeFullPlayer()
+    fun toggleQueue()
+    fun seekTo(positionMs: Long)
+    fun toggleShuffle()
+    fun toggleRepeat()
+
+    fun clearQueue()
+    fun playQueueIndex(index: Int)
+    fun removeFromQueue(track: MusicTrack)
+    fun playPlaybackPart(index: Int)
+
+    fun setSleepTimerDurationMinutes(minutes: Int)
+    fun clearSleepTimer()
+    fun setSleepTimerToEndOfTrack()
+
+    fun addToUpNext(track: MusicTrack)
+    fun download(track: MusicTrack)
+    fun deleteDownload(track: MusicTrack)
+    fun openTrackArtist(track: MusicTrack)
+    fun openTrackAlbum(track: MusicTrack)
+    fun openOriginalTrackDetail(track: MusicTrack)
+    fun openLocalMetadataEditor(track: MusicTrack)
+    fun canAddTrackToPlaylist(track: MusicTrack): Boolean
+    fun openPlaylistTargetPicker(track: MusicTrack)
+    fun canRemoveTrackFromSelectedPlaylist(track: MusicTrack): Boolean
+    fun removeTrackFromSelectedPlaylist(track: MusicTrack)
+    fun canSetSongDisliked(track: MusicTrack): Boolean
+    fun setSongDisliked(track: MusicTrack)
+
+    fun loadReplacementCandidates(track: MusicTrack)
+    fun selectReplacementCandidate(track: MusicTrack, candidate: ReplacementCandidate)
+    fun openReplacementTrackDetail(track: MusicTrack)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlayerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlayerScreen.kt
@@ -109,7 +109,12 @@ import kotlin.math.roundToInt
 @Composable
 @OptIn(ExperimentalSharedTransitionApi::class)
 fun MiniPlayer(controller: FuoPlayerController) {
-    MiniPlayerContent(controller)
+    RuntimeMiniPlayer(
+        playbackSession = LocalPlaybackSession.current,
+        isFullPlayerOpen = controller.isFullPlayerOpen,
+        transitionDirection = controller.trackChangeDirection,
+        onOpenFullPlayer = controller::openFullPlayer,
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeFullPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeFullPlayer.kt
@@ -1,0 +1,1118 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.RemoveCircleOutline
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionState
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+
+/** Controller-free FullPlayer/queue/lyrics entry point for P1-C2. */
+@Composable
+fun RuntimeFullPlayer() {
+    val playbackSession = LocalPlaybackSession.current
+    val uiPort = LocalPlaybackUiPort.current
+    val sessionState by playbackSession.state.collectAsStateWithLifecycle()
+    val state = sessionState.toPlayerRenderState(uiPort)
+
+    PlayerDynamicColorTheme(
+        themeMode = uiPort.themeMode,
+        dynamicCoverColorEnabled = uiPort.dynamicCoverColorEnabled,
+        coverImageUrl = uiPort.currentTrack?.coverUrl,
+        isLoading = sessionState.status == PlaybackSessionStatus.Loading,
+    ) {
+        RuntimeFullPlayerContent(
+            playbackSession = playbackSession,
+            uiPort = uiPort,
+            state = state,
+        )
+    }
+}
+
+private fun PlaybackSessionState.toPlayerRenderState(uiPort: PlaybackUiPort): PlaybackState =
+    PlaybackState(
+        status = status.toPlayerStatus(),
+        currentTrack = uiPort.currentTrack,
+        positionMs = positionMs,
+        durationMs = durationMs,
+        bufferedMs = bufferedMs,
+        queue = uiPort.queue,
+        queueIndex = queueIndex,
+        lyrics = lyrics,
+        audioQuality = uiPort.audioQuality,
+        audioFormatInfo = uiPort.audioFormatInfo,
+        audioDecoderInfo = uiPort.audioDecoderInfo,
+        playbackParts = uiPort.playbackParts,
+        currentPartIndex = uiPort.currentPartIndex,
+        errorMessage = errorMessage,
+    )
+
+private fun PlaybackSessionStatus.toPlayerStatus(): PlayerStatus = when (this) {
+    PlaybackSessionStatus.Idle -> PlayerStatus.Idle
+    PlaybackSessionStatus.Loading -> PlayerStatus.Loading
+    PlaybackSessionStatus.Playing -> PlayerStatus.Playing
+    PlaybackSessionStatus.Paused -> PlayerStatus.Paused
+    PlaybackSessionStatus.Error -> PlayerStatus.Error
+    PlaybackSessionStatus.Ended -> PlayerStatus.Ended
+}
+
+@Composable
+private fun RuntimeFullPlayerContent(
+    playbackSession: PlaybackSession,
+    uiPort: PlaybackUiPort,
+    state: PlaybackState,
+) {
+    val currentTrack = state.currentTrack
+    val pagerState = rememberPagerState(
+        initialPage = PlayerVisualTab.Cover.ordinal,
+        pageCount = { PlayerVisualTab.entries.size },
+    )
+    val scope = rememberCoroutineScope()
+
+    if (LocalAppLayoutInfo.current.isLandscape) {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .navigationBarsPadding()
+                        .padding(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 68.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    RuntimePlayerHeader(uiPort, currentTrack)
+                    BoxWithConstraints(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        val lyricsPaneWidth = (maxWidth * 0.46f)
+                            .coerceAtLeast(240.dp)
+                            .coerceAtMost(maxWidth * 0.52f)
+                        Row(
+                            modifier = Modifier.fillMaxSize(),
+                            horizontalArrangement = Arrangement.spacedBy(20.dp),
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .width(lyricsPaneWidth)
+                                    .fillMaxHeight(),
+                            ) {
+                                LyricsPanel(
+                                    state = state,
+                                    fontSize = uiPort.lyricFontSize,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
+                            }
+                            Column(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight(),
+                                verticalArrangement = Arrangement.spacedBy(12.dp),
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .fillMaxWidth()
+                                        .verticalScroll(rememberScrollState()),
+                                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                                ) {
+                                    RuntimePlayerCoverPage(
+                                        track = currentTrack,
+                                        uiPort = uiPort,
+                                        isLoading = state.status == PlayerStatus.Loading,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .heightIn(max = 260.dp),
+                                    )
+                                    RuntimePlayerTitleBlock(
+                                        track = currentTrack,
+                                        uiPort = uiPort,
+                                        partLabel = currentPlaybackPartLabel(state),
+                                    )
+                                    Text(
+                                        text = currentTrack?.let(::artistAlbumLabel).orEmpty(),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                                RuntimePlayerTransport(playbackSession, uiPort, state, dense = false)
+                            }
+                        }
+                    }
+                }
+                RuntimeQueueBottomSheet(uiPort, state)
+            }
+        }
+        return
+    }
+
+    Surface(modifier = Modifier.fillMaxSize()) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val compactPortrait = maxHeight < 720.dp || maxHeight < maxWidth * 1.55f
+            val portraitSpacing = if (compactPortrait) 8.dp else 14.dp
+            val portraitBottomPadding = if (compactPortrait) 28.dp else 82.dp
+            val portraitHorizontalPadding = if (compactPortrait) 16.dp else 20.dp
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
+                    .padding(horizontal = portraitHorizontalPadding)
+                    .padding(bottom = portraitBottomPadding),
+                verticalArrangement = Arrangement.spacedBy(portraitSpacing),
+            ) {
+                RuntimePlayerHeader(uiPort, currentTrack)
+                PrimaryTabRow(selectedTabIndex = pagerState.currentPage.coerceIn(0, PlayerVisualTab.entries.lastIndex)) {
+                    PlayerVisualTab.entries.forEach { tab ->
+                        Tab(
+                            selected = pagerState.currentPage == tab.ordinal,
+                            onClick = { scope.launch { pagerState.animateScrollToPage(tab.ordinal) } },
+                            text = { Text(tab.title) },
+                        )
+                    }
+                }
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    pageSpacing = 16.dp,
+                ) { page ->
+                    when (PlayerVisualTab.entries[page]) {
+                        PlayerVisualTab.Cover -> RuntimePlayerCoverPage(
+                            track = currentTrack,
+                            uiPort = uiPort,
+                            isLoading = state.status == PlayerStatus.Loading,
+                        )
+                        PlayerVisualTab.Lyrics -> LyricsPanel(
+                            state = state,
+                            fontSize = uiPort.lyricFontSize,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
+                RuntimePlayerTitleBlock(
+                    track = currentTrack,
+                    uiPort = uiPort,
+                    partLabel = currentPlaybackPartLabel(state),
+                )
+                Text(
+                    text = currentTrack?.let(::artistAlbumLabel).orEmpty(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                RuntimePlayerTransport(playbackSession, uiPort, state, dense = compactPortrait)
+            }
+            RuntimeQueueBottomSheet(uiPort, state)
+        }
+    }
+}
+
+@Composable
+private fun RuntimePlayerHeader(uiPort: PlaybackUiPort, currentTrack: MusicTrack?) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = uiPort::closeFullPlayer) {
+            Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "收起播放器")
+        }
+        Text(
+            text = "正在播放",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = uiPort::toggleQueue) {
+                Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = "播放队列")
+            }
+            currentTrack?.let { RuntimeNowPlayingTrackAction(uiPort, it) }
+        }
+    }
+}
+
+@Composable
+private fun RuntimePlayerTransport(
+    playbackSession: PlaybackSession,
+    uiPort: PlaybackUiPort,
+    state: PlaybackState,
+    dense: Boolean,
+) {
+    ProgressBlock(state, uiPort::seekTo)
+    PlayerControls(
+        state = state,
+        modifier = Modifier.fillMaxWidth(),
+        onPrevious = playbackSession::previous,
+        onToggle = playbackSession::toggle,
+        onNext = playbackSession::next,
+        dense = dense,
+        shuffleEnabled = uiPort.isShuffleEnabled,
+        shuffleAvailable = !uiPort.isFmQueueActive,
+        onShuffle = uiPort::toggleShuffle,
+        sleepTimerAction = { RuntimeSleepTimerAction(uiPort) },
+    )
+}
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+private fun RuntimePlayerCoverPage(
+    track: MusicTrack?,
+    uiPort: PlaybackUiPort,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier.fillMaxSize(),
+) {
+    BoxWithConstraints(modifier = modifier) {
+        val coverSize = minOf(maxWidth, maxHeight * 0.82f)
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PlayerSharedCover(
+                track = track ?: emptyDisplayTrack(),
+                heroEnabled = uiPort.isFullPlayerOpen,
+                transitionDirection = uiPort.trackChangeDirection,
+                isLoading = isLoading,
+                cornerRadius = 22.dp,
+                modifier = Modifier.size(coverSize),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RuntimePlayerTitleBlock(
+    track: MusicTrack?,
+    uiPort: PlaybackUiPort,
+    partLabel: String?,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = track?.title ?: "未播放",
+            style = MaterialTheme.typography.headlineSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        partLabel?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RuntimePlayerInfoTags(track, uiPort)
+    }
+}
+
+@Composable
+private fun RuntimePlayerInfoTags(track: MusicTrack?, uiPort: PlaybackUiPort) {
+    var replacementInfoTrack by remember(track?.id) { mutableStateOf<MusicTrack?>(null) }
+    var showAudioFormatInfo by remember(track?.id) { mutableStateOf(false) }
+    val canShowAudioInfo = uiPort.audioFormatInfo?.hasDisplayableValue() == true || uiPort.audioDecoderInfo != null
+
+    Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (track != null) {
+            if (track.isSmartReplacement) {
+                InfoTag(
+                    text = replacementSourceLabel(track),
+                    onClick = {
+                        replacementInfoTrack = track
+                        uiPort.loadReplacementCandidates(track)
+                    },
+                )
+            } else {
+                InfoTag(sourceLabel(track, null))
+            }
+        }
+        uiPort.audioQuality?.takeIf { it.isNotBlank() }?.let {
+            InfoTag(
+                text = it.uppercase(),
+                onClick = if (canShowAudioInfo) ({ showAudioFormatInfo = true }) else null,
+            )
+        }
+    }
+
+    replacementInfoTrack?.let { infoTrack ->
+        ReplacementInfoDialog(
+            track = infoTrack,
+            candidateState = uiPort.replacementCandidateState
+                .takeIf { it.trackId == (infoTrack.originalId ?: infoTrack.id) }
+                ?: ReplacementCandidateState(),
+            onDismiss = { replacementInfoTrack = null },
+            onRetry = { uiPort.loadReplacementCandidates(infoTrack) },
+            onSelectCandidate = { candidate ->
+                uiPort.selectReplacementCandidate(infoTrack, candidate)
+                replacementInfoTrack = null
+            },
+            onOpenDetail = if (infoTrack.replacementId?.isNotBlank() == true) {
+                { uiPort.openReplacementTrackDetail(infoTrack) }
+            } else {
+                null
+            },
+        )
+    }
+    if (showAudioFormatInfo) {
+        AudioFormatInfoDialog(
+            info = uiPort.audioFormatInfo,
+            decoderInfo = uiPort.audioDecoderInfo,
+            onDismiss = { showAudioFormatInfo = false },
+        )
+    }
+}
+
+@Composable
+private fun RuntimeNowPlayingTrackAction(uiPort: PlaybackUiPort, track: MusicTrack) {
+    val onShare = LocalShareHandler.current
+    val sharePayload = track.toSharePayload()
+    TrackAction(
+        track = track,
+        downloadState = uiPort.downloadStates[track.id],
+        onAddToUpNext = { uiPort.addToUpNext(track) },
+        onDownload = { uiPort.download(track) },
+        onDeleteDownload = { uiPort.deleteDownload(track) },
+        onOpenArtist = { uiPort.openTrackArtist(track) },
+        onOpenAlbum = { uiPort.openTrackAlbum(track) },
+        onOpenDetail = if (track.sourceType == TrackSourceType.Provider) {
+            { uiPort.openOriginalTrackDetail(track) }
+        } else {
+            null
+        },
+        onEditLocalMetadata = if (track.sourceType == TrackSourceType.LocalMediaStore) {
+            { uiPort.openLocalMetadataEditor(track) }
+        } else {
+            null
+        },
+        onAddToPlaylist = if (uiPort.canAddTrackToPlaylist(track)) {
+            { uiPort.openPlaylistTargetPicker(track) }
+        } else {
+            null
+        },
+        onRemoveFromProviderPlaylist = if (uiPort.canRemoveTrackFromSelectedPlaylist(track)) {
+            { uiPort.removeTrackFromSelectedPlaylist(track) }
+        } else {
+            null
+        },
+        onSetDisliked = if (uiPort.canSetSongDisliked(track)) {
+            { uiPort.setSongDisliked(track) }
+        } else {
+            null
+        },
+        dislikedActionLabel = "不喜欢",
+        onShare = sharePayload?.let { payload -> { onShare(payload) } },
+        roundButton = false,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RuntimeQueueBottomSheet(uiPort: PlaybackUiPort, state: PlaybackState) {
+    val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    if (!isWideLayout) {
+        if (uiPort.isQueueOpen) {
+            ModalBottomSheet(
+                onDismissRequest = uiPort::toggleQueue,
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ) {
+                RuntimeQueueContent(uiPort, state, sidePanel = false, embedded = true)
+            }
+        }
+        return
+    }
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = if (isWideLayout) Alignment.CenterEnd else Alignment.BottomCenter,
+    ) {
+        AnimatedVisibility(
+            visible = uiPort.isQueueOpen,
+            modifier = Modifier.fillMaxSize(),
+            enter = fadeIn(tween(160)),
+            exit = fadeOut(tween(140)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
+                    .clickable(role = Role.Button, onClick = uiPort::toggleQueue),
+            )
+        }
+        AnimatedVisibility(
+            visible = uiPort.isQueueOpen,
+            modifier = Modifier.align(if (isWideLayout) Alignment.CenterEnd else Alignment.BottomCenter),
+            enter = if (isWideLayout) {
+                slideInHorizontally(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it } +
+                    fadeIn(tween(FuoMotion.overlayFadeMillis))
+            } else {
+                error("Wide layout required for side-panel queue")
+            },
+            exit = if (isWideLayout) {
+                slideOutHorizontally(animationSpec = tween(FuoMotion.overlayExitMillis)) { it } +
+                    fadeOut(tween(FuoMotion.overlayFadeMillis))
+            } else {
+                error("Wide layout required for side-panel queue")
+            },
+        ) {
+            RuntimeQueueContent(uiPort, state, sidePanel = true)
+        }
+    }
+}
+
+@Composable
+private fun RuntimeQueueContent(
+    uiPort: PlaybackUiPort,
+    state: PlaybackState,
+    sidePanel: Boolean = false,
+    embedded: Boolean = false,
+) {
+    var showClearConfirmDialog by remember { mutableStateOf(false) }
+    val queueSize = state.queue.size
+
+    Surface(
+        modifier = if (sidePanel) {
+            Modifier
+                .width(380.dp)
+                .fillMaxHeight()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .clickable { }
+        } else {
+            Modifier
+                .fillMaxWidth()
+                .heightIn(max = 460.dp)
+                .then(if (embedded) Modifier else Modifier.navigationBarsPadding())
+        },
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 8.dp,
+        shape = if (sidePanel) {
+            MaterialTheme.shapes.large
+        } else {
+            MaterialTheme.shapes.large
+        },
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            QueueRepeatModeHeader(
+                isFmQueue = uiPort.isFmQueueActive,
+                repeatMode = uiPort.repeatMode,
+                onRepeat = uiPort::toggleRepeat,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "播放队列",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "$queueSize 首",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (queueSize > 1) {
+                        IconButton(onClick = { showClearConfirmDialog = true }) {
+                            Icon(Icons.Filled.Delete, contentDescription = "清空队列")
+                        }
+                    }
+                }
+            }
+            RuntimeQueueList(
+                uiPort = uiPort,
+                state = state,
+                modifier = if (sidePanel) {
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                } else {
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 380.dp)
+                },
+            )
+        }
+    }
+
+    if (showClearConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirmDialog = false },
+            title = { Text("清空播放队列") },
+            text = { Text("确定要清空播放队列吗？当前播放的歌曲将保留。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearConfirmDialog = false
+                    uiPort.clearQueue()
+                }) {
+                    Text("清空")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirmDialog = false }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun RuntimeQueueList(
+    uiPort: PlaybackUiPort,
+    state: PlaybackState,
+    modifier: Modifier,
+) {
+    val queue = state.queue
+    val playbackParts = uiPort.playbackParts
+    val currentPartIndex = uiPort.currentPartIndex
+    val currentCount = if (state.queueIndex == 0 && queue.isNotEmpty()) 1 else 0
+    val upNextCount = uiPort.displayUpNextCount
+    LazyColumn(
+        modifier = modifier,
+    ) {
+        itemsIndexed(queue) { index, track ->
+            if (index == 0 && currentCount == 1) {
+                Text(
+                    text = "当前播放",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 6.dp, bottom = 4.dp),
+                )
+            }
+            if (index == currentCount && upNextCount > 0) {
+                Text(
+                    text = "接下来播放",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 10.dp, bottom = 4.dp),
+                )
+            }
+            if (index == currentCount + upNextCount && index < queue.size && index > 0) {
+                Text(
+                    text = "队列后续",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 10.dp, bottom = 4.dp),
+                )
+            }
+            val isCurrent = index == state.queueIndex
+            val isUnavailable = track.isUnavailable
+            val titleColor = when {
+                isUnavailable -> MaterialTheme.colorScheme.onSurfaceVariant
+                isCurrent -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurface
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fuoInteractive()
+                    .clickable(
+                        enabled = !isUnavailable,
+                        role = Role.Button,
+                    ) { uiPort.playQueueIndex(index) }
+                    .padding(vertical = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CoverBox(track, modifier = Modifier.size(48.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "${index + 1}. ${track.title.ifBlank { "未知歌曲" }}",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = titleColor,
+                        fontWeight = if (isCurrent && !isUnavailable) FontWeight.SemiBold else FontWeight.Normal,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = listOf(track.artists, track.album).filter { it.isNotBlank() }.joinToString(" · ")
+                            .ifBlank { "未知歌手" },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = sourceLabel(track, null),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                IconButton(onClick = { uiPort.removeFromQueue(track) }) {
+                    Icon(Icons.Filled.RemoveCircleOutline, contentDescription = "从队列移除")
+                }
+            }
+            if (isCurrent && playbackParts.isNotEmpty()) {
+                PlaybackPartList(
+                    parts = playbackParts,
+                    currentPartIndex = currentPartIndex,
+                    onPartClick = uiPort::playPlaybackPart,
+                )
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun RuntimeSleepTimerAction(uiPort: PlaybackUiPort) {
+    var showSheet by remember { mutableStateOf(false) }
+    val timerState = uiPort.sleepTimerState
+    val isActive = timerState.mode != SleepTimerMode.Off
+    val contentDescription = when (timerState.mode) {
+        SleepTimerMode.Off -> "睡眠定时"
+        SleepTimerMode.Duration -> "睡眠定时，剩余 ${runtimeFormatSleepTimerRemaining(timerState.remainingMs ?: 0L)}"
+        SleepTimerMode.EndOfTrack -> "当前曲目结束后暂停"
+    }
+    Box {
+        RoundControlButton(
+            imageVector = Icons.Filled.Timer,
+            contentDescription = contentDescription,
+            onClick = { showSheet = true },
+            selected = isActive,
+        )
+        if (showSheet) {
+            RuntimeSleepTimerBottomSheet(
+                uiPort = uiPort,
+                onDismiss = { showSheet = false },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RuntimeSleepTimerBottomSheet(
+    uiPort: PlaybackUiPort,
+    onDismiss: () -> Unit,
+) {
+    val timerState = uiPort.sleepTimerState
+    var showCustomDurationDialog by remember { mutableStateOf(false) }
+    var customMinutesText by remember { mutableStateOf("") }
+    val customMinutes = customMinutesText.toIntOrNull()
+    val customMinutesValid = customMinutes?.let {
+        it in SLEEP_TIMER_MIN_MINUTES..SLEEP_TIMER_MAX_MINUTES
+    } == true
+    val presetMinutes = SLEEP_TIMER_PRESET_MINUTES.filter { it <= 90 }
+    val firstPresetRow = presetMinutes.take(3)
+    val secondPresetRow = presetMinutes.drop(3)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .navigationBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                text = "睡眠定时",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "选择自动暂停播放的时间",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (timerState.mode != SleepTimerMode.Off) {
+                RuntimeSleepTimerActiveStatus(
+                    timerState = timerState,
+                    onExtend = if (timerState.mode == SleepTimerMode.Duration) {
+                        {
+                            uiPort.setSleepTimerDurationMinutes(
+                                runtimeSleepTimerExtendedMinutes(timerState.remainingMs ?: 0L, 5),
+                            )
+                        }
+                    } else {
+                        null
+                    },
+                    onClear = {
+                        uiPort.clearSleepTimer()
+                        onDismiss()
+                    },
+                )
+            }
+            RuntimeSleepTimerSectionLabel("按时长")
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                firstPresetRow.forEach { minutes ->
+                    RuntimeSleepTimerPresetOption(
+                        minutes = minutes,
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            uiPort.setSleepTimerDurationMinutes(minutes)
+                            onDismiss()
+                        },
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                secondPresetRow.forEach { minutes ->
+                    RuntimeSleepTimerPresetOption(
+                        minutes = minutes,
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            uiPort.setSleepTimerDurationMinutes(minutes)
+                            onDismiss()
+                        },
+                    )
+                }
+                RuntimeSleepTimerCustomOption(
+                    modifier = Modifier.weight(1f),
+                    onClick = { showCustomDurationDialog = true },
+                )
+            }
+
+            RuntimeSleepTimerSectionLabel("播放结束")
+            RuntimeSleepTimerEndOfTrackOption(
+                selected = timerState.mode == SleepTimerMode.EndOfTrack,
+                onClick = {
+                    uiPort.setSleepTimerToEndOfTrack()
+                    onDismiss()
+                },
+            )
+        }
+    }
+
+    if (showCustomDurationDialog) {
+        AlertDialog(
+            onDismissRequest = { showCustomDurationDialog = false },
+            title = { Text("自定义睡眠定时") },
+            text = {
+                OutlinedTextField(
+                    value = customMinutesText,
+                    onValueChange = { value ->
+                        customMinutesText = value.filter(Char::isDigit)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = customMinutesText.isNotBlank() && !customMinutesValid,
+                    label = { Text("时长（分钟）") },
+                    placeholder = { Text("例如 45") },
+                    supportingText = if (customMinutesText.isNotBlank() && !customMinutesValid) {
+                        {
+                            Text("请输入 $SLEEP_TIMER_MIN_MINUTES–$SLEEP_TIMER_MAX_MINUTES 分钟")
+                        }
+                    } else {
+                        null
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = customMinutesValid,
+                    onClick = {
+                        customMinutes?.let(uiPort::setSleepTimerDurationMinutes)
+                        showCustomDurationDialog = false
+                        onDismiss()
+                    },
+                ) {
+                    Text("确定")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCustomDurationDialog = false }) {
+                    Text("取消")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun RuntimeSleepTimerActiveStatus(
+    timerState: SleepTimerState,
+    onExtend: (() -> Unit)?,
+    onClear: () -> Unit,
+) {
+    val isDuration = timerState.mode == SleepTimerMode.Duration
+    val canExtend = isDuration &&
+        (timerState.remainingMs ?: 0L) < SLEEP_TIMER_MAX_MINUTES * 60_000L
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        HorizontalDivider()
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = if (isDuration) Icons.Filled.Timer else Icons.Filled.MusicNote,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = if (isDuration) {
+                        "还有 ${runtimeFormatSleepTimerRemaining(timerState.remainingMs ?: 0L)}"
+                    } else {
+                        "当前曲目结束后暂停"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = if (isDuration) {
+                        "时间到后自动暂停播放"
+                    } else {
+                        "播放完当前曲目的全部内容后暂停"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (onExtend != null) {
+                TextButton(
+                    enabled = canExtend,
+                    onClick = onExtend,
+                ) {
+                    Text("+5 分钟")
+                }
+            }
+            TextButton(onClick = onClear) {
+                Text("关闭定时")
+            }
+        }
+        HorizontalDivider()
+    }
+}
+
+@Composable
+private fun RuntimeSleepTimerSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun RuntimeSleepTimerPresetOption(
+    minutes: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    AssistChip(
+        onClick = onClick,
+        modifier = modifier,
+        label = {
+            Text(
+                text = "$minutes 分钟",
+                maxLines = 1,
+            )
+        },
+    )
+}
+
+@Composable
+private fun RuntimeSleepTimerCustomOption(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    AssistChip(
+        onClick = onClick,
+        modifier = modifier,
+        label = { Text("自定义", maxLines = 1) },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Filled.Edit,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+        },
+    )
+}
+
+@Composable
+private fun RuntimeSleepTimerEndOfTrackOption(
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(role = Role.Button, onClick = onClick),
+        colors = ListItemDefaults.colors(
+            containerColor = if (selected) {
+                MaterialTheme.colorScheme.secondaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHighest
+            },
+        ),
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Filled.MusicNote,
+                contentDescription = null,
+                tint = if (selected) {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
+            )
+        },
+        headlineContent = {
+            Text(
+                text = "当前曲目结束后暂停",
+                fontWeight = FontWeight.Medium,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = "包含当前曲目的全部多段内容",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        trailingContent = if (selected) {
+            {
+                Text(
+                    text = "已选",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        } else {
+            null
+        },
+    )
+}
+
+private fun runtimeSleepTimerExtendedMinutes(remainingMs: Long, extraMinutes: Int): Int {
+    val roundedRemainingMinutes = ((remainingMs.coerceAtLeast(0L) + 30_000L) / 60_000L)
+        .coerceAtLeast(1L)
+    return (roundedRemainingMinutes + extraMinutes)
+        .coerceAtMost(SLEEP_TIMER_MAX_MINUTES.toLong())
+        .toInt()
+}
+
+private fun runtimeFormatSleepTimerRemaining(remainingMs: Long): String {
+    val totalSeconds = (remainingMs.coerceAtLeast(0L) + 999L) / 1_000L
+    val minutes = totalSeconds / 60L
+    val seconds = totalSeconds % 60L
+    return when {
+        minutes >= 60L -> "${minutes / 60L}小时${minutes % 60L}分"
+        minutes > 0L -> "${minutes}分${seconds}秒"
+        else -> "${seconds}秒"
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
@@ -1,0 +1,282 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.feeluown.mobile.core.model.TrackRef
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionState
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+
+/**
+ * Controller-free MiniPlayer implementation backed by the app-scoped playback session.
+ *
+ * Full-player visibility and cover-transition direction are still app-shell presentation details;
+ * C2 will move those alongside the remaining FullPlayer/queue/lyrics UI state.
+ */
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+internal fun RuntimeMiniPlayer(
+    playbackSession: PlaybackSession,
+    isFullPlayerOpen: Boolean,
+    transitionDirection: TrackChangeDirection,
+    onOpenFullPlayer: () -> Unit,
+) {
+    val state by playbackSession.state.collectAsStateWithLifecycle()
+    val isLoadingAudio = state.status == PlaybackSessionStatus.Loading
+    val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize(animationSpec = tween(220))
+            .fuoInteractive()
+            .clickable(role = Role.Button, onClick = onOpenFullPlayer),
+        shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 3.dp,
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = if (isWideLayout) 8.dp else 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                state.currentTrack?.let { track ->
+                    RuntimeMiniPlayerCover(
+                        track = track,
+                        heroEnabled = !isFullPlayerOpen,
+                        transitionDirection = transitionDirection,
+                        isLoading = isLoadingAudio,
+                        cornerRadius = if (isWideLayout) 10.dp else 12.dp,
+                        modifier = Modifier.size(if (isWideLayout) 44.dp else 56.dp),
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = state.currentTrack?.title ?: "未播放",
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = if (isLoadingAudio) {
+                            "正在加载音频"
+                        } else {
+                            state.currentTrack?.let(::runtimeArtistAlbumLabel) ?: "选择一首音乐开始播放"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (isLoadingAudio) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    RuntimeMiniPlayerLyricLine(state)
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RoundControlButton(
+                        imageVector = Icons.Filled.SkipPrevious,
+                        contentDescription = "上一首",
+                        onClick = playbackSession::previous,
+                        size = 48.dp,
+                        iconSize = 24.dp,
+                    )
+                    PlayPauseButton(
+                        isPlaying = state.status == PlaybackSessionStatus.Playing,
+                        isLoading = state.status == PlaybackSessionStatus.Loading,
+                        onClick = playbackSession::toggle,
+                        size = 48.dp,
+                        iconSize = 26.dp,
+                    )
+                    RoundControlButton(
+                        imageVector = Icons.Filled.SkipNext,
+                        contentDescription = "下一首",
+                        onClick = playbackSession::next,
+                        size = 48.dp,
+                        iconSize = 24.dp,
+                    )
+                }
+            }
+            RuntimeMiniPlayerProgress(state, isLoadingAudio)
+        }
+    }
+}
+
+@Composable
+private fun RuntimeMiniPlayerProgress(
+    state: PlaybackSessionState,
+    isLoadingAudio: Boolean,
+) {
+    val duration = state.durationMs.takeIf { it > 0 }
+    if (isLoadingAudio || duration != null) {
+        val targetProgress = duration?.let {
+            state.positionMs.coerceIn(0, it).toFloat() / it
+        } ?: 0f
+        val progress by animateFloatAsState(
+            targetValue = targetProgress,
+            animationSpec = tween(FuoMotion.progressAnimationMillis),
+            label = "mini player progress",
+        )
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp),
+        )
+    }
+}
+
+@Composable
+private fun RuntimeMiniPlayerLyricLine(state: PlaybackSessionState) {
+    val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
+    val currentIndex = currentLyricIndex(lines, state.positionMs)
+    val currentLine = lines.getOrNull(currentIndex)?.text?.takeIf { it.isNotBlank() } ?: return
+
+    AnimatedContent(
+        targetState = RuntimeMiniPlayerLyricState(currentIndex, currentLine),
+        transitionSpec = {
+            val direction = if (targetState.index >= initialState.index) 1 else -1
+            val enterOffset: (Int) -> Int = { height -> if (direction > 0) height else -height }
+            val exitOffset: (Int) -> Int = { height -> if (direction > 0) -height else height }
+            (slideInVertically(
+                animationSpec = tween(180),
+                initialOffsetY = enterOffset,
+            ) + fadeIn(animationSpec = tween(180))) togetherWith
+                (slideOutVertically(
+                    animationSpec = tween(180),
+                    targetOffsetY = exitOffset,
+                ) + fadeOut(animationSpec = tween(180)))
+        },
+        modifier = Modifier.fillMaxWidth(),
+        label = "mini player lyric line",
+    ) { lyric ->
+        Text(
+            text = lyric.text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+private data class RuntimeMiniPlayerLyricState(
+    val index: Int,
+    val text: String,
+)
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+private fun RuntimeMiniPlayerCover(
+    track: TrackRef,
+    heroEnabled: Boolean,
+    transitionDirection: TrackChangeDirection,
+    isLoading: Boolean,
+    cornerRadius: Dp,
+    modifier: Modifier,
+) {
+    val targetCoverImage = rememberPlatformCoverImage(track.coverUrl)
+    val hasCoverUrl = !track.coverUrl.isNullOrBlank()
+    var displayedTrack by remember { mutableStateOf(track) }
+    LaunchedEffect(track.id, track.coverUrl, isLoading, targetCoverImage) {
+        if (!isLoading || (hasCoverUrl && targetCoverImage != null)) {
+            displayedTrack = track
+        }
+    }
+    val sharedTransitionScope = LocalPlayerSharedTransitionScope.current
+    val sharedModifier = if (!heroEnabled || sharedTransitionScope == null) {
+        modifier
+    } else {
+        with(sharedTransitionScope) {
+            modifier.sharedElementWithCallerManagedVisibility(
+                sharedContentState = rememberSharedContentState("player-cover:${track.id}"),
+                visible = true,
+            )
+        }
+    }
+    Box(modifier = sharedModifier) {
+        AnimatedContent(
+            targetState = displayedTrack,
+            transitionSpec = { runtimeMiniPlayerCoverTransition(transitionDirection) },
+            modifier = Modifier.fillMaxSize(),
+            contentKey = { it.coverUrl },
+            label = "player cover transition",
+        ) { animatedTrack ->
+            PlatformCoverArt(
+                title = animatedTrack.title,
+                imageUrl = animatedTrack.coverUrl,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(cornerRadius)),
+                placeholder = CoverPlaceholder.Song,
+            )
+        }
+    }
+}
+
+private fun runtimeMiniPlayerCoverTransition(direction: TrackChangeDirection): ContentTransform {
+    val directionMultiplier = if (direction == TrackChangeDirection.Next) 1 else -1
+    return (
+        slideInHorizontally(
+            initialOffsetX = { width -> width * directionMultiplier },
+            animationSpec = tween(FuoMotion.coverTransitionMillis),
+        ) + fadeIn(animationSpec = tween(FuoMotion.coverFadeMillis))
+        ) togetherWith (
+        slideOutHorizontally(
+            targetOffsetX = { width -> -width * directionMultiplier },
+            animationSpec = tween(FuoMotion.coverTransitionMillis),
+        ) + fadeOut(animationSpec = tween(FuoMotion.coverFadeMillis))
+        )
+}
+
+private fun runtimeArtistAlbumLabel(track: TrackRef): String =
+    listOf(track.artists, track.album)
+        .filter(String::isNotBlank)
+        .joinToString(" · ")

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -189,6 +189,10 @@ private class IosAppContainer(
         recognitionFeatureController = recognitionController,
     )
 
+    private val playbackSession by lazy {
+        createIosPlaybackRuntimeSession(controller, playbackEngine, scope)
+    }
+
     private val searchAppPort = object : SearchAppPort {
         override val providers: List<ProviderInfo>
             get() = controller.providers
@@ -236,6 +240,7 @@ private class IosAppContainer(
 
     val appViewModel = FuoAppViewModel(
         controller = controller,
+        playbackSession = playbackSession,
         searchController = searchController,
         recognitionController = recognitionController,
         searchAppPort = searchAppPort,

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
@@ -1,0 +1,102 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.feeluown.mobile.core.model.TrackRef
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+import org.feeluown.mobile.playback.runtime.DefaultPlaybackRuntime
+import org.feeluown.mobile.playback.runtime.PlaybackRuntimeEngine
+import org.feeluown.mobile.playback.runtime.PlaybackRuntimeEngineState
+import org.feeluown.mobile.playback.runtime.PlaybackRuntimeOverlay
+import org.feeluown.mobile.playback.runtime.PlaybackRuntimeQueueActions
+
+/** iOS composition-edge adapter for the shared playback runtime. */
+internal fun createIosPlaybackRuntimeSession(
+    controller: FuoPlayerController,
+    playbackEngine: PlaybackEngine,
+    scope: CoroutineScope,
+): PlaybackSession {
+    val overlay = snapshotFlow { controller.playbackState.toPlaybackRuntimeOverlay() }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.Eagerly,
+            initialValue = controller.playbackState.toPlaybackRuntimeOverlay(),
+        )
+
+    return DefaultPlaybackRuntime(
+        engine = LegacyPlaybackRuntimeEngine(playbackEngine, scope),
+        overlay = overlay,
+        queueActions = LegacyPlaybackQueueActions(controller),
+        scope = scope,
+    )
+}
+
+private class LegacyPlaybackRuntimeEngine(
+    private val playbackEngine: PlaybackEngine,
+    scope: CoroutineScope,
+) : PlaybackRuntimeEngine {
+    override val state: StateFlow<PlaybackRuntimeEngineState> = playbackEngine.state
+        .map(PlaybackState::toPlaybackRuntimeEngineState)
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.Eagerly,
+            initialValue = playbackEngine.state.value.toPlaybackRuntimeEngineState(),
+        )
+
+    override fun pause() = playbackEngine.pause()
+
+    override fun resume() = playbackEngine.resume()
+}
+
+private class LegacyPlaybackQueueActions(
+    private val controller: FuoPlayerController,
+) : PlaybackRuntimeQueueActions {
+    override fun startCurrent() = controller.toggle()
+
+    override fun previous() = controller.previous()
+
+    override fun next() = controller.next()
+}
+
+private fun PlaybackState.toPlaybackRuntimeEngineState(): PlaybackRuntimeEngineState =
+    PlaybackRuntimeEngineState(
+        status = status.toPlaybackSessionStatus(),
+        positionMs = positionMs,
+        durationMs = durationMs,
+        bufferedMs = bufferedMs,
+        errorMessage = errorMessage,
+    )
+
+private fun PlaybackState.toPlaybackRuntimeOverlay(): PlaybackRuntimeOverlay =
+    PlaybackRuntimeOverlay(
+        currentTrack = currentTrack?.toTrackRef(),
+        lyrics = lyrics,
+        queueTrackIds = queue.map(MusicTrack::id),
+        queueIndex = queueIndex,
+    )
+
+private fun PlayerStatus.toPlaybackSessionStatus(): PlaybackSessionStatus = when (this) {
+    PlayerStatus.Idle -> PlaybackSessionStatus.Idle
+    PlayerStatus.Loading -> PlaybackSessionStatus.Loading
+    PlayerStatus.Playing -> PlaybackSessionStatus.Playing
+    PlayerStatus.Paused -> PlaybackSessionStatus.Paused
+    PlayerStatus.Error -> PlaybackSessionStatus.Error
+    PlayerStatus.Ended -> PlaybackSessionStatus.Ended
+}
+
+private fun MusicTrack.toTrackRef(): TrackRef = TrackRef(
+    id = id,
+    title = title,
+    artists = artists,
+    album = album,
+    source = source,
+    coverUrl = coverUrl,
+    durationMs = durationMs,
+)

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.feeluown.mobile.core.model.TrackRef
 import org.feeluown.mobile.playback.api.PlaybackSession
@@ -31,7 +31,7 @@ internal fun createIosPlaybackRuntimeSession(
         )
 
     return DefaultPlaybackRuntime(
-        engine = LegacyPlaybackRuntimeEngine(playbackEngine, scope),
+        engine = LegacyPlaybackRuntimeEngine(playbackEngine, controller, scope),
         overlay = overlay,
         queueActions = LegacyPlaybackQueueActions(controller),
         scope = scope,
@@ -40,15 +40,22 @@ internal fun createIosPlaybackRuntimeSession(
 
 private class LegacyPlaybackRuntimeEngine(
     private val playbackEngine: PlaybackEngine,
+    controller: FuoPlayerController,
     scope: CoroutineScope,
 ) : PlaybackRuntimeEngine {
-    override val state: StateFlow<PlaybackRuntimeEngineState> = playbackEngine.state
-        .map(PlaybackState::toPlaybackRuntimeEngineState)
-        .stateIn(
-            scope = scope,
-            started = SharingStarted.Eagerly,
-            initialValue = playbackEngine.state.value.toPlaybackRuntimeEngineState(),
-        )
+    override val state: StateFlow<PlaybackRuntimeEngineState> = combine(
+        playbackEngine.state,
+        snapshotFlow { controller.playbackState }.distinctUntilChanged(),
+    ) { engineState, coordinatorState ->
+        mergeIosPlaybackRuntimeEngineState(engineState, coordinatorState)
+    }.stateIn(
+        scope = scope,
+        started = SharingStarted.Eagerly,
+        initialValue = mergeIosPlaybackRuntimeEngineState(
+            engineState = playbackEngine.state.value,
+            coordinatorState = controller.playbackState,
+        ),
+    )
 
     override fun pause() = playbackEngine.pause()
 
@@ -65,14 +72,38 @@ private class LegacyPlaybackQueueActions(
     override fun next() = controller.next()
 }
 
-private fun PlaybackState.toPlaybackRuntimeEngineState(): PlaybackRuntimeEngineState =
-    PlaybackRuntimeEngineState(
-        status = status.toPlaybackSessionStatus(),
-        positionMs = positionMs,
-        durationMs = durationMs,
-        bufferedMs = bufferedMs,
-        errorMessage = errorMessage,
+/**
+ * iOS still resolves provider resources in the legacy coordinator before the native engine starts.
+ * During that window the engine is already Loading, so a resolution failure exists only on the
+ * coordinator state. Bridge that one transitional error into the session until resource resolution
+ * moves behind the playback runtime boundary in C2.
+ */
+internal fun mergeIosPlaybackRuntimeEngineState(
+    engineState: PlaybackState,
+    coordinatorState: PlaybackState,
+): PlaybackRuntimeEngineState {
+    val useCoordinatorResolutionError =
+        engineState.status == PlayerStatus.Loading &&
+            coordinatorState.status == PlayerStatus.Error &&
+            engineState.currentTrack?.id != null &&
+            engineState.currentTrack?.id == coordinatorState.currentTrack?.id
+
+    return PlaybackRuntimeEngineState(
+        status = if (useCoordinatorResolutionError) {
+            PlaybackSessionStatus.Error
+        } else {
+            engineState.status.toPlaybackSessionStatus()
+        },
+        positionMs = engineState.positionMs,
+        durationMs = engineState.durationMs,
+        bufferedMs = engineState.bufferedMs,
+        errorMessage = if (useCoordinatorResolutionError) {
+            coordinatorState.errorMessage
+        } else {
+            engineState.errorMessage
+        },
     )
+}
 
 private fun PlaybackState.toPlaybackRuntimeOverlay(): PlaybackRuntimeOverlay =
     PlaybackRuntimeOverlay(

--- a/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlaybackRuntimeTest.kt
+++ b/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlaybackRuntimeTest.kt
@@ -1,0 +1,57 @@
+package org.feeluown.mobile
+
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IosPlaybackRuntimeTest {
+    @Test
+    fun resolutionFailureOverridesLoadingEngineForSameTrack() {
+        val track = testTrack("track:1")
+        val merged = mergeIosPlaybackRuntimeEngineState(
+            engineState = PlaybackState(
+                status = PlayerStatus.Loading,
+                currentTrack = track,
+                positionMs = 1_200,
+                durationMs = 10_000,
+            ),
+            coordinatorState = PlaybackState(
+                status = PlayerStatus.Error,
+                currentTrack = track,
+                errorMessage = "资源解析失败",
+            ),
+        )
+
+        assertEquals(PlaybackSessionStatus.Error, merged.status)
+        assertEquals("资源解析失败", merged.errorMessage)
+        assertEquals(1_200, merged.positionMs)
+        assertEquals(10_000, merged.durationMs)
+    }
+
+    @Test
+    fun unrelatedCoordinatorErrorDoesNotOverrideEngineState() {
+        val merged = mergeIosPlaybackRuntimeEngineState(
+            engineState = PlaybackState(
+                status = PlayerStatus.Loading,
+                currentTrack = testTrack("track:1"),
+            ),
+            coordinatorState = PlaybackState(
+                status = PlayerStatus.Error,
+                currentTrack = testTrack("track:2"),
+                errorMessage = "其它页面加载失败",
+            ),
+        )
+
+        assertEquals(PlaybackSessionStatus.Loading, merged.status)
+        assertEquals(null, merged.errorMessage)
+    }
+
+    private fun testTrack(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = "Test",
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+}


### PR DESCRIPTION
## Summary

Complete P1-C on top of the dedicated playback runtime, keeping the stable `PlaybackSession` contract narrow while moving active player UI away from `FuoPlayerController`.

### C1 — MiniPlayer + cross-platform session injection
- expose the app-scoped `PlaybackSession` through `FuoAppViewModel`
- provide it to common playback UI through `LocalPlaybackSession`
- keep Android on `AndroidPlaybackRuntime.kt`
- add `IosPlaybackRuntime.kt` so iOS uses the same `DefaultPlaybackRuntime` contract
- add controller-free `RuntimeMiniPlayer` for track metadata, loading state, progress, lyrics and previous/toggle/next transport

### Review adjustment
A review found an iOS pre-engine resource-resolution failure path where the native engine could remain `Loading` after the legacy coordinator had already entered `Error`.

- bridge only the transitional same-track `Loading -> coordinator Error` state in `IosPlaybackRuntime`
- preserve engine timing/buffer fields
- add focused iOS regression tests proving the same-track error is surfaced and unrelated errors do not override engine state

### C2 — FullPlayer / queue / lyrics
- add `PlaybackUiPort` for rich UI/application operations that intentionally do not belong in the narrow `PlaybackSession` API
- add temporary app-shell `ControllerPlaybackUiPort` adapter over the remaining centralized owners
- add controller-free `RuntimeFullPlayer`
- source authoritative status, position, duration, buffer, lyrics, queue index, errors and previous/toggle/next transport from `PlaybackSession`
- route queue edits, seek/shuffle/repeat, sleep timer, rich `MusicTrack` metadata, downloads and replacement actions through `PlaybackUiPort`
- switch the active AppRoot full-player overlay to `RuntimeFullPlayer`
- move Home and LocalPlaylist MiniPlayer hosts to the controller-free `PlaybackMiniPlayer`
- preserve the existing player UI/interaction structure while changing only dependency/state ownership

Legacy feature screens that still call the old `MiniPlayer(controller)` signature are intentionally left for their own feature migrations; that call signature is now only a feature-shell compatibility entry point and does not own playback state/transport.

### Architecture guard
`checkArchitectureBoundaries` now covers:
- `PlaybackUiPort`
- playback composition contracts
- `RuntimeMiniPlayer`
- `RuntimeFullPlayer`

These migrated playback UI boundaries cannot directly depend on `FuoPlayerController`.

## Commit structure
1. `4f67af8` — C1 MiniPlayer/session migration
2. `e059fd4` — iOS review-fix + regression tests
3. `2e1f680` — C2 FullPlayer/queue/lyrics migration

## Validation
All CI checks are green on `2e1f6800f0ba9e5ad7e24d10b4b2a5a301d25c87`:
- ✅ `checkArchitectureBoundaries`
- ✅ `:playback:runtime:allTests`
- ✅ shared Android/iOS tests
- ✅ iOS resource-resolution regression tests
- ✅ Android coverage + Codecov
- ✅ signed multi-ABI Android release APK build and upload
- ✅ iOS simulator debug app build/package/upload
- ✅ iOS device debug app build + IPA package/upload

## Next architecture slice
- move `startCurrent` / `previous` / `next` queue-transition and resource-start orchestration out of `FuoPlayerController`
- remove the temporary iOS pre-engine error bridge once resource resolution becomes runtime-owned
- replace `ControllerPlaybackUiPort` responsibilities with explicit playback/download/provider-detail owners as those boundaries are extracted
