### PR TITLE
fix: load mine content after startup state is ready

### DIFF
--- a/feature/providercatalog/src/commonMain/kotlin/org/feeluown/mobile/ProviderCatalogFeature.kt
+++ b/feature/providercatalog/src/commonMain/kotlin/org/feeluown/mobile/ProviderCatalogFeature.kt
@@ -44,6 +44,7 @@ data class ProviderCatalogFeatureState<Provider, Feature, Capability, Session>(
     val exploreProviderIds: Set<String> = emptySet(),
     val mineProviderIds: Set<String> = emptySet(),
     val replacementProviderIds: Set<String> = emptySet(),
+    val isInitialized: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 )
@@ -114,6 +115,7 @@ private class DefaultProviderCatalogFeatureOwner<Provider, Feature, Capability, 
     private var catalogProviders: List<Provider> = emptyList()
     private var catalogFeatures: List<Feature> = emptyList()
     private var catalogCapabilities: Map<String, Capability> = emptyMap()
+    private var initialized = false
     private var loading = false
     private var error: String? = null
 
@@ -152,6 +154,7 @@ private class DefaultProviderCatalogFeatureOwner<Provider, Feature, Capability, 
             }.onFailure { throwable ->
                 error = throwable.message ?: throwable::class.simpleName
             }
+            initialized = true
             loading = false
             publish()
         }
@@ -240,6 +243,7 @@ private class DefaultProviderCatalogFeatureOwner<Provider, Feature, Capability, 
             exploreProviderIds = settings.exploreProviderIds,
             mineProviderIds = settings.mineProviderIds,
             replacementProviderIds = settings.replacementProviderIds,
+            isInitialized = initialized,
             isLoading = loading || !preferencesState.isLoaded,
             errorMessage = error ?: preferencesState.errorMessage,
         )

--- a/feature/providercatalog/src/commonTest/kotlin/org/feeluown/mobile/feature/providercatalog/ProviderCatalogFeatureTest.kt
+++ b/feature/providercatalog/src/commonTest/kotlin/org/feeluown/mobile/feature/providercatalog/ProviderCatalogFeatureTest.kt
@@ -34,6 +34,36 @@ class ProviderCatalogFeatureTest {
         assertEquals(listOf("netease", "qqmusic"), owner.state.value.providers.map { it.id })
         assertEquals(listOf("netease", "qqmusic"), sessions.refreshed)
         assertTrue(preferences.state.value.settings.enabledProviderIds == setOf("netease"))
+        assertTrue(owner.state.value.isInitialized)
+    }
+
+    @Test
+    fun initializationCompletionIsPublishedWhenCatalogHasNoFeatures() = runTest {
+        val owner = createProviderCatalogFeatureOwner(
+            repository = FakeRepository(featureValues = emptyList()),
+            preferences = FakePreferences(ProviderCatalogPreferences()),
+            sessions = FakeSessions(),
+            scope = backgroundScope,
+            defaultEnabledProviderIds = setOf("netease"),
+        )
+        runCurrent()
+
+        assertTrue(owner.state.value.features.isEmpty())
+        assertTrue(owner.state.value.isInitialized)
+    }
+
+    @Test
+    fun initializationCompletionIsPublishedAfterFailure() = runTest {
+        val owner = createProviderCatalogFeatureOwner(
+            repository = FakeRepository(initializeFailure = IllegalStateException("catalog failed")),
+            preferences = FakePreferences(ProviderCatalogPreferences()),
+            sessions = FakeSessions(),
+            scope = backgroundScope,
+        )
+        runCurrent()
+
+        assertEquals("catalog failed", owner.state.value.errorMessage)
+        assertTrue(owner.state.value.isInitialized)
     }
 
     @Test
