### PR TITLE
refactor: migrate low-risk app ownership

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -148,6 +148,10 @@ internal class AndroidAppContainer(
         )
     }
 
+    private val debugLogFeatureController: DebugLogFeatureController by lazy {
+        createDebugLogFeatureController(debugLogRepository, appScope)
+    }
+
     private val audioRecognitionRepository: AndroidAudioRecognitionRepository by lazy {
         AndroidAudioRecognitionRepository(context)
     }
@@ -228,6 +232,7 @@ internal class AndroidAppContainer(
             providerTrackActionPort = wiredController.providerTrackActionPort,
             localMusicActionPort = wiredController.localMusicActionPort,
             replacementActionPort = wiredController.replacementActionPort,
+            debugLogFeatureController = debugLogFeatureController,
             searchController = searchController,
             recognitionController = recognitionController,
             searchAppPort = searchAppPort,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,10 @@ val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeaturePortAdapters.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureController.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadController.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderTrackActionController.kt",
@@ -53,6 +56,7 @@ val platformCompositionRootFiles = listOf(
     "androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt",
     "shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt",
 )
+val appRootFile = "shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt"
 
 tasks.register("checkArchitectureBoundaries") {
     group = "verification"
@@ -82,6 +86,7 @@ tasks.register("checkArchitectureBoundaries") {
     inputs.files(commonMainSources)
     inputs.files(playbackRuntimeAdapterFiles.map(rootProject::file))
     inputs.files(platformCompositionRootFiles.map(rootProject::file))
+    inputs.file(rootProject.file(appRootFile))
 
     doLast {
         val retiredCompatViolations = retiredControllerCompatibilityFiles
@@ -119,6 +124,31 @@ tasks.register("checkArchitectureBoundaries") {
                     appendLine("FuoPlayerController leaked into migrated architecture boundaries:")
                     violations.forEach { appendLine(" - $it") }
                     append("Use feature-owned state/actions or a narrow app/playback/provider contract instead.")
+                },
+            )
+        }
+
+        val appRoot = rootProject.file(appRootFile)
+        val retiredAppShellReads = listOf(
+            "controller.isSettingsLoaded",
+            "controller.onboardingCompleted",
+            "controller.playlistOperationFeedback",
+            "controller.downloadQueueFeedback",
+            "controller.playbackFeedback",
+            "DebugLogScreen(controller",
+            "DownloadManagerScreen(controller",
+        )
+        val appRootViolations = appRoot.readLines().mapIndexedNotNull { index, line ->
+            retiredAppShellReads.firstOrNull(line::contains)?.let { legacyRead ->
+                "${appRoot.relativeTo(rootProject.projectDir).invariantSeparatorsPath}:${index + 1} ($legacyRead)"
+            }
+        }
+        if (appRootViolations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("AppRoot reintroduced retired app-shell controller reads:")
+                    appRootViolations.forEach { appendLine(" - $it") }
+                    append("Use AppUiState or the owning feature port for app-shell state and feedback.")
                 },
             )
         }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -251,19 +251,19 @@ fun AppRoot(
         val snackbarHostState = remember { SnackbarHostState() }
         val downloadQueueFeedback = downloadManagerState.queueFeedback
         LaunchedEffect(playlistOperationFeedback) {
-            playlistOperationFeedback ?: return@LaunchedEffect
-            snackbarHostState.showSnackbar(playlistOperationFeedback)
-            appViewModel.playlistActionPort.dismissFeedback(playlistOperationFeedback)
+            val feedback = playlistOperationFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(feedback)
+            appViewModel.playlistActionPort.dismissFeedback(feedback)
         }
         LaunchedEffect(downloadQueueFeedback) {
-            downloadQueueFeedback ?: return@LaunchedEffect
-            snackbarHostState.showSnackbar(downloadQueueFeedback)
-            appViewModel.downloadActionPort.dismissQueueFeedback(downloadQueueFeedback)
+            val feedback = downloadQueueFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(feedback)
+            appViewModel.downloadActionPort.dismissQueueFeedback(feedback)
         }
         LaunchedEffect(sleepTimerFeedback) {
-            sleepTimerFeedback ?: return@LaunchedEffect
-            snackbarHostState.showSnackbar(sleepTimerFeedback)
-            appViewModel.playbackSleepTimerPort.dismissFeedback(sleepTimerFeedback)
+            val feedback = sleepTimerFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(feedback)
+            appViewModel.playbackSleepTimerPort.dismissFeedback(feedback)
         }
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -222,6 +222,9 @@ fun AppRoot(
     onRequestImagePermission: () -> Unit = {},
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
+    val playlistOperationFeedback by appViewModel.playlistActionPort.feedback.collectAsStateWithLifecycle()
+    val downloadManagerState by appViewModel.downloadActionPort.managerState.collectAsStateWithLifecycle()
+    val sleepTimerFeedback by appViewModel.playbackSleepTimerPort.feedback.collectAsStateWithLifecycle()
     val controller = appViewModel.controller
     val playbackUiPort = appViewModel.playbackUiPort
     FuoTheme(
@@ -230,11 +233,11 @@ fun AppRoot(
         themePaletteStyle = appUiState.settings.settings.themePaletteStyle,
         themeColorSpec = appUiState.settings.settings.themeColorSpec,
     ) {
-        if (!controller.isSettingsLoaded) {
+        if (!appUiState.isInitialized) {
             AppInitializationLoadingScreen()
             return@FuoTheme
         }
-        if (!controller.onboardingCompleted) {
+        if (!appUiState.onboardingCompleted) {
             OnboardingScreen(
                 controller = controller,
                 onOpenProviderWebLogin = onOpenProviderWebLogin,
@@ -246,23 +249,21 @@ fun AppRoot(
             return@FuoTheme
         }
         val snackbarHostState = remember { SnackbarHostState() }
-        val playlistOperationFeedback = controller.playlistOperationFeedback
-        val downloadQueueFeedback = controller.downloadQueueFeedback
-        val playbackFeedback = controller.playbackFeedback
+        val downloadQueueFeedback = downloadManagerState.queueFeedback
         LaunchedEffect(playlistOperationFeedback) {
             playlistOperationFeedback ?: return@LaunchedEffect
             snackbarHostState.showSnackbar(playlistOperationFeedback)
-            controller.dismissPlaylistOperationFeedback(playlistOperationFeedback)
+            appViewModel.playlistActionPort.dismissFeedback(playlistOperationFeedback)
         }
         LaunchedEffect(downloadQueueFeedback) {
             downloadQueueFeedback ?: return@LaunchedEffect
             snackbarHostState.showSnackbar(downloadQueueFeedback)
-            controller.dismissDownloadQueueFeedback(downloadQueueFeedback)
+            appViewModel.downloadActionPort.dismissQueueFeedback(downloadQueueFeedback)
         }
-        LaunchedEffect(playbackFeedback) {
-            playbackFeedback ?: return@LaunchedEffect
-            snackbarHostState.showSnackbar(playbackFeedback)
-            controller.dismissPlaybackFeedback(playbackFeedback)
+        LaunchedEffect(sleepTimerFeedback) {
+            sleepTimerFeedback ?: return@LaunchedEffect
+            snackbarHostState.showSnackbar(sleepTimerFeedback)
+            appViewModel.playbackSleepTimerPort.dismissFeedback(sleepTimerFeedback)
         }
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) {
@@ -355,8 +356,14 @@ fun AppRoot(
                                                 onRequestImagePermission = onRequestImagePermission,
                                                 onOpenRecognition = appViewModel::openRecognition,
                                             )
-                                            AppRoute.DebugLogs -> DebugLogScreen(controller)
-                                            AppRoute.DownloadManager -> DownloadManagerScreen(controller)
+                                            AppRoute.DebugLogs -> DebugLogFeatureScreen(
+                                                controller = appViewModel.debugLogFeatureController,
+                                                onBack = appViewModel::closeDebugLogs,
+                                            )
+                                            AppRoute.DownloadManager -> DownloadManagerScreen(
+                                                port = appViewModel.downloadActionPort,
+                                                onBack = appViewModel::closeDownloadManager,
+                                            )
                                             AppRoute.Settings -> SettingsScreenV2(
                                                 controller = controller,
                                                 themePaletteStyle = appUiState.settings.settings.themePaletteStyle,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
@@ -154,7 +154,13 @@ data class AppUiState(
     val settings: SettingsState = SettingsState(),
     val providerSessions: ProviderSessionState = ProviderSessionState(),
     val backStack: List<AppRoute> = listOf(AppRoute.Home),
-)
+) {
+    val isInitialized: Boolean
+        get() = settings.isLoaded
+
+    val onboardingCompleted: Boolean
+        get() = settings.settings.onboardingCompleted
+}
 
 sealed interface AppIntent {
     data object NavigateBack : AppIntent
@@ -176,6 +182,7 @@ class FuoAppViewModel(
     val providerTrackActionPort: ProviderTrackActionPort,
     val localMusicActionPort: LocalMusicActionPort,
     val replacementActionPort: ReplacementActionPort,
+    val debugLogFeatureController: DebugLogFeatureController,
     private val searchController: SearchFeatureController,
     private val recognitionController: RecognitionFeatureController,
     internal val searchAppPort: SearchAppPort,
@@ -236,6 +243,24 @@ class FuoAppViewModel(
     fun closeRecognition() {
         recognitionController.dispatch(RecognitionAction.Close)
         navigator.pop(AppRoute.AudioRecognition)
+    }
+
+    fun openDebugLogs() {
+        if (debugLogFeatureController.isAvailable) {
+            navigator.navigate(AppRoute.DebugLogs)
+        }
+    }
+
+    fun closeDebugLogs() {
+        navigator.pop(AppRoute.DebugLogs)
+    }
+
+    fun openDownloadManager() {
+        navigator.navigate(AppRoute.DownloadManager)
+    }
+
+    fun closeDownloadManager() {
+        navigator.pop(AppRoute.DownloadManager)
     }
 
     fun onMicrophonePermissionChange(hasPermission: Boolean) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureController.kt
@@ -1,0 +1,113 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+private val DEFAULT_DEBUG_LOG_FILTERS =
+    setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error)
+
+data class DebugLogUiState(
+    val lines: List<String> = emptyList(),
+    val levelFilters: Set<DebugLogLevel> = DEFAULT_DEBUG_LOG_FILTERS,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val feedback: String? = null,
+)
+
+/** Feature-owned debug-log state and actions used by the production log viewer. */
+interface DebugLogFeatureController {
+    val isAvailable: Boolean
+    val uiState: StateFlow<DebugLogUiState>
+
+    fun refresh()
+    fun onLevelFilterChange(level: DebugLogLevel, selected: Boolean)
+    fun export(lines: List<String>)
+    fun dismissFeedback(feedback: String)
+}
+
+fun createDebugLogFeatureController(
+    repository: DebugLogRepository,
+    scope: CoroutineScope,
+): DebugLogFeatureController = DefaultDebugLogFeatureController(repository, scope)
+
+private class DefaultDebugLogFeatureController(
+    private val repository: DebugLogRepository,
+    private val scope: CoroutineScope,
+) : DebugLogFeatureController {
+    private val mutableUiState = MutableStateFlow(DebugLogUiState())
+    override val uiState: StateFlow<DebugLogUiState> = mutableUiState.asStateFlow()
+    override val isAvailable: Boolean
+        get() = repository.isAvailable
+
+    override fun refresh() {
+        if (!repository.isAvailable || mutableUiState.value.isLoading) return
+        scope.launch {
+            mutableUiState.value = mutableUiState.value.copy(
+                isLoading = true,
+                errorMessage = null,
+            )
+            try {
+                val lines = repository.logLines()
+                mutableUiState.value = mutableUiState.value.copy(
+                    lines = lines,
+                    isLoading = false,
+                    errorMessage = null,
+                )
+            } catch (cancelled: CancellationException) {
+                mutableUiState.value = mutableUiState.value.copy(isLoading = false)
+                throw cancelled
+            } catch (throwable: Throwable) {
+                mutableUiState.value = mutableUiState.value.copy(
+                    isLoading = false,
+                    errorMessage = throwable.message ?: throwable::class.simpleName.orEmpty(),
+                )
+            }
+        }
+    }
+
+    override fun onLevelFilterChange(level: DebugLogLevel, selected: Boolean) {
+        val current = mutableUiState.value
+        val filters = if (selected) {
+            current.levelFilters + level
+        } else {
+            current.levelFilters - level
+        }
+        mutableUiState.value = current.copy(levelFilters = filters)
+    }
+
+    override fun export(lines: List<String>) {
+        if (!repository.isAvailable || lines.isEmpty() || mutableUiState.value.isLoading) return
+        scope.launch {
+            mutableUiState.value = mutableUiState.value.copy(
+                isLoading = true,
+                errorMessage = null,
+            )
+            try {
+                val feedback = repository.exportLogFile(lines)
+                mutableUiState.value = mutableUiState.value.copy(
+                    isLoading = false,
+                    feedback = feedback,
+                )
+            } catch (cancelled: CancellationException) {
+                mutableUiState.value = mutableUiState.value.copy(isLoading = false)
+                throw cancelled
+            } catch (throwable: Throwable) {
+                mutableUiState.value = mutableUiState.value.copy(
+                    isLoading = false,
+                    errorMessage = throwable.message ?: throwable::class.simpleName.orEmpty(),
+                )
+            }
+        }
+    }
+
+    override fun dismissFeedback(feedback: String) {
+        val current = mutableUiState.value
+        if (current.feedback == feedback) {
+            mutableUiState.value = current.copy(feedback = null)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
@@ -1,0 +1,305 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+private val FEATURE_DEBUG_LOG_THREADTIME_LEVEL_REGEX =
+    Regex("""^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+\d+\s+\d+\s+([DIWEAF])\s+""")
+private val FEATURE_DEBUG_LOG_TIME_LEVEL_REGEX =
+    Regex("""^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+([DIWEAF])/""")
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun DebugLogFeatureScreen(
+    controller: DebugLogFeatureController,
+    onBack: () -> Unit,
+) {
+    val uiState by controller.uiState.collectAsStateWithLifecycle()
+    val clipboardManager = LocalClipboardManager.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    var selectionMode by remember { mutableStateOf(false) }
+    var selectedLineIndexes by remember { mutableStateOf<Set<Int>>(emptySet()) }
+    val visibleLogLines = remember(uiState.lines, uiState.levelFilters) {
+        uiState.lines.mapIndexedNotNull { index, line ->
+            val level = parseFeatureDebugLogLevel(line) ?: DebugLogLevel.Info
+            if (level in uiState.levelFilters) index to line else null
+        }
+    }
+    val selectedLines = remember(uiState.lines, selectedLineIndexes) {
+        selectedLineIndexes.sorted().mapNotNull { uiState.lines.getOrNull(it) }
+    }
+
+    LaunchedEffect(Unit) {
+        controller.refresh()
+    }
+    LaunchedEffect(uiState.lines) {
+        selectedLineIndexes = selectedLineIndexes.filter { it in uiState.lines.indices }.toSet()
+    }
+    LaunchedEffect(selectedLineIndexes) {
+        if (selectedLineIndexes.isEmpty()) {
+            selectionMode = false
+        }
+    }
+    LaunchedEffect(uiState.feedback) {
+        val feedback = uiState.feedback ?: return@LaunchedEffect
+        controller.dismissFeedback(feedback)
+        snackbarHostState.showSnackbar(feedback)
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("应用日志") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    IconButton(
+                        enabled = !uiState.isLoading,
+                        onClick = controller::refresh,
+                    ) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "刷新")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (uiState.isLoading) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            uiState.errorMessage?.let { ProviderContentMessage(it) }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DebugLogLevel.entries.forEach { level ->
+                    FilterChip(
+                        selected = level in uiState.levelFilters,
+                        onClick = {
+                            controller.onLevelFilterChange(
+                                level,
+                                level !in uiState.levelFilters,
+                            )
+                        },
+                        label = { Text(featureDebugLogLevelLabel(level)) },
+                        colors = settingsFilterChipColors(),
+                    )
+                }
+            }
+            if (selectionMode) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "已选 ${selectedLineIndexes.size}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    TextButton(
+                        enabled = visibleLogLines.isNotEmpty(),
+                        onClick = {
+                            val visibleIndexes = visibleLogLines.map { it.first }.toSet()
+                            selectedLineIndexes = if (visibleIndexes.all { it in selectedLineIndexes }) {
+                                selectedLineIndexes - visibleIndexes
+                            } else {
+                                selectedLineIndexes + visibleIndexes
+                            }
+                        },
+                    ) {
+                        Text("全选")
+                    }
+                    TextButton(
+                        enabled = selectedLines.isNotEmpty(),
+                        onClick = {
+                            clipboardManager.setText(AnnotatedString(selectedLines.joinToString(separator = "\n")))
+                        },
+                    ) {
+                        Icon(Icons.Filled.ContentCopy, contentDescription = null)
+                        Spacer(Modifier.size(8.dp))
+                        Text("复制所选")
+                    }
+                    TextButton(
+                        enabled = selectedLines.isNotEmpty() && !uiState.isLoading,
+                        onClick = { controller.export(selectedLines) },
+                    ) {
+                        Icon(Icons.Filled.Download, contentDescription = null)
+                        Spacer(Modifier.size(8.dp))
+                        Text("导出所选")
+                    }
+                }
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            ) {
+                if (visibleLogLines.isEmpty() && !uiState.isLoading && uiState.errorMessage == null) {
+                    item { ProviderContentMessage("暂无日志") }
+                } else {
+                    itemsIndexed(visibleLogLines) { _, indexedLine ->
+                        val originalIndex = indexedLine.first
+                        val line = indexedLine.second
+                        val level = parseFeatureDebugLogLevel(line)
+                        val selected = originalIndex in selectedLineIndexes
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                                .combinedClickable(
+                                    onClick = {
+                                        if (selectionMode) {
+                                            selectedLineIndexes = if (selected) {
+                                                selectedLineIndexes - originalIndex
+                                            } else {
+                                                selectedLineIndexes + originalIndex
+                                            }
+                                        }
+                                    },
+                                    onLongClick = {
+                                        selectionMode = true
+                                        selectedLineIndexes = selectedLineIndexes + originalIndex
+                                    },
+                                ),
+                            color = featureDebugLogLevelContainerColor(level),
+                            shape = MaterialTheme.shapes.medium,
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.Top,
+                            ) {
+                                if (selectionMode) {
+                                    Checkbox(
+                                        checked = selected,
+                                        onCheckedChange = { checked ->
+                                            selectedLineIndexes = if (checked) {
+                                                selectedLineIndexes + originalIndex
+                                            } else {
+                                                selectedLineIndexes - originalIndex
+                                            }
+                                        },
+                                    )
+                                }
+                                Text(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(top = 10.dp),
+                                    text = line,
+                                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                    color = featureDebugLogLevelContentColor(level),
+                                )
+                                IconButton(
+                                    modifier = Modifier.fuoInteractive().size(48.dp),
+                                    onClick = { clipboardManager.setText(AnnotatedString(line)) },
+                                ) {
+                                    Icon(Icons.Filled.ContentCopy, contentDescription = "复制")
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun parseFeatureDebugLogLevel(line: String): DebugLogLevel? {
+    val code = FEATURE_DEBUG_LOG_THREADTIME_LEVEL_REGEX.find(line)?.groupValues?.getOrNull(1)
+        ?: FEATURE_DEBUG_LOG_TIME_LEVEL_REGEX.find(line)?.groupValues?.getOrNull(1)
+        ?: return null
+    return when (code) {
+        "D" -> DebugLogLevel.Debug
+        "I" -> DebugLogLevel.Info
+        "W" -> DebugLogLevel.Warning
+        "E", "A", "F" -> DebugLogLevel.Error
+        else -> null
+    }
+}
+
+private fun featureDebugLogLevelLabel(level: DebugLogLevel): String = when (level) {
+    DebugLogLevel.Debug -> "Debug"
+    DebugLogLevel.Info -> "Info"
+    DebugLogLevel.Warning -> "Warn"
+    DebugLogLevel.Error -> "Error"
+}
+
+@Composable
+private fun featureDebugLogLevelContainerColor(level: DebugLogLevel?) = when (level) {
+    DebugLogLevel.Debug -> MaterialTheme.colorScheme.surfaceContainerHigh
+    DebugLogLevel.Info -> MaterialTheme.colorScheme.secondaryContainer
+    DebugLogLevel.Warning -> MaterialTheme.colorScheme.tertiaryContainer
+    DebugLogLevel.Error -> MaterialTheme.colorScheme.errorContainer
+    null -> MaterialTheme.colorScheme.surface
+}
+
+@Composable
+private fun featureDebugLogLevelContentColor(level: DebugLogLevel?) = when (level) {
+    DebugLogLevel.Info -> MaterialTheme.colorScheme.onSecondaryContainer
+    DebugLogLevel.Warning -> MaterialTheme.colorScheme.onTertiaryContainer
+    DebugLogLevel.Error -> MaterialTheme.colorScheme.onErrorContainer
+    else -> MaterialTheme.colorScheme.onSurface
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadController.kt
@@ -1,7 +1,15 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+data class DownloadManagerUiState(
+    val tasks: List<DownloadTask> = emptyList(),
+    val queueFeedback: String? = null,
+)
 
 internal class DownloadController(
     private val providerRepository: ProviderMusicRepository,
@@ -18,12 +26,15 @@ internal class DownloadController(
     private val setMessage: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
 ) : DownloadActionPort {
+    private val mutableManagerState = MutableStateFlow(DownloadManagerUiState())
+    override val managerState: StateFlow<DownloadManagerUiState> = mutableManagerState.asStateFlow()
+
     private val offlineLibraryCoordinator = OfflineLibraryControllerCoordinator(
         scope = scope,
         downloadRepository = downloadRepository,
         localRepository = localRepository,
-        onDownloadStates = { state.states = it },
-        onDownloadTasks = { state.tasks = it },
+        onDownloadStates = { states -> state.states = states },
+        onDownloadTasks = ::updateTasks,
         hasLocalMusicPermission = { localMusicController.hasPermission },
         shouldShowLocalMusicLoading = isLocalMusicSectionActive,
         refreshLocalMusic = localMusicController::refresh,
@@ -36,8 +47,10 @@ internal class DownloadController(
         offlineLibraryCoordinator.start()
     }
 
-    fun dismissQueueFeedback(feedback: String) {
-        if (state.queueFeedback == feedback) state.queueFeedback = null
+    override fun dismissQueueFeedback(feedback: String) {
+        if (state.queueFeedback == feedback) {
+            updateQueueFeedback(null)
+        }
     }
 
     fun onParallelismChange(value: Int) {
@@ -48,7 +61,7 @@ internal class DownloadController(
 
     override fun download(track: MusicTrack) {
         if (track.sourceType != TrackSourceType.Provider) return
-        state.queueFeedback = "已加入下载队列：${track.title}"
+        updateQueueFeedback("已加入下载队列：${track.title}")
         scope.launch {
             runCatching {
                 val payload = providerRepository.resolve(
@@ -64,13 +77,13 @@ internal class DownloadController(
         }
     }
 
-    fun pause(taskId: String) = runAction { downloadRepository.pause(taskId) }
+    override fun pause(taskId: String) = runAction { downloadRepository.pause(taskId) }
 
-    fun resume(taskId: String) = runAction { downloadRepository.resume(taskId) }
+    override fun resume(taskId: String) = runAction { downloadRepository.resume(taskId) }
 
-    fun retry(taskId: String) = runAction { downloadRepository.retry(taskId) }
+    override fun retry(taskId: String) = runAction { downloadRepository.retry(taskId) }
 
-    fun deleteTask(taskId: String, deleteFile: Boolean) = runAction {
+    override fun deleteTask(taskId: String, deleteFile: Boolean) = runAction {
         downloadRepository.deleteTask(taskId, deleteFile)
     }
 
@@ -91,6 +104,16 @@ internal class DownloadController(
     }
 
     fun deleteDownloaded(track: MusicTrack) = deleteDownload(track)
+
+    private fun updateTasks(tasks: List<DownloadTask>) {
+        state.tasks = tasks
+        mutableManagerState.value = mutableManagerState.value.copy(tasks = tasks)
+    }
+
+    private fun updateQueueFeedback(feedback: String?) {
+        state.queueFeedback = feedback
+        mutableManagerState.value = mutableManagerState.value.copy(queueFeedback = feedback)
+    }
 
     private fun runAction(action: suspend () -> Unit) {
         scope.launch {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt
@@ -3,11 +3,10 @@ package org.feeluown.mobile
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -37,16 +36,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DownloadManagerScreen(controller: FuoPlayerController) {
+fun DownloadManagerScreen(
+    port: DownloadActionPort,
+    onBack: () -> Unit,
+) {
+    val managerState by port.managerState.collectAsStateWithLifecycle()
     var completedLimit by remember { mutableStateOf(5) }
     var pendingDelete by remember { mutableStateOf<DownloadTask?>(null) }
     var deleteFile by remember { mutableStateOf(true) }
-    val tasks = controller.downloadTasks
-    val active = tasks.filter { it.status != DownloadTaskStatus.Completed }
-    val completed = tasks.filter { it.status == DownloadTaskStatus.Completed }
+    val active = managerState.tasks.filter { it.status != DownloadTaskStatus.Completed }
+    val completed = managerState.tasks.filter { it.status == DownloadTaskStatus.Completed }
         .sortedByDescending { it.createdAt }
 
     Scaffold(
@@ -54,7 +57,7 @@ fun DownloadManagerScreen(controller: FuoPlayerController) {
             CenterAlignedTopAppBar(
                 title = { Text("下载管理") },
                 navigationIcon = {
-                    IconButton(onClick = controller::closeDownloadManager) {
+                    IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
                     }
                 },
@@ -70,9 +73,9 @@ fun DownloadManagerScreen(controller: FuoPlayerController) {
                 items(active, key = { it.id }) { task ->
                     DownloadTaskCard(
                         task = task,
-                        onPause = { controller.pauseDownload(task.id) },
-                        onResume = { controller.resumeDownload(task.id) },
-                        onRetry = { controller.retryDownload(task.id) },
+                        onPause = { port.pause(task.id) },
+                        onResume = { port.resume(task.id) },
+                        onRetry = { port.retry(task.id) },
                         onDelete = { pendingDelete = task; deleteFile = true },
                     )
                 }
@@ -122,7 +125,7 @@ fun DownloadManagerScreen(controller: FuoPlayerController) {
             },
             confirmButton = {
                 TextButton(onClick = {
-                    controller.deleteDownloadTask(task.id, deleteFile || task.status != DownloadTaskStatus.Completed)
+                    port.deleteTask(task.id, deleteFile || task.status != DownloadTaskStatus.Completed)
                     pendingDelete = null
                 }) { Text("删除") }
             },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt
@@ -1,6 +1,9 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /** Owns provider/local playlist mutations initiated from the now-playing surface. */
@@ -22,6 +25,9 @@ internal class PlaylistActionController(
     private val setMessage: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
 ) : PlaylistActionPort {
+    private val mutableFeedback = MutableStateFlow<String?>(null)
+    override val feedback: StateFlow<String?> = mutableFeedback.asStateFlow()
+
     override fun canAddTrackToPlaylist(track: MusicTrack): Boolean =
         canAddTrackToProviderPlaylist(track) || canAddTrackToLocalPlaylist(track)
 
@@ -103,20 +109,20 @@ internal class PlaylistActionController(
                     if (result.success) {
                         val feedback = result.message.ifBlank { "已添加到：${playlist.title}" }
                         setMessage(feedback)
-                        state.playlistOperationFeedback = feedback
+                        updateFeedback(feedback)
                         closePlaylistTargetPicker()
                         refreshAfterProviderMutation(playlist.providerId)
                     } else {
                         state.playlistOperationError = result.message.ifBlank { "添加失败" }
                         setMessage(state.playlistOperationError.orEmpty())
-                        state.playlistOperationFeedback = state.playlistOperationError
+                        updateFeedback(state.playlistOperationError)
                     }
                 }
                 .onFailure {
                     val feedback = playlistMutationErrorMessage(it, playlist.providerId)
                     state.playlistOperationError = feedback
                     onError(it)
-                    state.playlistOperationFeedback = feedback
+                    updateFeedback(feedback)
                 }
             setLoading(false)
         }
@@ -146,22 +152,33 @@ internal class PlaylistActionController(
                         updateSelectedPlaylistTracks(selectedPlaylistTracks().filterNot { it.id == track.id })
                         val feedback = result.message.ifBlank { "已从歌单移除：${track.title}" }
                         setMessage(feedback)
-                        state.playlistOperationFeedback = feedback
+                        updateFeedback(feedback)
                         refreshAfterProviderMutation(playlist.providerId)
                     } else {
                         val error = result.message.ifBlank { "移除失败" }
                         updateSelectedPlaylistError(error)
                         setMessage(error)
-                        state.playlistOperationFeedback = error
+                        updateFeedback(error)
                     }
                 }
                 .onFailure {
                     val feedback = playlistMutationErrorMessage(it, playlist.providerId)
                     onError(it)
-                    state.playlistOperationFeedback = feedback
+                    updateFeedback(feedback)
                 }
             setLoading(false)
         }
+    }
+
+    override fun dismissFeedback(feedback: String) {
+        if (mutableFeedback.value == feedback) {
+            updateFeedback(null)
+        }
+    }
+
+    private fun updateFeedback(feedback: String?) {
+        state.playlistOperationFeedback = feedback
+        mutableFeedback.value = feedback
     }
 
     private fun trackProviderId(track: MusicTrack): String? =

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt
@@ -1,9 +1,7 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /** Owns provider/local playlist mutations initiated from the now-playing surface. */
@@ -25,8 +23,7 @@ internal class PlaylistActionController(
     private val setMessage: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
 ) : PlaylistActionPort {
-    private val mutableFeedback = MutableStateFlow<String?>(null)
-    override val feedback: StateFlow<String?> = mutableFeedback.asStateFlow()
+    override val feedback: StateFlow<String?> = state.playlistOperationFeedbackFlow
 
     override fun canAddTrackToPlaylist(track: MusicTrack): Boolean =
         canAddTrackToProviderPlaylist(track) || canAddTrackToLocalPlaylist(track)
@@ -171,14 +168,13 @@ internal class PlaylistActionController(
     }
 
     override fun dismissFeedback(feedback: String) {
-        if (mutableFeedback.value == feedback) {
+        if (state.playlistOperationFeedback == feedback) {
             updateFeedback(null)
         }
     }
 
     private fun updateFeedback(feedback: String?) {
         state.playlistOperationFeedback = feedback
-        mutableFeedback.value = feedback
     }
 
     private fun trackProviderId(track: MusicTrack): String? =

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
@@ -1,6 +1,8 @@
 package org.feeluown.mobile
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
@@ -1,8 +1,9 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 internal class PlaylistControllerState {
     var localPlaylists by mutableStateOf<List<LocalPlaylist>>(emptyList())
@@ -15,7 +16,17 @@ internal class PlaylistControllerState {
     var playlistTargetPickerShowSwitcher by mutableStateOf(true)
     var playlistOperationTargets by mutableStateOf<List<ProviderPlaylist>>(emptyList())
     var playlistOperationError by mutableStateOf<String?>(null)
-    var playlistOperationFeedback by mutableStateOf<String?>(null)
+
+    private val playlistOperationFeedbackState = mutableStateOf<String?>(null)
+    private val mutablePlaylistOperationFeedback = MutableStateFlow<String?>(null)
+    val playlistOperationFeedbackFlow: StateFlow<String?> = mutablePlaylistOperationFeedback.asStateFlow()
+    var playlistOperationFeedback: String?
+        get() = playlistOperationFeedbackState.value
+        set(value) {
+            playlistOperationFeedbackState.value = value
+            mutablePlaylistOperationFeedback.value = value
+        }
+
     var localPlaylistOperationError by mutableStateOf<String?>(null)
     var localPlaylistImportPreview by mutableStateOf<LocalPlaylistImportPreview?>(null)
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackSleepTimerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackSleepTimerController.kt
@@ -6,6 +6,9 @@ import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 internal class PlaybackSleepTimerController(
@@ -16,6 +19,9 @@ internal class PlaybackSleepTimerController(
     private val onFeedback: (String) -> Unit,
 ) : PlaybackSleepTimerPort, PlaybackEndSleepTimer {
     var state by mutableStateOf(SleepTimerState())
+
+    private val mutableFeedback = MutableStateFlow<String?>(null)
+    override val feedback: StateFlow<String?> = mutableFeedback.asStateFlow()
 
     override val sleepTimerState: SleepTimerState
         get() = state
@@ -33,13 +39,19 @@ internal class PlaybackSleepTimerController(
 
     override fun clearSleepTimer() = clear()
 
+    override fun dismissFeedback(feedback: String) {
+        if (mutableFeedback.value == feedback) {
+            mutableFeedback.value = null
+        }
+    }
+
     fun setDurationMinutes(minutes: Int, currentTrackId: String?) {
         if (currentTrackId == null) {
-            onFeedback("请先播放一首歌曲")
+            publishFeedback("请先播放一首歌曲")
             return
         }
         if (minutes !in SLEEP_TIMER_MIN_MINUTES..SLEEP_TIMER_MAX_MINUTES) {
-            onFeedback("请输入 $SLEEP_TIMER_MIN_MINUTES–$SLEEP_TIMER_MAX_MINUTES 分钟")
+            publishFeedback("请输入 $SLEEP_TIMER_MIN_MINUTES–$SLEEP_TIMER_MAX_MINUTES 分钟")
             return
         }
         val durationMs = minutes.toLong() * 60_000L
@@ -54,7 +66,7 @@ internal class PlaybackSleepTimerController(
 
     fun setToEndOfTrack(currentTrackId: String?) {
         if (currentTrackId == null) {
-            onFeedback("请先播放一首歌曲")
+            publishFeedback("请先播放一首歌曲")
             return
         }
         replace(
@@ -100,7 +112,7 @@ internal class PlaybackSleepTimerController(
 
     override fun completeEndOfTrack() {
         clear()
-        onFeedback("当前曲目已播放完，播放已暂停")
+        publishFeedback("当前曲目已播放完，播放已暂停")
     }
 
     private fun replace(nextState: SleepTimerState) {
@@ -116,12 +128,17 @@ internal class PlaybackSleepTimerController(
                 if (remainingMs <= 0L) {
                     clear()
                     playbackEngine.pause()
-                    onFeedback("睡眠定时已结束，播放已暂停")
+                    publishFeedback("睡眠定时已结束，播放已暂停")
                     break
                 }
                 state = state.copy(remainingMs = remainingMs)
                 delay(minOf(remainingMs, 1_000L))
             }
         }
+    }
+
+    private fun publishFeedback(message: String) {
+        mutableFeedback.value = message
+        onFeedback(message)
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -1,5 +1,12 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+private val EMPTY_FEEDBACK_FLOW: StateFlow<String?> = MutableStateFlow(null)
+private val EMPTY_DOWNLOAD_MANAGER_FLOW: StateFlow<DownloadManagerUiState> =
+    MutableStateFlow(DownloadManagerUiState())
+
 /** UI-only player navigation state. */
 interface PlaybackNavigationPort {
     val isFullPlayerOpen: Boolean
@@ -47,29 +54,43 @@ interface PlaybackQueueUiPort {
     fun addToUpNext(track: MusicTrack)
 }
 
-/** Sleep-timer state and commands owned by playback. */
+/** Sleep-timer state, commands and transient feedback owned by playback. */
 interface PlaybackSleepTimerPort {
     val sleepTimerState: SleepTimerState
+    val feedback: StateFlow<String?>
+        get() = EMPTY_FEEDBACK_FLOW
 
     fun setSleepTimerDurationMinutes(minutes: Int)
     fun clearSleepTimer()
     fun setSleepTimerToEndOfTrack()
+    fun dismissFeedback(feedback: String) = Unit
 }
 
-/** Download state/actions used by the now-playing surface. */
+/** Download state/actions used by player UI and the download-manager feature. */
 interface DownloadActionPort {
     val downloadStates: Map<String, DownloadState>
+    val managerState: StateFlow<DownloadManagerUiState>
+        get() = EMPTY_DOWNLOAD_MANAGER_FLOW
 
     fun download(track: MusicTrack)
     fun deleteDownload(track: MusicTrack)
+    fun pause(taskId: String) = Unit
+    fun resume(taskId: String) = Unit
+    fun retry(taskId: String) = Unit
+    fun deleteTask(taskId: String, deleteFile: Boolean) = Unit
+    fun dismissQueueFeedback(feedback: String) = Unit
 }
 
-/** Playlist mutations used by the now-playing surface. */
+/** Playlist mutations and their transient feedback used by the now-playing surface. */
 interface PlaylistActionPort {
+    val feedback: StateFlow<String?>
+        get() = EMPTY_FEEDBACK_FLOW
+
     fun canAddTrackToPlaylist(track: MusicTrack): Boolean
     fun openPlaylistTargetPicker(track: MusicTrack)
     fun canRemoveTrackFromSelectedPlaylist(track: MusicTrack): Boolean
     fun removeTrackFromSelectedPlaylist(track: MusicTrack)
+    fun dismissFeedback(feedback: String) = Unit
 }
 
 /** Provider-backed track navigation and dislike actions. */

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LowRiskOwnershipTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LowRiskOwnershipTest.kt
@@ -30,6 +30,22 @@ class LowRiskOwnershipTest {
     }
 
     @Test
+    fun playlistFeedbackBridgePublishesLegacyStateWritesToAppPortFlow() {
+        val state = PlaylistControllerState()
+
+        assertNull(state.playlistOperationFeedbackFlow.value)
+
+        state.playlistOperationFeedback = "歌单已新建"
+        assertEquals("歌单已新建", state.playlistOperationFeedbackFlow.value)
+
+        state.playlistOperationFeedback = "已从本地歌单移除"
+        assertEquals("已从本地歌单移除", state.playlistOperationFeedbackFlow.value)
+
+        state.playlistOperationFeedback = null
+        assertNull(state.playlistOperationFeedbackFlow.value)
+    }
+
+    @Test
     fun debugLogOwnerKeepsLoadingFilteringAndFeedbackFeatureLocal() = runTest {
         val repository = FakeDebugLogRepository(
             lines = listOf("info", "warning"),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LowRiskOwnershipTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LowRiskOwnershipTest.kt
@@ -1,0 +1,120 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LowRiskOwnershipTest {
+    @Test
+    fun appUiStateUsesSettingsRepositoryAsBootstrapSourceOfTruth() {
+        val loading = AppUiState()
+        assertFalse(loading.isInitialized)
+        assertFalse(loading.onboardingCompleted)
+
+        val ready = AppUiState(
+            settings = SettingsState(
+                isLoaded = true,
+                settings = AppSettings(onboardingCompleted = true),
+            ),
+        )
+        assertTrue(ready.isInitialized)
+        assertTrue(ready.onboardingCompleted)
+    }
+
+    @Test
+    fun debugLogOwnerKeepsLoadingFilteringAndFeedbackFeatureLocal() = runTest {
+        val repository = FakeDebugLogRepository(
+            lines = listOf("info", "warning"),
+            exportResult = "日志已导出",
+        )
+        val controller = createDebugLogFeatureController(repository, this)
+
+        controller.refresh()
+        advanceUntilIdle()
+
+        assertEquals(listOf("info", "warning"), controller.uiState.value.lines)
+        assertFalse(controller.uiState.value.isLoading)
+        assertNull(controller.uiState.value.errorMessage)
+        assertEquals(
+            setOf(DebugLogLevel.Info, DebugLogLevel.Warning, DebugLogLevel.Error),
+            controller.uiState.value.levelFilters,
+        )
+
+        controller.onLevelFilterChange(DebugLogLevel.Debug, true)
+        assertTrue(DebugLogLevel.Debug in controller.uiState.value.levelFilters)
+
+        controller.export(listOf("info"))
+        advanceUntilIdle()
+        assertEquals("日志已导出", controller.uiState.value.feedback)
+        controller.dismissFeedback("日志已导出")
+        assertNull(controller.uiState.value.feedback)
+    }
+
+    @Test
+    fun debugLogOwnerPublishesRepositoryFailureWithoutGlobalMessageState() = runTest {
+        val controller = createDebugLogFeatureController(
+            repository = FakeDebugLogRepository(loadFailure = IllegalStateException("read failed")),
+            scope = this,
+        )
+
+        controller.refresh()
+        advanceUntilIdle()
+
+        assertFalse(controller.uiState.value.isLoading)
+        assertEquals("read failed", controller.uiState.value.errorMessage)
+        assertTrue(controller.uiState.value.lines.isEmpty())
+    }
+
+    @Test
+    fun sleepTimerFeedbackIsOwnedByPlaybackPortAndDismissible() = runTest {
+        val engine = FakePlaybackEngine()
+        val compatibilityFeedback = mutableListOf<String>()
+        val controller = PlaybackSleepTimerController(
+            playbackEngine = engine,
+            scope = this,
+            currentTrackId = { null },
+            nowMillis = { 0L },
+            onFeedback = compatibilityFeedback::add,
+        )
+
+        controller.setSleepTimerDurationMinutes(30)
+
+        assertEquals("请先播放一首歌曲", controller.feedback.value)
+        assertEquals(listOf("请先播放一首歌曲"), compatibilityFeedback)
+        controller.dismissFeedback("请先播放一首歌曲")
+        assertNull(controller.feedback.value)
+    }
+
+    private class FakeDebugLogRepository(
+        private val lines: List<String> = emptyList(),
+        private val exportResult: String = "",
+        private val loadFailure: Throwable? = null,
+    ) : DebugLogRepository {
+        override val isAvailable: Boolean = true
+
+        override suspend fun logLines(): List<String> {
+            loadFailure?.let { throw it }
+            return lines
+        }
+
+        override suspend fun exportLogFile(lines: List<String>): String = exportResult
+    }
+
+    private class FakePlaybackEngine : PlaybackEngine {
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState())
+
+        override fun play(track: MusicTrack, payload: PlaybackPayload) = Unit
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun stop() = Unit
+        override fun seekTo(positionMs: Long) = Unit
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -159,6 +159,9 @@ private class IosAppContainer(
     }
     private val playbackQueueStore = IosPlaybackQueueStore()
     private val resourceCacheRepository = IosResourceCacheRepository()
+    private val debugLogFeatureController: DebugLogFeatureController by lazy {
+        createDebugLogFeatureController(NoOpDebugLogRepository, scope)
+    }
     private val audioRecognitionRepository = IosAudioRecognitionRepository(audioRecognitionOutput)
     private val recognitionController: RecognitionFeatureController by lazy {
         createRecognitionFeatureController(
@@ -242,6 +245,7 @@ private class IosAppContainer(
         providerTrackActionPort = controller.providerTrackActionPort,
         localMusicActionPort = controller.localMusicActionPort,
         replacementActionPort = controller.replacementActionPort,
+        debugLogFeatureController = debugLogFeatureController,
         searchController = searchController,
         recognitionController = recognitionController,
         searchAppPort = searchAppPort,


### PR DESCRIPTION
## Summary

Complete the low-risk P2 ownership work on top of #101 without pulling medium/high-risk Home, provider-detail, local-library or Settings/Auth rewrites into the same change.

### App shell ownership
- use `SettingsState.isLoaded` and persisted `AppSettings.onboardingCompleted` as the AppRoot bootstrap/onboarding source of truth instead of controller mirror flags
- move AppRoot playlist mutation feedback to `PlaylistActionPort`
- move AppRoot download queue feedback to `DownloadActionPort`
- move AppRoot sleep-timer feedback to `PlaybackSleepTimerPort`
- retain facade mirror state for unmigrated compatibility callers while production app-shell consumers use the owning ports

### Debug logs
- add `DebugLogFeatureController` with immutable `StateFlow<DebugLogUiState>`
- keep log loading, filters, errors and export feedback feature-local instead of using global `isLoading` / `message`
- compose the owner in Android/iOS roots
- migrate the production Debug Logs route to a controller-free screen

### Download manager
- expose download-manager tasks/queue feedback and task actions through the existing download owner
- migrate `DownloadManagerScreen` from `FuoPlayerController` to the narrow download port
- preserve the existing controller-facing state as compatibility state for Settings and remaining callers

### Architecture fitness
- prevent Debug/Download production screens from regaining `FuoPlayerController`
- prevent AppRoot from regaining controller bootstrap flags or playlist/download/playback feedback reads
- add focused tests for app bootstrap SSOT, feature-local debug state and sleep-timer feedback ownership

## Intentionally deferred
- `FuoAppViewModel` still retains the compatibility controller for legacy back policy
- `controller.activateRoute(route)` remains until provider-detail owners are migrated
- Home/provider content is unchanged
- Local Music / Local Playlist screen ownership is unchanged
- Settings/Auth/Onboarding UI is not broadly rewritten in this PR
- no Gradle feature modules are introduced

## Validation
- architecture checks and shared tests are covered by CI
- Android signed APK build and iOS simulator/device builds will validate both platform composition roots
