### PR TITLE
refactor: close P1 bridges and seed P2 ownership

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -183,52 +183,25 @@ internal class AndroidAppContainer(
     }
 
     private val searchAppPort: SearchAppPort by lazy {
-        object : SearchAppPort {
-            override val providers: List<ProviderInfo>
-                get() = controller.providers
-            override val downloadStates: Map<String, DownloadState>
-                get() = controller.downloadStates
-
-            override fun closeSearch() = controller.closeSearch()
-
-            override fun playResult(index: Int) = controller.playFromSearch(index)
-
-            override fun addToUpNext(track: MusicTrack) = controller.addToUpNext(track)
-
-            override fun download(track: MusicTrack) = controller.download(track)
-
-            override fun deleteDownload(track: MusicTrack) = controller.deleteDownload(track)
-
-            override fun openArtist(track: MusicTrack) = controller.openTrackArtist(track)
-
-            override fun openAlbum(track: MusicTrack) = controller.openTrackAlbum(track)
-
-            override fun openTrackDetail(track: MusicTrack) = controller.openTrackDetail(track)
-
-            override fun canAddToPlaylist(track: MusicTrack): Boolean =
-                controller.canAddTrackToPlaylist(track)
-
-            override fun openPlaylistTargetPicker(track: MusicTrack) =
-                controller.openPlaylistTargetPicker(track)
-
-            override fun openMediaItem(item: ProviderMediaItem) = controller.openMediaItem(item)
-
-            override fun openPlaylist(playlist: ProviderPlaylist) {
-                controller.openPlaylist(playlist)
-            }
-
-            override fun openVideo(video: ProviderVideo) = controller.openVideo(video)
-        }
+        val wiredController = controller
+        DefaultSearchAppPort(
+            searchController = searchController,
+            providerSessions = { providerSessionRepository.state.value },
+            playbackQueue = wiredController.playbackQueueUiPort,
+            downloads = wiredController.downloadActionPort,
+            playlists = wiredController.playlistActionPort,
+            providerTrackActions = wiredController.providerTrackActionPort,
+            navigator = navigator,
+        )
     }
 
     private val recognitionAppPort: RecognitionAppPort by lazy {
-        object : RecognitionAppPort {
-            override fun canOpenNeteaseDetail(song: RecognizedSong): Boolean =
-                controller.canOpenRecognizedNeteaseDetail(song)
-
-            override fun openNeteaseDetail(song: RecognizedSong) =
-                controller.openRecognizedNeteaseDetail(song)
-        }
+        DefaultRecognitionAppPort(
+            isProviderEnabled = { providerId ->
+                providerSessionRepository.state.value.providers.any { it.providerId == providerId }
+            },
+            navigator = navigator,
+        )
     }
 
     private val playbackPresentationPort: PlaybackPresentationPort by lazy {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -200,6 +200,7 @@ internal class AndroidAppContainer(
             isProviderEnabled = { providerId ->
                 providerSessionRepository.state.value.providers.any { it.providerId == providerId }
             },
+            loadTrackDetail = providerRepository::trackDetail,
             navigator = navigator,
         )
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ val migratedControllerBoundaryRoots = listOf(
 )
 val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePorts.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadController.kt",
@@ -48,6 +49,10 @@ val playbackRuntimeAdapterFiles = listOf(
     "androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt",
     "shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt",
 )
+val platformCompositionRootFiles = listOf(
+    "androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt",
+    "shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt",
+)
 
 tasks.register("checkArchitectureBoundaries") {
     group = "verification"
@@ -76,6 +81,7 @@ tasks.register("checkArchitectureBoundaries") {
     inputs.files(sourceFiles)
     inputs.files(commonMainSources)
     inputs.files(playbackRuntimeAdapterFiles.map(rootProject::file))
+    inputs.files(platformCompositionRootFiles.map(rootProject::file))
 
     doLast {
         val retiredCompatViolations = retiredControllerCompatibilityFiles
@@ -113,6 +119,29 @@ tasks.register("checkArchitectureBoundaries") {
                     appendLine("FuoPlayerController leaked into migrated architecture boundaries:")
                     violations.forEach { appendLine(" - $it") }
                     append("Use feature-owned state/actions or a narrow app/playback/provider contract instead.")
+                },
+            )
+        }
+
+        val platformAppPortPattern = Regex("object\\s*:\\s*(?:SearchAppPort|RecognitionAppPort)")
+        val platformAppPortViolations = platformCompositionRootFiles
+            .map(rootProject::file)
+            .filter { it.isFile }
+            .flatMap { file ->
+                file.readLines().mapIndexedNotNull { index, line ->
+                    if (platformAppPortPattern.containsMatchIn(line)) {
+                        "${file.relativeTo(rootProject.projectDir).invariantSeparatorsPath}:${index + 1}"
+                    } else {
+                        null
+                    }
+                }
+            }
+        if (platformAppPortViolations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("Platform composition roots rebuilt Search/Recognition app-port bridges:")
+                    platformAppPortViolations.forEach { appendLine(" - $it") }
+                    append("Use the shared controller-free app-port adapters composed from narrow owners instead.")
                 },
             )
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ Feature state should have one owner. New feature work should expose immutable UI
 
 App-scoped navigation belongs to `AppNavigator` / `FuoAppViewModel`. Playback status, timing, current stable track reference, lyrics, queue identity/index, errors, transport policy and playback-end lifecycle policy belong to playback-owned contracts/owners. Avoid introducing new app-global `isLoading`, `message`, or error flags; loading and errors should be feature-local.
 
-Queue and start orchestration have explicit playback owners. `PlaybackQueueCoordinator` owns `startCurrent` / `previous` / `next`, up-next priority, repeat/part transitions and queue-index selection while `PlaybackQueueController` remains the durable queue state holder. `PlaybackStartCoordinator` owns the prepare -> resolve/plan -> engine-start pipeline, including direct provider resolution on platforms that do not resolve resources inside the engine and `PlaybackPlan` construction for engines that do.
+Queue and start orchestration have explicit playback owners. `PlaybackQueueCoordinator` owns `startCurrent` / `previous` / `next`, up-next priority, repeat/part transitions, queue-index selection and controller-free source-queue selection for migrated cross-feature callers, while `PlaybackQueueController` remains the durable queue state holder. `PlaybackStartCoordinator` owns the prepare -> resolve/plan -> engine-start pipeline, including direct provider resolution on platforms that do not resolve resources inside the engine and `PlaybackPlan` construction for engines that do.
 
 Pre-engine start failures are published through `PlaybackStartFailureSource`. Android and iOS runtime adapters combine that playback-owned failure with engine state, so the old iOS compatibility path that read coordinator/controller `Error` state has been retired.
 
@@ -49,7 +49,7 @@ MiniPlayer and FullPlayer read authoritative playback state/transport from `Play
 
 - `PlaybackNavigationPort` owns FullPlayer / queue-overlay visibility.
 - `PlaybackPresentationPort` reads rich engine presentation plus lyric/theme settings and owns seek normalization.
-- `PlaybackQueueUiPort` is implemented by `PlaybackQueueCoordinator` and owns queue display/edit, shuffle/repeat and transition direction for player UI.
+- `PlaybackQueueUiPort` is implemented by `PlaybackQueueCoordinator` and owns queue display/edit, source-queue selection, shuffle/repeat and transition direction for player/cross-feature UI.
 - `PlaybackSleepTimerPort` is implemented directly by `PlaybackSleepTimerController`.
 - `DownloadActionPort` is implemented by `DownloadController`.
 - `PlaylistActionPort` is implemented by `PlaylistActionController`.
@@ -69,7 +69,7 @@ New features should depend on narrow provider capability interfaces (`ProviderSe
 
 Platform dependency construction is isolated in platform containers. Android uses `AndroidAppContainer`; iOS uses `IosAppContainer`. `Application`, `UIViewController`, activities and services should remain thin hosts around those composition roots.
 
-Search and Recognition are composed through explicit `SearchAppPort` / `RecognitionAppPort` contracts. Their routes and feature UI no longer accept `FuoPlayerController`. During the remaining migration, platform composition roots may adapt still-centralized controller operations to those ports; the dependency must not leak back into the feature or app route contract.
+Search and Recognition are composed through explicit `SearchAppPort` / `RecognitionAppPort` contracts. Their routes and feature UI no longer accept `FuoPlayerController`. Android and iOS use the same shared app-port adapters, which compose those routes from provider-session state plus narrow playback/download/playlist/provider/navigation owners instead of rebuilding per-platform controller forwarding objects.
 
 Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRuntime.kt` as composition-edge adapters. Both receive `PlaybackTransportCoordinator` and `PlaybackStartFailureSource` explicitly; they no longer dispatch runtime transport through controller methods or inspect controller error state. Android/iOS composition roots inject the playback navigation, presentation, queue, sleep-timer, download, playlist, provider-track, local-music and replacement owners explicitly into `FuoAppViewModel`. `AppRoot` only installs the resulting composition graph; it does not construct controller-backed playback adapters.
 
@@ -77,8 +77,10 @@ Android playback uses `AndroidPlaybackRuntime.kt` and iOS uses `IosPlaybackRunti
 
 `checkArchitectureBoundaries` rejects new `FuoPlayerController` code dependencies inside migrated Search/Recognition boundaries, the entire `:playback:runtime` common source tree, Download/Local Music/Playlist/Provider Track now-playing owners, playback queue/start/lifecycle/replacement/sleep-timer owners, player composition contracts, controller-free MiniPlayer/FullPlayer implementations, app-port contracts/routes, and Android playback service/Lyricon integration.
 
-It also rejects reintroduction of retired Search/Recognition route shims, `ControllerPlaybackSession`, `ControllerPlaybackUiPort`, and `ControllerPlaybackCompatibilityPorts`; rejects any new `PlaybackUiPort` aggregate declaration; rejects legacy `MiniPlayer(controller)` callers after their migration; and rejects direct `controller.toggle()/previous()/next()` calls in platform playback runtime adapters.
+It also rejects reintroduction of retired Search/Recognition route shims, `ControllerPlaybackSession`, `ControllerPlaybackUiPort`, and `ControllerPlaybackCompatibilityPorts`; rejects any new `PlaybackUiPort` aggregate declaration; rejects legacy `MiniPlayer(controller)` callers; rejects platform-local Search/Recognition app-port forwarding objects; and rejects direct `controller.toggle()/previous()/next()` calls in platform playback runtime adapters.
 
 ## Migration rule
 
 Architecture migration should be incremental and behavior-preserving. Move ownership first, introduce narrow ports at cross-feature boundaries, and remove legacy facades only after callers have migrated and tests cover the new boundary.
+
+The post-P1 migration order and exit criteria are tracked in [`p2-architecture-roadmap.md`](p2-architecture-roadmap.md).

--- a/docs/p2-architecture-roadmap.md
+++ b/docs/p2-architecture-roadmap.md
@@ -1,0 +1,116 @@
+# Post-P1 architecture roadmap
+
+This document defines the migration order after the playback ownership work completed in PRs #96-#100.
+
+The architectural target remains:
+
+`platform composition root -> app shell -> feature owner -> core/api`
+
+`FuoPlayerController` stays available only as a compatibility facade while production screens migrate to feature-owned state/actions. The goal is not to reduce the controller by line count in isolation; the exit criterion is that production UI and cross-feature composition no longer require the facade.
+
+## P1 closeout
+
+P1 is considered complete when the boundaries already extracted during the first migration phase cannot silently regress back to controller forwarding.
+
+The final closeout slice does the following:
+
+- Search and Recognition keep their feature-owned state/controllers.
+- Android and iOS stop rebuilding `SearchAppPort` / `RecognitionAppPort` objects that forward individual calls to `FuoPlayerController`.
+- Shared app-shell adapters compose Search/Recognition from narrow playback/download/playlist/provider/navigation owners.
+- Provider catalog data used by app-shell composition is published by `ProviderSessionRepository` instead of being read from controller facade state.
+- Search result playback enters playback through the queue owner (`PlaybackQueueUiPort.playTracks`) instead of `FuoPlayerController.playFromSearch`.
+- Architecture checks reject reintroduction of platform-local Search/Recognition forwarding adapters.
+
+After this slice, new Search/Recognition work must not add controller calls back into either platform composition root.
+
+## P2-1: remove controller ownership from app navigation and app-scoped feedback
+
+First move app-level responsibilities that are not feature business state:
+
+1. route activation and back-stack policy into `AppNavigator` / an app route coordinator;
+2. true app-scoped transient feedback into an explicit app event owner;
+3. startup/onboarding completion state into an app-owned state holder where practical.
+
+Do not replace `FuoPlayerController` with another broad `AppController`. Prefer small app contracts that only coordinate feature owners.
+
+Exit criteria:
+
+- `FuoAppViewModel` does not need a concrete `FuoPlayerController` for navigation policy;
+- typed routes can activate feature owners without a controller callback;
+- feature loading/errors do not compete through the global `isLoading` / `message` pair.
+
+## P2-2: migrate low-risk screens to feature-owned state/actions
+
+Migrate production UI one bounded context at a time. Suggested order:
+
+1. Debug logs;
+2. Download manager;
+3. Local music;
+4. Local playlists;
+5. Settings and provider authentication.
+
+For each migrated screen:
+
+- replace `Screen(FuoPlayerController)` with immutable UI state plus actions, or the narrow owning controller;
+- move transient loading/error/feedback to that feature owner;
+- add an architecture guard forbidding `FuoPlayerController` in the migrated screen/boundary;
+- keep legacy facade methods only while another caller still needs them.
+
+## P2-3: provider detail ownership
+
+Provider details should move only after the lower-risk screens above are stable because the current controller still coordinates pagination, selected-item state and route restoration for several provider destinations.
+
+Split state by destination rather than creating one replacement provider mega-controller:
+
+- feature detail;
+- track detail and related content;
+- playlist detail and background pagination;
+- media item detail;
+- video detail.
+
+Typed route payloads remain the navigation identity. Feature owners load/restore their own detail state from those payloads.
+
+## P2-4: home/provider content ownership
+
+Home is the highest-coupling slice and should be last among the major screens.
+
+Move Recommend / Explore / Mine loading and selection state out of the compatibility controller, while preserving the existing incremental provider loading behavior. Avoid merging Search, provider detail and Home back into one provider facade.
+
+Exit criteria:
+
+- Home consumes a dedicated home/provider-content UI state;
+- provider selection/filter state has one owner;
+- Home refresh operations do not mutate global loading/message state.
+
+## P2-5: retire the compatibility controller
+
+Delete `FuoPlayerController` only after production code search shows that remaining references are compatibility tests or platform migration glue scheduled for removal.
+
+Before removal:
+
+- all active screens use feature/app/playback owners;
+- playback runtime and player UI remain controller-free;
+- Search/Recognition platform adapters remain controller-free;
+- app navigation no longer delegates to the facade;
+- provider detail and Home have independent state owners;
+- characterization tests have moved to the new owners where appropriate.
+
+## P2-6: physical Gradle feature modules
+
+Only after the logical dependency graph above is stable should feature source sets become additional Gradle modules.
+
+Likely candidates:
+
+- `:feature:search`
+- `:feature:recognition`
+- `:feature:download`
+- `:feature:localmusic`
+- `:feature:localplaylist`
+- `:feature:settings`
+- later `:feature:provider-content` / `:feature:home`
+
+Do not modularize a feature while it still depends on `FuoPlayerController`; that would turn the current monolith into a distributed monolith rather than establish a real boundary.
+
+## Pull-request sizing rule
+
+Keep each architecture PR behavior-preserving and independently revertible. A normal P2 PR should migrate one ownership boundary, add regression/architecture coverage for it, and remove only the compatibility surface whose last caller moved in that same PR.

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
@@ -6,7 +6,7 @@ package org.feeluown.mobile
  * Search owns query/result state. Cross-feature actions are composed here from narrow owners so
  * Android and iOS do not rebuild controller-backed forwarding objects independently.
  */
-internal class DefaultSearchAppPort(
+class DefaultSearchAppPort(
     private val searchController: SearchFeatureController,
     private val providerSessions: () -> ProviderSessionState,
     private val playbackQueue: PlaybackQueueUiPort,
@@ -64,7 +64,7 @@ internal class DefaultSearchAppPort(
 }
 
 /** Controller-free app-shell adapter for recognition result navigation. */
-internal class DefaultRecognitionAppPort(
+class DefaultRecognitionAppPort(
     private val isProviderEnabled: (String) -> Boolean,
     private val navigator: AppNavigator,
 ) : RecognitionAppPort {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
@@ -1,0 +1,95 @@
+package org.feeluown.mobile
+
+/**
+ * Shared app-shell adapter for Search.
+ *
+ * Search owns query/result state. Cross-feature actions are composed here from narrow owners so
+ * Android and iOS do not rebuild controller-backed forwarding objects independently.
+ */
+internal class DefaultSearchAppPort(
+    private val searchController: SearchFeatureController,
+    private val providerSessions: () -> ProviderSessionState,
+    private val playbackQueue: PlaybackQueueUiPort,
+    private val downloads: DownloadActionPort,
+    private val playlists: PlaylistActionPort,
+    private val providerTrackActions: ProviderTrackActionPort,
+    private val navigator: AppNavigator,
+) : SearchAppPort {
+    override val providers: List<ProviderInfo>
+        get() = providerSessions().providers
+
+    override val downloadStates: Map<String, DownloadState>
+        get() = downloads.downloadStates
+
+    override fun closeSearch() {
+        navigator.pop(AppRoute.Search)
+    }
+
+    override fun playResult(index: Int) {
+        val tracks = searchController.uiState.value.searchResults
+        if (index !in tracks.indices) return
+        playbackQueue.playTracks(tracks, index)
+        closeSearch()
+    }
+
+    override fun addToUpNext(track: MusicTrack) = playbackQueue.addToUpNext(track)
+
+    override fun download(track: MusicTrack) = downloads.download(track)
+
+    override fun deleteDownload(track: MusicTrack) = downloads.deleteDownload(track)
+
+    override fun openArtist(track: MusicTrack) = providerTrackActions.openTrackArtist(track)
+
+    override fun openAlbum(track: MusicTrack) = providerTrackActions.openTrackAlbum(track)
+
+    override fun openTrackDetail(track: MusicTrack) {
+        navigator.navigate(AppRoute.TrackDetail(track.toNavigationTrack()))
+    }
+
+    override fun canAddToPlaylist(track: MusicTrack): Boolean = playlists.canAddTrackToPlaylist(track)
+
+    override fun openPlaylistTargetPicker(track: MusicTrack) = playlists.openPlaylistTargetPicker(track)
+
+    override fun openMediaItem(item: ProviderMediaItem) {
+        navigator.navigate(AppRoute.MediaItemDetail(item.toNavigationMediaItem()))
+    }
+
+    override fun openPlaylist(playlist: ProviderPlaylist) {
+        navigator.navigate(AppRoute.PlaylistDetail(playlist.toNavigationPlaylist()))
+    }
+
+    override fun openVideo(video: ProviderVideo) {
+        navigator.navigate(AppRoute.VideoDetail(video.toNavigationVideo()))
+    }
+}
+
+/** Controller-free app-shell adapter for recognition result navigation. */
+internal class DefaultRecognitionAppPort(
+    private val isProviderEnabled: (String) -> Boolean,
+    private val navigator: AppNavigator,
+) : RecognitionAppPort {
+    override fun canOpenNeteaseDetail(song: RecognizedSong): Boolean =
+        isProviderEnabled(NETEASE_PROVIDER_ID) && !song.neteaseSongId.isNullOrBlank()
+
+    override fun openNeteaseDetail(song: RecognizedSong) {
+        if (!canOpenNeteaseDetail(song)) return
+        val songId = song.neteaseSongId?.takeIf { it.isNotBlank() } ?: return
+        val trackId = "$NETEASE_PROVIDER_ID:$songId"
+        val routeTrack = MusicTrack(
+            id = trackId,
+            title = song.title,
+            artists = song.artists.joinToString(" / "),
+            album = song.album,
+            source = NETEASE_PROVIDER_ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = song.coverUrl,
+            providerId = trackId,
+            providerName = "网易云音乐",
+        )
+        navigator.navigate(AppRoute.TrackDetail(routeTrack.toNavigationTrack()))
+    }
+
+    private companion object {
+        const val NETEASE_PROVIDER_ID = "netease"
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt
@@ -1,5 +1,10 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
 /**
  * Shared app-shell adapter for Search.
  *
@@ -66,27 +71,42 @@ class DefaultSearchAppPort(
 /** Controller-free app-shell adapter for recognition result navigation. */
 class DefaultRecognitionAppPort(
     private val isProviderEnabled: (String) -> Boolean,
+    private val loadTrackDetail: suspend (String) -> MusicTrack,
     private val navigator: AppNavigator,
 ) : RecognitionAppPort {
+    private val mutableDetailLoadState = MutableStateFlow(RecognitionDetailLoadState())
+    override val detailLoadState: StateFlow<RecognitionDetailLoadState> = mutableDetailLoadState.asStateFlow()
+
     override fun canOpenNeteaseDetail(song: RecognizedSong): Boolean =
         isProviderEnabled(NETEASE_PROVIDER_ID) && !song.neteaseSongId.isNullOrBlank()
 
-    override fun openNeteaseDetail(song: RecognizedSong) {
+    override suspend fun openNeteaseDetail(song: RecognizedSong) {
         if (!canOpenNeteaseDetail(song)) return
+        if (mutableDetailLoadState.value.loadingTrackId != null) return
         val songId = song.neteaseSongId?.takeIf { it.isNotBlank() } ?: return
         val trackId = "$NETEASE_PROVIDER_ID:$songId"
-        val routeTrack = MusicTrack(
-            id = trackId,
-            title = song.title,
-            artists = song.artists.joinToString(" / "),
-            album = song.album,
-            source = NETEASE_PROVIDER_ID,
-            sourceType = TrackSourceType.Provider,
-            coverUrl = song.coverUrl,
-            providerId = trackId,
-            providerName = "网易云音乐",
-        )
-        navigator.navigate(AppRoute.TrackDetail(routeTrack.toNavigationTrack()))
+        mutableDetailLoadState.value = RecognitionDetailLoadState(loadingTrackId = trackId)
+        try {
+            val track = loadTrackDetail(trackId)
+            mutableDetailLoadState.value = RecognitionDetailLoadState()
+            navigator.navigate(AppRoute.TrackDetail(track.toNavigationTrack()))
+        } catch (cancelled: CancellationException) {
+            mutableDetailLoadState.value = RecognitionDetailLoadState()
+            throw cancelled
+        } catch (throwable: Throwable) {
+            mutableDetailLoadState.value = RecognitionDetailLoadState(
+                errorMessage = throwable.providerFailureOrNull(NETEASE_PROVIDER_ID)?.userMessage
+                    ?: throwable.message
+                    ?: "资源加载失败",
+            )
+        }
+    }
+
+    override fun clearDetailLoadError() {
+        val current = mutableDetailLoadState.value
+        if (current.errorMessage != null) {
+            mutableDetailLoadState.value = current.copy(errorMessage = null)
+        }
     }
 
     private companion object {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePorts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePorts.kt
@@ -1,10 +1,12 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.flow.StateFlow
+
 /**
  * App-shell capabilities that Search needs from sibling features.
  *
- * Implementations belong at platform composition roots while the legacy controller is being
- * decomposed. Search itself must only depend on this narrow port plus its feature owner.
+ * Shared app-shell adapters compose these capabilities from narrow feature owners so Search itself
+ * never depends on the compatibility controller or platform-specific forwarding objects.
  */
 interface SearchAppPort {
     val providers: List<ProviderInfo>
@@ -37,9 +39,18 @@ interface SearchAppPort {
     fun openVideo(video: ProviderVideo)
 }
 
+data class RecognitionDetailLoadState(
+    val loadingTrackId: String? = null,
+    val errorMessage: String? = null,
+)
+
 /** App-shell capabilities that Recognition needs outside its feature owner. */
 interface RecognitionAppPort {
+    val detailLoadState: StateFlow<RecognitionDetailLoadState>
+
     fun canOpenNeteaseDetail(song: RecognizedSong): Boolean
 
-    fun openNeteaseDetail(song: RecognizedSong)
+    suspend fun openNeteaseDetail(song: RecognizedSong)
+
+    fun clearDetailLoadError()
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
@@ -1,8 +1,18 @@
 package org.feeluown.mobile
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 
 /** App-shell composition for the recognition feature. */
 @Composable
@@ -13,17 +23,34 @@ internal fun RecognitionRoute(
     onRequestMicrophonePermission: () -> Unit,
 ) {
     val uiState by appViewModel.recognitionUiState.collectAsStateWithLifecycle()
+    val detailLoadState by appPort.detailLoadState.collectAsStateWithLifecycle()
+    val detailScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
-    AudioRecognitionFeatureScreen(
-        uiState = uiState,
-        actions = RecognitionFeatureActions(
-            dispatch = appViewModel::dispatchRecognition,
-            onBack = appViewModel::closeRecognition,
-            onSearchSong = appViewModel::searchRecognizedSong,
-            canOpenNeteaseDetail = appPort::canOpenNeteaseDetail,
-            onOpenNeteaseDetail = appPort::openNeteaseDetail,
-        ),
-        hasMicrophonePermission = hasMicrophonePermission,
-        onRequestMicrophonePermission = onRequestMicrophonePermission,
-    )
+    LaunchedEffect(detailLoadState.errorMessage) {
+        val message = detailLoadState.errorMessage ?: return@LaunchedEffect
+        appPort.clearDetailLoadError()
+        snackbarHostState.showSnackbar("资源详情加载失败：$message")
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AudioRecognitionFeatureScreen(
+            uiState = uiState,
+            actions = RecognitionFeatureActions(
+                dispatch = appViewModel::dispatchRecognition,
+                onBack = appViewModel::closeRecognition,
+                onSearchSong = appViewModel::searchRecognizedSong,
+                canOpenNeteaseDetail = appPort::canOpenNeteaseDetail,
+                onOpenNeteaseDetail = { song ->
+                    detailScope.launch { appPort.openNeteaseDetail(song) }
+                },
+            ),
+            hasMicrophonePermission = hasMicrophonePermission,
+            onRequestMicrophonePermission = onRequestMicrophonePermission,
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
@@ -58,6 +58,29 @@ internal class PlaybackQueueCoordinator(
         (queueState.currentTrack() ?: fallbackTrack())?.let { startPlayback(it, 0, null) }
     }
 
+    override fun playTracks(tracks: List<MusicTrack>, index: Int) {
+        if (tracks.isEmpty() || index !in tracks.indices) return
+        updateTrackChangeDirection(TrackChangeDirection.Next)
+        val restoreShuffle = if (queueState.isFmQueue) queueState.shuffleBeforeFm else null
+        if (restoreShuffle != null) {
+            queueState.shuffleEnabled = restoreShuffle
+            queueState.shuffleBeforeFm = null
+        }
+        queueState.isFmQueue = false
+        queueState.queueFeature = null
+        queueState.queuePlaylistId = null
+        queueState.currentUpNextTrack = null
+        queueState.currentIsUpNext = false
+        queueState.originalMainQueue = emptyList()
+        queueState.mainQueue = tracks
+        queueState.mainQueueIndex = index
+        if (queueState.shuffleEnabled) {
+            enableShuffle()
+        }
+        publishQueueMutation()
+        playMainIndexInternal(queueState.mainQueueIndex, 0, TrackChangeDirection.Next)
+    }
+
     override fun next() {
         updateTrackChangeDirection(TrackChangeDirection.Next)
         if (queueState.repeatMode == RepeatMode.SINGLE) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -36,6 +36,8 @@ interface PlaybackQueueUiPort {
     val isFmQueueActive: Boolean
     val trackChangeDirection: TrackChangeDirection
 
+    /** Replace the active source queue and start the selected item through the queue owner. */
+    fun playTracks(tracks: List<MusicTrack>, index: Int)
     fun toggleShuffle()
     fun toggleRepeat()
     fun clearQueue()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderSessionRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderSessionRepository.kt
@@ -13,6 +13,7 @@ enum class ProviderSessionOperation {
 }
 
 data class ProviderSessionState(
+    val providers: List<ProviderInfo> = emptyList(),
     val authStates: Map<String, ProviderAuthState> = emptyMap(),
     val operations: Map<String, ProviderSessionOperation> = emptyMap(),
     val errors: Map<String, String> = emptyMap(),
@@ -93,6 +94,7 @@ class DefaultProviderSessionRepository(
             val providerIds = providers.mapTo(mutableSetOf()) { it.providerId }
             val current = mutableState.value
             mutableState.value = current.copy(
+                providers = providers,
                 authStates = providers.associate { provider ->
                     provider.providerId to (current.authStates[provider.providerId] ?: ProviderAuthState(
                         providerId = provider.providerId,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppFeaturePortAdaptersTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppFeaturePortAdaptersTest.kt
@@ -1,0 +1,166 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppFeaturePortAdaptersTest {
+    @Test
+    fun searchPortUsesFeatureOwnersAndClosesSearchAfterPlaybackSelection() {
+        val first = track("netease:1")
+        val second = track("netease:2")
+        val search = FakeSearchController(SearchUiState(searchResults = listOf(first, second)))
+        val queue = RecordingPlaybackQueuePort()
+        val navigator = AppNavigator().apply { navigate(AppRoute.Search) }
+        val provider = ProviderInfo("netease", "网易云音乐")
+        val port = DefaultSearchAppPort(
+            searchController = search,
+            providerSessions = { ProviderSessionState(providers = listOf(provider)) },
+            playbackQueue = queue,
+            downloads = FakeDownloadActionPort(),
+            playlists = FakePlaylistActionPort(),
+            providerTrackActions = FakeProviderTrackActionPort(),
+            navigator = navigator,
+        )
+
+        assertEquals(listOf(provider), port.providers)
+        port.playResult(1)
+
+        assertEquals(listOf(first, second), queue.playedTracks)
+        assertEquals(1, queue.playedIndex)
+        assertEquals(AppRoute.Home, navigator.currentEntry)
+    }
+
+    @Test
+    fun searchPortUsesTypedProviderNavigationWithoutControllerState() {
+        val navigator = AppNavigator()
+        val port = DefaultSearchAppPort(
+            searchController = FakeSearchController(),
+            providerSessions = { ProviderSessionState() },
+            playbackQueue = RecordingPlaybackQueuePort(),
+            downloads = FakeDownloadActionPort(),
+            playlists = FakePlaylistActionPort(),
+            providerTrackActions = FakeProviderTrackActionPort(),
+            navigator = navigator,
+        )
+        val playlist = ProviderPlaylist(
+            id = "mine",
+            title = "我的歌单",
+            providerId = "netease",
+            providerName = "网易云音乐",
+        )
+
+        port.openPlaylist(playlist)
+
+        assertEquals(
+            AppRoute.PlaylistDetail(playlist.toNavigationPlaylist()),
+            navigator.currentEntry,
+        )
+    }
+
+    @Test
+    fun recognitionPortBuildsTypedNeteaseTrackRouteOnlyWhenProviderIsEnabled() {
+        val song = RecognizedSong(
+            neteaseSongId = "123",
+            title = "Song",
+            artists = listOf("Artist A", "Artist B"),
+            album = "Album",
+            coverUrl = "https://example.test/cover.jpg",
+        )
+        val disabledNavigator = AppNavigator()
+        val disabled = DefaultRecognitionAppPort(
+            isProviderEnabled = { false },
+            navigator = disabledNavigator,
+        )
+
+        assertFalse(disabled.canOpenNeteaseDetail(song))
+        disabled.openNeteaseDetail(song)
+        assertEquals(AppRoute.Home, disabledNavigator.currentEntry)
+
+        val enabledNavigator = AppNavigator()
+        val enabled = DefaultRecognitionAppPort(
+            isProviderEnabled = { it == "netease" },
+            navigator = enabledNavigator,
+        )
+
+        assertTrue(enabled.canOpenNeteaseDetail(song))
+        enabled.openNeteaseDetail(song)
+
+        val route = enabledNavigator.currentEntry as AppRoute.TrackDetail
+        assertEquals("netease:123", route.track.id)
+        assertEquals("Artist A / Artist B", route.track.artists)
+        assertEquals("netease", route.track.source)
+    }
+
+    private fun track(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = id,
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+
+    private class FakeSearchController(
+        initialState: SearchUiState = SearchUiState(),
+    ) : SearchFeatureController {
+        private val state = MutableStateFlow(initialState)
+        override val uiState: StateFlow<SearchUiState> = state
+
+        override fun dispatch(action: SearchAction) = Unit
+        override fun applyPreferences(searchScope: SearchScope, selectedSearchProviderId: String?) = Unit
+        override fun normalizeProviderSelection(providerIds: Set<String>) = Unit
+        override fun searchRecognizedSong(song: RecognizedSong) = Unit
+        override fun searchText(text: String, providerId: String?) = Unit
+    }
+
+    private class RecordingPlaybackQueuePort : PlaybackQueueUiPort {
+        var playedTracks: List<MusicTrack>? = null
+        var playedIndex: Int? = null
+
+        override val currentQueueTrack: MusicTrack? = null
+        override val queue: List<MusicTrack> = emptyList()
+        override val displayUpNextCount: Int = 0
+        override val isShuffleEnabled: Boolean = false
+        override val repeatMode: RepeatMode = RepeatMode.QUEUE
+        override val isFmQueueActive: Boolean = false
+        override val trackChangeDirection: TrackChangeDirection = TrackChangeDirection.Next
+
+        override fun playTracks(tracks: List<MusicTrack>, index: Int) {
+            playedTracks = tracks
+            playedIndex = index
+        }
+
+        override fun toggleShuffle() = Unit
+        override fun toggleRepeat() = Unit
+        override fun clearQueue() = Unit
+        override fun playQueueIndex(index: Int) = Unit
+        override fun removeFromQueue(track: MusicTrack) = Unit
+        override fun playPlaybackPart(index: Int) = Unit
+        override fun addToUpNext(track: MusicTrack) = Unit
+    }
+
+    private class FakeDownloadActionPort : DownloadActionPort {
+        override val downloadStates: Map<String, DownloadState> = emptyMap()
+        override fun download(track: MusicTrack) = Unit
+        override fun deleteDownload(track: MusicTrack) = Unit
+    }
+
+    private class FakePlaylistActionPort : PlaylistActionPort {
+        override fun canAddTrackToPlaylist(track: MusicTrack): Boolean = true
+        override fun openPlaylistTargetPicker(track: MusicTrack) = Unit
+        override fun canRemoveTrackFromSelectedPlaylist(track: MusicTrack): Boolean = false
+        override fun removeTrackFromSelectedPlaylist(track: MusicTrack) = Unit
+    }
+
+    private class FakeProviderTrackActionPort : ProviderTrackActionPort {
+        override fun openTrackArtist(track: MusicTrack) = Unit
+        override fun openTrackAlbum(track: MusicTrack) = Unit
+        override fun openOriginalTrackDetail(track: MusicTrack) = Unit
+        override fun canSetSongDisliked(track: MusicTrack): Boolean = false
+        override fun setSongDisliked(track: MusicTrack) = Unit
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppFeaturePortAdaptersTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppFeaturePortAdaptersTest.kt
@@ -2,9 +2,11 @@ package org.feeluown.mobile
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AppFeaturePortAdaptersTest {
@@ -62,38 +64,80 @@ class AppFeaturePortAdaptersTest {
     }
 
     @Test
-    fun recognitionPortBuildsTypedNeteaseTrackRouteOnlyWhenProviderIsEnabled() {
-        val song = RecognizedSong(
-            neteaseSongId = "123",
-            title = "Song",
-            artists = listOf("Artist A", "Artist B"),
-            album = "Album",
-            coverUrl = "https://example.test/cover.jpg",
-        )
-        val disabledNavigator = AppNavigator()
-        val disabled = DefaultRecognitionAppPort(
+    fun recognitionPortDoesNotLoadDetailWhenProviderIsDisabled() = runTest {
+        val navigator = AppNavigator()
+        var loadCount = 0
+        val port = DefaultRecognitionAppPort(
             isProviderEnabled = { false },
-            navigator = disabledNavigator,
+            loadTrackDetail = {
+                loadCount += 1
+                track(it)
+            },
+            navigator = navigator,
         )
+        val song = recognizedSong()
 
-        assertFalse(disabled.canOpenNeteaseDetail(song))
-        disabled.openNeteaseDetail(song)
-        assertEquals(AppRoute.Home, disabledNavigator.currentEntry)
+        assertFalse(port.canOpenNeteaseDetail(song))
+        port.openNeteaseDetail(song)
 
-        val enabledNavigator = AppNavigator()
-        val enabled = DefaultRecognitionAppPort(
-            isProviderEnabled = { it == "netease" },
-            navigator = enabledNavigator,
-        )
-
-        assertTrue(enabled.canOpenNeteaseDetail(song))
-        enabled.openNeteaseDetail(song)
-
-        val route = enabledNavigator.currentEntry as AppRoute.TrackDetail
-        assertEquals("netease:123", route.track.id)
-        assertEquals("Artist A / Artist B", route.track.artists)
-        assertEquals("netease", route.track.source)
+        assertEquals(0, loadCount)
+        assertEquals(AppRoute.Home, navigator.currentEntry)
+        assertEquals(RecognitionDetailLoadState(), port.detailLoadState.value)
     }
+
+    @Test
+    fun recognitionPortLoadsCanonicalNeteaseTrackBeforeTypedNavigation() = runTest {
+        val navigator = AppNavigator()
+        val canonical = track("netease:123").copy(
+            title = "Canonical title",
+            artists = "Canonical artist",
+            durationMs = 245_000,
+        )
+        var requestedTrackId: String? = null
+        val port = DefaultRecognitionAppPort(
+            isProviderEnabled = { it == "netease" },
+            loadTrackDetail = { trackId ->
+                requestedTrackId = trackId
+                canonical
+            },
+            navigator = navigator,
+        )
+        val song = recognizedSong()
+
+        assertTrue(port.canOpenNeteaseDetail(song))
+        port.openNeteaseDetail(song)
+
+        assertEquals("netease:123", requestedTrackId)
+        val route = navigator.currentEntry as AppRoute.TrackDetail
+        assertEquals(canonical.toNavigationTrack(), route.track)
+        assertEquals(RecognitionDetailLoadState(), port.detailLoadState.value)
+    }
+
+    @Test
+    fun recognitionPortSurfacesDetailLoadFailureWithoutNavigating() = runTest {
+        val navigator = AppNavigator()
+        val port = DefaultRecognitionAppPort(
+            isProviderEnabled = { it == "netease" },
+            loadTrackDetail = { throw IllegalStateException("detail failed") },
+            navigator = navigator,
+        )
+
+        port.openNeteaseDetail(recognizedSong())
+
+        assertEquals(AppRoute.Home, navigator.currentEntry)
+        assertNull(port.detailLoadState.value.loadingTrackId)
+        assertEquals("detail failed", port.detailLoadState.value.errorMessage)
+        port.clearDetailLoadError()
+        assertEquals(RecognitionDetailLoadState(), port.detailLoadState.value)
+    }
+
+    private fun recognizedSong() = RecognizedSong(
+        neteaseSongId = "123",
+        title = "Song",
+        artists = listOf("Artist A", "Artist B"),
+        album = "Album",
+        coverUrl = "https://example.test/cover.jpg",
+    )
 
     private fun track(id: String): MusicTrack = MusicTrack(
         id = id,
@@ -102,6 +146,8 @@ class AppFeaturePortAdaptersTest {
         album = "Album",
         source = "netease",
         sourceType = TrackSourceType.Provider,
+        providerId = id,
+        providerName = "网易云音乐",
     )
 
     private class FakeSearchController(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueSelectionPortTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueSelectionPortTest.kt
@@ -1,0 +1,102 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class PlaybackQueueSelectionPortTest {
+    @Test
+    fun playTracksReplacesSourceQueueStartsSelectionAndLeavesUpNextIntact() = runTest {
+        val queued = track("upnext")
+        val first = track("first")
+        val selected = track("selected")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(track("old"))
+            mainQueueIndex = 0
+            upNextQueue = listOf(queued)
+            queueFeature = ProviderFeature(
+                id = "netease_radio",
+                providerId = "netease",
+                providerName = "网易云音乐",
+                title = "私人 FM",
+                category = ProviderFeatureCategory.Recommend,
+                contentType = ProviderContentType.Songs,
+                requiresLogin = true,
+            )
+            isFmQueue = true
+            shuffleBeforeFm = false
+        }
+        var started: MusicTrack? = null
+        var updateCount = 0
+        var persistCount = 0
+        val coordinator = PlaybackQueueCoordinator(
+            queue = queue,
+            scope = this,
+            fallbackTrack = { null },
+            playbackParts = { emptyList() },
+            currentPartIndex = { -1 },
+            startPlayback = { track, _, _ -> started = track },
+            stopPlayback = {},
+            persistQueue = { persistCount += 1 },
+            updateQueueState = { updateCount += 1 },
+            appendFeatureQueue = { 0 },
+            setTrackChangeDirection = {},
+            setMessage = {},
+        )
+
+        coordinator.playTracks(listOf(first, selected), 1)
+
+        assertEquals(selected, started)
+        assertEquals(listOf(first, selected), queue.mainQueue)
+        assertEquals(1, queue.mainQueueIndex)
+        assertEquals(listOf(queued), queue.upNextQueue)
+        assertFalse(queue.isFmQueue)
+        assertNull(queue.queueFeature)
+        assertNull(queue.queuePlaylistId)
+        assertEquals(1, updateCount)
+        assertEquals(1, persistCount)
+    }
+
+    @Test
+    fun playTracksKeepsSelectedTrackFirstWhenShuffleIsEnabled() = runTest {
+        val first = track("first")
+        val selected = track("selected")
+        val third = track("third")
+        val queue = PlaybackQueueController().apply {
+            shuffleEnabled = true
+        }
+        var started: MusicTrack? = null
+        val coordinator = PlaybackQueueCoordinator(
+            queue = queue,
+            scope = this,
+            fallbackTrack = { null },
+            playbackParts = { emptyList() },
+            currentPartIndex = { -1 },
+            startPlayback = { track, _, _ -> started = track },
+            stopPlayback = {},
+            persistQueue = {},
+            updateQueueState = {},
+            appendFeatureQueue = { 0 },
+            setTrackChangeDirection = {},
+            setMessage = {},
+        )
+
+        coordinator.playTracks(listOf(first, selected, third), 1)
+
+        assertEquals(selected, started)
+        assertEquals(selected, queue.mainQueue.first())
+        assertEquals(0, queue.mainQueueIndex)
+        assertEquals(listOf(first, selected, third), queue.originalMainQueue)
+    }
+
+    private fun track(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = id,
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderSessionRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderSessionRepositoryTest.kt
@@ -15,6 +15,8 @@ class ProviderSessionRepositoryTest {
         val repository = DefaultProviderSessionRepository(provider)
         repository.updateProviders(listOf(PROVIDER))
 
+        assertEquals(listOf(PROVIDER), repository.state.value.providers)
+
         val refresh = async { repository.refresh(PROVIDER.providerId, refreshUserInfo = true) }
         provider.refreshStarted.await()
         val login = async { repository.loginWithCookies(PROVIDER.providerId, "{}") }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -216,6 +216,7 @@ private class IosAppContainer(
             isProviderEnabled = { providerId ->
                 providerSessionRepository.state.value.providers.any { it.providerId == providerId }
             },
+            loadTrackDetail = providerRepository::trackDetail,
             navigator = navigator,
         )
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -199,49 +199,25 @@ private class IosAppContainer(
         )
     }
 
-    private val searchAppPort = object : SearchAppPort {
-        override val providers: List<ProviderInfo>
-            get() = controller.providers
-        override val downloadStates: Map<String, DownloadState>
-            get() = controller.downloadStates
-
-        override fun closeSearch() = controller.closeSearch()
-
-        override fun playResult(index: Int) = controller.playFromSearch(index)
-
-        override fun addToUpNext(track: MusicTrack) = controller.addToUpNext(track)
-
-        override fun download(track: MusicTrack) = controller.download(track)
-
-        override fun deleteDownload(track: MusicTrack) = controller.deleteDownload(track)
-
-        override fun openArtist(track: MusicTrack) = controller.openTrackArtist(track)
-
-        override fun openAlbum(track: MusicTrack) = controller.openTrackAlbum(track)
-
-        override fun openTrackDetail(track: MusicTrack) = controller.openTrackDetail(track)
-
-        override fun canAddToPlaylist(track: MusicTrack): Boolean =
-            controller.canAddTrackToPlaylist(track)
-
-        override fun openPlaylistTargetPicker(track: MusicTrack) =
-            controller.openPlaylistTargetPicker(track)
-
-        override fun openMediaItem(item: ProviderMediaItem) = controller.openMediaItem(item)
-
-        override fun openPlaylist(playlist: ProviderPlaylist) {
-            controller.openPlaylist(playlist)
-        }
-
-        override fun openVideo(video: ProviderVideo) = controller.openVideo(video)
+    private val searchAppPort: SearchAppPort by lazy {
+        DefaultSearchAppPort(
+            searchController = searchController,
+            providerSessions = { providerSessionRepository.state.value },
+            playbackQueue = controller.playbackQueueUiPort,
+            downloads = controller.downloadActionPort,
+            playlists = controller.playlistActionPort,
+            providerTrackActions = controller.providerTrackActionPort,
+            navigator = navigator,
+        )
     }
 
-    private val recognitionAppPort = object : RecognitionAppPort {
-        override fun canOpenNeteaseDetail(song: RecognizedSong): Boolean =
-            controller.canOpenRecognizedNeteaseDetail(song)
-
-        override fun openNeteaseDetail(song: RecognizedSong) =
-            controller.openRecognizedNeteaseDetail(song)
+    private val recognitionAppPort: RecognitionAppPort by lazy {
+        DefaultRecognitionAppPort(
+            isProviderEnabled = { providerId ->
+                providerSessionRepository.state.value.providers.any { it.providerId == providerId }
+            },
+            navigator = navigator,
+        )
     }
 
     private val playbackPresentationPort: PlaybackPresentationPort by lazy {


### PR DESCRIPTION
## Summary

Close the remaining P1 app-shell compatibility bridge after #100 and establish the first P2 ownership seams without expanding the refactor into Home / Settings / Provider Detail.

### P1 closeout
- replace Android/iOS `SearchAppPort` and `RecognitionAppPort` controller-forwarding objects with shared commonMain adapters
- compose Search actions from the existing playback queue, download, playlist, provider-track and navigation owners
- route Search provider destinations and Recognition NetEase results through typed app routes instead of controller detail methods
- publish the active provider catalog through `ProviderSessionRepository` so app-shell adapters do not read `controller.providers`
- add an architecture fitness check that rejects reintroducing platform-local Search/Recognition forwarding objects

### P2 foundation
- add `PlaybackQueueUiPort.playTracks(...)` and implement source-queue selection in `PlaybackQueueCoordinator`
- move Search result playback from `FuoPlayerController.playFromSearch(...)` onto the playback queue owner
- preserve existing queue replacement behavior: current selection, Up Next, FM exit, shuffle restoration and queue persistence
- add focused tests for the shared app-port adapters, provider catalog publication and controller-free source-queue selection

### Follow-up direction
- add `docs/p2-architecture-roadmap.md` with explicit sequencing and exit criteria
- P2-1: app navigation / app-scoped feedback ownership
- P2-2: Debug, Download, Local Music, Local Playlist, Settings/Auth screen ownership
- P2-3: provider detail owners by destination
- P2-4: Home/provider-content ownership
- P2-5: retire `FuoPlayerController` only after production callers are gone
- P2-6: split physical Gradle feature modules only after logical boundaries are stable

## Compatibility / intentionally deferred
- `FuoPlayerController` remains the compatibility facade for unmigrated screens
- `AppRoot`, Home, Settings and provider-detail screen signatures are not changed in this PR
- existing typed-route activation continues to own provider detail loading
- existing legacy controller playback paths remain untouched
- no new Gradle feature modules are introduced

## Validation
- focused common tests added for the new boundaries
- `checkArchitectureBoundaries` extended for the P1 closeout guard
- full Android/iOS CI is expected to validate shared tests, architecture checks and platform builds
