### PR TITLE
fix: make active playback replacement transactional

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
@@ -380,13 +380,17 @@ internal class PlaybackQueueCoordinator(
                 queueState.mainQueueIndex = 0
             }
         }
-        publishQueueMutation()
+
+        // Starting the selected track is part of the same queue-replacement transaction. Do not
+        // publish the new queue first: Android runtime observers may still republish a restored
+        // paused engine state in response and let the old track race the intended selection.
         playMainIndexInternal(
             queueState.mainQueueIndex,
             0,
             TrackChangeDirection.Next,
             if (keepSelectedTrack) PlaybackStartReason.USER_SELECTION else PlaybackStartReason.PLAYLIST_REPLACE,
         )
+        publishQueueMutation()
     }
 
     private fun playMainIndexInternal(
@@ -413,8 +417,8 @@ internal class PlaybackQueueCoordinator(
         queueState.upNextQueue = queueState.upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
         queueState.currentUpNextTrack = track
         queueState.currentIsUpNext = true
-        publishQueueMutation()
         startTrack(track, 0, null, reason)
+        publishQueueMutation()
     }
 
     private fun startTrack(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackStartCoordinator.kt
@@ -97,6 +97,19 @@ internal class PlaybackStartCoordinator(
         }
         queue.updateCurrentTrack(playbackTrack)
         resetLyricsForPlaybackRequest()
+
+        // Establish the platform playback transaction before publishing the new queue/current-track
+        // overlay. Android can still hold a restored paused Media3 session at this point; publishing
+        // B first lets runtime observers republish stale A before the engine has invalidated it.
+        // prepareLoading() is therefore the transaction boundary: after it returns, active selections
+        // have discarded the old resumable session and stale service state is generation-gated.
+        val reasonAwareEngine = playbackEngine as? PlaybackStartReasonAwareEngine
+        if (reasonAwareEngine != null) {
+            reasonAwareEngine.prepareLoading(playbackTrack, startReason)
+        } else {
+            playbackEngine.prepareLoading(playbackTrack)
+        }
+
         publishPlaybackState(
             currentPlaybackState().copy(
                 status = PlayerStatus.Loading,
@@ -111,12 +124,6 @@ internal class PlaybackStartCoordinator(
             )
         )
         persistQueue()
-        val reasonAwareEngine = playbackEngine as? PlaybackStartReasonAwareEngine
-        if (reasonAwareEngine != null) {
-            reasonAwareEngine.prepareLoading(playbackTrack, startReason)
-        } else {
-            playbackEngine.prepareLoading(playbackTrack)
-        }
         setLoading(true)
         setMessage(messageAfterStart ?: "正在播放：${track.title}")
 

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PlaybackStartCoordinatorTest {
     @Test
@@ -80,12 +81,45 @@ class PlaybackStartCoordinatorTest {
         assertNull(fixture.coordinator.startFailure.value)
     }
 
+    @Test
+    fun activeSelectionPreparesEngineBeforePublishingNewPlaybackState() = runTest {
+        val restored = track("netease:restored")
+        val selected = track("qqmusic:selected")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(selected)
+            mainQueueIndex = 0
+            markNextPlaybackStart(PlaybackStartReason.PLAYLIST_REPLACE)
+        }
+        val engine = FakePlaybackEngine(resolvesInternally = true)
+        val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
+        var published = false
+        val fixture = fixture(
+            queue = queue,
+            engine = engine,
+            repository = repository,
+            initialPlaybackState = PlaybackState(status = PlayerStatus.Paused, currentTrack = restored),
+            onPublishPlaybackState = {
+                assertEquals(selected, engine.preparedTrack)
+                assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, engine.preparedReason)
+                published = true
+            },
+        )
+
+        fixture.coordinator.start(selected)
+
+        assertTrue(published)
+        assertEquals(selected, fixture.playbackState.currentTrack)
+        assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
+    }
+
     private fun TestScope.fixture(
         queue: PlaybackQueueController,
         engine: FakePlaybackEngine,
         repository: FakePlaybackRepository,
+        initialPlaybackState: PlaybackState = PlaybackState(),
+        onPublishPlaybackState: (PlaybackState) -> Unit = {},
     ): Fixture {
-        var playbackState = PlaybackState()
+        var playbackState = initialPlaybackState
         var requestSerial = 0L
         var parts = emptyList<PlaybackPart>()
         var currentPartIndex = -1
@@ -96,7 +130,10 @@ class PlaybackStartCoordinatorTest {
             playbackRepository = repository,
             scope = this,
             currentPlaybackState = { playbackState },
-            publishPlaybackState = { playbackState = it },
+            publishPlaybackState = {
+                onPublishPlaybackState(it)
+                playbackState = it
+            },
             prepareTrack = { it },
             unavailablePlaybackPolicy = { UnavailablePlaybackPolicy.Skip },
             smartReplacementProviderIds = { setOf("bilibili") },
@@ -131,7 +168,7 @@ class PlaybackStartCoordinatorTest {
         title = "Original title",
         artists = "Artist",
         album = "Album",
-        source = "netease",
+        source = id.substringBefore(':'),
         sourceType = TrackSourceType.Provider,
         providerId = id,
     )
@@ -156,18 +193,24 @@ class PlaybackStartCoordinatorTest {
 
     private class FakePlaybackEngine(
         private val resolvesInternally: Boolean = false,
-    ) : PlaybackEngine {
+    ) : PlaybackEngine, PlaybackStartReasonAwareEngine {
         private val mutableState = MutableStateFlow(PlaybackState())
         override val state: StateFlow<PlaybackState> = mutableState
         override val resolvesResourcesInternally: Boolean get() = resolvesInternally
 
         var preparedTrack: MusicTrack? = null
+        var preparedReason: PlaybackStartReason? = null
         var playedTrack: MusicTrack? = null
         var playedPayload: PlaybackPayload? = null
         var playedPlan: PlaybackPlan? = null
 
         override fun prepareLoading(track: MusicTrack) {
             preparedTrack = track
+        }
+
+        override fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason) {
+            preparedTrack = track
+            preparedReason = reason
         }
 
         override fun play(track: MusicTrack, payload: PlaybackPayload) {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
@@ -75,16 +75,16 @@ class PlaybackStartReasonTest {
         var playbackStarted = false
         val coordinator = coordinator(
             queue = queue,
-            onStart = { track, _, _ ->
-                playbackStarted = true
-                startedTrack = track
-                startReason = queue.consumePlaybackStartReason()
-            },
             onQueueUpdate = {
                 // Reproduce the old Android race: publishing the replacement queue caused runtime
                 // observers to republish the restored paused track, which synchronized it into the
                 // current queue slot before startPlayback() read that slot.
                 if (!playbackStarted) queue.updateCurrentTrack(restoredTrack)
+            },
+            onStart = { track, _, _ ->
+                playbackStarted = true
+                startedTrack = track
+                startReason = queue.consumePlaybackStartReason()
             },
         )
 
@@ -141,8 +141,8 @@ class PlaybackStartReasonTest {
 
     private fun TestScope.coordinator(
         queue: PlaybackQueueController,
-        onStart: (MusicTrack, Int, Int?) -> Unit,
         onQueueUpdate: () -> Unit = {},
+        onStart: (MusicTrack, Int, Int?) -> Unit,
     ): PlaybackQueueCoordinator = PlaybackQueueCoordinator(
         queue = queue,
         scope = this,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
@@ -62,6 +62,42 @@ class PlaybackStartReasonTest {
     }
 
     @Test
+    fun restoredTrackCannotReplaceNewPlaylistBeforeFirstStart() = runTest {
+        val restoredTrack = track("track:restored")
+        val first = track("track:new-first")
+        val second = track("track:new-second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(restoredTrack)
+            mainQueueIndex = 0
+        }
+        var startedTrack: MusicTrack? = null
+        var startReason: PlaybackStartReason? = null
+        var playbackStarted = false
+        val coordinator = coordinator(
+            queue = queue,
+            onStart = { track, _, _ ->
+                playbackStarted = true
+                startedTrack = track
+                startReason = queue.consumePlaybackStartReason()
+            },
+            onQueueUpdate = {
+                // Reproduce the old Android race: publishing the replacement queue caused runtime
+                // observers to republish the restored paused track, which synchronized it into the
+                // current queue slot before startPlayback() read that slot.
+                if (!playbackStarted) queue.updateCurrentTrack(restoredTrack)
+            },
+        )
+
+        coordinator.playAllPlaylistTracks(
+            tracks = listOf(first, second),
+            sourcePlaylistId = "playlist:new",
+        )
+
+        assertEquals(first, startedTrack)
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, startReason)
+    }
+
+    @Test
     fun startingCurrentTrackUsesResumeReason() = runTest {
         val pausedTrack = track("track:a")
         val queue = PlaybackQueueController().apply {
@@ -106,6 +142,7 @@ class PlaybackStartReasonTest {
     private fun TestScope.coordinator(
         queue: PlaybackQueueController,
         onStart: (MusicTrack, Int, Int?) -> Unit,
+        onQueueUpdate: () -> Unit = {},
     ): PlaybackQueueCoordinator = PlaybackQueueCoordinator(
         queue = queue,
         scope = this,
@@ -115,7 +152,7 @@ class PlaybackStartReasonTest {
         startPlayback = onStart,
         stopPlayback = {},
         persistQueue = {},
-        updateQueueState = {},
+        updateQueueState = onQueueUpdate,
         appendFeatureQueue = { 0 },
         setTrackChangeDirection = {},
         setMessage = {},


### PR DESCRIPTION
## 问题

应用重启恢复暂停歌曲 A 后，第一次对新歌单点击“播放全部”仍可能播放 A，第二次点击才正常播放新歌单第一首 B。

前两次修复分别处理了 Media3 paused session 复用和启动 queue snapshot 延迟覆盖，但仍存在一条更早的发布竞态：

1. 新歌单队列先被写成 B/C/D；
2. queue mutation / playback overlay 先对 runtime 发布；
3. Android runtime 观察到状态变化时仍可能 `republishRestoredState(A)`；
4. 此时 Android engine 尚未执行 `prepareLoading(B, PLAYLIST_REPLACE)`，旧恢复态仍有效；
5. 恢复态 A 因而能在新播放事务真正建立前重新参与状态同步，导致第一次主动选择失效。

## 完整修复

把主动播放改成严格的事务顺序，而不是继续添加恢复态特判：

- `PlaybackQueueCoordinator`
  - 替换主队列或切换 Up Next 当前项时，先进入 `startPlayback()`，再发布额外的 queue mutation。
  - 不再暴露“新队列已经生效、但 engine 仍属于旧恢复会话”的中间状态。

- `PlaybackStartCoordinator`
  - 先执行 engine `prepareLoading()`，再发布新的 current track / Loading overlay。
  - 对 Android active selection，`prepareLoading()` 会同步清理 restored session、进入 `startingPlayback/freshStartPending`，并启用 generation gate；因此 B 对 runtime 可见之前，A 已经失去恢复态发布权限。
  - RESUME / RESTORE_SESSION 仍保留原恢复语义。

## 回归测试

- 模拟 queue replacement 发布时旧恢复歌曲 A 反向写回当前 slot：第一次 `playAllPlaylistTracks()` 必须仍以 B 启动。
- 验证 active selection 中 reason-aware engine 的 `prepareLoading(B, PLAYLIST_REPLACE)` 必须发生在新 playback state 发布之前。
- 保留原 USER_SELECTION / PLAYLIST_REPLACE / AUTO_NEXT / RESUME reason 覆盖。

## 影响范围

不修改持久化格式，不增加新的 Android Media3 特判；修正的是 shared playback transaction 的发布顺序，因此 Android 恢复场景和其他平台播放事务采用同一顺序约束。