### PR TITLE
refactor: move playback orchestration out of controller

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -247,7 +247,13 @@ internal class AndroidAppContainer(
     }
 
     private fun wireController(controller: FuoPlayerController) {
-        val playbackSession = createPlaybackRuntimeSession(controller, playbackEngine, appScope)
+        val playbackSession = createPlaybackRuntimeSession(
+            controller = controller,
+            playbackEngine = playbackEngine,
+            transportCoordinator = controller.playbackTransportCoordinator,
+            startFailureSource = controller.playbackStartFailureSource,
+            scope = appScope,
+        )
         playbackSessionHolder = playbackSession
 
         controller.updateStatusBarLyricsAvailability(isLyriconInstalled(context))

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.feeluown.mobile.core.model.TrackRef
 import org.feeluown.mobile.playback.api.PlaybackSession
@@ -20,6 +20,8 @@ import org.feeluown.mobile.playback.runtime.PlaybackRuntimeQueueActions
 internal fun createPlaybackRuntimeSession(
     controller: FuoPlayerController,
     playbackEngine: PlaybackEngine,
+    transportCoordinator: PlaybackTransportCoordinator,
+    startFailureSource: PlaybackStartFailureSource,
     scope: CoroutineScope,
 ): PlaybackSession {
     val overlay = snapshotFlow { controller.playbackState.toPlaybackRuntimeOverlay() }
@@ -31,52 +33,60 @@ internal fun createPlaybackRuntimeSession(
         )
 
     return DefaultPlaybackRuntime(
-        engine = LegacyPlaybackRuntimeEngine(playbackEngine, scope),
+        engine = PlaybackRuntimeEngineAdapter(playbackEngine, startFailureSource, scope),
         overlay = overlay,
-        queueActions = LegacyPlaybackQueueActions(controller),
+        queueActions = PlaybackCoordinatorQueueActions(transportCoordinator),
         scope = scope,
     )
 }
 
-private class LegacyPlaybackRuntimeEngine(
+private class PlaybackRuntimeEngineAdapter(
     private val playbackEngine: PlaybackEngine,
+    startFailureSource: PlaybackStartFailureSource,
     scope: CoroutineScope,
 ) : PlaybackRuntimeEngine {
-    override val state: StateFlow<PlaybackRuntimeEngineState> = playbackEngine.state
-        .map(PlaybackState::toPlaybackRuntimeEngineState)
-        .stateIn(
-            scope = scope,
-            started = SharingStarted.Eagerly,
-            initialValue = playbackEngine.state.value.toPlaybackRuntimeEngineState(),
-        )
+    override val state: StateFlow<PlaybackRuntimeEngineState> = combine(
+        playbackEngine.state,
+        startFailureSource.startFailure,
+    ) { engineState, startFailure ->
+        engineState.toPlaybackRuntimeEngineState(startFailure)
+    }.stateIn(
+        scope = scope,
+        started = SharingStarted.Eagerly,
+        initialValue = playbackEngine.state.value.toPlaybackRuntimeEngineState(
+            startFailureSource.startFailure.value,
+        ),
+    )
 
     override fun pause() = playbackEngine.pause()
 
     override fun resume() = playbackEngine.resume()
 }
 
-/**
- * Queue selection and resource resolution are still controller-owned in this migration slice.
- * Keeping that bridge explicit avoids leaking the controller into the runtime module itself.
- */
-private class LegacyPlaybackQueueActions(
-    private val controller: FuoPlayerController,
+private class PlaybackCoordinatorQueueActions(
+    private val coordinator: PlaybackTransportCoordinator,
 ) : PlaybackRuntimeQueueActions {
-    override fun startCurrent() = controller.toggle()
+    override fun startCurrent() = coordinator.startCurrent()
 
-    override fun previous() = controller.previous()
+    override fun previous() = coordinator.previous()
 
-    override fun next() = controller.next()
+    override fun next() = coordinator.next()
 }
 
-private fun PlaybackState.toPlaybackRuntimeEngineState(): PlaybackRuntimeEngineState =
-    PlaybackRuntimeEngineState(
-        status = status.toPlaybackSessionStatus(),
+private fun PlaybackState.toPlaybackRuntimeEngineState(
+    startFailure: PlaybackStartFailure? = null,
+): PlaybackRuntimeEngineState {
+    val activeFailure = startFailure?.takeIf { failure ->
+        status == PlayerStatus.Loading && currentTrack?.id == failure.trackId
+    }
+    return PlaybackRuntimeEngineState(
+        status = if (activeFailure != null) PlaybackSessionStatus.Error else status.toPlaybackSessionStatus(),
         positionMs = positionMs,
         durationMs = durationMs,
         bufferedMs = bufferedMs,
-        errorMessage = errorMessage,
+        errorMessage = activeFailure?.message ?: errorMessage,
     )
+}
 
 private fun PlaybackState.toPlaybackRuntimeOverlay(): PlaybackRuntimeOverlay =
     PlaybackRuntimeOverlay(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt",
@@ -30,6 +32,10 @@ val retiredControllerCompatibilityFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRouteCompat.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRouteCompat.kt",
     "androidApp/src/main/kotlin/org/feeluown/mobile/ControllerPlaybackSession.kt",
+)
+val playbackRuntimeAdapterFiles = listOf(
+    "androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt",
+    "shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt",
 )
 
 tasks.register("checkArchitectureBoundaries") {
@@ -49,6 +55,7 @@ tasks.register("checkArchitectureBoundaries") {
         }.distinct()
     }
     inputs.files(sourceFiles)
+    inputs.files(playbackRuntimeAdapterFiles.map(rootProject::file))
 
     doLast {
         val retiredCompatViolations = retiredControllerCompatibilityFiles
@@ -86,6 +93,31 @@ tasks.register("checkArchitectureBoundaries") {
                     appendLine("FuoPlayerController leaked into migrated architecture boundaries:")
                     violations.forEach { appendLine(" - $it") }
                     append("Use feature-owned state/actions or a narrow app/playback/provider contract instead.")
+                },
+            )
+        }
+
+        val retiredTransportCalls = listOf(
+            "controller.toggle()",
+            "controller.previous()",
+            "controller.next()",
+        )
+        val transportViolations = playbackRuntimeAdapterFiles
+            .map(rootProject::file)
+            .filter { it.isFile }
+            .flatMap { file ->
+                file.readLines().mapIndexedNotNull { index, line ->
+                    retiredTransportCalls.firstOrNull(line::contains)?.let { call ->
+                        "${file.relativeTo(rootProject.projectDir).invariantSeparatorsPath}:${index + 1} ($call)"
+                    }
+                }
+            }
+        if (transportViolations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("Playback runtime adapters reintroduced legacy controller transport calls:")
+                    transportViolations.forEach { appendLine(" - $it") }
+                    append("Inject PlaybackTransportCoordinator instead.")
                 },
             )
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ The first compile-time module boundaries are now explicit:
 - `:playback:runtime` owns the default `PlaybackSession` state/transport implementation and depends only on `:playback:api` plus coroutines.
 - `:provider:api` owns provider-neutral cross-feature capability contracts.
 - `:shared` consumes the playback/provider API contracts and contains the current feature implementations and legacy playback/provider contracts that are still being migrated.
-- `:androidApp` consumes `:shared` plus playback/core APIs and adapts the existing platform engine/queue coordinator into `:playback:runtime`.
+- `:androidApp` consumes `:shared` plus playback/core APIs and adapts the platform engine and playback-owned coordinators into `:playback:runtime`.
 
 These modules intentionally start small. New cross-feature/platform contracts should move into the appropriate API/runtime module instead of expanding the flat shared contract surface. Feature implementation modules can be split later after their ownership boundaries are stable.
 
@@ -29,7 +29,7 @@ The first migration stage groups existing source files physically while keeping 
 - `core/model/`: legacy shared models during migration; stable new architecture models belong in `:core:model`.
 - `core/ui/`: design system and cross-feature UI/platform abstractions.
 - `feature/<name>/`: feature-local controller, state and UI.
-- `feature/playback/`: playback session composition plus the remaining legacy coordinator/presentation helpers during migration.
+- `feature/playback/`: playback composition, queue/start coordinators, and the remaining presentation compatibility adapters during migration.
 
 Provider protocol implementations remain under `provider/<provider>` because they already have a useful adapter boundary.
 
@@ -39,9 +39,11 @@ Feature state should have one owner. New feature work should expose immutable UI
 
 App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback status, timing, current stable track reference, lyrics, queue identity/index, errors, and transport policy belong to `PlaybackSession` / `DefaultPlaybackRuntime`. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
 
-Platform playback integrations and migrated playback UI consume `PlaybackSession`, not the global controller. `ControllerPlaybackSession` has been retired. Android and iOS both adapt their existing engine/queue coordinator into the same runtime contract. The composition edge still supplies three temporary queue-transition callbacks (`startCurrent`, `previous`, `next`) while queue selection and resource-resolution policy are extracted from the legacy coordinator.
+Queue and start orchestration now have explicit playback owners. `PlaybackQueueCoordinator` owns `startCurrent` / `previous` / `next`, up-next priority, repeat/part transitions and queue-index selection while `PlaybackQueueController` remains the durable queue state holder. `PlaybackStartCoordinator` owns the prepare -> resolve/plan -> engine-start pipeline, including direct provider resolution on platforms that do not resolve resources inside the engine and `PlaybackPlan` construction for engines that do.
 
-MiniPlayer and FullPlayer now read authoritative playback state/transport from `PlaybackSession`. FullPlayer-specific rich presentation and feature operations that do not belong in the narrow session contract—queue editing, seek/shuffle/repeat, sleep timer, rich `MusicTrack` metadata, downloads and replacement actions—flow through `PlaybackUiPort`. `ControllerPlaybackUiPort` is an app-shell compatibility adapter only; migrated playback UI does not depend on `FuoPlayerController` directly.
+Pre-engine start failures are published through `PlaybackStartFailureSource`. Android and iOS runtime adapters combine that playback-owned failure with engine state, so the old iOS compatibility path that read coordinator/controller `Error` state has been retired.
+
+MiniPlayer and FullPlayer read authoritative playback state/transport from `PlaybackSession`. FullPlayer-specific rich presentation and feature operations that do not belong in the narrow session contract—queue editing, seek/shuffle/repeat, sleep timer, rich `MusicTrack` metadata, downloads and replacement actions—flow through `PlaybackUiPort`. `ControllerPlaybackUiPort` is an app-shell compatibility adapter only; migrated playback UI does not depend on `FuoPlayerController` directly.
 
 Legacy feature screens that still call the old `MiniPlayer(controller)` signature are outside the playback UI boundary. That signature remains only as a feature-shell compatibility call site while those screens are migrated; playback state and transport themselves remain session-owned.
 
@@ -55,11 +57,11 @@ Platform dependency construction is isolated in platform containers. Android use
 
 Search and Recognition are composed through explicit `SearchAppPort` / `RecognitionAppPort` contracts. Their routes and feature UI no longer accept `FuoPlayerController`. During the remaining migration, platform composition roots may adapt still-centralized controller operations to those ports; the dependency must not leak back into the feature or app route contract.
 
-Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. The shared runtime module remains controller-free. `FuoAppViewModel` exposes the resulting app-scoped `PlaybackSession`, and `AppRoot` supplies it to playback UI through `LocalPlaybackSession`. `AppRoot` also supplies the temporary `PlaybackUiPort` adapter separately so the stable runtime API does not expand into app-specific UI operations.
+Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. Both receive `PlaybackTransportCoordinator` and `PlaybackStartFailureSource` explicitly; they no longer dispatch runtime transport through controller methods or inspect controller error state. `FuoAppViewModel` exposes the resulting app-scoped `PlaybackSession`, and `AppRoot` supplies it to playback UI through `LocalPlaybackSession`. `AppRoot` also supplies the temporary `PlaybackUiPort` adapter separately so the stable runtime API does not expand into app-specific UI operations.
 
 ## Architecture fitness check
 
-`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, `PlaybackUiPort`, playback composition contracts, controller-free MiniPlayer/FullPlayer implementations, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter.
+`checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, `PlaybackQueueCoordinator`, `PlaybackStartCoordinator`, `PlaybackUiPort`, playback composition contracts, controller-free MiniPlayer/FullPlayer implementations, app-port contracts/routes, and Android playback service/Lyricon integration. It also rejects reintroduction of the retired Search/Recognition route shims and `ControllerPlaybackSession` adapter, plus direct `controller.toggle()/previous()/next()` calls in platform playback runtime adapters.
 
 ## Migration rule
 

--- a/docs/player-controller-refactor.md
+++ b/docs/player-controller-refactor.md
@@ -48,8 +48,8 @@ Playback platform state and transport policy now have a dedicated owner.
 - New `:playback:runtime` contains `DefaultPlaybackRuntime`, which owns the authoritative `PlaybackSessionState` consumed by platform integrations.
 - Runtime state combines engine timing/status/error with queue/current-track/lyrics presentation supplied at the composition edge.
 - Play/pause/toggle decisions now live in the runtime and call the engine directly for pause/resume instead of round-tripping through `FuoPlayerController`.
-- The former Android-only `ControllerPlaybackSession` adapter is removed. Android now uses `AndroidPlaybackRuntime.kt` only to adapt the existing engine and the remaining legacy queue coordinator into the controller-free runtime module.
-- Only `startCurrent`, `previous`, and `next` remain as temporary queue-transition callbacks to the legacy coordinator; queue selection and resource resolution are intentionally deferred so this slice stays behavior-preserving.
+- The former Android-only `ControllerPlaybackSession` adapter is removed. Android now uses `AndroidPlaybackRuntime.kt` only to adapt the existing engine and playback composition edge into the controller-free runtime module.
+- `startCurrent`, `previous`, and `next` were initially left as temporary queue-transition callbacks while queue selection and resource resolution remained in the compatibility controller.
 - Focused runtime tests cover state composition and transport dispatch, and CI runs `:playback:runtime:allTests` on both Android and iOS workflows.
 - Architecture fitness rules scan the runtime module and reject reintroduction of `ControllerPlaybackSession`.
 
@@ -62,7 +62,7 @@ The MiniPlayer rendering/transport path consumes the dedicated playback session 
 - iOS has `IosPlaybackRuntime.kt`, mirroring the Android composition-edge adapter and constructing the same `DefaultPlaybackRuntime` contract.
 - `FuoAppViewModel` receives the app-scoped `PlaybackSession`; `AppRoot` provides it to playback UI through `LocalPlaybackSession`.
 - `RuntimeMiniPlayer` renders `PlaybackSessionState`, cover metadata from `TrackRef`, progress, lyrics, and previous/toggle/next transport without reading `FuoPlayerController`.
-- Review feedback exposed an iOS pre-engine resource-resolution failure path. `IosPlaybackRuntime` now bridges only the same-track `Loading -> coordinator Error` transition until resource resolution becomes runtime-owned, with focused iOS regression tests.
+- Review feedback exposed an iOS pre-engine resource-resolution failure path. C1 temporarily bridged the same-track `Loading -> coordinator Error` transition until start orchestration received a playback-owned failure channel.
 
 ### C2: FullPlayer, queue and lyrics
 
@@ -76,10 +76,23 @@ The active FullPlayer path is now controller-free.
 - Home and local-playlist MiniPlayer call sites now use the controller-free `PlaybackMiniPlayer` host. Other legacy feature screens can keep their old call signature until their own feature migration; that compatibility call does not change playback state/transport ownership.
 - Architecture fitness rules scan `PlaybackUiPort`, playback composition contracts, `RuntimeMiniPlayer`, and `RuntimeFullPlayer` to prevent direct controller dependencies from returning.
 
+## Phase 7: playback orchestration ownership (P1-D)
+
+Queue transition and playback-start policy now have dedicated playback owners instead of living in `FuoPlayerController`.
+
+- `PlaybackQueueCoordinator` owns `startCurrent`, `previous`, `next`, queue-index selection, up-next priority, repeat behavior, multi-part transitions, and dynamic-feature continuation decisions.
+- `PlaybackQueueController` remains the durable queue state holder; the compatibility controller delegates queue transition entry points to the coordinator instead of implementing the policy itself.
+- `PlaybackStartCoordinator` owns the prepare -> resolve/plan -> engine-start pipeline, including downloaded/local payload handling, provider resolution on iOS-style engines, `PlaybackPlan` look-ahead construction on Android-style internally resolving engines, multi-part payload mapping, stale-request protection, and start-failure publication.
+- `PlaybackStartFailureSource` publishes pre-engine resolution failures. Android and iOS runtime adapters combine this playback-owned failure with engine state, replacing the temporary iOS bridge that inspected `FuoPlayerController.playbackState` for an `Error`.
+- Android and iOS composition roots explicitly pass `PlaybackTransportCoordinator` and `PlaybackStartFailureSource` into their runtime adapters. Runtime transport no longer dispatches `controller.toggle()`, `controller.previous()`, or `controller.next()`.
+- `FuoPlayerController` keeps facade methods for legacy feature callers, but those methods delegate to the playback owners. Request serial / part-selection storage remains facade-compatible in this phase so the migration does not mix state relocation with orchestration policy changes.
+- Focused common tests cover up-next/repeat/part queue transitions, direct resource resolution success/failure, and internally resolving playback-plan construction. iOS tests verify same-track playback-start failures override Loading without unrelated failures leaking across tracks.
+- Architecture checks prevent the new coordinators from depending on `FuoPlayerController` and reject direct controller transport calls in the platform runtime adapters.
+
 ## Next phases
 
-1. Move the remaining `startCurrent` / `previous` / `next` queue-transition policy and resource-start orchestration out of `FuoPlayerController`, removing the final runtime queue bridge and the iOS pre-engine error compatibility bridge.
-2. Replace `ControllerPlaybackUiPort` responsibilities with explicit playback/download/provider-detail owners as those feature boundaries become available.
-3. Replace controller-backed Search/Recognition app-port operations as their sibling playback/download/provider-detail owners become explicit domain/feature ports.
-4. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings; remove their legacy MiniPlayer call signatures during those migrations.
+1. Split the remaining `ControllerPlaybackUiPort` responsibilities into explicit playback presentation, download, provider-detail and navigation owners, then remove the app-shell compatibility adapter.
+2. Replace controller-backed Search/Recognition app-port operations as their sibling download/provider-detail owners become explicit domain/feature ports.
+3. Apply the feature-owned state plus app-shell composition pattern to local music, downloads, provider content, and settings; remove their legacy MiniPlayer call signatures during those migrations.
+4. Move remaining queue/start compatibility state (request serial, playback parts/index, rich queue presentation) behind playback-owned state once downstream feature callers are ready, then retire the playback facade methods from `FuoPlayerController`.
 5. Continue moving stable contracts into compile-time modules and retire legacy aggregate provider dependencies and global loading/message state.

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/FuoPlayerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/FuoPlayerController.kt
@@ -332,6 +332,10 @@ class FuoPlayerController(
         get() = isFmQueue
     val displayUpNextCount: Int
         get() = upNextQueue.size
+    val playbackTransportCoordinator: PlaybackTransportCoordinator
+        get() = playbackQueueCoordinator
+    val playbackStartFailureSource: PlaybackStartFailureSource
+        get() = playbackStartCoordinator
     val canNavigateBack: Boolean
         get() = isFullPlayerOpen ||
             selectedLocalMusicCollection != null ||
@@ -501,6 +505,71 @@ class FuoPlayerController(
         currentTrackId = { currentQueueTrack()?.id ?: playbackState.currentTrack?.id },
         currentLyrics = { playbackState.lyrics },
         updateLyrics = { lyrics -> playbackState = playbackState.copy(lyrics = lyrics) },
+    )
+    private val playbackStartCoordinator = PlaybackStartCoordinator(
+        queue = playbackQueueController,
+        playbackEngine = playbackEngine,
+        playbackRepository = playbackProviderRepository,
+        scope = scope,
+        currentPlaybackState = { playbackState },
+        publishPlaybackState = { playbackState = it },
+        prepareTrack = { track -> track.withRememberedReplacement().preferDownloaded() },
+        unavailablePlaybackPolicy = { unavailablePlaybackPolicy },
+        smartReplacementProviderIds = ::selectedSmartReplacementProviderIds,
+        smartReplacementMinScore = { smartReplacementMinScore },
+        nextRequestSerial = { ++playRequestSerial },
+        currentRequestSerial = { playRequestSerial },
+        playbackParts = { playbackParts },
+        setPlaybackParts = { playbackParts = it },
+        currentPartIndex = { currentPartIndex },
+        setCurrentPartIndex = { currentPartIndex = it },
+        prepareSleepTimer = sleepTimerController::prepareForTrack,
+        resetLyricsForPlaybackRequest = playbackLyricsController::resetForPlaybackRequest,
+        maybeLoadLyrics = playbackLyricsController::maybeLoad,
+        persistQueue = ::persistPlaybackQueue,
+        setLoading = { isLoading = it },
+        setMessage = { message = it },
+        failureMessage = { throwable ->
+            providerErrorMessage(throwable, throwable::class.simpleName.orEmpty())
+        },
+        onRequestStarted = { serial, suppressRecovery ->
+            suppressPlaybackRecoveryRequestSerial = serial.takeIf { suppressRecovery }
+        },
+        onManualSelectionStarted = { serial, playbackTrack, selection, rollbackTrack ->
+            pendingManualReplacementSwitch = PendingManualReplacementSwitch(
+                requestSerial = serial,
+                previousTrack = rollbackTrack,
+                originalTrackId = playbackTrack.originalId ?: playbackTrack.id,
+                selection = selection,
+            )
+        },
+        onStartFailure = startFailure@{ serial, playbackTrack, skippedUnavailableCount, manualSelection, throwable ->
+            if (manualSelection != null && rollbackManualReplacement(serial, throwable.message)) {
+                return@startFailure
+            }
+            if (suppressPlaybackRecoveryRequestSerial == serial) {
+                showManualReplacementRestoreFailure(throwable.message)
+            } else if (!skipUnavailableTrack(playbackTrack, skippedUnavailableCount, throwable)) {
+                setError(throwable)
+            }
+        },
+        prefetchQueue = ::prefetchFeatureQueueIfNeeded,
+    )
+    private val playbackQueueCoordinator = PlaybackQueueCoordinator(
+        queue = playbackQueueController,
+        scope = scope,
+        fallbackTrack = { playbackState.currentTrack },
+        playbackParts = { playbackParts },
+        currentPartIndex = { currentPartIndex },
+        startPlayback = { track, skippedUnavailableCount, requestedPartIndex ->
+            startPlayback(track, skippedUnavailableCount, requestedPartIndex)
+        },
+        stopPlayback = playbackEngine::stop,
+        persistQueue = ::persistPlaybackQueue,
+        updateQueueState = ::updatePlaybackQueueState,
+        appendFeatureQueue = ::appendFeatureQueue,
+        setTrackChangeDirection = { trackChangeDirection = it },
+        setMessage = { message = it },
     )
 
     init {
@@ -2592,36 +2661,9 @@ class FuoPlayerController(
         play(track, selectedTrackSimilar, index)
     }
 
-    fun playQueueIndex(index: Int) {
-        trackChangeDirection = TrackChangeDirection.Next
-        val currentOffset = if (currentQueueTrack() != null) 1 else 0
-        if (index == 0 && currentOffset == 1) {
-            currentQueueTrack()?.let(::startPlayback)
-            return
-        }
-        val pendingOffset = currentOffset
-        val pendingEnd = pendingOffset + upNextQueue.size
-        when {
-            index in pendingOffset until pendingEnd -> {
-                val upNextIndex = index - pendingOffset
-                playUpNextIndex(upNextIndex)
-            }
-            else -> {
-                val mainStartIndex = when {
-                    currentIsUpNext -> mainQueueIndex + 1
-                    mainQueueIndex >= 0 -> mainQueueIndex + 1
-                    else -> 0
-                }
-                val mainIndex = mainStartIndex + (index - pendingEnd)
-                playMainIndex(mainIndex)
-            }
-        }
-    }
+    fun playQueueIndex(index: Int) = playbackQueueCoordinator.playQueueIndex(index)
 
-    fun playPlaybackPart(index: Int) {
-        if (index !in playbackParts.indices) return
-        currentQueueTrack()?.let { startPlayback(it, requestedPartIndex = index) }
-    }
+    fun playPlaybackPart(index: Int) = playbackQueueCoordinator.playPlaybackPart(index)
 
     fun toggle() {
         when (playbackState.status) {
@@ -2630,73 +2672,14 @@ class FuoPlayerController(
                 if (playbackState.currentTrack != null) playbackEngine.resume()
             }
             PlayerStatus.Idle, PlayerStatus.Ended, PlayerStatus.Loading, PlayerStatus.Error -> {
-                (currentQueueTrack() ?: playbackState.currentTrack)?.let(::startPlayback)
+                playbackQueueCoordinator.startCurrent()
             }
         }
     }
 
-    fun next() {
-        trackChangeDirection = TrackChangeDirection.Next
-        if (_repeatMode == RepeatMode.SINGLE) {
-            if (playPlaybackPartOffset(1, wrap = true)) return
-            (currentQueueTrack() ?: playbackState.currentTrack)?.let { startPlayback(it) }
-            return
-        }
-        if (playPlaybackPartOffset(1)) return
-        if (currentIsUpNext) {
-            currentUpNextTrack = null
-            currentIsUpNext = false
-            persistPlaybackQueue()
-        }
-        if (upNextQueue.isNotEmpty()) {
-            playUpNextIndex(0)
-            return
-        }
-        if (mainQueue.isEmpty()) return
-        val feature = queueFeature
-        if (feature != null && mainQueueIndex >= mainQueue.lastIndex) {
-            scope.launch {
-                val nextIndex = mainQueue.size
-                val appendedCount = appendFeatureQueue(feature)
-                if (appendedCount > 0 && queueFeature == feature) {
-                    playMainIndex(nextIndex)
-                } else if (queueFeature == feature) {
-                    message = "${feature.title} 暂无后续歌曲"
-                }
-            }
-            return
-        }
-        val nextIndex = mainQueueIndex + 1
-        if (nextIndex < mainQueue.size) {
-            playMainIndex(nextIndex)
-        } else if (_repeatMode == RepeatMode.QUEUE) {
-            playMainIndex(0)
-        }
-    }
+    fun next() = playbackQueueCoordinator.next()
 
-    fun previous() {
-        trackChangeDirection = TrackChangeDirection.Previous
-        if (_repeatMode == RepeatMode.SINGLE) {
-            if (playPlaybackPartOffset(-1, wrap = true)) return
-            (currentQueueTrack() ?: playbackState.currentTrack)?.let { startPlayback(it) }
-            return
-        }
-        if (playPlaybackPartOffset(-1)) return
-        if (currentIsUpNext) {
-            currentUpNextTrack = null
-            currentIsUpNext = false
-            persistPlaybackQueue()
-            playMainIndex(mainQueueIndex.coerceAtLeast(0))
-            return
-        }
-        if (mainQueue.isEmpty()) return
-        val previousIndex = mainQueueIndex - 1
-        if (previousIndex >= 0) {
-            playMainIndex(previousIndex)
-        } else if (_repeatMode == RepeatMode.QUEUE) {
-            playMainIndex(mainQueue.lastIndex)
-        }
-    }
+    fun previous() = playbackQueueCoordinator.previous()
 
     fun seekTo(positionMs: Long) {
         val normalizedPosition = positionMs.coerceAtLeast(0).let { position ->
@@ -3117,210 +3100,14 @@ class FuoPlayerController(
         messageAfterStart: String? = null,
         suppressPlaybackRecovery: Boolean = false,
     ) {
-        sleepTimerController.prepareForTrack(track.id)
-        val requestSerial = ++playRequestSerial
-        suppressPlaybackRecoveryRequestSerial = requestSerial.takeIf { suppressPlaybackRecovery }
-        val playbackTrack = if (manualSelection != null) {
-            track
-        } else {
-            track.withRememberedReplacement().preferDownloaded()
-        }
-        pendingManualReplacementSwitch = manualSelection?.let { selection ->
-            PendingManualReplacementSwitch(
-                requestSerial = requestSerial,
-                previousTrack = rollbackTrack,
-                originalTrackId = playbackTrack.originalId ?: playbackTrack.id,
-                selection = selection,
-            )
-        }
-        val isPlaybackPartRequest = requestedPartIndex != null && playbackParts.isNotEmpty()
-        if (!isPlaybackPartRequest) {
-            playbackParts = emptyList()
-            currentPartIndex = -1
-        }
-        updateCurrentTrack(playbackTrack)
-        playbackLyricsController.resetForPlaybackRequest()
-        playbackState = playbackState.copy(
-            status = PlayerStatus.Loading,
-            currentTrack = playbackTrack,
-            queue = displayQueue(),
-            queueIndex = displayQueueIndex(),
-            positionMs = 0,
-            playbackParts = playbackParts,
-            currentPartIndex = requestedPartIndex.takeIf { isPlaybackPartRequest } ?: -1,
-            lyrics = playbackTrack.lyrics,
-            errorMessage = null,
-        )
-        persistPlaybackQueue()
-        playbackEngine.prepareLoading(playbackTrack)
-        isLoading = true
-        message = messageAfterStart ?: "正在播放：${track.title}"
-        val resolveTrack = requestedPartIndex
-            ?.let { index -> playbackParts.getOrNull(index) }
-            ?.toTrack(playbackTrack)
-            ?: playbackTrack
-        playbackLyricsController.maybeLoad(playbackTrack)
-        if (!playbackEngine.resolvesResourcesInternally) {
-            scope.launch playRequest@{
-                runCatching {
-                    val payload = resolveTrack.toPayload()
-                        ?: if (manualSelection != null) {
-                            playbackProviderRepository.resolveSelectedReplacement(
-                                resolveTrack,
-                                true,
-                                true,
-                                selectedSmartReplacementProviderIds(),
-                            )
-                        } else {
-                            playbackProviderRepository.resolve(
-                                resolveTrack,
-                                unavailablePlaybackPolicy,
-                                selectedSmartReplacementProviderIds(),
-                                smartReplacementMinScore,
-                                true,
-                                true,
-                            )
-                        }
-                    if (requestSerial != playRequestSerial) return@playRequest
-                    if (suppressPlaybackRecoveryRequestSerial == requestSerial) {
-                        suppressPlaybackRecoveryRequestSerial = null
-                    }
-                    val nextParts = payload.parts
-                    val nextPartIndex = when {
-                        nextParts.isEmpty() -> -1
-                        payload.currentPartIndex in nextParts.indices -> payload.currentPartIndex
-                        requestedPartIndex != null && requestedPartIndex in nextParts.indices -> requestedPartIndex
-                        else -> -1
-                    }
-                    playbackParts = nextParts
-                    currentPartIndex = nextPartIndex
-                    val isMultipartPlayback = playbackParts.isNotEmpty()
-                    val isSmartReplacementPlayback = payload.isSmartReplacement || manualSelection != null
-                    val playableTrack = playbackTrack.copy(
-                        title = if (isMultipartPlayback) playbackTrack.title else payload.title.ifBlank { playbackTrack.title },
-                        artists = payload.artists.ifBlank { playbackTrack.artists },
-                        album = payload.album.ifBlank { playbackTrack.album },
-                        source = if (isSmartReplacementPlayback) {
-                            payload.originalSource?.takeIf { it.isNotBlank() } ?: playbackTrack.source
-                        } else {
-                            payload.source.ifBlank { playbackTrack.source }
-                        },
-                        coverUrl = payload.coverUrl ?: playbackTrack.coverUrl,
-                        durationMs = if (isMultipartPlayback) playbackTrack.durationMs else payload.durationMs ?: playbackTrack.durationMs,
-                        providerName = if (isSmartReplacementPlayback) {
-                            payload.providerName ?: payload.replacementProviderName ?: playbackTrack.providerName
-                        } else {
-                            payload.providerName ?: playbackTrack.providerName
-                        },
-                        providerId = if (isSmartReplacementPlayback) {
-                            payload.originalId ?: playbackTrack.providerId
-                        } else {
-                            playbackTrack.providerId
-                        },
-                        isSmartReplacement = isSmartReplacementPlayback,
-                        originalId = payload.originalId.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalId.takeIf { isSmartReplacementPlayback },
-                        originalTitle = payload.originalTitle.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalTitle.takeIf { isSmartReplacementPlayback },
-                        originalArtists = payload.originalArtists.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalArtists.takeIf { isSmartReplacementPlayback },
-                        originalAlbum = payload.originalAlbum.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalAlbum.takeIf { isSmartReplacementPlayback },
-                        originalSource = payload.originalSource.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalSource.takeIf { isSmartReplacementPlayback },
-                        originalProviderName = payload.originalProviderName.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalProviderName.takeIf { isSmartReplacementPlayback },
-                        originalCoverUrl = payload.originalCoverUrl.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.originalCoverUrl.takeIf { isSmartReplacementPlayback },
-                        replacementId = payload.replacementId.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementId.takeIf { isSmartReplacementPlayback },
-                        replacementTitle = payload.replacementTitle.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementTitle.takeIf { isSmartReplacementPlayback },
-                        replacementArtists = payload.replacementArtists.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementArtists.takeIf { isSmartReplacementPlayback },
-                        replacementAlbum = payload.replacementAlbum.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementAlbum.takeIf { isSmartReplacementPlayback },
-                        replacementSource = payload.replacementSource.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementSource.takeIf { isSmartReplacementPlayback },
-                        replacementProviderName = payload.replacementProviderName.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementProviderName.takeIf { isSmartReplacementPlayback },
-                        replacementCoverUrl = payload.replacementCoverUrl.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementCoverUrl.takeIf { isSmartReplacementPlayback },
-                        replacementStrategy = payload.replacementStrategy.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementStrategy.takeIf { isSmartReplacementPlayback },
-                        replacementScore = payload.replacementScore.takeIf { isSmartReplacementPlayback }
-                            ?: playbackTrack.replacementScore.takeIf { isSmartReplacementPlayback },
-                        isUnavailable = false,
-                    )
-                    updateCurrentTrack(playableTrack)
-                    playbackEngine.play(playableTrack, payload)
-                    playbackState = playbackState.copy(
-                        status = PlayerStatus.Loading,
-                        currentTrack = playableTrack,
-                        queue = displayQueue(),
-                        queueIndex = displayQueueIndex(),
-                        lyrics = payload.lyrics?.takeIf { it.isNotBlank() } ?: playbackState.lyrics,
-                        audioQuality = payload.audioQuality,
-                        playbackParts = playbackParts,
-                        currentPartIndex = currentPartIndex,
-                    )
-                    playbackLyricsController.maybeLoad(playableTrack)
-                    persistPlaybackQueue()
-                    message = messageAfterStart
-                        ?: currentPlaybackPartLabel()?.let { "${playableTrack.title} · $it" }
-                        ?: "${playableTrack.title} - ${playableTrack.artists}"
-                    prefetchFeatureQueueIfNeeded()
-                }.onFailure { throwable ->
-                    if (requestSerial == playRequestSerial) {
-                        if (manualSelection != null && rollbackManualReplacement(requestSerial, throwable.message)) {
-                            return@onFailure
-                        }
-                        if (suppressPlaybackRecoveryRequestSerial == requestSerial) {
-                            showManualReplacementRestoreFailure(throwable.message)
-                        } else if (!skipUnavailableTrack(playbackTrack, skippedUnavailableCount, throwable)) {
-                            setError(throwable)
-                        }
-                    }
-                }
-                if (requestSerial == playRequestSerial) isLoading = false
-            }
-            return
-        }
-        playbackEngine.play(
-            PlaybackPlan(
-                generation = requestSerial,
-                requests = buildList {
-                    add(
-                        PlaybackRequest(
-                            track = playbackTrack,
-                            resolveTrack = resolveTrack,
-                            requestedPartIndex = requestedPartIndex,
-                            unavailablePolicy = unavailablePlaybackPolicy,
-                            smartReplacementProviderIds = selectedSmartReplacementProviderIds(),
-                            smartReplacementMinScore = smartReplacementMinScore,
-                            smartReplacementUseOriginalMetadata = true,
-                            smartReplacementUseOriginalLyrics = true,
-                            resolveOnlySelectedReplacement = manualSelection != null,
-                        ),
-                    )
-                    displayQueue()
-                        .drop(1)
-                        .take(PLAYBACK_PLAN_LOOKAHEAD)
-                        .forEach { queuedTrack ->
-                            val nextTrack = queuedTrack.withRememberedReplacement().preferDownloaded()
-                            add(
-                                PlaybackRequest(
-                                    track = nextTrack,
-                                    unavailablePolicy = unavailablePlaybackPolicy,
-                                    smartReplacementProviderIds = selectedSmartReplacementProviderIds(),
-                                    smartReplacementMinScore = smartReplacementMinScore,
-                                    smartReplacementUseOriginalMetadata = true,
-                                    smartReplacementUseOriginalLyrics = true,
-                                ),
-                            )
-                        }
-                },
-            ),
+        playbackStartCoordinator.start(
+            track = track,
+            skippedUnavailableCount = skippedUnavailableCount,
+            requestedPartIndex = requestedPartIndex,
+            manualSelection = manualSelection,
+            rollbackTrack = rollbackTrack,
+            messageAfterStart = messageAfterStart,
+            suppressPlaybackRecovery = suppressPlaybackRecovery,
         )
     }
 
@@ -3413,23 +3200,10 @@ class FuoPlayerController(
         persistPlaybackQueue()
     }
 
-    private fun playMainIndex(index: Int, skippedUnavailableCount: Int = 0) {
-        val track = mainQueue.getOrNull(index) ?: return
-        currentUpNextTrack = null
-        currentIsUpNext = false
-        mainQueueIndex = index
-        startPlayback(track, skippedUnavailableCount)
-    }
+    private fun playMainIndex(index: Int, skippedUnavailableCount: Int = 0) =
+        playbackQueueCoordinator.playMainIndex(index, skippedUnavailableCount)
 
-    private fun playUpNextIndex(index: Int) {
-        val track = upNextQueue.getOrNull(index) ?: return
-        upNextQueue = upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
-        currentUpNextTrack = track
-        currentIsUpNext = true
-        updatePlaybackQueueState()
-        persistPlaybackQueue()
-        startPlayback(track)
-    }
+    private fun playUpNextIndex(index: Int) = playbackQueueCoordinator.playUpNextIndex(index)
 
     private fun loadFeatureAndPlayAll(feature: ProviderFeature) {
         scope.launch {
@@ -3633,17 +3407,8 @@ class FuoPlayerController(
         )
     }
 
-    private fun playPlaybackPartOffset(offset: Int, wrap: Boolean = false): Boolean {
-        if (playbackParts.isEmpty() || currentPartIndex < 0) return false
-        val nextPartIndex = currentPartIndex + offset
-        val targetPartIndex = if (wrap) {
-            nextPartIndex.floorMod(playbackParts.size)
-        } else {
-            nextPartIndex.takeIf { it in playbackParts.indices } ?: return false
-        }
-        currentQueueTrack()?.let { startPlayback(it, requestedPartIndex = targetPartIndex) } ?: return false
-        return true
-    }
+    private fun playPlaybackPartOffset(offset: Int, wrap: Boolean = false): Boolean =
+        playbackQueueCoordinator.playPlaybackPartOffset(offset, wrap)
 
     private fun Int.floorMod(divisor: Int): Int {
         return ((this % divisor) + divisor) % divisor
@@ -3660,14 +3425,7 @@ class FuoPlayerController(
 
     private fun displayQueueIndex(): Int = playbackQueueController.displayQueueIndex()
 
-    private fun updateCurrentTrack(track: MusicTrack) {
-        if (currentIsUpNext) {
-            currentUpNextTrack = track
-        } else if (mainQueueIndex in mainQueue.indices) {
-            mainQueue = mainQueue.mapIndexed { index, item -> if (index == mainQueueIndex) track else item }
-            originalMainQueue = originalMainQueue.map { item -> if (item.id == track.id) track else item }
-        }
-    }
+    private fun updateCurrentTrack(track: MusicTrack) = playbackQueueController.updateCurrentTrack(track)
 
     private fun synchronizePlaybackTrack(track: MusicTrack) {
         val current = currentQueueTrack()
@@ -4078,7 +3836,6 @@ class FuoPlayerController(
 
     private fun String.isMediaNotFoundMessage(): Boolean =
         contains("media not found", ignoreCase = true) || contains("MediaNotFound", ignoreCase = true)
-
 }
 
 internal fun normalizedPlaylistPlaybackStats(settings: AppSettings): Map<String, PlaylistPlaybackStat> {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -3,9 +3,8 @@ package org.feeluown.mobile
 /**
  * Owns the durable playback-queue state independently from the app controller.
  *
- * Queue mutation policy still lives in the playback coordinator/facade while it is
- * migrated, but the queue's single source of truth and persistence snapshot no
- * longer belong to [FuoPlayerController].
+ * Queue transition policy is coordinated by [PlaybackQueueCoordinator]; this
+ * type remains the single source of truth for queue state and persistence.
  */
 internal class PlaybackQueueController {
     var mainQueue: List<MusicTrack> = emptyList()
@@ -38,6 +37,15 @@ internal class PlaybackQueueController {
     }
 
     fun displayQueueIndex(): Int = if (currentTrack() != null) 0 else -1
+
+    fun updateCurrentTrack(track: MusicTrack) {
+        if (currentIsUpNext) {
+            currentUpNextTrack = track
+        } else if (mainQueueIndex in mainQueue.indices) {
+            mainQueue = mainQueue.mapIndexed { index, item -> if (index == mainQueueIndex) track else item }
+            originalMainQueue = originalMainQueue.map { item -> if (item.id == track.id) track else item }
+        }
+    }
 
     fun restore(snapshot: PlaybackQueueSnapshot) {
         mainQueue = snapshot.mainQueue

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
@@ -1,0 +1,168 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Runtime-facing transport contract owned by the playback feature.
+ *
+ * Platform runtime adapters depend on this contract instead of calling the
+ * legacy app-controller transport facade.
+ */
+interface PlaybackTransportCoordinator {
+    fun startCurrent()
+    fun previous()
+    fun next()
+}
+
+/**
+ * Owns queue/part transition policy while [PlaybackQueueController] remains the
+ * durable queue state holder.
+ */
+internal class PlaybackQueueCoordinator(
+    private val queue: PlaybackQueueController,
+    private val scope: CoroutineScope,
+    private val fallbackTrack: () -> MusicTrack?,
+    private val playbackParts: () -> List<PlaybackPart>,
+    private val currentPartIndex: () -> Int,
+    private val startPlayback: (MusicTrack, Int, Int?) -> Unit,
+    @Suppress("UNUSED_PARAMETER") private val stopPlayback: () -> Unit,
+    private val persistQueue: () -> Unit,
+    private val updateQueueState: () -> Unit,
+    private val appendFeatureQueue: suspend (ProviderFeature) -> Int,
+    private val setTrackChangeDirection: (TrackChangeDirection) -> Unit,
+    private val setMessage: (String) -> Unit,
+) : PlaybackTransportCoordinator {
+
+    override fun startCurrent() {
+        (queue.currentTrack() ?: fallbackTrack())?.let { startPlayback(it, 0, null) }
+    }
+
+    override fun next() {
+        setTrackChangeDirection(TrackChangeDirection.Next)
+        if (queue.repeatMode == RepeatMode.SINGLE) {
+            if (playPlaybackPartOffset(1, wrap = true)) return
+            startCurrent()
+            return
+        }
+        if (playPlaybackPartOffset(1)) return
+        if (queue.currentIsUpNext) {
+            queue.currentUpNextTrack = null
+            queue.currentIsUpNext = false
+            persistQueue()
+        }
+        if (queue.upNextQueue.isNotEmpty()) {
+            playUpNextIndex(0)
+            return
+        }
+        if (queue.mainQueue.isEmpty()) return
+        val feature = queue.queueFeature
+        if (feature != null && queue.mainQueueIndex >= queue.mainQueue.lastIndex) {
+            scope.launch {
+                val nextIndex = queue.mainQueue.size
+                val appendedCount = appendFeatureQueue(feature)
+                if (appendedCount > 0 && queue.queueFeature == feature) {
+                    playMainIndex(nextIndex)
+                } else if (queue.queueFeature == feature) {
+                    setMessage("${feature.title} 暂无后续歌曲")
+                }
+            }
+            return
+        }
+        val nextIndex = queue.mainQueueIndex + 1
+        if (nextIndex < queue.mainQueue.size) {
+            playMainIndex(nextIndex)
+        } else if (queue.repeatMode == RepeatMode.QUEUE) {
+            playMainIndex(0)
+        }
+    }
+
+    override fun previous() {
+        setTrackChangeDirection(TrackChangeDirection.Previous)
+        if (queue.repeatMode == RepeatMode.SINGLE) {
+            if (playPlaybackPartOffset(-1, wrap = true)) return
+            startCurrent()
+            return
+        }
+        if (playPlaybackPartOffset(-1)) return
+        if (queue.currentIsUpNext) {
+            queue.currentUpNextTrack = null
+            queue.currentIsUpNext = false
+            persistQueue()
+            playMainIndex(queue.mainQueueIndex.coerceAtLeast(0))
+            return
+        }
+        if (queue.mainQueue.isEmpty()) return
+        val previousIndex = queue.mainQueueIndex - 1
+        if (previousIndex >= 0) {
+            playMainIndex(previousIndex)
+        } else if (queue.repeatMode == RepeatMode.QUEUE) {
+            playMainIndex(queue.mainQueue.lastIndex)
+        }
+    }
+
+    fun playQueueIndex(index: Int) {
+        setTrackChangeDirection(TrackChangeDirection.Next)
+        val currentOffset = if (queue.currentTrack() != null) 1 else 0
+        if (index == 0 && currentOffset == 1) {
+            startCurrent()
+            return
+        }
+        val pendingOffset = currentOffset
+        val pendingEnd = pendingOffset + queue.upNextQueue.size
+        when {
+            index in pendingOffset until pendingEnd -> {
+                playUpNextIndex(index - pendingOffset)
+            }
+            else -> {
+                val mainStartIndex = when {
+                    queue.currentIsUpNext -> queue.mainQueueIndex + 1
+                    queue.mainQueueIndex >= 0 -> queue.mainQueueIndex + 1
+                    else -> 0
+                }
+                val mainIndex = mainStartIndex + (index - pendingEnd)
+                playMainIndex(mainIndex)
+            }
+        }
+    }
+
+    fun playPlaybackPart(index: Int) {
+        val parts = playbackParts()
+        if (index !in parts.indices) return
+        queue.currentTrack()?.let { startPlayback(it, 0, index) }
+    }
+
+    fun playMainIndex(index: Int, skippedUnavailableCount: Int = 0) {
+        val track = queue.mainQueue.getOrNull(index) ?: return
+        queue.currentUpNextTrack = null
+        queue.currentIsUpNext = false
+        queue.mainQueueIndex = index
+        startPlayback(track, skippedUnavailableCount, null)
+    }
+
+    fun playUpNextIndex(index: Int) {
+        val track = queue.upNextQueue.getOrNull(index) ?: return
+        queue.upNextQueue = queue.upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
+        queue.currentUpNextTrack = track
+        queue.currentIsUpNext = true
+        updateQueueState()
+        persistQueue()
+        startPlayback(track, 0, null)
+    }
+
+    fun playPlaybackPartOffset(offset: Int, wrap: Boolean = false): Boolean {
+        val parts = playbackParts()
+        val partIndex = currentPartIndex()
+        if (parts.isEmpty() || partIndex < 0) return false
+        val nextPartIndex = partIndex + offset
+        val targetPartIndex = if (wrap) {
+            nextPartIndex.floorMod(parts.size)
+        } else {
+            nextPartIndex.takeIf { it in parts.indices } ?: return false
+        }
+        queue.currentTrack()?.let { startPlayback(it, 0, targetPartIndex) } ?: return false
+        return true
+    }
+
+    private fun Int.floorMod(divisor: Int): Int = ((this % divisor) + divisor) % divisor
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
@@ -1,0 +1,344 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+private const val PLAYBACK_START_PLAN_LOOKAHEAD = 8
+
+data class PlaybackStartFailure(
+    val trackId: String,
+    val message: String,
+)
+
+interface PlaybackStartFailureSource {
+    val startFailure: StateFlow<PlaybackStartFailure?>
+}
+
+/** Owns the prepare -> resolve/plan -> engine start pipeline. */
+internal class PlaybackStartCoordinator(
+    private val queue: PlaybackQueueController,
+    private val playbackEngine: PlaybackEngine,
+    private val playbackRepository: ProviderPlaybackRepository,
+    private val scope: CoroutineScope,
+    private val currentPlaybackState: () -> PlaybackState,
+    private val publishPlaybackState: (PlaybackState) -> Unit,
+    private val prepareTrack: (MusicTrack) -> MusicTrack,
+    private val unavailablePlaybackPolicy: () -> UnavailablePlaybackPolicy,
+    private val smartReplacementProviderIds: () -> Set<String>,
+    private val smartReplacementMinScore: () -> Double,
+    private val nextRequestSerial: () -> Long,
+    private val currentRequestSerial: () -> Long,
+    private val playbackParts: () -> List<PlaybackPart>,
+    private val setPlaybackParts: (List<PlaybackPart>) -> Unit,
+    private val currentPartIndex: () -> Int,
+    private val setCurrentPartIndex: (Int) -> Unit,
+    private val prepareSleepTimer: (String) -> Unit,
+    private val resetLyricsForPlaybackRequest: () -> Unit,
+    private val maybeLoadLyrics: (MusicTrack?) -> Unit,
+    private val persistQueue: () -> Unit,
+    private val setLoading: (Boolean) -> Unit,
+    private val setMessage: (String) -> Unit,
+    private val failureMessage: (Throwable) -> String,
+    private val onRequestStarted: (Long, Boolean) -> Unit,
+    private val onManualSelectionStarted: (Long, MusicTrack, SmartReplacementSelection, MusicTrack?) -> Unit,
+    private val onStartFailure: (Long, MusicTrack, Int, SmartReplacementSelection?, Throwable) -> Unit,
+    private val prefetchQueue: () -> Unit,
+) : PlaybackStartFailureSource {
+    private val _startFailure = MutableStateFlow<PlaybackStartFailure?>(null)
+    override val startFailure: StateFlow<PlaybackStartFailure?> = _startFailure.asStateFlow()
+
+    fun start(
+        track: MusicTrack,
+        skippedUnavailableCount: Int = 0,
+        requestedPartIndex: Int? = null,
+        manualSelection: SmartReplacementSelection? = null,
+        rollbackTrack: MusicTrack? = null,
+        messageAfterStart: String? = null,
+        suppressPlaybackRecovery: Boolean = false,
+    ) {
+        prepareSleepTimer(track.id)
+        val serial = nextRequestSerial()
+        _startFailure.value = null
+        onRequestStarted(serial, suppressPlaybackRecovery)
+        val playbackTrack = if (manualSelection != null) track else prepareTrack(track)
+        manualSelection?.let { selection ->
+            onManualSelectionStarted(serial, playbackTrack, selection, rollbackTrack)
+        }
+
+        val existingParts = playbackParts()
+        val isPlaybackPartRequest = requestedPartIndex != null && existingParts.isNotEmpty()
+        if (!isPlaybackPartRequest) {
+            setPlaybackParts(emptyList())
+            setCurrentPartIndex(-1)
+        }
+        queue.updateCurrentTrack(playbackTrack)
+        resetLyricsForPlaybackRequest()
+        publishPlaybackState(
+            currentPlaybackState().copy(
+                status = PlayerStatus.Loading,
+                currentTrack = playbackTrack,
+                queue = queue.displayQueue(),
+                queueIndex = queue.displayQueueIndex(),
+                positionMs = 0,
+                playbackParts = playbackParts(),
+                currentPartIndex = requestedPartIndex.takeIf { isPlaybackPartRequest } ?: -1,
+                lyrics = playbackTrack.lyrics,
+                errorMessage = null,
+            )
+        )
+        persistQueue()
+        playbackEngine.prepareLoading(playbackTrack)
+        setLoading(true)
+        setMessage(messageAfterStart ?: "正在播放：${track.title}")
+
+        val resolveTrack = requestedPartIndex
+            ?.let { index -> playbackParts().getOrNull(index) }
+            ?.toTrack(playbackTrack)
+            ?: playbackTrack
+        maybeLoadLyrics(playbackTrack)
+
+        if (!playbackEngine.resolvesResourcesInternally) {
+            resolveAndStart(
+                serial = serial,
+                playbackTrack = playbackTrack,
+                resolveTrack = resolveTrack,
+                skippedUnavailableCount = skippedUnavailableCount,
+                requestedPartIndex = requestedPartIndex,
+                manualSelection = manualSelection,
+                messageAfterStart = messageAfterStart,
+            )
+            return
+        }
+
+        playbackEngine.play(
+            PlaybackPlan(
+                generation = serial,
+                requests = buildList {
+                    add(
+                        PlaybackRequest(
+                            track = playbackTrack,
+                            resolveTrack = resolveTrack,
+                            requestedPartIndex = requestedPartIndex,
+                            unavailablePolicy = unavailablePlaybackPolicy(),
+                            smartReplacementProviderIds = smartReplacementProviderIds(),
+                            smartReplacementMinScore = smartReplacementMinScore(),
+                            smartReplacementUseOriginalMetadata = true,
+                            smartReplacementUseOriginalLyrics = true,
+                            resolveOnlySelectedReplacement = manualSelection != null,
+                        )
+                    )
+                    queue.displayQueue()
+                        .drop(1)
+                        .take(PLAYBACK_START_PLAN_LOOKAHEAD)
+                        .forEach { queuedTrack ->
+                            val nextTrack = prepareTrack(queuedTrack)
+                            add(
+                                PlaybackRequest(
+                                    track = nextTrack,
+                                    unavailablePolicy = unavailablePlaybackPolicy(),
+                                    smartReplacementProviderIds = smartReplacementProviderIds(),
+                                    smartReplacementMinScore = smartReplacementMinScore(),
+                                    smartReplacementUseOriginalMetadata = true,
+                                    smartReplacementUseOriginalLyrics = true,
+                                )
+                            )
+                        }
+                },
+            )
+        )
+    }
+
+    private fun resolveAndStart(
+        serial: Long,
+        playbackTrack: MusicTrack,
+        resolveTrack: MusicTrack,
+        skippedUnavailableCount: Int,
+        requestedPartIndex: Int?,
+        manualSelection: SmartReplacementSelection?,
+        messageAfterStart: String?,
+    ) {
+        scope.launch playRequest@{
+            runCatching {
+                val payload = resolveTrack.toLocalPayload()
+                    ?: if (manualSelection != null) {
+                        playbackRepository.resolveSelectedReplacement(
+                            resolveTrack,
+                            true,
+                            true,
+                            smartReplacementProviderIds(),
+                        )
+                    } else {
+                        playbackRepository.resolve(
+                            resolveTrack,
+                            unavailablePlaybackPolicy(),
+                            smartReplacementProviderIds(),
+                            smartReplacementMinScore(),
+                            true,
+                            true,
+                        )
+                    }
+                if (serial != currentRequestSerial()) return@playRequest
+                // The legacy direct-resolution path cleared recovery suppression once
+                // media resolution succeeded, before engine playback started.
+                onRequestStarted(serial, false)
+
+                val nextParts = payload.parts
+                val nextPartIndex = when {
+                    nextParts.isEmpty() -> -1
+                    payload.currentPartIndex in nextParts.indices -> payload.currentPartIndex
+                    requestedPartIndex != null && requestedPartIndex in nextParts.indices -> requestedPartIndex
+                    else -> -1
+                }
+                setPlaybackParts(nextParts)
+                setCurrentPartIndex(nextPartIndex)
+                val playableTrack = playbackTrack.withResolvedPayload(payload, manualSelection != null)
+                queue.updateCurrentTrack(playableTrack)
+                playbackEngine.play(playableTrack, payload)
+                publishPlaybackState(
+                    currentPlaybackState().copy(
+                        status = PlayerStatus.Loading,
+                        currentTrack = playableTrack,
+                        queue = queue.displayQueue(),
+                        queueIndex = queue.displayQueueIndex(),
+                        lyrics = payload.lyrics?.takeIf { it.isNotBlank() } ?: currentPlaybackState().lyrics,
+                        audioQuality = payload.audioQuality,
+                        playbackParts = playbackParts(),
+                        currentPartIndex = currentPartIndex(),
+                    )
+                )
+                maybeLoadLyrics(playableTrack)
+                persistQueue()
+                setMessage(
+                    messageAfterStart
+                        ?: currentPlaybackPartLabel(playableTrack)
+                        ?: "${playableTrack.title} - ${playableTrack.artists}"
+                )
+                prefetchQueue()
+            }.onFailure { throwable ->
+                if (serial == currentRequestSerial()) {
+                    _startFailure.value = PlaybackStartFailure(
+                        trackId = playbackTrack.id,
+                        message = failureMessage(throwable),
+                    )
+                    onStartFailure(
+                        serial,
+                        playbackTrack,
+                        skippedUnavailableCount,
+                        manualSelection,
+                        throwable,
+                    )
+                }
+            }
+            if (serial == currentRequestSerial()) setLoading(false)
+        }
+    }
+
+    private fun currentPlaybackPartLabel(track: MusicTrack): String? {
+        val index = currentPartIndex()
+        val part = playbackParts().getOrNull(index) ?: return null
+        return "${track.title} · 第 ${index + 1}P · ${part.title.ifBlank { "未命名分段" }}"
+    }
+}
+
+private fun MusicTrack.toLocalPayload(): PlaybackPayload? {
+    val uri = localUri ?: return null
+    return PlaybackPayload(
+        url = uri,
+        title = title,
+        artists = artists,
+        album = album,
+        source = source,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        lyrics = lyrics,
+        audioQuality = null,
+        providerName = providerName,
+        isSmartReplacement = isSmartReplacement,
+        originalId = originalId,
+        originalTitle = originalTitle,
+        originalArtists = originalArtists,
+        originalAlbum = originalAlbum,
+        originalSource = originalSource,
+        originalProviderName = originalProviderName,
+        originalCoverUrl = originalCoverUrl,
+        replacementId = replacementId,
+        replacementTitle = replacementTitle,
+        replacementArtists = replacementArtists,
+        replacementAlbum = replacementAlbum,
+        replacementSource = replacementSource,
+        replacementProviderName = replacementProviderName,
+        replacementCoverUrl = replacementCoverUrl,
+        replacementStrategy = replacementStrategy,
+        replacementScore = replacementScore,
+    )
+}
+
+private fun PlaybackPart.toTrack(parent: MusicTrack): MusicTrack = parent.copy(
+    id = id,
+    title = title.ifBlank { parent.title },
+    durationMs = durationMs ?: parent.durationMs,
+    providerId = id,
+)
+
+private fun MusicTrack.withResolvedPayload(
+    payload: PlaybackPayload,
+    manualSelection: Boolean,
+): MusicTrack {
+    val isMultipartPlayback = payload.parts.isNotEmpty()
+    val isSmartReplacementPlayback = payload.isSmartReplacement || manualSelection
+    return copy(
+        title = if (isMultipartPlayback) title else payload.title.ifBlank { title },
+        artists = payload.artists.ifBlank { artists },
+        album = payload.album.ifBlank { album },
+        source = if (isSmartReplacementPlayback) {
+            payload.originalSource?.takeIf { it.isNotBlank() } ?: source
+        } else {
+            payload.source.ifBlank { source }
+        },
+        coverUrl = payload.coverUrl ?: coverUrl,
+        durationMs = if (isMultipartPlayback) durationMs else payload.durationMs ?: durationMs,
+        providerName = if (isSmartReplacementPlayback) {
+            payload.providerName ?: payload.replacementProviderName ?: providerName
+        } else {
+            payload.providerName ?: providerName
+        },
+        providerId = if (isSmartReplacementPlayback) payload.originalId ?: providerId else providerId,
+        isSmartReplacement = isSmartReplacementPlayback,
+        originalId = payload.originalId.takeIf { isSmartReplacementPlayback }
+            ?: originalId.takeIf { isSmartReplacementPlayback },
+        originalTitle = payload.originalTitle.takeIf { isSmartReplacementPlayback }
+            ?: originalTitle.takeIf { isSmartReplacementPlayback },
+        originalArtists = payload.originalArtists.takeIf { isSmartReplacementPlayback }
+            ?: originalArtists.takeIf { isSmartReplacementPlayback },
+        originalAlbum = payload.originalAlbum.takeIf { isSmartReplacementPlayback }
+            ?: originalAlbum.takeIf { isSmartReplacementPlayback },
+        originalSource = payload.originalSource.takeIf { isSmartReplacementPlayback }
+            ?: originalSource.takeIf { isSmartReplacementPlayback },
+        originalProviderName = payload.originalProviderName.takeIf { isSmartReplacementPlayback }
+            ?: originalProviderName.takeIf { isSmartReplacementPlayback },
+        originalCoverUrl = payload.originalCoverUrl.takeIf { isSmartReplacementPlayback }
+            ?: originalCoverUrl.takeIf { isSmartReplacementPlayback },
+        replacementId = payload.replacementId.takeIf { isSmartReplacementPlayback }
+            ?: replacementId.takeIf { isSmartReplacementPlayback },
+        replacementTitle = payload.replacementTitle.takeIf { isSmartReplacementPlayback }
+            ?: replacementTitle.takeIf { isSmartReplacementPlayback },
+        replacementArtists = payload.replacementArtists.takeIf { isSmartReplacementPlayback }
+            ?: replacementArtists.takeIf { isSmartReplacementPlayback },
+        replacementAlbum = payload.replacementAlbum.takeIf { isSmartReplacementPlayback }
+            ?: replacementAlbum.takeIf { isSmartReplacementPlayback },
+        replacementSource = payload.replacementSource.takeIf { isSmartReplacementPlayback }
+            ?: replacementSource.takeIf { isSmartReplacementPlayback },
+        replacementProviderName = payload.replacementProviderName.takeIf { isSmartReplacementPlayback }
+            ?: replacementProviderName.takeIf { isSmartReplacementPlayback },
+        replacementCoverUrl = payload.replacementCoverUrl.takeIf { isSmartReplacementPlayback }
+            ?: replacementCoverUrl.takeIf { isSmartReplacementPlayback },
+        replacementStrategy = payload.replacementStrategy.takeIf { isSmartReplacementPlayback }
+            ?: replacementStrategy.takeIf { isSmartReplacementPlayback },
+        replacementScore = payload.replacementScore.takeIf { isSmartReplacementPlayback }
+            ?: replacementScore.takeIf { isSmartReplacementPlayback },
+        isUnavailable = false,
+    )
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCoordinatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCoordinatorTest.kt
@@ -1,0 +1,144 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackQueueCoordinatorTest {
+    @Test
+    fun nextConsumesUpNextBeforeAdvancingMainQueue() = runTest {
+        val first = track("main:1")
+        val second = track("main:2")
+        val upNext = track("upnext:1")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(first, second)
+            mainQueueIndex = 0
+            upNextQueue = listOf(upNext)
+        }
+        var started: StartRequest? = null
+        val coordinator = coordinator(
+            queue = queue,
+            onStart = { track, skipped, part -> started = StartRequest(track, skipped, part) },
+        )
+
+        coordinator.next()
+
+        assertEquals(upNext, started?.track)
+        assertEquals(0, queue.mainQueueIndex)
+        assertTrue(queue.currentIsUpNext)
+        assertEquals(upNext, queue.currentUpNextTrack)
+        assertTrue(queue.upNextQueue.isEmpty())
+    }
+
+    @Test
+    fun queueRepeatWrapsFromLastTrackToFirstTrack() = runTest {
+        val first = track("main:1")
+        val second = track("main:2")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(first, second)
+            mainQueueIndex = 1
+            repeatMode = RepeatMode.QUEUE
+        }
+        var started: StartRequest? = null
+        val coordinator = coordinator(
+            queue = queue,
+            onStart = { track, skipped, part -> started = StartRequest(track, skipped, part) },
+        )
+
+        coordinator.next()
+
+        assertEquals(first, started?.track)
+        assertEquals(0, queue.mainQueueIndex)
+        assertFalse(queue.currentIsUpNext)
+    }
+
+    @Test
+    fun nextAdvancesPlaybackPartBeforeQueueTrack() = runTest {
+        val current = track("main:1")
+        val next = track("main:2")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(current, next)
+            mainQueueIndex = 0
+            repeatMode = RepeatMode.OFF
+        }
+        var started: StartRequest? = null
+        val coordinator = coordinator(
+            queue = queue,
+            parts = listOf(
+                PlaybackPart("part:1", "P1"),
+                PlaybackPart("part:2", "P2"),
+            ),
+            currentPartIndex = 0,
+            onStart = { track, skipped, part -> started = StartRequest(track, skipped, part) },
+        )
+
+        coordinator.next()
+
+        assertEquals(current, started?.track)
+        assertEquals(1, started?.partIndex)
+        assertEquals(0, queue.mainQueueIndex)
+    }
+
+    @Test
+    fun singleRepeatWrapsPlaybackPartsWithoutChangingTrack() = runTest {
+        val current = track("main:1")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(current)
+            mainQueueIndex = 0
+            repeatMode = RepeatMode.SINGLE
+        }
+        var started: StartRequest? = null
+        val coordinator = coordinator(
+            queue = queue,
+            parts = listOf(
+                PlaybackPart("part:1", "P1"),
+                PlaybackPart("part:2", "P2"),
+            ),
+            currentPartIndex = 1,
+            onStart = { track, skipped, part -> started = StartRequest(track, skipped, part) },
+        )
+
+        coordinator.next()
+
+        assertEquals(current, started?.track)
+        assertEquals(0, started?.partIndex)
+        assertEquals(0, queue.mainQueueIndex)
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.coordinator(
+        queue: PlaybackQueueController,
+        parts: List<PlaybackPart> = emptyList(),
+        currentPartIndex: Int = -1,
+        onStart: (MusicTrack, Int, Int?) -> Unit,
+    ): PlaybackQueueCoordinator = PlaybackQueueCoordinator(
+        queue = queue,
+        scope = this,
+        fallbackTrack = { null },
+        playbackParts = { parts },
+        currentPartIndex = { currentPartIndex },
+        startPlayback = onStart,
+        stopPlayback = {},
+        persistQueue = {},
+        updateQueueState = {},
+        appendFeatureQueue = { 0 },
+        setTrackChangeDirection = {},
+        setMessage = {},
+    )
+
+    private fun track(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = id,
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+
+    private data class StartRequest(
+        val track: MusicTrack,
+        val skippedCount: Int,
+        val partIndex: Int?,
+    )
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
@@ -1,0 +1,229 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PlaybackStartCoordinatorTest {
+    @Test
+    fun directResolutionStartsEngineAndPublishesResolvedTrack() = runTest {
+        val track = track("netease:1")
+        val payload = payload(title = "Resolved title")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(track)
+            mainQueueIndex = 0
+        }
+        val engine = FakePlaybackEngine()
+        val repository = FakePlaybackRepository(resolvePayload = payload)
+        val fixture = fixture(queue, engine, repository)
+
+        fixture.coordinator.start(track)
+        advanceUntilIdle()
+
+        assertEquals(track, engine.preparedTrack)
+        assertEquals(1, repository.resolveCalls)
+        assertEquals(payload, engine.playedPayload)
+        assertEquals("Resolved title", engine.playedTrack?.title)
+        assertEquals("Resolved title", queue.currentTrack()?.title)
+        assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
+        assertEquals("Resolved title", fixture.playbackState.currentTrack?.title)
+        assertNull(fixture.coordinator.startFailure.value)
+        assertEquals(0, fixture.failureCount)
+    }
+
+    @Test
+    fun directResolutionFailurePublishesPlaybackOwnedFailure() = runTest {
+        val track = track("netease:1")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(track)
+            mainQueueIndex = 0
+        }
+        val engine = FakePlaybackEngine()
+        val repository = FakePlaybackRepository(resolveError = IllegalStateException("missing media"))
+        val fixture = fixture(queue, engine, repository)
+
+        fixture.coordinator.start(track)
+        advanceUntilIdle()
+
+        val failure = assertNotNull(fixture.coordinator.startFailure.value)
+        assertEquals(track.id, failure.trackId)
+        assertEquals("start failed: missing media", failure.message)
+        assertEquals(1, fixture.failureCount)
+        assertNull(engine.playedPayload)
+        assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
+    }
+
+    @Test
+    fun internalResolutionBuildsPlanWithoutCallingProviderResolver() = runTest {
+        val current = track("netease:1")
+        val next = track("netease:2")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(current, next)
+            mainQueueIndex = 0
+        }
+        val engine = FakePlaybackEngine(resolvesInternally = true)
+        val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
+        val fixture = fixture(queue, engine, repository)
+
+        fixture.coordinator.start(current)
+
+        val plan = assertNotNull(engine.playedPlan)
+        assertEquals(1L, plan.generation)
+        assertEquals(listOf(current.id, next.id), plan.requests.map { it.track.id })
+        assertEquals(0, repository.resolveCalls)
+        assertNull(fixture.coordinator.startFailure.value)
+    }
+
+    private fun TestScope.fixture(
+        queue: PlaybackQueueController,
+        engine: FakePlaybackEngine,
+        repository: FakePlaybackRepository,
+    ): Fixture {
+        var playbackState = PlaybackState()
+        var requestSerial = 0L
+        var parts = emptyList<PlaybackPart>()
+        var currentPartIndex = -1
+        var failureCount = 0
+        val coordinator = PlaybackStartCoordinator(
+            queue = queue,
+            playbackEngine = engine,
+            playbackRepository = repository,
+            scope = this,
+            currentPlaybackState = { playbackState },
+            publishPlaybackState = { playbackState = it },
+            prepareTrack = { it },
+            unavailablePlaybackPolicy = { UnavailablePlaybackPolicy.Skip },
+            smartReplacementProviderIds = { setOf("bilibili") },
+            smartReplacementMinScore = { 0.7 },
+            nextRequestSerial = { ++requestSerial },
+            currentRequestSerial = { requestSerial },
+            playbackParts = { parts },
+            setPlaybackParts = { parts = it },
+            currentPartIndex = { currentPartIndex },
+            setCurrentPartIndex = { currentPartIndex = it },
+            prepareSleepTimer = {},
+            resetLyricsForPlaybackRequest = {},
+            maybeLoadLyrics = {},
+            persistQueue = {},
+            setLoading = {},
+            setMessage = {},
+            failureMessage = { "start failed: ${it.message}" },
+            onRequestStarted = { _, _ -> },
+            onManualSelectionStarted = { _, _, _, _ -> },
+            onStartFailure = { _, _, _, _, _ -> failureCount += 1 },
+            prefetchQueue = {},
+        )
+        return Fixture(
+            coordinator = coordinator,
+            playbackStateProvider = { playbackState },
+            failureCountProvider = { failureCount },
+        )
+    }
+
+    private fun track(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = "Original title",
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+    )
+
+    private fun payload(title: String): PlaybackPayload = PlaybackPayload(
+        url = "https://example.test/audio.mp3",
+        title = title,
+        artists = "Resolved artist",
+        album = "Resolved album",
+        source = "netease",
+        durationMs = 123_000,
+    )
+
+    private class Fixture(
+        val coordinator: PlaybackStartCoordinator,
+        private val playbackStateProvider: () -> PlaybackState,
+        private val failureCountProvider: () -> Int,
+    ) {
+        val playbackState: PlaybackState get() = playbackStateProvider()
+        val failureCount: Int get() = failureCountProvider()
+    }
+
+    private class FakePlaybackEngine(
+        private val resolvesInternally: Boolean = false,
+    ) : PlaybackEngine {
+        private val mutableState = MutableStateFlow(PlaybackState())
+        override val state: StateFlow<PlaybackState> = mutableState
+        override val resolvesResourcesInternally: Boolean get() = resolvesInternally
+
+        var preparedTrack: MusicTrack? = null
+        var playedTrack: MusicTrack? = null
+        var playedPayload: PlaybackPayload? = null
+        var playedPlan: PlaybackPlan? = null
+
+        override fun prepareLoading(track: MusicTrack) {
+            preparedTrack = track
+        }
+
+        override fun play(track: MusicTrack, payload: PlaybackPayload) {
+            playedTrack = track
+            playedPayload = payload
+        }
+
+        override fun play(plan: PlaybackPlan) {
+            playedPlan = plan
+        }
+
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun stop() = Unit
+        override fun seekTo(positionMs: Long) = Unit
+    }
+
+    private class FakePlaybackRepository(
+        private val resolvePayload: PlaybackPayload? = null,
+        private val resolveError: Throwable? = null,
+    ) : ProviderPlaybackRepository {
+        var resolveCalls: Int = 0
+
+        override suspend fun replacementCandidates(
+            track: MusicTrack,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+        ): List<ReplacementCandidate> = emptyList()
+
+        override suspend fun resolve(
+            track: MusicTrack,
+            unavailablePolicy: UnavailablePlaybackPolicy,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+        ): PlaybackPayload {
+            resolveCalls += 1
+            resolveError?.let { throw it }
+            return requireNotNull(resolvePayload)
+        }
+
+        override suspend fun resolveSelectedReplacement(
+            track: MusicTrack,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+            smartReplacementProviderIds: Set<String>,
+        ): PlaybackPayload = resolve(
+            track = track,
+            unavailablePolicy = UnavailablePlaybackPolicy.SmartReplace,
+            smartReplacementProviderIds = smartReplacementProviderIds,
+            smartReplacementMinScore = 0.0,
+            smartReplacementUseOriginalMetadata = smartReplacementUseOriginalMetadata,
+            smartReplacementUseOriginalLyrics = smartReplacementUseOriginalLyrics,
+        )
+
+        override suspend fun lyrics(track: MusicTrack): String? = null
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -190,7 +190,13 @@ private class IosAppContainer(
     )
 
     private val playbackSession by lazy {
-        createIosPlaybackRuntimeSession(controller, playbackEngine, scope)
+        createIosPlaybackRuntimeSession(
+            controller = controller,
+            playbackEngine = playbackEngine,
+            transportCoordinator = controller.playbackTransportCoordinator,
+            startFailureSource = controller.playbackStartFailureSource,
+            scope = scope,
+        )
     }
 
     private val searchAppPort = object : SearchAppPort {

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
@@ -20,6 +20,8 @@ import org.feeluown.mobile.playback.runtime.PlaybackRuntimeQueueActions
 internal fun createIosPlaybackRuntimeSession(
     controller: FuoPlayerController,
     playbackEngine: PlaybackEngine,
+    transportCoordinator: PlaybackTransportCoordinator,
+    startFailureSource: PlaybackStartFailureSource,
     scope: CoroutineScope,
 ): PlaybackSession {
     val overlay = snapshotFlow { controller.playbackState.toPlaybackRuntimeOverlay() }
@@ -31,29 +33,29 @@ internal fun createIosPlaybackRuntimeSession(
         )
 
     return DefaultPlaybackRuntime(
-        engine = LegacyPlaybackRuntimeEngine(playbackEngine, controller, scope),
+        engine = PlaybackRuntimeEngineAdapter(playbackEngine, startFailureSource, scope),
         overlay = overlay,
-        queueActions = LegacyPlaybackQueueActions(controller),
+        queueActions = PlaybackCoordinatorQueueActions(transportCoordinator),
         scope = scope,
     )
 }
 
-private class LegacyPlaybackRuntimeEngine(
+private class PlaybackRuntimeEngineAdapter(
     private val playbackEngine: PlaybackEngine,
-    controller: FuoPlayerController,
+    startFailureSource: PlaybackStartFailureSource,
     scope: CoroutineScope,
 ) : PlaybackRuntimeEngine {
     override val state: StateFlow<PlaybackRuntimeEngineState> = combine(
         playbackEngine.state,
-        snapshotFlow { controller.playbackState }.distinctUntilChanged(),
-    ) { engineState, coordinatorState ->
-        mergeIosPlaybackRuntimeEngineState(engineState, coordinatorState)
+        startFailureSource.startFailure,
+    ) { engineState, startFailure ->
+        mergePlaybackStartFailure(engineState, startFailure)
     }.stateIn(
         scope = scope,
         started = SharingStarted.Eagerly,
-        initialValue = mergeIosPlaybackRuntimeEngineState(
-            engineState = playbackEngine.state.value,
-            coordinatorState = controller.playbackState,
+        initialValue = mergePlaybackStartFailure(
+            playbackEngine.state.value,
+            startFailureSource.startFailure.value,
         ),
     )
 
@@ -62,34 +64,26 @@ private class LegacyPlaybackRuntimeEngine(
     override fun resume() = playbackEngine.resume()
 }
 
-private class LegacyPlaybackQueueActions(
-    private val controller: FuoPlayerController,
+private class PlaybackCoordinatorQueueActions(
+    private val coordinator: PlaybackTransportCoordinator,
 ) : PlaybackRuntimeQueueActions {
-    override fun startCurrent() = controller.toggle()
+    override fun startCurrent() = coordinator.startCurrent()
 
-    override fun previous() = controller.previous()
+    override fun previous() = coordinator.previous()
 
-    override fun next() = controller.next()
+    override fun next() = coordinator.next()
 }
 
-/**
- * iOS still resolves provider resources in the legacy coordinator before the native engine starts.
- * During that window the engine is already Loading, so a resolution failure exists only on the
- * coordinator state. Bridge that one transitional error into the session until resource resolution
- * moves behind the playback runtime boundary in C2.
- */
-internal fun mergeIosPlaybackRuntimeEngineState(
+/** Pre-engine resource failures are now published by PlaybackStartCoordinator. */
+internal fun mergePlaybackStartFailure(
     engineState: PlaybackState,
-    coordinatorState: PlaybackState,
+    startFailure: PlaybackStartFailure?,
 ): PlaybackRuntimeEngineState {
-    val useCoordinatorResolutionError =
-        engineState.status == PlayerStatus.Loading &&
-            coordinatorState.status == PlayerStatus.Error &&
-            engineState.currentTrack?.id != null &&
-            engineState.currentTrack?.id == coordinatorState.currentTrack?.id
-
+    val activeFailure = startFailure?.takeIf { failure ->
+        engineState.status == PlayerStatus.Loading && engineState.currentTrack?.id == failure.trackId
+    }
     return PlaybackRuntimeEngineState(
-        status = if (useCoordinatorResolutionError) {
+        status = if (activeFailure != null) {
             PlaybackSessionStatus.Error
         } else {
             engineState.status.toPlaybackSessionStatus()
@@ -97,11 +91,7 @@ internal fun mergeIosPlaybackRuntimeEngineState(
         positionMs = engineState.positionMs,
         durationMs = engineState.durationMs,
         bufferedMs = engineState.bufferedMs,
-        errorMessage = if (useCoordinatorResolutionError) {
-            coordinatorState.errorMessage
-        } else {
-            engineState.errorMessage
-        },
+        errorMessage = activeFailure?.message ?: engineState.errorMessage,
     )
 }
 

--- a/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlaybackRuntimeTest.kt
+++ b/shared/src/iosTest/kotlin/org/feeluown/mobile/IosPlaybackRuntimeTest.kt
@@ -6,19 +6,19 @@ import kotlin.test.assertEquals
 
 class IosPlaybackRuntimeTest {
     @Test
-    fun resolutionFailureOverridesLoadingEngineForSameTrack() {
+    fun playbackStartFailureOverridesLoadingEngineForSameTrack() {
         val track = testTrack("track:1")
-        val merged = mergeIosPlaybackRuntimeEngineState(
+        val merged = mergePlaybackStartFailure(
             engineState = PlaybackState(
                 status = PlayerStatus.Loading,
                 currentTrack = track,
                 positionMs = 1_200,
                 durationMs = 10_000,
+                bufferedMs = 4_000,
             ),
-            coordinatorState = PlaybackState(
-                status = PlayerStatus.Error,
-                currentTrack = track,
-                errorMessage = "资源解析失败",
+            startFailure = PlaybackStartFailure(
+                trackId = track.id,
+                message = "资源解析失败",
             ),
         )
 
@@ -26,19 +26,19 @@ class IosPlaybackRuntimeTest {
         assertEquals("资源解析失败", merged.errorMessage)
         assertEquals(1_200, merged.positionMs)
         assertEquals(10_000, merged.durationMs)
+        assertEquals(4_000, merged.bufferedMs)
     }
 
     @Test
-    fun unrelatedCoordinatorErrorDoesNotOverrideEngineState() {
-        val merged = mergeIosPlaybackRuntimeEngineState(
+    fun unrelatedPlaybackStartFailureDoesNotOverrideEngineState() {
+        val merged = mergePlaybackStartFailure(
             engineState = PlaybackState(
                 status = PlayerStatus.Loading,
                 currentTrack = testTrack("track:1"),
             ),
-            coordinatorState = PlaybackState(
-                status = PlayerStatus.Error,
-                currentTrack = testTrack("track:2"),
-                errorMessage = "其它页面加载失败",
+            startFailure = PlaybackStartFailure(
+                trackId = "track:2",
+                message = "其它歌曲解析失败",
             ),
         )
 


### PR DESCRIPTION
## Summary

Implement P1-D as one independent architecture slice, moving both queue-transition policy and playback-start/resource orchestration out of `FuoPlayerController` while keeping existing feature call sites behavior-compatible.

### D1 — queue transition ownership
- add `PlaybackTransportCoordinator` as the runtime-facing transport contract
- add `PlaybackQueueCoordinator` as the owner of `startCurrent`, `previous`, `next`, queue-index selection, up-next priority, repeat behavior, multi-part transitions and dynamic-feature continuation
- keep `PlaybackQueueController` as the durable queue state holder
- change `FuoPlayerController` transport/queue methods into compatibility facade delegates
- inject the playback transport coordinator into Android/iOS runtime adapters instead of dispatching `controller.toggle()/previous()/next()`

### D2 — playback-start/resource orchestration
- add `PlaybackStartCoordinator` to own prepare -> resolve/plan -> engine-start
- keep local/download payload fast-path behavior
- keep provider resolution for engines that do not resolve resources internally
- keep Android-style `PlaybackPlan` look-ahead construction for internally resolving engines
- preserve request-generation/stale-result checks, multi-part mapping, smart-replacement/manual rollback hooks, lyrics/persistence/prefetch and existing recovery semantics
- add `PlaybackStartFailureSource` for pre-engine resolution failures
- replace the temporary iOS controller-error bridge with playback-owned start failures

### Architecture guard
- `PlaybackQueueCoordinator` and `PlaybackStartCoordinator` are scanned as controller-free boundaries
- platform runtime adapters reject reintroduction of direct `controller.toggle()`, `controller.previous()` or `controller.next()` calls

### Tests
- queue coordinator: up-next priority, queue-repeat wrap, part-before-track transition, single-repeat part wrap
- start coordinator: direct resolution success, direct resolution failure publication, internally resolving plan construction
- iOS runtime: same-track start failure overrides Loading while unrelated failures remain isolated

## Intentional compatibility scope
- `FuoPlayerController` remains a facade for existing feature callers; policy is delegated to playback-owned coordinators
- request serial and playback-part/index storage remain facade-compatible in this slice to avoid mixing state relocation with orchestration-policy migration
- `ControllerPlaybackUiPort` is not decomposed in P1-D; that is the next architecture phase

## Validation
All CI checks are green on `32ca322c8e523fb59d4b53b3758d24a567e1ce2f`:
- ✅ `checkArchitectureBoundaries`
- ✅ `:playback:runtime:allTests`
- ✅ shared/common queue + start coordinator tests
- ✅ shared Android/iOS tests
- ✅ iOS playback-start failure regression tests
- ✅ Android coverage + Codecov
- ✅ signed multi-ABI Android release APK build and upload
- ✅ iOS simulator debug app build/package/upload
- ✅ iOS device debug app build + IPA package/upload

## Next architecture slice
- split `ControllerPlaybackUiPort` into explicit playback presentation, download, provider-detail and navigation owners
- migrate remaining feature-shell controller dependencies and legacy MiniPlayer signatures as those owners become available
- later move remaining request serial / playback part/index compatibility state fully behind playback-owned state and retire the playback facade methods
