### PR TITLE
fix: prevent startup queue restore from overriding new playback

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -434,7 +434,7 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun restorePlaybackQueue(snapshot: PlaybackQueueSnapshot) {
-        queueState.restore(snapshot)
+        if (!queueState.restore(snapshot)) return
         playbackParts = emptyList()
         currentPartIndex = -1
         updatePlaybackState { current ->

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -105,6 +105,5 @@ internal class PlaybackQueueController {
             !shuffleEnabled &&
             repeatMode == RepeatMode.QUEUE &&
             !isFmQueue &&
-            shuffleBeforeFm == null &&
-            pendingPlaybackStartReason == null
+            shuffleBeforeFm == null
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -1,8 +1,9 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
 /**
  * Owns the durable playback-queue state independently from the app controller.
@@ -11,18 +12,21 @@ import androidx.compose.runtime.setValue
  * type remains the single source of truth for queue state and persistence.
  */
 internal class PlaybackQueueController {
-    var mainQueue by mutableStateOf<List<MusicTrack>>(emptyList())
-    var originalMainQueue by mutableStateOf<List<MusicTrack>>(emptyList())
-    var upNextQueue by mutableStateOf<List<MusicTrack>>(emptyList())
-    var mainQueueIndex by mutableStateOf(-1)
-    var currentUpNextTrack by mutableStateOf<MusicTrack?>(null)
-    var currentIsUpNext by mutableStateOf(false)
-    var queueFeature by mutableStateOf<ProviderFeature?>(null)
-    var queuePlaylistId by mutableStateOf<String?>(null)
-    var shuffleEnabled by mutableStateOf(false)
-    var repeatMode by mutableStateOf(RepeatMode.QUEUE)
-    var isFmQueue by mutableStateOf(false)
-    var shuffleBeforeFm by mutableStateOf<Boolean?>(null)
+    private var applyingStartupSnapshot = false
+    private var startupDirty = false
+
+    var mainQueue by trackedStateOf<List<MusicTrack>>(emptyList())
+    var originalMainQueue by trackedStateOf<List<MusicTrack>>(emptyList())
+    var upNextQueue by trackedStateOf<List<MusicTrack>>(emptyList())
+    var mainQueueIndex by trackedStateOf(-1)
+    var currentUpNextTrack by trackedStateOf<MusicTrack?>(null)
+    var currentIsUpNext by trackedStateOf(false)
+    var queueFeature by trackedStateOf<ProviderFeature?>(null)
+    var queuePlaylistId by trackedStateOf<String?>(null)
+    var shuffleEnabled by trackedStateOf(false)
+    var repeatMode by trackedStateOf(RepeatMode.QUEUE)
+    var isFmQueue by trackedStateOf(false)
+    var shuffleBeforeFm by trackedStateOf<Boolean?>(null)
     private var pendingPlaybackStartReason: PlaybackStartReason? = null
 
     fun currentTrack(): MusicTrack? =
@@ -61,25 +65,33 @@ internal class PlaybackQueueController {
     }
 
     /**
-     * Applies the persisted startup queue only while no live queue state has been established.
+     * Applies the persisted startup queue only if no live queue mutation happened first.
      *
-     * The platform engine can restore its paused track immediately, while the durable queue is
-     * loaded asynchronously. If the user selects/replaces a queue before this snapshot arrives,
-     * that live queue is newer and must not be overwritten by the startup snapshot.
+     * Mutation history is tracked monotonically rather than inferred from current values so user
+     * actions that return the queue to its defaults (for example clearing an already-empty queue or
+     * toggling shuffle twice) still invalidate a delayed startup snapshot.
+     *
+     * @return true when the snapshot was applied, false when a newer live mutation won the race.
      */
-    fun restore(snapshot: PlaybackQueueSnapshot) {
-        if (!isPristineStartupState()) return
-        mainQueue = snapshot.mainQueue
-        originalMainQueue = snapshot.originalMainQueue
-        upNextQueue = snapshot.upNextQueue
-        mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex)
-        shuffleEnabled = snapshot.shuffleEnabled
-        repeatMode = snapshot.repeatMode
-        isFmQueue = snapshot.isFmQueue
-        shuffleBeforeFm = snapshot.shuffleBeforeFm
-        currentUpNextTrack = null
-        currentIsUpNext = false
-        pendingPlaybackStartReason = null
+    fun restore(snapshot: PlaybackQueueSnapshot): Boolean {
+        if (startupDirty) return false
+        applyingStartupSnapshot = true
+        try {
+            mainQueue = snapshot.mainQueue
+            originalMainQueue = snapshot.originalMainQueue
+            upNextQueue = snapshot.upNextQueue
+            mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex)
+            shuffleEnabled = snapshot.shuffleEnabled
+            repeatMode = snapshot.repeatMode
+            isFmQueue = snapshot.isFmQueue
+            shuffleBeforeFm = snapshot.shuffleBeforeFm
+            currentUpNextTrack = null
+            currentIsUpNext = false
+            pendingPlaybackStartReason = null
+        } finally {
+            applyingStartupSnapshot = false
+        }
+        return true
     }
 
     fun snapshot(): PlaybackQueueSnapshot = PlaybackQueueSnapshot(
@@ -93,17 +105,15 @@ internal class PlaybackQueueController {
         shuffleBeforeFm = shuffleBeforeFm,
     )
 
-    private fun isPristineStartupState(): Boolean =
-        mainQueue.isEmpty() &&
-            originalMainQueue.isEmpty() &&
-            upNextQueue.isEmpty() &&
-            mainQueueIndex == -1 &&
-            currentUpNextTrack == null &&
-            !currentIsUpNext &&
-            queueFeature == null &&
-            queuePlaylistId == null &&
-            !shuffleEnabled &&
-            repeatMode == RepeatMode.QUEUE &&
-            !isFmQueue &&
-            shuffleBeforeFm == null
+    private fun <T> trackedStateOf(initialValue: T): ReadWriteProperty<Any?, T> {
+        val state: MutableState<T> = mutableStateOf(initialValue)
+        return object : ReadWriteProperty<Any?, T> {
+            override fun getValue(thisRef: Any?, property: KProperty<*>): T = state.value
+
+            override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+                if (!applyingStartupSnapshot) startupDirty = true
+                state.value = value
+            }
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -60,7 +60,15 @@ internal class PlaybackQueueController {
         }
     }
 
+    /**
+     * Applies the persisted startup queue only while no live queue state has been established.
+     *
+     * The platform engine can restore its paused track immediately, while the durable queue is
+     * loaded asynchronously. If the user selects/replaces a queue before this snapshot arrives,
+     * that live queue is newer and must not be overwritten by the startup snapshot.
+     */
     fun restore(snapshot: PlaybackQueueSnapshot) {
+        if (!isPristineStartupState()) return
         mainQueue = snapshot.mainQueue
         originalMainQueue = snapshot.originalMainQueue
         upNextQueue = snapshot.upNextQueue
@@ -84,4 +92,19 @@ internal class PlaybackQueueController {
         isFmQueue = isFmQueue,
         shuffleBeforeFm = shuffleBeforeFm,
     )
+
+    private fun isPristineStartupState(): Boolean =
+        mainQueue.isEmpty() &&
+            originalMainQueue.isEmpty() &&
+            upNextQueue.isEmpty() &&
+            mainQueueIndex == -1 &&
+            currentUpNextTrack == null &&
+            !currentIsUpNext &&
+            queueFeature == null &&
+            queuePlaylistId == null &&
+            !shuffleEnabled &&
+            repeatMode == RepeatMode.QUEUE &&
+            !isFmQueue &&
+            shuffleBeforeFm == null &&
+            pendingPlaybackStartReason == null
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
@@ -22,9 +22,8 @@ class PlaybackQueueControllerTest {
             shuffleBeforeFm = false
         }
 
-        val restored = PlaybackQueueController().apply {
-            restore(source.snapshot())
-        }
+        val restored = PlaybackQueueController()
+        assertTrue(restored.restore(source.snapshot()))
 
         assertEquals(listOf(first, second), restored.mainQueue)
         assertEquals(listOf(second, first), restored.originalMainQueue)
@@ -53,7 +52,7 @@ class PlaybackQueueControllerTest {
             markNextPlaybackStart(PlaybackStartReason.PLAYLIST_REPLACE)
         }
 
-        controller.restore(oldSnapshot)
+        assertFalse(controller.restore(oldSnapshot))
 
         assertEquals(listOf(firstNew, secondNew), controller.mainQueue)
         assertEquals(firstNew, controller.currentTrack())
@@ -72,11 +71,45 @@ class PlaybackQueueControllerTest {
             repeatMode = RepeatMode.OFF
         }
 
-        controller.restore(oldSnapshot)
+        assertFalse(controller.restore(oldSnapshot))
 
         assertTrue(controller.mainQueue.isEmpty())
         assertEquals(-1, controller.mainQueueIndex)
         assertEquals(RepeatMode.OFF, controller.repeatMode)
+    }
+
+    @Test
+    fun mutationReturnedToDefaultStillRejectsDelayedStartupRestore() {
+        val restoredTrack = track("netease:old", "Restored")
+        val oldSnapshot = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }.snapshot()
+        val controller = PlaybackQueueController().apply {
+            shuffleEnabled = true
+            shuffleEnabled = false
+        }
+
+        assertFalse(controller.restore(oldSnapshot))
+        assertTrue(controller.mainQueue.isEmpty())
+        assertFalse(controller.shuffleEnabled)
+    }
+
+    @Test
+    fun noOpQueueClearMutationStillRejectsDelayedStartupRestore() {
+        val restoredTrack = track("netease:old", "Restored")
+        val oldSnapshot = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }.snapshot()
+        val controller = PlaybackQueueController().apply {
+            mainQueue = emptyList()
+            mainQueueIndex = -1
+        }
+
+        assertFalse(controller.restore(oldSnapshot))
+        assertTrue(controller.mainQueue.isEmpty())
+        assertEquals(-1, controller.mainQueueIndex)
     }
 
     @Test
@@ -90,7 +123,7 @@ class PlaybackQueueControllerTest {
             markNextPlaybackStart(PlaybackStartReason.RESUME)
         }
 
-        controller.restore(oldSnapshot)
+        assertTrue(controller.restore(oldSnapshot))
 
         assertEquals(listOf(restoredTrack), controller.mainQueue)
         assertEquals(restoredTrack, controller.currentTrack())

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
@@ -80,6 +80,24 @@ class PlaybackQueueControllerTest {
     }
 
     @Test
+    fun resumeIntentStillAllowsStartupQueueRestore() {
+        val restoredTrack = track("netease:old", "Restored")
+        val oldSnapshot = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }.snapshot()
+        val controller = PlaybackQueueController().apply {
+            markNextPlaybackStart(PlaybackStartReason.RESUME)
+        }
+
+        controller.restore(oldSnapshot)
+
+        assertEquals(listOf(restoredTrack), controller.mainQueue)
+        assertEquals(restoredTrack, controller.currentTrack())
+        assertEquals(PlaybackStartReason.AUTO_NEXT, controller.consumePlaybackStartReason())
+    }
+
+    @Test
     fun displayQueueKeepsCurrentThenUpNextThenRemainingMainQueue() {
         val first = track("netease:1", "First")
         val second = track("netease:2", "Second")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
@@ -38,6 +38,48 @@ class PlaybackQueueControllerTest {
     }
 
     @Test
+    fun delayedStartupRestoreDoesNotOverwriteNewPlaylistSelection() {
+        val restoredTrack = track("netease:old", "Restored")
+        val oldSnapshot = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }.snapshot()
+        val firstNew = track("qqmusic:new-1", "New 1")
+        val secondNew = track("qqmusic:new-2", "New 2")
+        val controller = PlaybackQueueController().apply {
+            mainQueue = listOf(firstNew, secondNew)
+            mainQueueIndex = 0
+            queuePlaylistId = "playlist:new"
+            markNextPlaybackStart(PlaybackStartReason.PLAYLIST_REPLACE)
+        }
+
+        controller.restore(oldSnapshot)
+
+        assertEquals(listOf(firstNew, secondNew), controller.mainQueue)
+        assertEquals(firstNew, controller.currentTrack())
+        assertEquals("playlist:new", controller.queuePlaylistId)
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, controller.consumePlaybackStartReason())
+    }
+
+    @Test
+    fun delayedStartupRestoreDoesNotOverwriteQueuePolicyMutation() {
+        val restoredTrack = track("netease:old", "Restored")
+        val oldSnapshot = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }.snapshot()
+        val controller = PlaybackQueueController().apply {
+            repeatMode = RepeatMode.OFF
+        }
+
+        controller.restore(oldSnapshot)
+
+        assertTrue(controller.mainQueue.isEmpty())
+        assertEquals(-1, controller.mainQueueIndex)
+        assertEquals(RepeatMode.OFF, controller.repeatMode)
+    }
+
+    @Test
     fun displayQueueKeepsCurrentThenUpNextThenRemainingMainQueue() {
         val first = track("netease:1", "First")
         val second = track("netease:2", "Second")


### PR DESCRIPTION
## 问题

PR #111 修复了 Android Media3 paused session 被主动选曲误恢复的问题，但应用重启场景还有另一条独立竞态：

1. Android 播放引擎会立即从 resume snapshot 恢复旧歌曲 A 的播放状态；
2. `PlaybackFeatureOwner` 的播放队列则在启动后异步加载；
3. 用户在队列快照加载完成前进入新歌单并点击“全部播放”，新歌单已经替换当前队列并准备播放 B；
4. 随后旧的启动队列快照到达，`PlaybackQueueController.restore()` 无条件覆盖 live queue，导致当前队列/歌曲重新回到 A。

因此表象与 #111 很像，但根因不是 Media3 resume，而是 startup queue hydration 晚于用户操作。

## 修复

- 启动队列快照只允许应用到仍处于初始 pristine 状态的 `PlaybackQueueController`。
- 如果用户已经选择歌曲、替换歌单、添加待播歌曲或修改队列策略，则当前 live queue 视为更新状态，延迟到达的启动快照不再覆盖它。
- 单纯的 `RESUME` 播放意图不会阻止正常启动队列恢复，避免破坏“重启后继续旧歌曲并恢复原队列”的行为。

## 回归覆盖

新增测试覆盖：

- 旧 A 队列延迟恢复时，新歌单 B 已经替换队列 -> 保留 B；
- 队列策略已经被用户修改 -> 延迟启动快照不覆盖；
- 仅存在 `RESUME` 意图、队列本身尚未修改 -> 仍正常恢复旧队列；
- 原有 snapshot/restore 行为保持不变。

## 影响范围

仅调整启动阶段持久化队列快照的应用条件，不修改 Media3 播放逻辑、播放计划和队列持久化格式。