### PR TITLE
refactor: migrate local music feature ownership

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,8 @@ val migratedControllerBoundaryFiles = listOf(
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadController.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/download/DownloadManagerScreen.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicControllerState.kt",
+    "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicSection.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistActionController.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderTrackActionController.kt",
     "shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackComposition.kt",
@@ -135,8 +137,11 @@ tasks.register("checkArchitectureBoundaries") {
             "controller.playlistOperationFeedback",
             "controller.downloadQueueFeedback",
             "controller.playbackFeedback",
+            "controller.localMetadataEditorTrack",
             "DebugLogScreen(controller",
             "DownloadManagerScreen(controller",
+            "LocalMusicCollectionScreen(controller",
+            "LocalMetadataDialog(controller",
         )
         val appRootViolations = appRoot.readLines().mapIndexedNotNull { index, line ->
             retiredAppShellReads.firstOrNull(line::contains)?.let { legacyRead ->

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -227,6 +227,8 @@ fun AppRoot(
     val sleepTimerFeedback by appViewModel.playbackSleepTimerPort.feedback.collectAsStateWithLifecycle()
     val controller = appViewModel.controller
     val playbackUiPort = appViewModel.playbackUiPort
+    val localMusicFeature = appViewModel.localMusicActionPort as? LocalMusicFeatureController
+        ?: error("Local Music feature owner is not installed")
     FuoTheme(
         themeMode = appUiState.settings.settings.themeMode,
         themeColorScheme = appUiState.settings.settings.themeColorScheme,
@@ -317,6 +319,12 @@ fun AppRoot(
             CompositionLocalProvider(
                 LocalPlaybackSession provides appViewModel.playbackSession,
                 LocalPlaybackUiPort provides playbackUiPort,
+                LocalLocalMusicUiGraph provides LocalMusicUiGraph(
+                    feature = localMusicFeature,
+                    playbackQueue = appViewModel.playbackQueueUiPort,
+                    downloads = appViewModel.downloadActionPort,
+                    providerTrackActions = appViewModel.providerTrackActionPort,
+                ),
                 LocalShareHandler provides { onShareText(it.text) },
                 LocalLocalPlaylistFileActions provides LocalPlaylistFileActions(
                     importFile = onImportLocalPlaylistFile,
@@ -415,7 +423,7 @@ fun AppRoot(
                                                 controller,
                                                 currentLocalPlaylist ?: lastLocalPlaylist,
                                             )
-                                            AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen(controller)
+                                            AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen()
                                             AppRoute.MediaItem -> ProviderMediaItemScreen(controller, currentMediaItem ?: lastMediaItem)
                                             is AppRoute.MediaItemDetail -> ProviderMediaItemScreen(
                                                 controller,
@@ -435,9 +443,7 @@ fun AppRoot(
                             ) {
                                 RuntimeFullPlayer()
                             }
-                            controller.localMetadataEditorTrack?.let { track ->
-                                LocalMetadataDialog(controller = controller, track = track)
-                            }
+                            LocalMetadataDialog()
                             controller.playlistTargetTrack?.let { track ->
                                 PlaylistTargetDialog(controller = controller, track = track)
                             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/LocalMusicHomeBridge.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/LocalMusicHomeBridge.kt
@@ -1,0 +1,37 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Temporary Home integration bridge.
+ *
+ * Home remains a controller-owned surface until P2-4. Local Music itself is already
+ * controller-free and consumes [LocalLocalMusicUiGraph] installed by the app shell.
+ */
+@Composable
+fun LocalMusicSection(
+    @Suppress("UNUSED_PARAMETER") controller: FuoPlayerController,
+    hasAudioPermission: Boolean,
+    onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
+    showModeFilter: Boolean,
+    modifier: Modifier,
+) {
+    LocalMusicSection(
+        hasAudioPermission = hasAudioPermission,
+        onRequestAudioPermission = onRequestAudioPermission,
+        hasImagePermission = hasImagePermission,
+        onRequestImagePermission = onRequestImagePermission,
+        showModeFilter = showModeFilter,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun LocalMusicViewModeTabs(
+    @Suppress("UNUSED_PARAMETER") controller: FuoPlayerController,
+) {
+    LocalMusicViewModeTabs()
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt
@@ -56,6 +56,7 @@ internal class LocalMusicController(
         private set
 
     private var refreshSerial: Long = 0
+    private var activeRefreshLoadingSerial: Long? = null
     private var featureLoading = false
     private var featureMessage: String? = null
     private var featureErrorMessage: String? = null
@@ -101,7 +102,10 @@ internal class LocalMusicController(
         val serial = ++refreshSerial
         scope.launch {
             if (showLoading) {
-                publishLoading(if (forceRefresh) "正在刷新本地音乐库" else "正在加载本地音乐")
+                publishLoading(
+                    message = if (forceRefresh) "正在刷新本地音乐库" else "正在加载本地音乐",
+                    loadingRefreshSerial = serial,
+                )
             }
             val result = runCatching {
                 updateScanSettings()
@@ -110,11 +114,12 @@ internal class LocalMusicController(
                 val shouldRefresh = forceRefresh || !databaseReady || databaseStale
                 if (showLoading) {
                     publishLoading(
-                        when {
+                        message = when {
                             !databaseReady -> "正在建立本地音乐库"
                             shouldRefresh -> "正在更新本地音乐库"
                             else -> "正在加载本地音乐"
-                        }
+                        },
+                        loadingRefreshSerial = serial,
                     )
                 }
                 val tracks = if (shouldRefresh) {
@@ -125,23 +130,29 @@ internal class LocalMusicController(
                 tracks to repository.directories()
             }
             if (serial == refreshSerial) {
-                result
-                    .onSuccess { (tracks, directories) ->
-                        state.tracks = tracks
-                        state.directories = directories
-                        if (
-                            state.selectedDirectoryId != null &&
-                            directories.none { it.id == state.selectedDirectoryId }
-                        ) {
-                            closeCollection()
-                        }
-                        if (showLoading) {
+                result.onSuccess { (tracks, directories) ->
+                    state.tracks = tracks
+                    state.directories = directories
+                    if (
+                        state.selectedDirectoryId != null &&
+                        directories.none { it.id == state.selectedDirectoryId }
+                    ) {
+                        closeCollection()
+                    }
+                }
+            }
+            if (showLoading && activeRefreshLoadingSerial == serial) {
+                if (serial == refreshSerial) {
+                    result
+                        .onSuccess { (tracks, _) ->
                             finishLoading(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
                         }
-                    }
-                    .onFailure { throwable ->
-                        if (showLoading) publishError(throwable)
-                    }
+                        .onFailure(::publishError)
+                } else {
+                    clearLoading()
+                }
+            } else if (!showLoading && serial == refreshSerial) {
+                clearSupersededRefreshLoading(serial)
             }
         }
     }
@@ -364,7 +375,7 @@ internal class LocalMusicController(
         if (!hasPermission) return
         val serial = ++refreshSerial
         scope.launch {
-            publishLoading("正在更新本地音乐筛选")
+            publishLoading("正在更新本地音乐筛选", loadingRefreshSerial = serial)
             val result = runCatching {
                 updateScanSettings()
                 repository.tracks() to repository.directories()
@@ -383,11 +394,14 @@ internal class LocalMusicController(
                         finishLoading(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
                     }
                     .onFailure(::publishError)
+            } else if (activeRefreshLoadingSerial == serial) {
+                clearLoading()
             }
         }
     }
 
-    private fun publishLoading(message: String) {
+    private fun publishLoading(message: String, loadingRefreshSerial: Long? = null) {
+        activeRefreshLoadingSerial = loadingRefreshSerial
         featureLoading = true
         featureMessage = message
         featureErrorMessage = null
@@ -397,10 +411,24 @@ internal class LocalMusicController(
     }
 
     private fun finishLoading(message: String) {
+        activeRefreshLoadingSerial = null
         featureLoading = false
         featureMessage = message
         featureErrorMessage = null
         setMessage(message)
+        setLoading(false)
+        publishUiState()
+    }
+
+    private fun clearSupersededRefreshLoading(latestRefreshSerial: Long) {
+        val loadingSerial = activeRefreshLoadingSerial ?: return
+        if (loadingSerial >= latestRefreshSerial) return
+        clearLoading()
+    }
+
+    private fun clearLoading() {
+        activeRefreshLoadingSerial = null
+        featureLoading = false
         setLoading(false)
         publishUiState()
     }
@@ -420,6 +448,7 @@ internal class LocalMusicController(
     }
 
     private fun publishError(throwable: Throwable, message: String) {
+        activeRefreshLoadingSerial = null
         featureLoading = false
         featureMessage = message
         featureErrorMessage = message

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicController.kt
@@ -1,12 +1,40 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
+interface LocalMusicFeatureController : LocalMusicActionPort {
+    val uiState: StateFlow<LocalMusicUiState>
+    val hasPermission: Boolean
+
+    fun onPermissionChange(hasPermission: Boolean)
+    fun ensure()
+    fun refresh()
+    fun refresh(forceRefresh: Boolean, showLoading: Boolean)
+    fun onViewModeChange(value: LocalMusicViewMode)
+    fun openDirectory(directoryId: String)
+    fun openCollection(mode: LocalMusicViewMode, key: String)
+    fun closeCollection()
+    fun onDirectoryEnabledChange(directoryId: String, enabled: Boolean)
+    fun onMinDurationChange(value: Int)
+    fun openMetadataEditor(track: MusicTrack)
+    fun closeMetadataEditor()
+    fun onMetadataProviderChange(providerId: String)
+    fun saveMetadata(track: MusicTrack, title: String, artists: String, album: String)
+    fun searchMetadata(title: String, artists: String, album: String)
+    fun applyProviderMetadata(track: MusicTrack, providerTrack: MusicTrack)
+    fun downloadLyrics(track: MusicTrack, providerTrack: MusicTrack)
+    fun refreshDirectories()
+    suspend fun updateScanSettings()
+}
+
 internal class LocalMusicController(
     private val repository: LocalMusicRepository,
-    private val providerRepository: ProviderMusicRepository,
+    providerRepository: ProviderMusicRepository,
     private val navigator: AppNavigator,
     private val scope: CoroutineScope,
     val state: LocalMusicControllerState = LocalMusicControllerState(),
@@ -18,11 +46,23 @@ internal class LocalMusicController(
     private val setMessage: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
     private val onTrackUpdated: (String, MusicTrack) -> Unit,
-) : LocalMusicActionPort {
-    var hasPermission: Boolean = false
+) : LocalMusicFeatureController {
+    private val providerSearchRepository: ProviderSearchRepository = ProviderSearchRepositoryView(providerRepository)
+    private val providerPlaybackRepository: ProviderPlaybackRepository = ProviderPlaybackRepositoryView(providerRepository)
+    private val mutableUiState = MutableStateFlow(LocalMusicUiState())
+
+    override val uiState: StateFlow<LocalMusicUiState> = mutableUiState.asStateFlow()
+    override var hasPermission: Boolean = false
         private set
 
     private var refreshSerial: Long = 0
+    private var featureLoading = false
+    private var featureMessage: String? = null
+    private var featureErrorMessage: String? = null
+
+    init {
+        state.observeChanges(::publishUiState)
+    }
 
     fun restore(
         viewMode: LocalMusicViewMode,
@@ -36,7 +76,7 @@ internal class LocalMusicController(
         state.minDurationSeconds = minDurationSeconds
     }
 
-    fun onPermissionChange(hasPermission: Boolean) {
+    override fun onPermissionChange(hasPermission: Boolean) {
         val wasGranted = this.hasPermission
         this.hasPermission = hasPermission
         if (hasPermission && !wasGranted && isLocalMusicSectionActive()) {
@@ -44,25 +84,24 @@ internal class LocalMusicController(
         }
     }
 
-    fun ensure() {
+    override fun ensure() {
         if (!hasPermission) return
         refresh(forceRefresh = false, showLoading = true)
     }
 
-    fun refresh() {
+    override fun refresh() {
         if (!hasPermission) {
-            setMessage("允许访问音频后可加载本地音乐")
+            publishMessage("允许访问音频后可加载本地音乐")
             return
         }
         refresh(forceRefresh = true, showLoading = true)
     }
 
-    fun refresh(forceRefresh: Boolean, showLoading: Boolean) {
+    override fun refresh(forceRefresh: Boolean, showLoading: Boolean) {
         val serial = ++refreshSerial
         scope.launch {
             if (showLoading) {
-                setLoading(true)
-                setMessage(if (forceRefresh) "正在刷新本地音乐库" else "正在加载本地音乐")
+                publishLoading(if (forceRefresh) "正在刷新本地音乐库" else "正在加载本地音乐")
             }
             val result = runCatching {
                 updateScanSettings()
@@ -70,7 +109,7 @@ internal class LocalMusicController(
                 val databaseStale = databaseReady && repository.isDatabaseStale()
                 val shouldRefresh = forceRefresh || !databaseReady || databaseStale
                 if (showLoading) {
-                    setMessage(
+                    publishLoading(
                         when {
                             !databaseReady -> "正在建立本地音乐库"
                             shouldRefresh -> "正在更新本地音乐库"
@@ -97,24 +136,23 @@ internal class LocalMusicController(
                             closeCollection()
                         }
                         if (showLoading) {
-                            setMessage(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
+                            finishLoading(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
                         }
                     }
-                    .onFailure {
-                        if (showLoading) onError(it)
+                    .onFailure { throwable ->
+                        if (showLoading) publishError(throwable)
                     }
             }
-            if (showLoading) setLoading(false)
         }
     }
 
-    fun onViewModeChange(value: LocalMusicViewMode) {
+    override fun onViewModeChange(value: LocalMusicViewMode) {
         state.viewMode = value
         closeCollection()
         persistSettings()
     }
 
-    fun openDirectory(directoryId: String) {
+    override fun openDirectory(directoryId: String) {
         if (isLocalMusicDirectoryExcluded(directoryId, state.excludedDirectoryIds)) return
         if (state.directories.none { it.id == directoryId }) return
         navigator.navigate(AppRoute.LocalMusicCollection)
@@ -122,7 +160,7 @@ internal class LocalMusicController(
         state.selectedDirectoryId = directoryId
     }
 
-    fun openCollection(mode: LocalMusicViewMode, key: String) {
+    override fun openCollection(mode: LocalMusicViewMode, key: String) {
         if (key.isBlank()) return
         if (mode == LocalMusicViewMode.All) {
             openDirectory(key)
@@ -133,13 +171,13 @@ internal class LocalMusicController(
         state.selectedCollection = LocalMusicCollectionSelection(mode, key)
     }
 
-    fun closeCollection() {
+    override fun closeCollection() {
         navigator.pop(AppRoute.LocalMusicCollection)
         state.selectedDirectoryId = null
         state.selectedCollection = null
     }
 
-    fun onDirectoryEnabledChange(directoryId: String, enabled: Boolean) {
+    override fun onDirectoryEnabledChange(directoryId: String, enabled: Boolean) {
         val canonicalDirectoryId = canonicalLocalMusicDirectoryId(directoryId) ?: directoryId
         val normalizedExcludedIds = state.excludedDirectoryIds.mapNotNull {
             canonicalLocalMusicDirectoryId(it)
@@ -156,7 +194,7 @@ internal class LocalMusicController(
         reload()
     }
 
-    fun onMinDurationChange(value: Int) {
+    override fun onMinDurationChange(value: Int) {
         state.minDurationSeconds = value
         persistSettings()
         reload()
@@ -164,7 +202,7 @@ internal class LocalMusicController(
 
     override fun openLocalMetadataEditor(track: MusicTrack) = openMetadataEditor(track)
 
-    fun openMetadataEditor(track: MusicTrack) {
+    override fun openMetadataEditor(track: MusicTrack) {
         if (track.sourceType == TrackSourceType.Provider) return
         state.metadataEditorTrack = track
         state.metadataSearchResults = emptyList()
@@ -174,27 +212,29 @@ internal class LocalMusicController(
             ?.takeIf { providerId -> availableProviders.any { it.providerId == providerId } }
             ?: selectedSearchProviderId()?.takeIf { providerId -> availableProviders.any { it.providerId == providerId } }
             ?: availableProviders.firstOrNull()?.providerId
+        featureErrorMessage = null
+        publishUiState()
     }
 
-    fun closeMetadataEditor() {
+    override fun closeMetadataEditor() {
         state.metadataEditorTrack = null
         state.metadataSearchResults = emptyList()
         state.metadataSearchMessage = null
     }
 
-    fun onMetadataProviderChange(providerId: String) {
+    override fun onMetadataProviderChange(providerId: String) {
+        if (providers().none { it.providerId == providerId }) return
         state.selectedMetadataProviderId = providerId
     }
 
-    fun saveMetadata(track: MusicTrack, title: String, artists: String, album: String) {
+    override fun saveMetadata(track: MusicTrack, title: String, artists: String, album: String) {
         val metadata = LocalTrackMetadata(
             title = title.trim().ifBlank { track.title },
             artists = artists.trim(),
             album = album.trim(),
         )
         scope.launch {
-            setLoading(true)
-            setMessage("正在保存元信息")
+            publishLoading("正在保存元信息")
             runCatching {
                 repository.updateMetadata(track, metadata)
                 updateScanSettings()
@@ -209,13 +249,12 @@ internal class LocalMusicController(
                 onTrackUpdated(track.id, updatedTrack)
                 state.metadataEditorTrack = tracks.firstOrNull { item -> item.id == track.id }
                     ?: state.metadataEditorTrack
-                setMessage("已保存元信息：${metadata.title}")
-            }.onFailure(onError)
-            setLoading(false)
+                finishLoading("已保存元信息：${metadata.title}")
+            }.onFailure(::publishError)
         }
     }
 
-    fun searchMetadata(title: String, artists: String, album: String) {
+    override fun searchMetadata(title: String, artists: String, album: String) {
         val availableProviders = providers()
         val providerId = state.selectedMetadataProviderId ?: availableProviders.firstOrNull()?.providerId
         if (providerId == null) {
@@ -233,42 +272,42 @@ internal class LocalMusicController(
         }
         state.selectedMetadataProviderId = providerId
         scope.launch {
-            setLoading(true)
+            publishLoading("正在搜索元信息")
             state.metadataSearchMessage = "正在搜索元信息"
             runCatching {
                 withTimeout(25_000) {
-                    providerRepository.search(keyword, providerId)
+                    providerSearchRepository.search(keyword, providerId)
                 }
-            }.onSuccess {
-                state.metadataSearchResults = it
-                state.metadataSearchMessage = if (it.isEmpty()) "没有搜索结果" else "搜索到 ${it.size} 首"
-            }.onFailure {
-                state.metadataSearchMessage = it.message ?: it::class.simpleName.orEmpty()
-                onError(it)
+            }.onSuccess { results ->
+                state.metadataSearchResults = results
+                state.metadataSearchMessage = if (results.isEmpty()) "没有搜索结果" else "搜索到 ${results.size} 首"
+                finishLoading(state.metadataSearchMessage.orEmpty())
+            }.onFailure { throwable ->
+                val message = providerFailureMessage(throwable, providerId)
+                state.metadataSearchMessage = message
+                publishError(throwable, message)
             }
-            setLoading(false)
         }
     }
 
-    fun applyProviderMetadata(track: MusicTrack, providerTrack: MusicTrack) {
+    override fun applyProviderMetadata(track: MusicTrack, providerTrack: MusicTrack) {
         saveMetadata(track, providerTrack.title, providerTrack.artists, providerTrack.album)
     }
 
-    fun downloadLyrics(track: MusicTrack, providerTrack: MusicTrack) {
+    override fun downloadLyrics(track: MusicTrack, providerTrack: MusicTrack) {
         scope.launch {
-            setLoading(true)
-            setMessage("正在下载歌词")
+            publishLoading("正在下载歌词")
             runCatching {
                 withTimeout(25_000) {
-                    providerRepository.lyrics(
+                    providerPlaybackRepository.lyrics(
                         providerTrack.copy(providerId = providerTrack.providerId ?: providerTrack.id),
                     )
                 }
             }.onSuccess { lyricsText ->
                 val lyrics = lyricsText?.takeIf { it.isNotBlank() }
                 if (lyrics == null) {
-                    setMessage("未获取到歌词")
                     state.metadataSearchMessage = "未获取到歌词"
+                    finishLoading("未获取到歌词")
                 } else {
                     runCatching {
                         repository.saveLyrics(track, lyrics)
@@ -280,36 +319,39 @@ internal class LocalMusicController(
                             ?: track.copy(lyrics = lyrics)
                         onTrackUpdated(track.id, updatedTrack)
                         state.metadataEditorTrack = updatedTrack
-                        setMessage("已保存歌词：${track.title}")
                         state.metadataSearchMessage = "歌词已保存"
-                    }.onFailure(onError)
+                        finishLoading("已保存歌词：${track.title}")
+                    }.onFailure(::publishError)
                 }
-            }.onFailure {
-                state.metadataSearchMessage = it.message ?: it::class.simpleName.orEmpty()
-                onError(it)
+            }.onFailure { throwable ->
+                val providerId = providerTrack.providerId ?: providerTrack.source
+                val message = providerFailureMessage(throwable, providerId)
+                state.metadataSearchMessage = message
+                publishError(throwable, message)
             }
-            setLoading(false)
         }
     }
 
-    fun refreshDirectories() {
+    override fun refreshDirectories() {
         scope.launch {
             runCatching {
                 updateScanSettings()
                 repository.directories()
-            }.onSuccess {
-                state.directories = it
+            }.onSuccess { directories ->
+                state.directories = directories
                 if (
                     state.selectedDirectoryId != null &&
-                    it.none { directory -> directory.id == state.selectedDirectoryId }
+                    directories.none { directory -> directory.id == state.selectedDirectoryId }
                 ) {
                     closeCollection()
                 }
-            }.onFailure(onError)
+                featureErrorMessage = null
+                publishUiState()
+            }.onFailure(::publishError)
         }
     }
 
-    suspend fun updateScanSettings() {
+    override suspend fun updateScanSettings() {
         repository.updateScanSettings(
             LocalMusicScanSettings(
                 excludedDirectoryIds = state.excludedDirectoryIds,
@@ -322,8 +364,7 @@ internal class LocalMusicController(
         if (!hasPermission) return
         val serial = ++refreshSerial
         scope.launch {
-            setLoading(true)
-            setMessage("正在更新本地音乐筛选")
+            publishLoading("正在更新本地音乐筛选")
             val result = runCatching {
                 updateScanSettings()
                 repository.tracks() to repository.directories()
@@ -339,11 +380,67 @@ internal class LocalMusicController(
                         ) {
                             closeCollection()
                         }
-                        setMessage(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
+                        finishLoading(if (tracks.isEmpty()) "未发现本地音乐" else "本地音乐 ${tracks.size} 首")
                     }
-                    .onFailure(onError)
+                    .onFailure(::publishError)
             }
-            setLoading(false)
         }
+    }
+
+    private fun publishLoading(message: String) {
+        featureLoading = true
+        featureMessage = message
+        featureErrorMessage = null
+        setLoading(true)
+        setMessage(message)
+        publishUiState()
+    }
+
+    private fun finishLoading(message: String) {
+        featureLoading = false
+        featureMessage = message
+        featureErrorMessage = null
+        setMessage(message)
+        setLoading(false)
+        publishUiState()
+    }
+
+    private fun publishMessage(message: String) {
+        featureMessage = message
+        featureErrorMessage = null
+        setMessage(message)
+        publishUiState()
+    }
+
+    private fun publishError(throwable: Throwable) {
+        publishError(
+            throwable = throwable,
+            message = throwable.message ?: throwable::class.simpleName.orEmpty().ifBlank { "操作失败" },
+        )
+    }
+
+    private fun publishError(throwable: Throwable, message: String) {
+        featureLoading = false
+        featureMessage = message
+        featureErrorMessage = message
+        onError(throwable)
+        setLoading(false)
+        publishUiState()
+    }
+
+    private fun providerFailureMessage(throwable: Throwable, providerId: String): String =
+        throwable.providerFailureOrNull(providerId)?.userMessage
+            ?: throwable.message
+            ?: throwable::class.simpleName.orEmpty().ifBlank { "操作失败" }
+
+    private fun publishUiState() {
+        mutableUiState.value = state.toUiState(
+            LocalMusicUiState(
+                metadataProviders = providers(),
+                isLoading = featureLoading,
+                message = featureMessage,
+                errorMessage = featureErrorMessage,
+            )
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicControllerState.kt
@@ -4,24 +4,152 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
-internal class LocalMusicControllerState {
-    var tracks by mutableStateOf<List<MusicTrack>>(emptyList())
-    var viewMode by mutableStateOf(LocalMusicViewMode.All)
-    var directories by mutableStateOf<List<LocalMusicDirectory>>(emptyList())
-    var selectedDirectoryId by mutableStateOf<String?>(null)
-    var selectedCollection by mutableStateOf<LocalMusicCollectionSelection?>(null)
-    var excludedDirectoryIds by mutableStateOf<Set<String>>(emptySet())
-    var minDurationSeconds by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
-    var metadataEditorTrack by mutableStateOf<MusicTrack?>(null)
-    var selectedMetadataProviderId by mutableStateOf<String?>(null)
-    var metadataSearchResults by mutableStateOf<List<MusicTrack>>(emptyList())
-    var metadataSearchMessage by mutableStateOf<String?>(null)
+data class LocalMusicUiState(
+    val tracks: List<MusicTrack> = emptyList(),
+    val viewMode: LocalMusicViewMode = LocalMusicViewMode.All,
+    val directories: List<LocalMusicDirectory> = emptyList(),
+    val selectedDirectoryId: String? = null,
+    val selectedCollection: LocalMusicCollectionSelection? = null,
+    val excludedDirectoryIds: Set<String> = emptySet(),
+    val minDurationSeconds: Int = DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS,
+    val metadataEditorTrack: MusicTrack? = null,
+    val metadataProviders: List<ProviderInfo> = emptyList(),
+    val selectedMetadataProviderId: String? = null,
+    val metadataSearchResults: List<MusicTrack> = emptyList(),
+    val metadataSearchMessage: String? = null,
+    val isLoading: Boolean = false,
+    val message: String? = null,
+    val errorMessage: String? = null,
+)
 
-    // Transitional alias used by the app facade while feature state is moved behind
-    // dedicated state holders. Remove when the facade no longer delegates this field.
+data class LocalTrackUpdate(
+    val previousTrackId: String,
+    val track: MusicTrack,
+)
+
+/**
+ * Feature state with Compose compatibility properties for the remaining facade callers.
+ * [LocalMusicController] publishes the same state as immutable [LocalMusicUiState] for
+ * production feature UI.
+ */
+internal class LocalMusicControllerState {
+    private var changeListener: (() -> Unit)? = null
+
+    private var tracksState by mutableStateOf<List<MusicTrack>>(emptyList())
+    var tracks: List<MusicTrack>
+        get() = tracksState
+        set(value) {
+            tracksState = value
+            changed()
+        }
+
+    private var viewModeState by mutableStateOf(LocalMusicViewMode.All)
+    var viewMode: LocalMusicViewMode
+        get() = viewModeState
+        set(value) {
+            viewModeState = value
+            changed()
+        }
+
+    private var directoriesState by mutableStateOf<List<LocalMusicDirectory>>(emptyList())
+    var directories: List<LocalMusicDirectory>
+        get() = directoriesState
+        set(value) {
+            directoriesState = value
+            changed()
+        }
+
+    private var selectedDirectoryIdState by mutableStateOf<String?>(null)
+    var selectedDirectoryId: String?
+        get() = selectedDirectoryIdState
+        set(value) {
+            selectedDirectoryIdState = value
+            changed()
+        }
+
+    private var selectedCollectionState by mutableStateOf<LocalMusicCollectionSelection?>(null)
+    var selectedCollection: LocalMusicCollectionSelection?
+        get() = selectedCollectionState
+        set(value) {
+            selectedCollectionState = value
+            changed()
+        }
+
+    private var excludedDirectoryIdsState by mutableStateOf<Set<String>>(emptySet())
+    var excludedDirectoryIds: Set<String>
+        get() = excludedDirectoryIdsState
+        set(value) {
+            excludedDirectoryIdsState = value
+            changed()
+        }
+
+    private var minDurationSecondsState by mutableStateOf(DEFAULT_LOCAL_MUSIC_MIN_DURATION_SECONDS)
+    var minDurationSeconds: Int
+        get() = minDurationSecondsState
+        set(value) {
+            minDurationSecondsState = value
+            changed()
+        }
+
+    private var metadataEditorTrackState by mutableStateOf<MusicTrack?>(null)
+    var metadataEditorTrack: MusicTrack?
+        get() = metadataEditorTrackState
+        set(value) {
+            metadataEditorTrackState = value
+            changed()
+        }
+
+    private var selectedMetadataProviderIdState by mutableStateOf<String?>(null)
+    var selectedMetadataProviderId: String?
+        get() = selectedMetadataProviderIdState
+        set(value) {
+            selectedMetadataProviderIdState = value
+            changed()
+        }
+
+    private var metadataSearchResultsState by mutableStateOf<List<MusicTrack>>(emptyList())
+    var metadataSearchResults: List<MusicTrack>
+        get() = metadataSearchResultsState
+        set(value) {
+            metadataSearchResultsState = value
+            changed()
+        }
+
+    private var metadataSearchMessageState by mutableStateOf<String?>(null)
+    var metadataSearchMessage: String?
+        get() = metadataSearchMessageState
+        set(value) {
+            metadataSearchMessageState = value
+            changed()
+        }
+
+    // Transitional alias used by the compatibility facade.
     var localMetadataSearchMessage: String?
         get() = metadataSearchMessage
         set(value) {
             metadataSearchMessage = value
         }
+
+    fun observeChanges(listener: () -> Unit) {
+        changeListener = listener
+        listener()
+    }
+
+    fun toUiState(base: LocalMusicUiState = LocalMusicUiState()): LocalMusicUiState = base.copy(
+        tracks = tracks,
+        viewMode = viewMode,
+        directories = directories,
+        selectedDirectoryId = selectedDirectoryId,
+        selectedCollection = selectedCollection,
+        excludedDirectoryIds = excludedDirectoryIds,
+        minDurationSeconds = minDurationSeconds,
+        metadataEditorTrack = metadataEditorTrack,
+        selectedMetadataProviderId = selectedMetadataProviderId,
+        metadataSearchResults = metadataSearchResults,
+        metadataSearchMessage = metadataSearchMessage,
+    )
+
+    private fun changed() {
+        changeListener?.invoke()
+    }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localmusic/LocalMusicSection.kt
@@ -5,20 +5,20 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -42,11 +42,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+internal data class LocalMusicUiGraph(
+    val feature: LocalMusicFeatureController,
+    val playbackQueue: PlaybackQueueUiPort,
+    val downloads: DownloadActionPort,
+    val providerTrackActions: ProviderTrackActionPort,
+)
+
+internal val LocalLocalMusicUiGraph = staticCompositionLocalOf<LocalMusicUiGraph> {
+    error("LocalMusicUiGraph is not installed")
+}
 
 internal data class LocalMusicCollection(
     val key: String,
@@ -59,7 +72,6 @@ internal data class LocalMusicCollection(
 
 @Composable
 fun LocalMusicSection(
-    controller: FuoPlayerController,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
     hasImagePermission: Boolean,
@@ -67,30 +79,32 @@ fun LocalMusicSection(
     showModeFilter: Boolean,
     modifier: Modifier,
 ) {
+    val graph = LocalLocalMusicUiGraph.current
+    val uiState by graph.feature.uiState.collectAsStateWithLifecycle()
     var previousImagePermission by remember { mutableStateOf<Boolean?>(null) }
     LaunchedEffect(hasAudioPermission, hasImagePermission) {
-        controller.onLocalMusicPermissionChange(hasAudioPermission)
+        graph.feature.onPermissionChange(hasAudioPermission)
         if (hasAudioPermission) {
             if (previousImagePermission == false && hasImagePermission) {
-                controller.refreshLocalMusic()
+                graph.feature.refresh()
             } else {
-                controller.ensureLocalMusic()
+                graph.feature.ensure()
             }
         }
         previousImagePermission = hasImagePermission
     }
-    val viewMode = controller.localMusicViewMode
+    val viewMode = uiState.viewMode
     val collections = remember(
-        controller.localTracks,
-        controller.localMusicDirectories,
-        controller.excludedLocalMusicDirectoryIds,
+        uiState.tracks,
+        uiState.directories,
+        uiState.excludedDirectoryIds,
         viewMode,
     ) {
         buildLocalMusicCollections(
             mode = viewMode,
-            tracks = controller.localTracks,
-            directories = controller.localMusicDirectories,
-            excludedDirectoryIds = controller.excludedLocalMusicDirectoryIds,
+            tracks = uiState.tracks,
+            directories = uiState.directories,
+            excludedDirectoryIds = uiState.excludedDirectoryIds,
         )
     }
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
@@ -105,13 +119,15 @@ fun LocalMusicSection(
         if (!hasImagePermission) {
             LocalMusicImagePermissionPanel(onRequestImagePermission)
         }
+        LoadingIndicator(uiState.isLoading)
+        uiState.errorMessage?.let { ProviderContentMessage(it) }
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (showModeFilter) {
-                LocalMusicViewModeTabs(controller)
+                LocalMusicViewModeTabs()
             } else {
                 Spacer(Modifier)
             }
@@ -119,7 +135,7 @@ fun LocalMusicSection(
         LocalMusicCollectionOverview(
             mode = viewMode,
             collections = collections,
-            onClick = { controller.openLocalMusicCollection(viewMode, it.key) },
+            onClick = { graph.feature.openCollection(viewMode, it.key) },
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
@@ -129,28 +145,31 @@ fun LocalMusicSection(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LocalMusicCollectionScreen(controller: FuoPlayerController) {
-    val selection = controller.selectedLocalMusicCollection ?: return
+fun LocalMusicCollectionScreen() {
+    val graph = LocalLocalMusicUiGraph.current
+    val uiState by graph.feature.uiState.collectAsStateWithLifecycle()
+    val selection = uiState.selectedCollection ?: return
     val collections = remember(
-        controller.localTracks,
-        controller.localMusicDirectories,
-        controller.excludedLocalMusicDirectoryIds,
+        uiState.tracks,
+        uiState.directories,
+        uiState.excludedDirectoryIds,
         selection.mode,
     ) {
         buildLocalMusicCollections(
             mode = selection.mode,
-            tracks = controller.localTracks,
-            directories = controller.localMusicDirectories,
-            excludedDirectoryIds = controller.excludedLocalMusicDirectoryIds,
+            tracks = uiState.tracks,
+            directories = uiState.directories,
+            excludedDirectoryIds = uiState.excludedDirectoryIds,
         )
     }
     val selectedCollection = collections.firstOrNull { it.key == selection.key }
-    LaunchedEffect(selection, selectedCollection, controller.isLoading) {
-        if (!controller.isLoading && selectedCollection == null) {
-            controller.closeLocalMusicCollection()
+    LaunchedEffect(selection, selectedCollection, uiState.isLoading) {
+        if (!uiState.isLoading && selectedCollection == null) {
+            graph.feature.closeCollection()
         }
     }
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    val playbackUiPort = LocalPlaybackUiPort.current
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -162,7 +181,7 @@ fun LocalMusicCollectionScreen(controller: FuoPlayerController) {
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = controller::closeLocalMusicCollection) {
+                    IconButton(onClick = graph.feature::closeCollection) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "返回",
@@ -172,25 +191,33 @@ fun LocalMusicCollectionScreen(controller: FuoPlayerController) {
             )
         },
         bottomBar = {
-            if (controller.playbackState.currentTrack != null) {
+            if (playbackUiPort.currentTrack != null) {
                 PlaybackMiniPlayer()
             }
         },
     ) { paddingValues ->
-        selectedCollection?.let { collection ->
-            LocalMusicCollectionDetail(
-                controller = controller,
-                collection = collection,
-                mode = selection.mode,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(
-                        horizontal = if (isWideLayout) 20.dp else 16.dp,
-                        vertical = if (isWideLayout) 12.dp else 0.dp,
-                    ),
-                isWideLayout = isWideLayout,
-            )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            LoadingIndicator(uiState.isLoading)
+            uiState.errorMessage?.let { ProviderContentMessage(it) }
+            selectedCollection?.let { collection ->
+                LocalMusicCollectionDetail(
+                    graph = graph,
+                    collection = collection,
+                    mode = selection.mode,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = if (isWideLayout) 20.dp else 16.dp,
+                            vertical = if (isWideLayout) 12.dp else 0.dp,
+                        ),
+                    isWideLayout = isWideLayout,
+                )
+            }
         }
     }
 }
@@ -255,7 +282,7 @@ private fun LocalMusicCollectionOverview(
 
 @Composable
 private fun LocalMusicCollectionDetail(
-    controller: FuoPlayerController,
+    graph: LocalMusicUiGraph,
     collection: LocalMusicCollection,
     mode: LocalMusicViewMode,
     modifier: Modifier,
@@ -264,6 +291,11 @@ private fun LocalMusicCollectionDetail(
     val displayTrack = collection.toDisplayTrack(mode)
     val placeholder = mode.localMusicCollectionPlaceholder()
     val subtitle = mode.localMusicCollectionSubtitle(collection.trackCount)
+    val playAll = {
+        if (collection.tracks.isNotEmpty()) {
+            graph.playbackQueue.playTracks(collection.tracks, 0)
+        }
+    }
     if (isWideLayout) {
         Row(
             modifier = modifier,
@@ -295,11 +327,11 @@ private fun LocalMusicCollectionDetail(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 if (collection.tracks.isNotEmpty()) {
-                    PlayAllButton(onClick = { controller.playAllLocalTracks(collection.tracks) })
+                    PlayAllButton(onClick = playAll)
                 }
             }
             LocalMusicTrackList(
-                controller = controller,
+                graph = graph,
                 tracks = collection.tracks,
                 modifier = Modifier
                     .weight(1f)
@@ -320,13 +352,13 @@ private fun LocalMusicCollectionDetail(
                 placeholder = placeholder,
                 action = {
                     PlayAllButton(
-                        onClick = { controller.playAllLocalTracks(collection.tracks) },
+                        onClick = playAll,
                         enabled = collection.tracks.isNotEmpty(),
                     )
                 },
             )
             LocalMusicTrackList(
-                controller = controller,
+                graph = graph,
                 tracks = collection.tracks,
                 modifier = Modifier
                     .weight(1f)
@@ -339,7 +371,7 @@ private fun LocalMusicCollectionDetail(
 
 @Composable
 private fun LocalMusicTrackList(
-    controller: FuoPlayerController,
+    graph: LocalMusicUiGraph,
     tracks: List<MusicTrack>,
     modifier: Modifier,
     isWideLayout: Boolean,
@@ -357,7 +389,7 @@ private fun LocalMusicTrackList(
                 }
             } else {
                 items(tracks, key = { it.id }) { track ->
-                    LocalMusicTrackRow(controller, track, tracks)
+                    LocalMusicTrackRow(graph, track, tracks)
                 }
             }
         }
@@ -367,7 +399,7 @@ private fun LocalMusicTrackList(
                 item { ProviderContentMessage("暂无歌曲") }
             } else {
                 itemsIndexed(tracks, key = { _, item -> item.id }) { _, track ->
-                    LocalMusicTrackRow(controller, track, tracks)
+                    LocalMusicTrackRow(graph, track, tracks)
                     HorizontalDivider()
                 }
             }
@@ -377,20 +409,23 @@ private fun LocalMusicTrackList(
 
 @Composable
 private fun LocalMusicTrackRow(
-    controller: FuoPlayerController,
+    graph: LocalMusicUiGraph,
     track: MusicTrack,
     queue: List<MusicTrack>,
 ) {
     TrackRow(
         track = track,
-        downloadState = controller.downloadStates[track.id],
-        onClick = { controller.playLocalTrack(track, queue) },
-        onAddToUpNext = { controller.addToUpNext(track) },
-        onDownload = { controller.download(track) },
-        onDeleteDownload = { controller.deleteDownload(track) },
-        onOpenArtist = { controller.openTrackArtist(track) },
-        onOpenAlbum = { controller.openTrackAlbum(track) },
-        onEditLocalMetadata = { controller.openLocalMetadataEditor(track) },
+        downloadState = graph.downloads.downloadStates[track.id],
+        onClick = {
+            val index = queue.indexOfFirst { it.id == track.id }.coerceAtLeast(0)
+            graph.playbackQueue.playTracks(queue, index)
+        },
+        onAddToUpNext = { graph.playbackQueue.addToUpNext(track) },
+        onDownload = { graph.downloads.download(track) },
+        onDeleteDownload = { graph.downloads.deleteDownload(track) },
+        onOpenArtist = { graph.providerTrackActions.openTrackArtist(track) },
+        onOpenAlbum = { graph.providerTrackActions.openTrackAlbum(track) },
+        onEditLocalMetadata = { graph.feature.openMetadataEditor(track) },
     )
 }
 
@@ -506,15 +541,15 @@ private fun LocalMusicImagePermissionPanel(onRequestImagePermission: () -> Unit)
 }
 
 @Composable
-fun LocalMetadataDialog(
-    controller: FuoPlayerController,
-    track: MusicTrack,
-) {
+fun LocalMetadataDialog() {
+    val feature = LocalLocalMusicUiGraph.current.feature
+    val uiState by feature.uiState.collectAsStateWithLifecycle()
+    val track = uiState.metadataEditorTrack ?: return
     var title by remember(track.id, track.title) { mutableStateOf(track.title) }
     var artists by remember(track.id, track.artists) { mutableStateOf(track.artists) }
     var album by remember(track.id, track.album) { mutableStateOf(track.album) }
     AlertDialog(
-        onDismissRequest = controller::closeLocalMetadataEditor,
+        onDismissRequest = feature::closeMetadataEditor,
         title = { Text("修改元信息") },
         text = {
             Column(
@@ -548,22 +583,22 @@ fun LocalMetadataDialog(
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
-                if (controller.providers.isNotEmpty()) {
+                if (uiState.metadataProviders.isNotEmpty()) {
                     Row(
                         modifier = Modifier.horizontalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        controller.orderedProviders().forEach { provider ->
+                        uiState.metadataProviders.forEach { provider ->
                             FilterChip(
-                                selected = controller.selectedLocalMetadataProviderId == provider.providerId,
-                                onClick = { controller.onLocalMetadataProviderChange(provider.providerId) },
+                                selected = uiState.selectedMetadataProviderId == provider.providerId,
+                                onClick = { feature.onMetadataProviderChange(provider.providerId) },
                                 label = { Text(provider.providerName) },
                             )
                         }
                     }
                     TextButton(
-                        enabled = !controller.isLoading,
-                        onClick = { controller.searchLocalMetadata(title, artists, album) },
+                        enabled = !uiState.isLoading,
+                        onClick = { feature.searchMetadata(title, artists, album) },
                     ) {
                         Icon(Icons.Filled.Search, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(Modifier.size(4.dp))
@@ -576,21 +611,21 @@ fun LocalMetadataDialog(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                controller.localMetadataSearchMessage?.let { message ->
+                uiState.metadataSearchMessage?.let { message ->
                     Text(
                         text = message,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                if (controller.localMetadataSearchResults.isNotEmpty()) {
+                if (uiState.metadataSearchResults.isNotEmpty()) {
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxWidth()
                             .heightIn(max = 280.dp),
                     ) {
                         itemsIndexed(
-                            controller.localMetadataSearchResults,
+                            uiState.metadataSearchResults,
                             key = { _, item -> item.id },
                         ) { _, result ->
                             LocalMetadataSearchResultRow(
@@ -599,9 +634,9 @@ fun LocalMetadataDialog(
                                     title = result.title
                                     artists = result.artists
                                     album = result.album
-                                    controller.applyProviderMetadata(track, result)
+                                    feature.applyProviderMetadata(track, result)
                                 },
-                                onDownloadLyrics = { controller.downloadLocalLyrics(track, result) },
+                                onDownloadLyrics = { feature.downloadLyrics(track, result) },
                             )
                             HorizontalDivider()
                         }
@@ -611,14 +646,14 @@ fun LocalMetadataDialog(
         },
         confirmButton = {
             TextButton(
-                enabled = !controller.isLoading,
-                onClick = { controller.saveLocalMetadata(track, title, artists, album) },
+                enabled = !uiState.isLoading,
+                onClick = { feature.saveMetadata(track, title, artists, album) },
             ) {
                 Text("保存")
             }
         },
         dismissButton = {
-            TextButton(onClick = controller::closeLocalMetadataEditor) {
+            TextButton(onClick = feature::closeMetadataEditor) {
                 Text("关闭")
             }
         },
@@ -672,7 +707,9 @@ fun LocalMetadataSearchResultRow(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LocalMusicViewModeTabs(controller: FuoPlayerController) {
+fun LocalMusicViewModeTabs() {
+    val feature = LocalLocalMusicUiGraph.current.feature
+    val uiState by feature.uiState.collectAsStateWithLifecycle()
     val modes = listOf(
         LocalMusicViewMode.All to "全部",
         LocalMusicViewMode.Artist to "歌手",
@@ -681,8 +718,8 @@ fun LocalMusicViewModeTabs(controller: FuoPlayerController) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         modes.forEach { (mode, label) ->
             CompactFilterChip(
-                selected = controller.localMusicViewMode == mode,
-                onClick = { controller.onLocalMusicViewModeChange(mode) },
+                selected = uiState.viewMode == mode,
+                onClick = { feature.onViewModeChange(mode) },
                 label = label,
             )
         }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicOwnershipTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicOwnershipTest.kt
@@ -1,9 +1,17 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class LocalMusicOwnershipTest {
     @Test
     fun compatibilityStatePublishesImmutableFeatureProjection() {
@@ -64,6 +72,47 @@ class LocalMusicOwnershipTest {
         assertEquals(listOf("one"), collections.single().tracks.map { it.id })
     }
 
+    @Test
+    fun silentRefreshClearsLoadingWhenItSupersedesVisibleRefresh() = runTest {
+        val repository = RacingLocalMusicRepository()
+        var compatibilityLoading = false
+        val controller = LocalMusicController(
+            repository = repository,
+            providerRepository = FakeProviderRepository,
+            navigator = AppNavigator(),
+            scope = this,
+            providers = { emptyList() },
+            selectedSearchProviderId = { null },
+            isLocalMusicSectionActive = { false },
+            persistSettings = {},
+            setLoading = { compatibilityLoading = it },
+            setMessage = {},
+            onError = { throw it },
+            onTrackUpdated = { _, _ -> },
+        )
+
+        controller.refresh(forceRefresh = true, showLoading = true)
+        repository.firstRefreshStarted.await()
+
+        assertTrue(controller.uiState.value.isLoading)
+        assertTrue(compatibilityLoading)
+
+        controller.refresh(forceRefresh = true, showLoading = false)
+        repository.secondRefreshStarted.await()
+        runCurrent()
+
+        assertFalse(controller.uiState.value.isLoading)
+        assertFalse(compatibilityLoading)
+        assertEquals(listOf("latest"), controller.uiState.value.tracks.map { it.id })
+
+        repository.allowFirstRefreshToFinish.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(controller.uiState.value.isLoading)
+        assertFalse(compatibilityLoading)
+        assertEquals(listOf("latest"), controller.uiState.value.tracks.map { it.id })
+    }
+
     private fun localTrack(id: String, title: String, directoryId: String) = MusicTrack(
         id = id,
         title = title,
@@ -73,4 +122,85 @@ class LocalMusicOwnershipTest {
         sourceType = TrackSourceType.LocalMediaStore,
         localDirectoryId = directoryId,
     )
+
+    private class RacingLocalMusicRepository : LocalMusicRepository {
+        val firstRefreshStarted = CompletableDeferred<Unit>()
+        val allowFirstRefreshToFinish = CompletableDeferred<Unit>()
+        val secondRefreshStarted = CompletableDeferred<Unit>()
+        private var refreshCalls = 0
+
+        private val directory = LocalMusicDirectory(
+            id = "Music/",
+            name = "Music",
+            trackCount = 1,
+        )
+        private val staleTrack = MusicTrack(
+            id = "stale",
+            title = "Stale",
+            artists = "Artist",
+            album = "Album",
+            source = "local",
+            sourceType = TrackSourceType.LocalMediaStore,
+            localDirectoryId = directory.id,
+        )
+        private val latestTrack = staleTrack.copy(id = "latest", title = "Latest")
+
+        override suspend fun updateScanSettings(settings: LocalMusicScanSettings) = Unit
+        override suspend fun isDatabaseReady(): Boolean = false
+        override suspend fun directories(): List<LocalMusicDirectory> = listOf(directory)
+        override suspend fun tracks(): List<MusicTrack> = listOf(latestTrack)
+
+        override suspend fun refreshDatabase(): List<MusicTrack> {
+            refreshCalls += 1
+            return if (refreshCalls == 1) {
+                firstRefreshStarted.complete(Unit)
+                allowFirstRefreshToFinish.await()
+                listOf(staleTrack)
+            } else {
+                secondRefreshStarted.complete(Unit)
+                listOf(latestTrack)
+            }
+        }
+
+        override suspend fun search(keyword: String): List<MusicTrack> = emptyList()
+    }
+
+    private object FakeProviderRepository : ProviderMusicRepository {
+        override suspend fun initialize() = Unit
+        override suspend fun providers(): List<ProviderInfo> = emptyList()
+        override suspend fun search(keyword: String, providerId: String?): List<MusicTrack> = emptyList()
+
+        override suspend fun resolve(
+            track: MusicTrack,
+            unavailablePolicy: UnavailablePlaybackPolicy,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+        ): PlaybackPayload = PlaybackPayload(
+            url = "",
+            title = track.title,
+            artists = track.artists,
+            album = track.album,
+            source = track.source,
+        )
+
+        override suspend fun authState(providerId: String): ProviderAuthState =
+            ProviderAuthState(providerId = providerId, providerName = providerId, isLoggedIn = false)
+
+        override suspend fun loginWithCookies(providerId: String, cookiesJson: String): ProviderAuthState =
+            authState(providerId)
+
+        override suspend fun logout(providerId: String): ProviderAuthState = authState(providerId)
+
+        override suspend fun updateAudioQualityPolicies(
+            wifiPolicy: AudioQualityPolicy,
+            cellularPolicy: AudioQualityPolicy,
+        ) = Unit
+
+        override suspend fun features(): List<ProviderFeature> = emptyList()
+        override suspend fun loadFeature(feature: ProviderFeature): ProviderContentSection = ProviderContentSection(feature)
+        override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = emptyList()
+        override suspend fun mediaItemTracks(item: ProviderMediaItem): List<MusicTrack> = emptyList()
+    }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicOwnershipTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LocalMusicOwnershipTest.kt
@@ -1,0 +1,76 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalMusicOwnershipTest {
+    @Test
+    fun compatibilityStatePublishesImmutableFeatureProjection() {
+        val state = LocalMusicControllerState()
+        var projection = LocalMusicUiState()
+        var publishCount = 0
+        state.observeChanges {
+            projection = state.toUiState(projection)
+            publishCount += 1
+        }
+
+        val track = MusicTrack(
+            id = "local:1",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "local",
+            sourceType = TrackSourceType.LocalMediaStore,
+            localDirectoryId = "Music/",
+        )
+        state.tracks = listOf(track)
+        state.viewMode = LocalMusicViewMode.Artist
+        state.excludedDirectoryIds = setOf("Podcasts/")
+        state.selectedCollection = LocalMusicCollectionSelection(LocalMusicViewMode.Artist, "Artist")
+        state.metadataEditorTrack = track
+
+        assertEquals(listOf(track), projection.tracks)
+        assertEquals(LocalMusicViewMode.Artist, projection.viewMode)
+        assertEquals(setOf("Podcasts/"), projection.excludedDirectoryIds)
+        assertEquals(LocalMusicCollectionSelection(LocalMusicViewMode.Artist, "Artist"), projection.selectedCollection)
+        assertEquals(track, projection.metadataEditorTrack)
+        assertEquals(6, publishCount)
+
+        state.metadataEditorTrack = null
+        assertNull(projection.metadataEditorTrack)
+        assertEquals(7, publishCount)
+    }
+
+    @Test
+    fun localCollectionsRespectExcludedDirectories() {
+        val tracks = listOf(
+            localTrack("one", "One", "Music/"),
+            localTrack("two", "Two", "Podcasts/"),
+        )
+        val directories = listOf(
+            LocalMusicDirectory(id = "Music/", name = "Music", trackCount = 1),
+            LocalMusicDirectory(id = "Podcasts/", name = "Podcasts", trackCount = 1),
+        )
+
+        val collections = buildLocalMusicCollections(
+            mode = LocalMusicViewMode.All,
+            tracks = tracks,
+            directories = directories,
+            excludedDirectoryIds = setOf("Podcasts"),
+        )
+
+        assertEquals(listOf("Music/"), collections.map { it.key })
+        assertEquals(listOf("one"), collections.single().tracks.map { it.id })
+    }
+
+    private fun localTrack(id: String, title: String, directoryId: String) = MusicTrack(
+        id = id,
+        title = title,
+        artists = "Artist",
+        album = "Album",
+        source = "local",
+        sourceType = TrackSourceType.LocalMediaStore,
+        localDirectoryId = directoryId,
+    )
+}


### PR DESCRIPTION
## Summary

Continue P2-2 on top of #102 by migrating the Local Music bounded context away from production `FuoPlayerController` UI dependencies without pulling Local Playlist, Settings/Auth, provider-detail, or Home ownership into the same change.

### Local Music owner
- upgrade the existing `LocalMusicController` into a `LocalMusicFeatureController`
- publish immutable `StateFlow<LocalMusicUiState>` for tracks, directories, view mode, selected collection, metadata editor/search state, and feature-local loading/error/message state
- keep the existing Compose state object as a compatibility mirror so Settings and controller characterization callers continue to observe the same single owner
- keep global loading/message/error callbacks only as compatibility mirrors for unmigrated callers
- use narrow provider search/playback capability views inside the Local Music owner

### Controller-free Local Music UI
- remove `FuoPlayerController` from `LocalMusicSection`, `LocalMusicCollectionScreen`, collection/track rendering, metadata editing, and Local Music view-mode tabs
- route playback through `PlaybackQueueUiPort`
- route downloads through `DownloadActionPort`
- route artist/album navigation through `ProviderTrackActionPort`
- route metadata actions through the Local Music feature owner
- install a Local Music UI graph once from `AppRoot`

### App shell
- `AppRoute.LocalMusicCollection` renders the controller-free screen
- metadata-editor overlay observes Local Music feature state rather than `controller.localMetadataEditorTrack`
- retain a small Home integration bridge because Home remains scheduled for P2-4 and is intentionally not refactored here

### Architecture fitness
- guard Local Music controller/state/UI files against `FuoPlayerController` reintroduction
- guard AppRoot against reintroducing the retired Local Music route/metadata controller calls
- add focused ownership/projection and collection-filter regression tests

## Intentionally deferred
- Local Playlist ownership
- Settings/Auth/Onboarding ownership
- Home/provider-content ownership; `LocalMusicHomeBridge` is temporary until P2-4
- provider-detail ownership
- full app `navigateBack()` / `activateRoute()` cleanup
- physical Gradle feature modules

## Validation
- full Android/iOS/KMP CI will validate the migrated boundary on this draft PR
