### PR TITLE
fix: separate user playback selection from resume session

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -21,7 +21,7 @@ import kotlin.math.abs
 class AndroidNativeAudioEngine(
     private val context: Context,
     private val scope: CoroutineScope,
-) : PlaybackEngine {
+) : PlaybackEngine, PlaybackStartReasonAwareEngine {
     private val playbackResumeStore = AndroidPlaybackResumeStore(context)
     private var restoredSession: AndroidPlaybackResumeSnapshot? = playbackResumeStore.load()
     private val mutableState = MutableStateFlow(restoredSession?.toPlaybackState() ?: PlaybackState())
@@ -34,6 +34,7 @@ class AndroidNativeAudioEngine(
     private var preparedRestoredSession: AndroidPlaybackResumeSnapshot? = null
     private var explicitStopRequested = false
     private var startingPlayback = false
+    private var freshStartPending = false
     private var lastPersistedIdentity: String? = null
     private var lastPersistedPositionMs: Long = restoredSession?.positionMs ?: 0L
     private var restoredRepublishSerial = 0L
@@ -58,6 +59,29 @@ class AndroidNativeAudioEngine(
         }
         scope.launch {
             FuoPlaybackService.playbackState.collect { serviceState ->
+                if (startingPlayback && freshStartPending) {
+                    if (serviceState.isEmptyIdleState()) return@collect
+                    val expectedState = mutableState.value
+                    val expectedTrackId = expectedState.currentTrack?.id
+                    val serviceTrackId = serviceState.currentTrack?.id
+                    val expectedGeneration = expectedState.playbackGeneration
+                    val isFreshGeneration = expectedGeneration > 0L &&
+                        serviceState.playbackGeneration == expectedGeneration
+                    val isExpectedTrack = expectedTrackId == null || serviceTrackId == null ||
+                        expectedTrackId == serviceTrackId
+                    if (!isFreshGeneration || !isExpectedTrack) {
+                        Log.d(
+                            TAG,
+                            "ignoring stale service state while starting " +
+                                "expectedTrackId=${expectedTrackId.orEmpty()} " +
+                                "serviceTrackId=${serviceTrackId.orEmpty()} " +
+                                "expectedGeneration=$expectedGeneration " +
+                                "serviceGeneration=${serviceState.playbackGeneration}",
+                        )
+                        return@collect
+                    }
+                }
+
                 if (serviceState.isEmptyIdleState() && !explicitStopRequested && !startingPlayback) {
                     val session = restoredSession ?: playbackResumeStore.load()
                     if (session != null) {
@@ -69,8 +93,9 @@ class AndroidNativeAudioEngine(
                 }
 
                 if (!serviceState.isEmptyIdleState()) {
-                    startingPlayback = false
                     if (serviceState.currentTrack != null) {
+                        startingPlayback = false
+                        freshStartPending = false
                         restoredSession = null
                         preparedRestoredSession = null
                     }
@@ -110,16 +135,20 @@ class AndroidNativeAudioEngine(
     }
 
     override fun prepareLoading(track: MusicTrack) {
+        prepareLoading(track, PlaybackStartReason.RESTORE_SESSION)
+    }
+
+    override fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason) {
         pendingLockScreenLyrics = null
         pendingResumePositionMs = null
 
-        // FuoPlayerController can briefly still expose Idle after process recreation even though
-        // this engine has already restored the same track as Paused. MiniPlayer becomes visible
-        // from the restored queue during that window, and its play button would otherwise call
-        // startPlayback(), clearing the saved position before resume() gets a chance to use it.
-        // Preserve the resumable session here and let play(plan) turn that stale restart into the
-        // same resume path used by FullPlayer.
-        val session = restoredSession ?: playbackResumeStore.load()
+        // Only resume-like starts may convert a same-track restart into restoration. Explicit user
+        // selections are new playback transactions even when they happen to select the same track.
+        val session = if (reason.mayResumePausedSession) {
+            restoredSession ?: playbackResumeStore.load()
+        } else {
+            null
+        }
         val shouldResumeRestoredSession = mutableState.value.status == PlayerStatus.Paused &&
             session?.currentTrack?.id == track.id &&
             session.resumePlan() != null
@@ -129,8 +158,9 @@ class AndroidNativeAudioEngine(
             activePlan = session.plan
             explicitStopRequested = false
             startingPlayback = false
+            freshStartPending = false
             connectController()
-            Log.d(TAG, "preserving restored session for prepared trackId=${track.id}")
+            Log.d(TAG, "preserving restored session for prepared trackId=${track.id} reason=$reason")
             return
         }
 
@@ -138,7 +168,14 @@ class AndroidNativeAudioEngine(
         restoredSession = null
         explicitStopRequested = false
         startingPlayback = true
+        freshStartPending = true
         rawAudioQuality = null
+        if (reason.isActiveSelection) {
+            activePlan = null
+            lastPersistedIdentity = null
+            lastPersistedPositionMs = 0L
+            playbackResumeStore.clear()
+        }
         mutableState.value = mutableState.value.copy(
             status = PlayerStatus.Loading,
             currentTrack = track,
@@ -150,8 +187,12 @@ class AndroidNativeAudioEngine(
             audioFormatInfo = null,
             playbackParts = emptyList(),
             currentPartIndex = -1,
+            playbackGeneration = 0L,
             errorMessage = null,
         )
+        if (reason.isActiveSelection) {
+            discardLivePausedSession(track.id)
+        }
         connectController()
     }
 
@@ -175,6 +216,7 @@ class AndroidNativeAudioEngine(
         preparedRestoredSession = null
         explicitStopRequested = false
         startingPlayback = true
+        freshStartPending = true
         restoredSession = null
         pendingResumePositionMs = null
         activePlan = plan
@@ -198,6 +240,7 @@ class AndroidNativeAudioEngine(
         runCatching { FuoPlaybackService.play(context, plan.toJson()) }
             .onFailure { throwable ->
                 startingPlayback = false
+                freshStartPending = false
                 Log.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
                 mutableState.value = mutableState.value.copy(
                     status = PlayerStatus.Error,
@@ -209,6 +252,7 @@ class AndroidNativeAudioEngine(
     }
 
     override fun pause() {
+        freshStartPending = false
         mediaController?.pause()
         FuoPlaybackService.pause(context)
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
@@ -218,6 +262,7 @@ class AndroidNativeAudioEngine(
     override fun resume() {
         explicitStopRequested = false
         preparedRestoredSession = null
+        freshStartPending = false
         val controller = mediaController
         val canResumeLiveSession = controller?.currentMediaItem != null &&
             controller.playbackState != Player.STATE_IDLE
@@ -269,6 +314,7 @@ class AndroidNativeAudioEngine(
         activePlan = null
         explicitStopRequested = true
         startingPlayback = false
+        freshStartPending = false
         lastPersistedIdentity = null
         lastPersistedPositionMs = 0L
         playbackResumeStore.clear()
@@ -316,6 +362,22 @@ class AndroidNativeAudioEngine(
         }
         pendingLockScreenLyrics = PendingLockScreenLyrics(trackId, normalizedLyrics)
         applyPendingLockScreenLyrics()
+    }
+
+    private fun discardLivePausedSession(nextTrackId: String) {
+        val controller = mediaController ?: return
+        runCatching {
+            controller.pause()
+            if (controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
+                controller.clearMediaItems()
+            } else {
+                controller.stop()
+            }
+        }.onSuccess {
+            Log.d(TAG, "discarded paused Media3 session before active selection trackId=$nextTrackId")
+        }.onFailure { throwable ->
+            Log.w(TAG, "failed to discard paused Media3 session before trackId=$nextTrackId", throwable)
+        }
     }
 
     private fun connectController() {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -23,6 +23,7 @@ internal class PlaybackQueueController {
     var repeatMode by mutableStateOf(RepeatMode.QUEUE)
     var isFmQueue by mutableStateOf(false)
     var shuffleBeforeFm by mutableStateOf<Boolean?>(null)
+    private var pendingPlaybackStartReason: PlaybackStartReason? = null
 
     fun currentTrack(): MusicTrack? =
         if (currentIsUpNext) currentUpNextTrack else mainQueue.getOrNull(mainQueueIndex)
@@ -41,6 +42,14 @@ internal class PlaybackQueueController {
     }
 
     fun displayQueueIndex(): Int = if (currentTrack() != null) 0 else -1
+
+    fun markNextPlaybackStart(reason: PlaybackStartReason) {
+        pendingPlaybackStartReason = reason
+    }
+
+    fun consumePlaybackStartReason(): PlaybackStartReason =
+        pendingPlaybackStartReason?.also { pendingPlaybackStartReason = null }
+            ?: PlaybackStartReason.AUTO_NEXT
 
     fun updateCurrentTrack(track: MusicTrack) {
         if (currentIsUpNext) {
@@ -62,6 +71,7 @@ internal class PlaybackQueueController {
         shuffleBeforeFm = snapshot.shuffleBeforeFm
         currentUpNextTrack = null
         currentIsUpNext = false
+        pendingPlaybackStartReason = null
     }
 
     fun snapshot(): PlaybackQueueSnapshot = PlaybackQueueSnapshot(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
@@ -64,7 +64,9 @@ internal class PlaybackQueueCoordinator(
         get() = queueState.isFmQueue
 
     override fun startCurrent() {
-        (queueState.currentTrack() ?: fallbackTrack())?.let { startPlayback(it, 0, null) }
+        (queueState.currentTrack() ?: fallbackTrack())?.let { track ->
+            startTrack(track, 0, null, PlaybackStartReason.RESUME)
+        }
     }
 
     override fun playTracks(tracks: List<MusicTrack>, index: Int) {
@@ -125,7 +127,9 @@ internal class PlaybackQueueCoordinator(
         updateTrackChangeDirection(TrackChangeDirection.Next)
         if (queueState.repeatMode == RepeatMode.SINGLE) {
             if (playPlaybackPartOffset(1, wrap = true)) return
-            startCurrent()
+            (queueState.currentTrack() ?: fallbackTrack())?.let { track ->
+                startTrack(track, 0, null, PlaybackStartReason.AUTO_NEXT)
+            }
             return
         }
         if (playPlaybackPartOffset(1)) return
@@ -169,7 +173,9 @@ internal class PlaybackQueueCoordinator(
         updateTrackChangeDirection(TrackChangeDirection.Previous)
         if (queueState.repeatMode == RepeatMode.SINGLE) {
             if (playPlaybackPartOffset(-1, wrap = true)) return
-            startCurrent()
+            (queueState.currentTrack() ?: fallbackTrack())?.let { track ->
+                startTrack(track, 0, null, PlaybackStartReason.AUTO_NEXT)
+            }
             return
         }
         if (playPlaybackPartOffset(-1)) return
@@ -197,14 +203,20 @@ internal class PlaybackQueueCoordinator(
         updateTrackChangeDirection(TrackChangeDirection.Next)
         val currentOffset = if (queueState.currentTrack() != null) 1 else 0
         if (index == 0 && currentOffset == 1) {
-            startCurrent()
+            queueState.currentTrack()?.let { track ->
+                startTrack(track, 0, null, PlaybackStartReason.USER_SELECTION)
+            }
             return
         }
         val pendingOffset = currentOffset
         val pendingEnd = pendingOffset + queueState.upNextQueue.size
         when {
             index in pendingOffset until pendingEnd -> {
-                playUpNextIndexInternal(index - pendingOffset, TrackChangeDirection.Next)
+                playUpNextIndexInternal(
+                    index - pendingOffset,
+                    TrackChangeDirection.Next,
+                    PlaybackStartReason.USER_SELECTION,
+                )
             }
             else -> {
                 val mainStartIndex = when {
@@ -213,7 +225,12 @@ internal class PlaybackQueueCoordinator(
                     else -> 0
                 }
                 val mainIndex = mainStartIndex + (index - pendingEnd)
-                playMainIndexInternal(mainIndex, 0, TrackChangeDirection.Next)
+                playMainIndexInternal(
+                    mainIndex,
+                    0,
+                    TrackChangeDirection.Next,
+                    PlaybackStartReason.USER_SELECTION,
+                )
             }
         }
     }
@@ -221,7 +238,9 @@ internal class PlaybackQueueCoordinator(
     override fun playPlaybackPart(index: Int) {
         val parts = playbackParts()
         if (index !in parts.indices) return
-        queueState.currentTrack()?.let { startPlayback(it, 0, index) }
+        queueState.currentTrack()?.let { track ->
+            startTrack(track, 0, index, PlaybackStartReason.USER_SELECTION)
+        }
     }
 
     override fun removeFromQueue(track: MusicTrack) {
@@ -320,7 +339,9 @@ internal class PlaybackQueueCoordinator(
         } else {
             nextPartIndex.takeIf { it in parts.indices } ?: return false
         }
-        queueState.currentTrack()?.let { startPlayback(it, 0, targetPartIndex) } ?: return false
+        queueState.currentTrack()?.let { track ->
+            startTrack(track, 0, targetPartIndex, PlaybackStartReason.AUTO_NEXT)
+        } ?: return false
         return true
     }
 
@@ -360,30 +381,50 @@ internal class PlaybackQueueCoordinator(
             }
         }
         publishQueueMutation()
-        playMainIndexInternal(queueState.mainQueueIndex, 0, TrackChangeDirection.Next)
+        playMainIndexInternal(
+            queueState.mainQueueIndex,
+            0,
+            TrackChangeDirection.Next,
+            if (keepSelectedTrack) PlaybackStartReason.USER_SELECTION else PlaybackStartReason.PLAYLIST_REPLACE,
+        )
     }
 
     private fun playMainIndexInternal(
         index: Int,
         skippedUnavailableCount: Int,
         direction: TrackChangeDirection,
+        reason: PlaybackStartReason = PlaybackStartReason.AUTO_NEXT,
     ) {
         val track = queueState.mainQueue.getOrNull(index) ?: return
         updateTrackChangeDirection(direction)
         queueState.currentUpNextTrack = null
         queueState.currentIsUpNext = false
         queueState.mainQueueIndex = index
-        startPlayback(track, skippedUnavailableCount, null)
+        startTrack(track, skippedUnavailableCount, null, reason)
     }
 
-    private fun playUpNextIndexInternal(index: Int, direction: TrackChangeDirection) {
+    private fun playUpNextIndexInternal(
+        index: Int,
+        direction: TrackChangeDirection,
+        reason: PlaybackStartReason = PlaybackStartReason.AUTO_NEXT,
+    ) {
         val track = queueState.upNextQueue.getOrNull(index) ?: return
         updateTrackChangeDirection(direction)
         queueState.upNextQueue = queueState.upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
         queueState.currentUpNextTrack = track
         queueState.currentIsUpNext = true
         publishQueueMutation()
-        startPlayback(track, 0, null)
+        startTrack(track, 0, null, reason)
+    }
+
+    private fun startTrack(
+        track: MusicTrack,
+        skippedUnavailableCount: Int,
+        requestedPartIndex: Int?,
+        reason: PlaybackStartReason,
+    ) {
+        queueState.markNextPlaybackStart(reason)
+        startPlayback(track, skippedUnavailableCount, requestedPartIndex)
     }
 
     private fun updateTrackChangeDirection(direction: TrackChangeDirection) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
@@ -8,6 +8,26 @@ import kotlinx.coroutines.launch
 
 private const val PLAYBACK_START_PLAN_LOOKAHEAD = 8
 
+enum class PlaybackStartReason {
+    USER_SELECTION,
+    PLAYLIST_REPLACE,
+    AUTO_NEXT,
+    RESUME,
+    RESTORE_SESSION,
+    ;
+
+    val isActiveSelection: Boolean
+        get() = this == USER_SELECTION || this == PLAYLIST_REPLACE
+
+    val mayResumePausedSession: Boolean
+        get() = this == RESUME || this == RESTORE_SESSION
+}
+
+/** Optional engine capability for distinguishing a fresh selection from session resume. */
+interface PlaybackStartReasonAwareEngine {
+    fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason)
+}
+
 data class PlaybackStartFailure(
     val trackId: String,
     val message: String,
@@ -59,6 +79,7 @@ internal class PlaybackStartCoordinator(
         messageAfterStart: String? = null,
         suppressPlaybackRecovery: Boolean = false,
     ) {
+        val startReason = queue.consumePlaybackStartReason()
         prepareSleepTimer(track.id)
         val serial = nextRequestSerial()
         _startFailure.value = null
@@ -90,7 +111,12 @@ internal class PlaybackStartCoordinator(
             )
         )
         persistQueue()
-        playbackEngine.prepareLoading(playbackTrack)
+        val reasonAwareEngine = playbackEngine as? PlaybackStartReasonAwareEngine
+        if (reasonAwareEngine != null) {
+            reasonAwareEngine.prepareLoading(playbackTrack, startReason)
+        } else {
+            playbackEngine.prepareLoading(playbackTrack)
+        }
         setLoading(true)
         setMessage(messageAfterStart ?: "正在播放：${track.title}")
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
@@ -1,0 +1,132 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaybackStartReasonTest {
+    @Test
+    fun selectingTrackFromNewPlaylistStartsSelectedTrackAsUserSelection() = runTest {
+        val pausedTrack = track("track:a")
+        val first = track("track:first")
+        val selected = track("track:b")
+        val last = track("track:last")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(pausedTrack)
+            mainQueueIndex = 0
+        }
+        var startedTrack: MusicTrack? = null
+        var startReason: PlaybackStartReason? = null
+        val coordinator = coordinator(queue) { track, _, _ ->
+            startedTrack = track
+            startReason = queue.consumePlaybackStartReason()
+        }
+
+        coordinator.playPlaylistTracks(
+            tracks = listOf(first, selected, last),
+            index = 1,
+            sourcePlaylistId = "playlist:new",
+        )
+
+        assertEquals(selected, startedTrack)
+        assertEquals(PlaybackStartReason.USER_SELECTION, startReason)
+        assertEquals(selected, queue.currentTrack())
+        assertEquals("playlist:new", queue.queuePlaylistId)
+    }
+
+    @Test
+    fun playingAllNewPlaylistStartsFirstTrackAsPlaylistReplacement() = runTest {
+        val pausedTrack = track("track:a")
+        val first = track("track:b")
+        val second = track("track:c")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(pausedTrack)
+            mainQueueIndex = 0
+        }
+        var startedTrack: MusicTrack? = null
+        var startReason: PlaybackStartReason? = null
+        val coordinator = coordinator(queue) { track, _, _ ->
+            startedTrack = track
+            startReason = queue.consumePlaybackStartReason()
+        }
+
+        coordinator.playAllPlaylistTracks(
+            tracks = listOf(first, second),
+            sourcePlaylistId = "playlist:new",
+        )
+
+        assertEquals(first, startedTrack)
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, startReason)
+        assertEquals(first, queue.currentTrack())
+    }
+
+    @Test
+    fun startingCurrentTrackUsesResumeReason() = runTest {
+        val pausedTrack = track("track:a")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(pausedTrack)
+            mainQueueIndex = 0
+        }
+        var startedTrack: MusicTrack? = null
+        var startReason: PlaybackStartReason? = null
+        val coordinator = coordinator(queue) { track, _, _ ->
+            startedTrack = track
+            startReason = queue.consumePlaybackStartReason()
+        }
+
+        coordinator.startCurrent()
+
+        assertEquals(pausedTrack, startedTrack)
+        assertEquals(PlaybackStartReason.RESUME, startReason)
+    }
+
+    @Test
+    fun automaticNextUsesAutoNextReason() = runTest {
+        val first = track("track:a")
+        val second = track("track:b")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(first, second)
+            mainQueueIndex = 0
+            repeatMode = RepeatMode.OFF
+        }
+        var startedTrack: MusicTrack? = null
+        var startReason: PlaybackStartReason? = null
+        val coordinator = coordinator(queue) { track, _, _ ->
+            startedTrack = track
+            startReason = queue.consumePlaybackStartReason()
+        }
+
+        coordinator.next()
+
+        assertEquals(second, startedTrack)
+        assertEquals(PlaybackStartReason.AUTO_NEXT, startReason)
+    }
+
+    private fun TestScope.coordinator(
+        queue: PlaybackQueueController,
+        onStart: (MusicTrack, Int, Int?) -> Unit,
+    ): PlaybackQueueCoordinator = PlaybackQueueCoordinator(
+        queue = queue,
+        scope = this,
+        fallbackTrack = { null },
+        playbackParts = { emptyList() },
+        currentPartIndex = { -1 },
+        startPlayback = onStart,
+        stopPlayback = {},
+        persistQueue = {},
+        updateQueueState = {},
+        appendFeatureQueue = { 0 },
+        setTrackChangeDirection = {},
+        setMessage = {},
+    )
+
+    private fun track(id: String): MusicTrack = MusicTrack(
+        id = id,
+        title = id,
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+    )
+}


### PR DESCRIPTION
## 问题

当已有播放队列且歌曲 A 处于暂停状态时，从新歌单点击歌曲 B 会替换队列，但 Android Media3 的旧 paused session / MediaItem 仍可能被恢复，导致 A 被重新播放，而不是启动 B。

## 修复

- 增加明确的播放启动原因：`USER_SELECTION`、`PLAYLIST_REPLACE`、`AUTO_NEXT`、`RESUME`、`RESTORE_SESSION`。
- 单曲/歌单选曲与“全部播放”作为主动播放事务进入启动链路；播放按钮恢复当前曲目仍保持 `RESUME` 语义。
- Android 播放引擎仅允许 `RESUME` / `RESTORE_SESSION` 复用暂停恢复会话。
- 主动选曲时清理旧 resume snapshot 和 Media3 paused item，避免旧媒体项被 `play()` 恢复。
- 新播放计划启动期间过滤旧 service generation / track 的陈旧状态，防止 A 覆盖正在启动的 B。

## 回归覆盖

新增测试覆盖：

- 暂停 A 后从新歌单选择 B -> 启动 B，原因是 `USER_SELECTION`。
- 暂停 A 后“全部播放”新歌单 -> 启动新歌单第一首，原因是 `PLAYLIST_REPLACE`。
- 暂停 A 后点击当前播放按钮 -> 保持 `RESUME`，继续 A。
- 自动下一首 -> 保持 `AUTO_NEXT`。

## 影响范围

仅涉及播放启动语义、队列协调、Android Media3 会话隔离和对应测试；不改变现有恢复播放功能和播放队列持久化结构。