@@ -53,16 +83,22 @@ class ProviderCatalogFeatureTest {
     private data class Provider(val id: String, val name: String)
     private data class Capability(val providerId: String)
 
-    private class FakeRepository : ProviderCatalogRepositoryPort<Provider, String, Capability> {
+    private class FakeRepository(
+        private val featureValues: List<String> = listOf("recommend"),
+        private val initializeFailure: Throwable? = null,
+    ) : ProviderCatalogRepositoryPort<Provider, String, Capability> {
         var enabled: Set<String> = emptySet()
 
-        override suspend fun initialize() = Unit
+        override suspend fun initialize() {
+            initializeFailure?.let { throw it }
+        }
+
         override suspend fun availableProviders(): List<Provider> = listOf(
             Provider("netease", "NetEase"),
             Provider("qqmusic", "QQ Music"),
         )
         override suspend fun providers(): List<Provider> = availableProviders()
-        override suspend fun features(): List<String> = listOf("recommend")
+        override suspend fun features(): List<String> = featureValues
         override suspend fun capabilities(): List<Capability> = listOf(Capability("netease"))
         override suspend fun updateEnabledProviders(providerIds: Set<String>) {
             enabled = providerIds

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeFeatureController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeFeatureController.kt
@@ -105,7 +105,7 @@ private class DefaultHomeFeatureController(
                         playlistPlaybackStats = settings.playlistPlaybackStats,
                         errorMessage = mutableUiState.value.errorMessage ?: catalog.errorMessage ?: settingsState.errorMessage,
                     )
-                    if (settingsState.isLoaded && catalog.features.isNotEmpty()) ensureInitialContent()
+                    if (settingsState.isLoaded && catalog.isInitialized) ensureInitialContent()
                 }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -289,8 +289,8 @@ fun HomeSectionRail(
     }
 }
 
-@Suppress("DEPRECATION")
 @Composable
+@Suppress("DEPRECATION")
 fun HomeSectionTabs(
     sections: List<Pair<HomeSection, String>>,
     selectedIndex: Int,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -76,7 +76,6 @@ fun HomeScreen(
     val layoutInfo = LocalAppLayoutInfo.current
     val playbackUiPort = LocalPlaybackUiPort.current
     val state = home.uiState.collectAsStateWithLifecycle().value
-    LaunchedEffect(Unit) { home.ensureInitialContent() }
     Scaffold(
         topBar = {
             if (!layoutInfo.useWideLayout) {
@@ -290,8 +289,8 @@ fun HomeSectionRail(
     }
 }
 
-@Composable
 @Suppress("DEPRECATION")
+@Composable
 fun HomeSectionTabs(
     sections: List<Pair<HomeSection, String>>,
     selectedIndex: Int,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderCatalogFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderCatalogFeatureFactory.kt
@@ -28,6 +28,7 @@ data class ProviderCatalogUiState(
     val exploreProviderIds: Set<String> = emptySet(),
     val mineProviderIds: Set<String> = emptySet(),
     val replacementProviderIds: Set<String> = emptySet(),
+    val isInitialized: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 )
@@ -160,6 +161,7 @@ private fun CoreProviderCatalogFeatureState<
     exploreProviderIds = exploreProviderIds,
     mineProviderIds = mineProviderIds,
     replacementProviderIds = replacementProviderIds,
+    isInitialized = isInitialized,
     isLoading = isLoading,
     errorMessage = errorMessage,
 )


### PR DESCRIPTION
## Summary
- remove the HomeScreen first-frame call to `ensureInitialContent()`
- let `HomeFeatureController` start initial loading only from its existing settings/provider-catalog readiness collector

## Root cause
`HomeScreen` called `ensureInitialContent()` immediately on first composition. At that moment persisted settings and the provider catalog can still be uninitialized, but `ensureInitialContent()` sets `initialRefreshStarted = true` before starting a refresh using the default state.

When settings later restore `HomeSection.Mine`, the controller's readiness collector calls `ensureInitialContent()` again, but that call is ignored because the initial-refresh flag was already consumed. Since the restored `homeSection` is already `Mine`, pager synchronization also does not invoke `setHomeSection()` in a way that would trigger `refreshMineIfNeeded()`. The Mine page therefore stays empty until a manual refresh or section switch.

## Fix
The controller already observes `settingsRepository.state` and `providerCatalog.uiState`, and invokes `ensureInitialContent()` only after settings are loaded and provider features are available. Removing the eager UI call makes that readiness-aware path the single owner of startup loading.

This also avoids the same cold-start race for Recommend/Explore without adding extra refreshes.

## Validation
- final diff is one deletion in `HomeScreen.kt`
- no provider/session behavior changed
- CI should run the repository test/build checks on this PR