### PR TITLE
feat: support BYD instrument lyrics

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.BYDAUTO_INSTRUMENT_COMMON" />
+    <uses-permission android:name="android.permission.BYDAUTO_INSTRUMENT_SET" />
 
     <queries>
         <package android:name="io.github.proify.lyricon" />

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.BYDAUTO_INSTRUMENT_COMMON" />
+    <uses-permission android:name="android.permission.BYDAUTO_INSTRUMENT_GET" />
     <uses-permission android:name="android.permission.BYDAUTO_INSTRUMENT_SET" />
 
     <queries>

--- a/androidApp/src/main/java/org/feeluown/mobile/BydPermissionContext.java
+++ b/androidApp/src/main/java/org/feeluown/mobile/BydPermissionContext.java
@@ -5,35 +5,41 @@ import android.content.ContextWrapper;
 import android.content.pm.PackageManager;
 
 final class BydPermissionContext extends ContextWrapper {
+    private static final String INSTRUMENT_COMMON = "android.permission.BYDAUTO_INSTRUMENT_COMMON";
+    private static final String INSTRUMENT_GET = "android.permission.BYDAUTO_INSTRUMENT_GET";
+    private static final String INSTRUMENT_SET = "android.permission.BYDAUTO_INSTRUMENT_SET";
+
     BydPermissionContext(Context base) {
         super(base);
     }
 
-    private static boolean isBydAutoPermission(String permission) {
-        return permission != null && permission.startsWith("android.permission.BYDAUTO_");
+    private static boolean isBydInstrumentPermission(String permission) {
+        return INSTRUMENT_COMMON.equals(permission)
+                || INSTRUMENT_GET.equals(permission)
+                || INSTRUMENT_SET.equals(permission);
     }
 
     @Override
     public void enforceCallingOrSelfPermission(String permission, String message) {
-        if (isBydAutoPermission(permission)) return;
+        if (isBydInstrumentPermission(permission)) return;
         super.enforceCallingOrSelfPermission(permission, message);
     }
 
     @Override
     public int checkCallingOrSelfPermission(String permission) {
-        if (isBydAutoPermission(permission)) return PackageManager.PERMISSION_GRANTED;
+        if (isBydInstrumentPermission(permission)) return PackageManager.PERMISSION_GRANTED;
         return super.checkCallingOrSelfPermission(permission);
     }
 
     @Override
     public void enforcePermission(String permission, int pid, int uid, String message) {
-        if (isBydAutoPermission(permission)) return;
+        if (isBydInstrumentPermission(permission)) return;
         super.enforcePermission(permission, pid, uid, message);
     }
 
     @Override
     public int checkPermission(String permission, int pid, int uid) {
-        if (isBydAutoPermission(permission)) return PackageManager.PERMISSION_GRANTED;
+        if (isBydInstrumentPermission(permission)) return PackageManager.PERMISSION_GRANTED;
         return super.checkPermission(permission, pid, uid);
     }
 }

--- a/androidApp/src/main/java/org/feeluown/mobile/BydPermissionContext.java
+++ b/androidApp/src/main/java/org/feeluown/mobile/BydPermissionContext.java
@@ -1,0 +1,39 @@
+package org.feeluown.mobile;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.PackageManager;
+
+final class BydPermissionContext extends ContextWrapper {
+    BydPermissionContext(Context base) {
+        super(base);
+    }
+
+    private static boolean isBydAutoPermission(String permission) {
+        return permission != null && permission.startsWith("android.permission.BYDAUTO_");
+    }
+
+    @Override
+    public void enforceCallingOrSelfPermission(String permission, String message) {
+        if (isBydAutoPermission(permission)) return;
+        super.enforceCallingOrSelfPermission(permission, message);
+    }
+
+    @Override
+    public int checkCallingOrSelfPermission(String permission) {
+        if (isBydAutoPermission(permission)) return PackageManager.PERMISSION_GRANTED;
+        return super.checkCallingOrSelfPermission(permission);
+    }
+
+    @Override
+    public void enforcePermission(String permission, int pid, int uid, String message) {
+        if (isBydAutoPermission(permission)) return;
+        super.enforcePermission(permission, pid, uid, message);
+    }
+
+    @Override
+    public int checkPermission(String permission, int pid, int uid) {
+        if (isBydAutoPermission(permission)) return PackageManager.PERMISSION_GRANTED;
+        return super.checkPermission(permission, pid, uid);
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -21,6 +21,7 @@ internal class AndroidAppContainer(
     private val context: Context = application.applicationContext
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var lyriconLyricsPublisher: LyriconLyricsPublisher? = null
+    private var bydInstrumentLyricsPublisher: BydInstrumentLyricsPublisher? = null
 
     val providerRepository: ProviderMusicRepository by lazy {
         createFuoProviderRepository(
@@ -245,6 +246,7 @@ internal class AndroidAppContainer(
             debugLogViewerAvailable = debugLogFeatureController.isAvailable,
             navigator = navigator,
             scope = appScope,
+            bydInstrumentLyricsAvailable = isBydInstrumentLyricsAvailable(),
         )
     }
 
@@ -348,6 +350,16 @@ internal class AndroidAppContainer(
                 .distinctUntilChanged(),
             scope = appScope,
         ).also(LyriconLyricsPublisher::start)
+        if (isBydInstrumentLyricsAvailable()) {
+            bydInstrumentLyricsPublisher = BydInstrumentLyricsPublisher(
+                context = context,
+                playbackSession = session,
+                enabled = settingsRepository.state
+                    .map { state -> state.settings.bydInstrumentLyricsEnabled }
+                    .distinctUntilChanged(),
+                scope = appScope,
+            ).also(BydInstrumentLyricsPublisher::start)
+        }
 
         FuoPlaybackService.transportControls = object : FuoPlaybackService.TransportControls {
             override fun toggle() = session.toggle()
@@ -378,6 +390,8 @@ internal class AndroidAppContainer(
 
     override fun close() {
         FuoPlaybackService.transportControls = null
+        bydInstrumentLyricsPublisher?.close()
+        bydInstrumentLyricsPublisher = null
         lyriconLyricsPublisher?.close()
         lyriconLyricsPublisher = null
         appScope.cancel()

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -20,13 +20,21 @@ internal const val BYD_INSTRUMENT_DEVICE_CLASS = "android.hardware.bydauto.instr
 
 internal fun isBydInstrumentLyricsAvailable(): Boolean = runCatching {
     val instrumentClass = Class.forName(BYD_INSTRUMENT_DEVICE_CLASS)
-    instrumentClass.methods.any { method ->
-        method.name == "sendThreeLineLyrics" &&
-            method.parameterTypes.contentEquals(
-                arrayOf(String::class.java, String::class.java, String::class.java),
-            )
-    } && instrumentClass.methods.any { method -> method.name == "getInstance" }
+    val hasInstanceFactory = instrumentClass.methods.any { method -> method.name == "getInstance" }
+    val hasThreeLineLyrics = instrumentClass.methods.any(::isThreeLineLyricsMethod)
+    val hasMusicName = instrumentClass.methods.any(::isMusicNameMethod)
+    hasInstanceFactory && (hasThreeLineLyrics || hasMusicName)
 }.getOrDefault(false)
+
+private fun isThreeLineLyricsMethod(method: Method): Boolean =
+    method.name == "sendThreeLineLyrics" &&
+        method.parameterTypes.contentEquals(
+            arrayOf(String::class.java, String::class.java, String::class.java),
+        )
+
+private fun isMusicNameMethod(method: Method): Boolean =
+    method.name == "sendMusicName" &&
+        method.parameterTypes.contentEquals(arrayOf(String::class.java))
 
 internal class BydInstrumentLyricsPublisher(
     context: Context,
@@ -42,6 +50,7 @@ internal class BydInstrumentLyricsPublisher(
     private var publicationFailed = false
     private var lastTrackKey: String? = null
     private var lastWindow: InstrumentLyricsWindow? = null
+    private var lastStatus: PlaybackSessionStatus? = null
     private var hasPublishedLyrics = false
     private var cachedLyricsKey: String? = null
     private var cachedPayload: StatusBarLyricsPayload = StatusBarLyricsPayload.Empty
@@ -113,15 +122,16 @@ internal class BydInstrumentLyricsPublisher(
         }
 
         val trackKey = listOf(track.source, track.id, track.title, track.artists).joinToString("\u0000")
-        if (trackKey == lastTrackKey && window == lastWindow) return true
+        if (trackKey == lastTrackKey && window == lastWindow && snapshot.status == lastStatus) return true
 
         val activeBridge = ensureBridge() ?: return false
-        if (!activeBridge.sendThreeLineLyrics(window.previous, window.current, window.next)) {
+        if (!activeBridge.publish(window, snapshot.status)) {
             publicationFailed = true
             return false
         }
         lastTrackKey = trackKey
         lastWindow = window
+        lastStatus = snapshot.status
         hasPublishedLyrics = true
         return true
     }
@@ -176,7 +186,10 @@ internal class BydInstrumentLyricsPublisher(
                 Log.w(TAG, "Unable to initialize BYD instrument lyrics; playback is unaffected", throwable)
             }
             .getOrNull()
-            ?.also { bridge = it }
+            ?.also { createdBridge ->
+                Log.i(TAG, "Using BYD instrument lyrics transport=${createdBridge.transportName}")
+                bridge = createdBridge
+            }
     }
 
     private fun deactivate() {
@@ -194,10 +207,11 @@ internal class BydInstrumentLyricsPublisher(
 
     private fun clearPublishedLyrics() {
         if (hasPublishedLyrics) {
-            bridge?.sendThreeLineLyrics("", "", "")
+            bridge?.clear()
         }
         lastTrackKey = null
         lastWindow = null
+        lastStatus = null
         hasPublishedLyrics = false
     }
 
@@ -218,18 +232,87 @@ internal class BydInstrumentLyricsPublisher(
 
 private class BydInstrumentLyricsBridge(
     private val device: Any,
-    private val sendThreeLineLyricsMethod: Method,
+    private val threeLineLyricsMethod: Method?,
+    private val musicNameMethod: Method?,
+    private val musicStateMethod: Method?,
+    private val musicSourceMethod: Method?,
+    private val musicPlayValue: Int?,
+    private val musicPauseValue: Int?,
+    private val musicStopValue: Int?,
+    private val musicSourceOthersValue: Int?,
 ) {
-    fun sendThreeLineLyrics(previous: String, current: String, next: String): Boolean = runCatching {
-        val result = sendThreeLineLyricsMethod.invoke(device, previous, current, next)
-        val success = (result as? Number)?.toInt()?.let { it == 0 } ?: true
-        if (!success) {
-            Log.w(TAG, "BYD sendThreeLineLyrics returned $result")
+    val transportName: String = if (threeLineLyricsMethod != null) "three-line" else "DiLink-music-name"
+
+    private var lastMusicStateValue: Int? = null
+    private var musicSourceInitialized = false
+
+    fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
+        threeLineLyricsMethod?.let { method ->
+            return invokeRequired(method, window.previous, window.current, window.next)
         }
-        success
+
+        val nameMethod = musicNameMethod ?: return false
+        initializeMusicSourceIfAvailable()
+        publishMusicStateIfAvailable(status)
+        return invokeRequired(nameMethod, window.current)
+    }
+
+    fun clear() {
+        if (threeLineLyricsMethod != null) {
+            invokeOptional(threeLineLyricsMethod, "", "", "")
+            return
+        }
+        musicNameMethod?.let { invokeOptional(it, "") }
+        publishMusicStateValueIfAvailable(musicStopValue)
+    }
+
+    private fun initializeMusicSourceIfAvailable() {
+        if (musicSourceInitialized) return
+        musicSourceInitialized = true
+        val method = musicSourceMethod ?: return
+        val value = musicSourceOthersValue ?: return
+        invokeOptional(method, value)
+    }
+
+    private fun publishMusicStateIfAvailable(status: PlaybackSessionStatus) {
+        val value = when (status) {
+            PlaybackSessionStatus.Playing -> musicPlayValue
+            PlaybackSessionStatus.Paused -> musicPauseValue
+            PlaybackSessionStatus.Ended,
+            PlaybackSessionStatus.Idle,
+            PlaybackSessionStatus.Error,
+            -> musicStopValue
+            PlaybackSessionStatus.Loading -> null
+        }
+        publishMusicStateValueIfAvailable(value)
+    }
+
+    private fun publishMusicStateValueIfAvailable(value: Int?) {
+        val method = musicStateMethod ?: return
+        val stateValue = value ?: return
+        if (lastMusicStateValue == stateValue) return
+        if (invokeOptional(method, stateValue)) lastMusicStateValue = stateValue
+    }
+
+    private fun invokeRequired(method: Method, vararg args: Any): Boolean = runCatching {
+        val result = method.invoke(device, *args)
+        commandSucceeded(result)
     }.onFailure { throwable ->
-        Log.w(TAG, "Failed to publish lyrics to BYD instrument", unwrapInvocationException(throwable))
+        Log.w(TAG, "Failed to publish lyrics through ${method.name}", unwrapInvocationException(throwable))
     }.getOrDefault(false)
+
+    private fun invokeOptional(method: Method, vararg args: Any): Boolean = runCatching {
+        val result = method.invoke(device, *args)
+        commandSucceeded(result)
+    }.onFailure { throwable ->
+        Log.d(TAG, "Optional BYD instrument call ${method.name} failed", unwrapInvocationException(throwable))
+    }.getOrDefault(false)
+
+    private fun commandSucceeded(result: Any?): Boolean {
+        val success = (result as? Number)?.toInt()?.let { it == 0 } ?: true
+        if (!success) Log.w(TAG, "BYD instrument command returned $result")
+        return success
+    }
 
     companion object {
         private const val TAG = "BydInstrumentLyrics"
@@ -250,18 +333,36 @@ private class BydInstrumentLyricsBridge(
                 getInstanceMethod.invoke(null, permissionContext)
             } ?: error("BYDAutoInstrumentDevice.getInstance returned null")
 
-            val sendMethod = instrumentClass.getMethod(
-                "sendThreeLineLyrics",
-                String::class.java,
-                String::class.java,
-                String::class.java,
+            val threeLineMethod = instrumentClass.methods.firstOrNull(::isThreeLineLyricsMethod)
+            val musicNameMethod = instrumentClass.methods.firstOrNull(::isMusicNameMethod)
+            if (threeLineMethod == null && musicNameMethod == null) {
+                error("No supported BYD instrument lyrics transport is available")
+            }
+
+            BydInstrumentLyricsBridge(
+                device = device,
+                threeLineLyricsMethod = threeLineMethod,
+                musicNameMethod = musicNameMethod,
+                musicStateMethod = instrumentClass.optionalIntMethod("sendMusicState"),
+                musicSourceMethod = instrumentClass.optionalIntMethod("sendMusicSource"),
+                musicPlayValue = instrumentClass.optionalStaticInt("MUSIC_PLAY"),
+                musicPauseValue = instrumentClass.optionalStaticInt("MUSIC_PAUSE"),
+                musicStopValue = instrumentClass.optionalStaticInt("MUSIC_STOP"),
+                musicSourceOthersValue = instrumentClass.optionalStaticInt("MUSIC_SOURCE_OTHERS"),
             )
-            BydInstrumentLyricsBridge(device, sendMethod)
         }.recoverCatching { throwable ->
             throw unwrapInvocationException(throwable)
         }
     }
 }
+
+private fun Class<*>.optionalIntMethod(name: String): Method? = methods.firstOrNull { method ->
+    method.name == name && method.parameterTypes.contentEquals(arrayOf(Int::class.javaPrimitiveType))
+}
+
+private fun Class<*>.optionalStaticInt(name: String): Int? = runCatching {
+    getField(name).getInt(null)
+}.getOrNull()
 
 private fun unwrapInvocationException(throwable: Throwable): Throwable =
     (throwable as? InvocationTargetException)?.targetException ?: throwable

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -1,0 +1,185 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import android.util.Log
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.core.model.TrackRef
+import org.feeluown.mobile.playback.api.PlaybackSession
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+
+internal const val BYD_INSTRUMENT_DEVICE_CLASS = "android.hardware.bydauto.instrument.BYDAutoInstrumentDevice"
+
+internal fun isBydInstrumentLyricsAvailable(): Boolean = runCatching {
+    val instrumentClass = Class.forName(BYD_INSTRUMENT_DEVICE_CLASS)
+    instrumentClass.methods.any { method ->
+        method.name == "sendThreeLineLyrics" &&
+            method.parameterTypes.contentEquals(
+                arrayOf(String::class.java, String::class.java, String::class.java),
+            )
+    } && instrumentClass.methods.any { method -> method.name == "getInstance" }
+}.getOrDefault(false)
+
+internal class BydInstrumentLyricsPublisher(
+    context: Context,
+    private val playbackSession: PlaybackSession,
+    private val enabled: Flow<Boolean>,
+    private val scope: CoroutineScope,
+) {
+    private val appContext = context.applicationContext
+    private var collectJob: Job? = null
+    private var bridge: BydInstrumentLyricsBridge? = null
+    private var lastTrackKey: String? = null
+    private var lastWindow: InstrumentLyricsWindow? = null
+    private var hasPublishedLyrics = false
+
+    fun start() {
+        if (collectJob != null) return
+        collectJob = scope.launch {
+            combine(
+                playbackSession.state,
+                enabled.distinctUntilChanged(),
+            ) { state, isEnabled ->
+                Snapshot(
+                    enabled = isEnabled,
+                    status = state.status,
+                    track = state.currentTrack,
+                    positionMs = state.positionMs,
+                    durationMs = state.durationMs,
+                    lyrics = state.lyrics,
+                )
+            }
+                .distinctUntilChanged()
+                .collect(::publish)
+        }
+    }
+
+    fun close() {
+        collectJob?.cancel()
+        collectJob = null
+        clearPublishedLyrics()
+        bridge = null
+    }
+
+    private fun publish(snapshot: Snapshot) {
+        val track = snapshot.track
+        if (
+            !snapshot.enabled ||
+            track == null ||
+            snapshot.status == PlaybackSessionStatus.Idle ||
+            snapshot.status == PlaybackSessionStatus.Error ||
+            snapshot.status == PlaybackSessionStatus.Ended
+        ) {
+            clearPublishedLyrics()
+            return
+        }
+
+        val payload = buildStatusBarLyricsPayload(
+            rawLyrics = snapshot.lyrics,
+            durationMs = snapshot.durationMs.takeIf { it > 0L } ?: track.durationMs,
+        )
+        val window = buildInstrumentLyricsWindow(payload, snapshot.positionMs)
+        if (window == null) {
+            clearPublishedLyrics()
+            return
+        }
+
+        val trackKey = listOf(track.source, track.id, track.title, track.artists).joinToString("\u0000")
+        if (trackKey == lastTrackKey && window == lastWindow) return
+
+        val activeBridge = ensureBridge() ?: return
+        if (activeBridge.sendThreeLineLyrics(window.previous, window.current, window.next)) {
+            lastTrackKey = trackKey
+            lastWindow = window
+            hasPublishedLyrics = true
+        }
+    }
+
+    private fun ensureBridge(): BydInstrumentLyricsBridge? {
+        bridge?.let { return it }
+        return BydInstrumentLyricsBridge.create(appContext)
+            .onFailure { throwable ->
+                Log.w(TAG, "Unable to initialize BYD instrument lyrics; playback is unaffected", throwable)
+            }
+            .getOrNull()
+            ?.also { bridge = it }
+    }
+
+    private fun clearPublishedLyrics() {
+        if (hasPublishedLyrics) {
+            bridge?.sendThreeLineLyrics("", "", "")
+        }
+        lastTrackKey = null
+        lastWindow = null
+        hasPublishedLyrics = false
+    }
+
+    private data class Snapshot(
+        val enabled: Boolean,
+        val status: PlaybackSessionStatus,
+        val track: TrackRef?,
+        val positionMs: Long,
+        val durationMs: Long,
+        val lyrics: String?,
+    )
+
+    private companion object {
+        const val TAG = "BydInstrumentLyrics"
+    }
+}
+
+private class BydInstrumentLyricsBridge(
+    private val device: Any,
+    private val sendThreeLineLyricsMethod: Method,
+) {
+    fun sendThreeLineLyrics(previous: String, current: String, next: String): Boolean = runCatching {
+        val result = sendThreeLineLyricsMethod.invoke(device, previous, current, next)
+        val success = (result as? Number)?.toInt()?.let { it == 0 } ?: true
+        if (!success) {
+            Log.w(TAG, "BYD sendThreeLineLyrics returned $result")
+        }
+        success
+    }.onFailure { throwable ->
+        Log.w(TAG, "Failed to publish lyrics to BYD instrument", unwrapInvocationException(throwable))
+    }.getOrDefault(false)
+
+    companion object {
+        private const val TAG = "BydInstrumentLyrics"
+
+        fun create(context: Context): Result<BydInstrumentLyricsBridge> = runCatching {
+            val instrumentClass = Class.forName(BYD_INSTRUMENT_DEVICE_CLASS)
+            val permissionContext = BydPermissionContext(context.applicationContext)
+            val getInstanceMethod = instrumentClass.methods.firstOrNull { method ->
+                method.name == "getInstance" &&
+                    method.parameterTypes.contentEquals(arrayOf(Context::class.java))
+            } ?: instrumentClass.methods.firstOrNull { method ->
+                method.name == "getInstance" && method.parameterCount == 0
+            } ?: error("BYDAutoInstrumentDevice.getInstance is unavailable")
+
+            val device = if (getInstanceMethod.parameterCount == 0) {
+                getInstanceMethod.invoke(null)
+            } else {
+                getInstanceMethod.invoke(null, permissionContext)
+            } ?: error("BYDAutoInstrumentDevice.getInstance returned null")
+
+            val sendMethod = instrumentClass.getMethod(
+                "sendThreeLineLyrics",
+                String::class.java,
+                String::class.java,
+                String::class.java,
+            )
+            BydInstrumentLyricsBridge(device, sendMethod)
+        }.recoverCatching { throwable ->
+            throw unwrapInvocationException(throwable)
+        }
+    }
+}
+
+private fun unwrapInvocationException(throwable: Throwable): Throwable =
+    (throwable as? InvocationTargetException)?.targetException ?: throwable

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -65,7 +65,7 @@ internal class BydInstrumentLyricsPublisher(
             combine(
                 playbackSession.state,
                 enabled.distinctUntilChanged(),
-                BydInstrumentPermissionState.granted.distinctUntilChanged(),
+                BydInstrumentPermissionState.granted,
             ) { state, isEnabled, permissionGranted ->
                 Snapshot(
                     enabled = isEnabled,

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -65,9 +65,11 @@ internal class BydInstrumentLyricsPublisher(
             combine(
                 playbackSession.state,
                 enabled.distinctUntilChanged(),
-            ) { state, isEnabled ->
+                BydInstrumentPermissionState.granted.distinctUntilChanged(),
+            ) { state, isEnabled, permissionGranted ->
                 Snapshot(
                     enabled = isEnabled,
+                    permissionGranted = permissionGranted,
                     status = state.status,
                     track = state.currentTrack,
                     positionMs = state.positionMs,
@@ -100,6 +102,11 @@ internal class BydInstrumentLyricsPublisher(
             snapshot.status == PlaybackSessionStatus.Ended
         ) {
             deactivate()
+            return
+        }
+
+        if (!snapshot.permissionGranted) {
+            suspendForPermission()
             return
         }
 
@@ -165,7 +172,14 @@ internal class BydInstrumentLyricsPublisher(
         positionSyncJob = scope.launch {
             while (true) {
                 val snapshot = latestSnapshot ?: break
-                if (!snapshot.enabled || snapshot.status != PlaybackSessionStatus.Playing || snapshot.track == null) break
+                if (
+                    !snapshot.enabled ||
+                    !snapshot.permissionGranted ||
+                    snapshot.status != PlaybackSessionStatus.Playing ||
+                    snapshot.track == null
+                ) {
+                    break
+                }
                 if (!publishAtPosition(snapshot, estimatedPositionMs())) break
                 delay(POSITION_SYNC_INTERVAL_MS)
             }
@@ -190,6 +204,17 @@ internal class BydInstrumentLyricsPublisher(
                 Log.i(TAG, "Using BYD instrument lyrics transport=${createdBridge.transportName}")
                 bridge = createdBridge
             }
+    }
+
+    private fun suspendForPermission() {
+        stopPositionSyncLoop()
+        bridge = null
+        bridgeInitializationAttempted = false
+        publicationFailed = false
+        lastTrackKey = null
+        lastWindow = null
+        lastStatus = null
+        hasPublishedLyrics = false
     }
 
     private fun deactivate() {
@@ -217,6 +242,7 @@ internal class BydInstrumentLyricsPublisher(
 
     private data class Snapshot(
         val enabled: Boolean,
+        val permissionGranted: Boolean,
         val status: PlaybackSessionStatus,
         val track: TrackRef?,
         val positionMs: Long,
@@ -241,14 +267,26 @@ private class BydInstrumentLyricsBridge(
     private val musicStopValue: Int?,
     private val musicSourceOthersValue: Int?,
 ) {
-    val transportName: String = if (threeLineLyricsMethod != null) "three-line" else "DiLink-music-name"
+    val transportName: String
+        get() = if (useMusicNameTransport || threeLineLyricsMethod == null) {
+            "DiLink-music-name"
+        } else {
+            "three-line"
+        }
 
+    private var useMusicNameTransport = threeLineLyricsMethod == null
     private var lastMusicStateValue: Int? = null
     private var musicSourceInitialized = false
 
     fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
-        threeLineLyricsMethod?.let { method ->
-            return invokeRequired(method, window.previous, window.current, window.next)
+        if (!useMusicNameTransport) {
+            val method = threeLineLyricsMethod
+            if (method != null && invokeRequired(method, window.previous, window.current, window.next)) {
+                return true
+            }
+            if (musicNameMethod == null) return false
+            useMusicNameTransport = true
+            Log.w(TAG, "Falling back to BYD sendMusicName after three-line lyrics publishing failed")
         }
 
         val nameMethod = musicNameMethod ?: return false
@@ -258,9 +296,9 @@ private class BydInstrumentLyricsBridge(
     }
 
     fun clear() {
-        if (threeLineLyricsMethod != null) {
-            invokeOptional(threeLineLyricsMethod, "", "", "")
-            return
+        if (!useMusicNameTransport) {
+            val method = threeLineLyricsMethod
+            if (method != null && invokeOptional(method, "", "", "")) return
         }
         musicNameMethod?.let { invokeOptional(it, "") }
         publishMusicStateValueIfAvailable(musicStopValue)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -1,11 +1,13 @@
 package org.feeluown.mobile
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -34,10 +36,17 @@ internal class BydInstrumentLyricsPublisher(
 ) {
     private val appContext = context.applicationContext
     private var collectJob: Job? = null
+    private var positionSyncJob: Job? = null
     private var bridge: BydInstrumentLyricsBridge? = null
     private var lastTrackKey: String? = null
     private var lastWindow: InstrumentLyricsWindow? = null
     private var hasPublishedLyrics = false
+    private var cachedLyricsKey: String? = null
+    private var cachedPayload: StatusBarLyricsPayload = StatusBarLyricsPayload.Empty
+    private var anchorPositionMs: Long = 0L
+    private var anchorRealtimeMs: Long = 0L
+    private var anchorPlaying: Boolean = false
+    private var latestSnapshot: Snapshot? = null
 
     fun start() {
         if (collectJob != null) return
@@ -63,11 +72,14 @@ internal class BydInstrumentLyricsPublisher(
     fun close() {
         collectJob?.cancel()
         collectJob = null
-        clearPublishedLyrics()
+        deactivate()
         bridge = null
     }
 
     private fun publish(snapshot: Snapshot) {
+        latestSnapshot = snapshot
+        updatePositionAnchor(snapshot)
+
         val track = snapshot.track
         if (
             !snapshot.enabled ||
@@ -76,15 +88,22 @@ internal class BydInstrumentLyricsPublisher(
             snapshot.status == PlaybackSessionStatus.Error ||
             snapshot.status == PlaybackSessionStatus.Ended
         ) {
-            clearPublishedLyrics()
+            deactivate()
             return
         }
 
-        val payload = buildStatusBarLyricsPayload(
-            rawLyrics = snapshot.lyrics,
-            durationMs = snapshot.durationMs.takeIf { it > 0L } ?: track.durationMs,
-        )
-        val window = buildInstrumentLyricsWindow(payload, snapshot.positionMs)
+        publishAtPosition(snapshot, snapshot.positionMs)
+        if (snapshot.status == PlaybackSessionStatus.Playing) {
+            ensurePositionSyncLoop()
+        } else {
+            stopPositionSyncLoop()
+        }
+    }
+
+    private fun publishAtPosition(snapshot: Snapshot, positionMs: Long) {
+        val track = snapshot.track ?: return
+        val payload = payloadFor(snapshot, track)
+        val window = buildInstrumentLyricsWindow(payload, positionMs)
         if (window == null) {
             clearPublishedLyrics()
             return
@@ -101,6 +120,47 @@ internal class BydInstrumentLyricsPublisher(
         }
     }
 
+    private fun payloadFor(snapshot: Snapshot, track: TrackRef): StatusBarLyricsPayload {
+        val durationMs = snapshot.durationMs.takeIf { it > 0L } ?: track.durationMs
+        val lyricsKey = listOf(track.source, track.id, snapshot.lyrics.orEmpty(), durationMs).joinToString("\u0000")
+        if (lyricsKey != cachedLyricsKey) {
+            cachedLyricsKey = lyricsKey
+            cachedPayload = buildStatusBarLyricsPayload(
+                rawLyrics = snapshot.lyrics,
+                durationMs = durationMs,
+            )
+        }
+        return cachedPayload
+    }
+
+    private fun updatePositionAnchor(snapshot: Snapshot, realtimeMs: Long = SystemClock.elapsedRealtime()) {
+        anchorPositionMs = snapshot.positionMs.coerceAtLeast(0L)
+        anchorRealtimeMs = realtimeMs
+        anchorPlaying = snapshot.status == PlaybackSessionStatus.Playing
+    }
+
+    private fun estimatedPositionMs(realtimeMs: Long = SystemClock.elapsedRealtime()): Long {
+        if (!anchorPlaying) return anchorPositionMs
+        return (anchorPositionMs + (realtimeMs - anchorRealtimeMs).coerceAtLeast(0L)).coerceAtLeast(0L)
+    }
+
+    private fun ensurePositionSyncLoop() {
+        if (positionSyncJob?.isActive == true) return
+        positionSyncJob = scope.launch {
+            while (true) {
+                val snapshot = latestSnapshot ?: break
+                if (!snapshot.enabled || snapshot.status != PlaybackSessionStatus.Playing || snapshot.track == null) break
+                publishAtPosition(snapshot, estimatedPositionMs())
+                delay(POSITION_SYNC_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun stopPositionSyncLoop() {
+        positionSyncJob?.cancel()
+        positionSyncJob = null
+    }
+
     private fun ensureBridge(): BydInstrumentLyricsBridge? {
         bridge?.let { return it }
         return BydInstrumentLyricsBridge.create(appContext)
@@ -109,6 +169,17 @@ internal class BydInstrumentLyricsPublisher(
             }
             .getOrNull()
             ?.also { bridge = it }
+    }
+
+    private fun deactivate() {
+        stopPositionSyncLoop()
+        clearPublishedLyrics()
+        latestSnapshot = null
+        anchorPositionMs = 0L
+        anchorRealtimeMs = 0L
+        anchorPlaying = false
+        cachedLyricsKey = null
+        cachedPayload = StatusBarLyricsPayload.Empty
     }
 
     private fun clearPublishedLyrics() {
@@ -131,6 +202,7 @@ internal class BydInstrumentLyricsPublisher(
 
     private companion object {
         const val TAG = "BydInstrumentLyrics"
+        const val POSITION_SYNC_INTERVAL_MS = 100L
     }
 }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -38,6 +38,8 @@ internal class BydInstrumentLyricsPublisher(
     private var collectJob: Job? = null
     private var positionSyncJob: Job? = null
     private var bridge: BydInstrumentLyricsBridge? = null
+    private var bridgeInitializationAttempted = false
+    private var publicationFailed = false
     private var lastTrackKey: String? = null
     private var lastWindow: InstrumentLyricsWindow? = null
     private var hasPublishedLyrics = false
@@ -92,32 +94,36 @@ internal class BydInstrumentLyricsPublisher(
             return
         }
 
-        publishAtPosition(snapshot, snapshot.positionMs)
-        if (snapshot.status == PlaybackSessionStatus.Playing) {
+        val canSync = publishAtPosition(snapshot, snapshot.positionMs)
+        if (canSync && snapshot.status == PlaybackSessionStatus.Playing) {
             ensurePositionSyncLoop()
         } else {
             stopPositionSyncLoop()
         }
     }
 
-    private fun publishAtPosition(snapshot: Snapshot, positionMs: Long) {
-        val track = snapshot.track ?: return
+    private fun publishAtPosition(snapshot: Snapshot, positionMs: Long): Boolean {
+        if (publicationFailed) return false
+        val track = snapshot.track ?: return false
         val payload = payloadFor(snapshot, track)
         val window = buildInstrumentLyricsWindow(payload, positionMs)
         if (window == null) {
             clearPublishedLyrics()
-            return
+            return false
         }
 
         val trackKey = listOf(track.source, track.id, track.title, track.artists).joinToString("\u0000")
-        if (trackKey == lastTrackKey && window == lastWindow) return
+        if (trackKey == lastTrackKey && window == lastWindow) return true
 
-        val activeBridge = ensureBridge() ?: return
-        if (activeBridge.sendThreeLineLyrics(window.previous, window.current, window.next)) {
-            lastTrackKey = trackKey
-            lastWindow = window
-            hasPublishedLyrics = true
+        val activeBridge = ensureBridge() ?: return false
+        if (!activeBridge.sendThreeLineLyrics(window.previous, window.current, window.next)) {
+            publicationFailed = true
+            return false
         }
+        lastTrackKey = trackKey
+        lastWindow = window
+        hasPublishedLyrics = true
+        return true
     }
 
     private fun payloadFor(snapshot: Snapshot, track: TrackRef): StatusBarLyricsPayload {
@@ -150,7 +156,7 @@ internal class BydInstrumentLyricsPublisher(
             while (true) {
                 val snapshot = latestSnapshot ?: break
                 if (!snapshot.enabled || snapshot.status != PlaybackSessionStatus.Playing || snapshot.track == null) break
-                publishAtPosition(snapshot, estimatedPositionMs())
+                if (!publishAtPosition(snapshot, estimatedPositionMs())) break
                 delay(POSITION_SYNC_INTERVAL_MS)
             }
         }
@@ -163,6 +169,8 @@ internal class BydInstrumentLyricsPublisher(
 
     private fun ensureBridge(): BydInstrumentLyricsBridge? {
         bridge?.let { return it }
+        if (bridgeInitializationAttempted) return null
+        bridgeInitializationAttempted = true
         return BydInstrumentLyricsBridge.create(appContext)
             .onFailure { throwable ->
                 Log.w(TAG, "Unable to initialize BYD instrument lyrics; playback is unaffected", throwable)
@@ -180,6 +188,8 @@ internal class BydInstrumentLyricsPublisher(
         anchorPlaying = false
         cachedLyricsKey = null
         cachedPayload = StatusBarLyricsPayload.Empty
+        bridgeInitializationAttempted = false
+        publicationFailed = false
     }
 
     private fun clearPublishedLyrics() {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
@@ -1,0 +1,33 @@
+package org.feeluown.mobile
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+internal const val BYD_INSTRUMENT_COMMON_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_COMMON"
+internal const val BYD_INSTRUMENT_GET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_GET"
+internal const val BYD_INSTRUMENT_SET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_SET"
+
+private val BYD_INSTRUMENT_PERMISSIONS = arrayOf(
+    BYD_INSTRUMENT_COMMON_PERMISSION,
+    BYD_INSTRUMENT_GET_PERMISSION,
+    BYD_INSTRUMENT_SET_PERMISSION,
+)
+
+internal fun Activity.requestBydInstrumentPermissionsIfNeeded(requestCode: Int) {
+    if (!isBydInstrumentLyricsAvailable()) return
+    val missingPermissions = declaredBydInstrumentPermissions()
+        .filter { permission ->
+            ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED
+        }
+        .toTypedArray()
+    if (missingPermissions.isEmpty()) return
+    ActivityCompat.requestPermissions(this, missingPermissions, requestCode)
+}
+
+@Suppress("DEPRECATION")
+private fun Activity.declaredBydInstrumentPermissions(): List<String> =
+    BYD_INSTRUMENT_PERMISSIONS.filter { permission ->
+        runCatching { packageManager.getPermissionInfo(permission, 0) }.isSuccess
+    }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
@@ -9,25 +9,22 @@ internal const val BYD_INSTRUMENT_COMMON_PERMISSION = "android.permission.BYDAUT
 internal const val BYD_INSTRUMENT_GET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_GET"
 internal const val BYD_INSTRUMENT_SET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_SET"
 
-private val BYD_INSTRUMENT_PERMISSIONS = arrayOf(
-    BYD_INSTRUMENT_COMMON_PERMISSION,
-    BYD_INSTRUMENT_GET_PERMISSION,
-    BYD_INSTRUMENT_SET_PERMISSION,
-)
-
 internal fun Activity.requestBydInstrumentPermissionsIfNeeded(requestCode: Int) {
     if (!isBydInstrumentLyricsAvailable()) return
-    val missingPermissions = declaredBydInstrumentPermissions()
-        .filter { permission ->
-            ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED
-        }
-        .toTypedArray()
-    if (missingPermissions.isEmpty()) return
-    ActivityCompat.requestPermissions(this, missingPermissions, requestCode)
+    if (!isPermissionDeclared(BYD_INSTRUMENT_COMMON_PERMISSION)) return
+    if (
+        ContextCompat.checkSelfPermission(this, BYD_INSTRUMENT_COMMON_PERMISSION) ==
+        PackageManager.PERMISSION_GRANTED
+    ) {
+        return
+    }
+    ActivityCompat.requestPermissions(
+        this,
+        arrayOf(BYD_INSTRUMENT_COMMON_PERMISSION),
+        requestCode,
+    )
 }
 
 @Suppress("DEPRECATION")
-private fun Activity.declaredBydInstrumentPermissions(): List<String> =
-    BYD_INSTRUMENT_PERMISSIONS.filter { permission ->
-        runCatching { packageManager.getPermissionInfo(permission, 0) }.isSuccess
-    }
+private fun Activity.isPermissionDeclared(permission: String): Boolean =
+    runCatching { packageManager.getPermissionInfo(permission, 0) }.isSuccess

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentPermissions.kt
@@ -1,30 +1,61 @@
 package org.feeluown.mobile
 
-import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
-import androidx.core.app.ActivityCompat
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 internal const val BYD_INSTRUMENT_COMMON_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_COMMON"
 internal const val BYD_INSTRUMENT_GET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_GET"
 internal const val BYD_INSTRUMENT_SET_PERMISSION = "android.permission.BYDAUTO_INSTRUMENT_SET"
 
-internal fun Activity.requestBydInstrumentPermissionsIfNeeded(requestCode: Int) {
+internal object BydInstrumentPermissionState {
+    private val mutableGranted = MutableStateFlow(false)
+    val granted: StateFlow<Boolean> = mutableGranted.asStateFlow()
+
+    fun refresh(context: Context): Boolean {
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            BYD_INSTRUMENT_COMMON_PERMISSION,
+        ) == PackageManager.PERMISSION_GRANTED
+        mutableGranted.value = granted
+        return granted
+    }
+
+    fun update(granted: Boolean) {
+        mutableGranted.value = granted
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+internal fun ComponentActivity.requestBydInstrumentPermissionsIfNeeded(requestCode: Int) {
     if (!isBydInstrumentLyricsAvailable()) return
     if (!isPermissionDeclared(BYD_INSTRUMENT_COMMON_PERMISSION)) return
-    if (
-        ContextCompat.checkSelfPermission(this, BYD_INSTRUMENT_COMMON_PERMISSION) ==
-        PackageManager.PERMISSION_GRANTED
-    ) {
-        return
+
+    val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        BydInstrumentPermissionState.update(
+            granted || BydInstrumentPermissionState.refresh(this),
+        )
     }
-    ActivityCompat.requestPermissions(
-        this,
-        arrayOf(BYD_INSTRUMENT_COMMON_PERMISSION),
-        requestCode,
-    )
+
+    lifecycle.addObserver(object : DefaultLifecycleObserver {
+        override fun onResume(owner: LifecycleOwner) {
+            BydInstrumentPermissionState.refresh(this@requestBydInstrumentPermissionsIfNeeded)
+        }
+    })
+
+    if (BydInstrumentPermissionState.refresh(this)) return
+    permissionLauncher.launch(BYD_INSTRUMENT_COMMON_PERMISSION)
 }
 
 @Suppress("DEPRECATION")
-private fun Activity.isPermissionDeclared(permission: String): Boolean =
+private fun ComponentActivity.isPermissionDeclared(permission: String): Boolean =
     runCatching { packageManager.getPermissionInfo(permission, 0) }.isSuccess

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -38,11 +38,13 @@ private data class PendingLocalPlaylistImport(val fileName: String, val content:
 private const val LOCAL_PLAYLIST_MIME_TYPE = "application/x-fuo"
 private const val CONTENT_URI_SCHEME = "content"
 private const val FILE_URI_SCHEME = "file"
+private const val BYD_INSTRUMENT_PERMISSION_REQUEST_CODE = 4104
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        requestBydInstrumentPermissionsIfNeeded(BYD_INSTRUMENT_PERMISSION_REQUEST_CODE)
         val fuoApplication = application as FuoEvolveApplication
         handleOAuthUserCodeCopyIntent(intent)
         val launchLocalPlaylistImport = localPlaylistImportFromIntent(intent)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
@@ -55,7 +55,7 @@ enum class ThemeColorSpec(
     val label: String,
 ) {
     Material3_2021("Material 3 (2021)"),
-    Expressive_2025("Expressive (2025)"),
+    Expressive_2025("Material 3 (2025)"),
 }
 
 @Serializable
@@ -91,6 +91,7 @@ data class AppSettings(
     val pauseOnOtherAppPlayback: Boolean = DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
     val statusBarLyricsEnabled: Boolean = false,
+    val bydInstrumentLyricsEnabled: Boolean = false,
     val themeMode: ThemeMode = ThemeMode.System,
     val themeColorScheme: ThemeColorScheme = ThemeColorScheme.Dynamic,
     val themePaletteStyle: ThemePaletteStyle = ThemePaletteStyle.Expressive,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
@@ -55,7 +55,7 @@ enum class ThemeColorSpec(
     val label: String,
 ) {
     Material3_2021("Material 3 (2021)"),
-    Expressive_2025("Material 3 (2025)"),
+    Expressive_2025("Expressive (2025)"),
 }
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/InstrumentLyricsWindow.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/InstrumentLyricsWindow.kt
@@ -1,0 +1,45 @@
+package org.feeluown.mobile
+
+data class InstrumentLyricsWindow(
+    val previous: String,
+    val current: String,
+    val next: String,
+)
+
+fun buildInstrumentLyricsWindow(
+    payload: StatusBarLyricsPayload,
+    positionMs: Long,
+): InstrumentLyricsWindow? = when (payload) {
+    StatusBarLyricsPayload.Empty -> null
+    is StatusBarLyricsPayload.Text -> {
+        val lines = payload.text.lineSequence()
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .toList()
+        if (lines.isEmpty()) {
+            null
+        } else {
+            InstrumentLyricsWindow(
+                previous = "",
+                current = lines[0],
+                next = lines.getOrNull(1).orEmpty(),
+            )
+        }
+    }
+    is StatusBarLyricsPayload.Timed -> {
+        val lines = payload.lines
+        if (lines.isEmpty()) {
+            null
+        } else {
+            val safePositionMs = positionMs.coerceAtLeast(0L)
+            val currentIndex = lines.indexOfLast { line -> safePositionMs >= line.beginMs }
+                .coerceAtLeast(0)
+                .coerceAtMost(lines.lastIndex)
+            InstrumentLyricsWindow(
+                previous = lines.getOrNull(currentIndex - 1)?.text.orEmpty(),
+                current = lines[currentIndex].text,
+                next = lines.getOrNull(currentIndex + 1)?.text.orEmpty(),
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
@@ -174,7 +174,7 @@ private class BoundSettingsFeatureController(
     override fun setAudioCacheLimitMb(value: Int) = owner.setAudioCacheLimitMb(value)
     override fun setImageCacheLimitMb(value: Int) = owner.setImageCacheLimitMb(value)
     override fun refreshLocalMusicDirectories() = owner.refreshLocalMusicDirectories()
-    override fun setLocalMusicDirectoryEnabled(directoryId: String, enabled: Boolean) = owner.setDirectoryEnabled(directoryId, enabled)
+    override fun setLocalMusicDirectoryEnabled(directoryId: String, enabled: Boolean) = owner.setLocalMusicDirectoryEnabled(directoryId, enabled)
     override fun setLocalMusicMinDurationSeconds(value: Int) = owner.setLocalMusicMinDurationSeconds(value)
     override fun clearCache() = owner.clearCache()
     override fun refreshCacheUsage() = owner.refreshCacheUsage()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
@@ -2,7 +2,11 @@ package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import org.feeluown.mobile.feature.settings.SettingsAudioQualityPort as CoreAudioQualityPort
 import org.feeluown.mobile.feature.settings.SettingsCachePort as CoreCachePort
 import org.feeluown.mobile.feature.settings.SettingsDownloadPort as CoreDownloadPort
@@ -30,6 +34,7 @@ data class SettingsFeatureUiState(
     val downloadTasks: List<DownloadTask> = emptyList(),
     val localMusic: LocalMusicUiState = LocalMusicUiState(viewMode = LocalMusicViewMode.All),
     val statusBarLyricsAvailable: Boolean = false,
+    val bydInstrumentLyricsAvailable: Boolean = false,
     val debugLogViewerAvailable: Boolean = false,
     val isBusy: Boolean = false,
     val feedback: String? = null,
@@ -65,6 +70,7 @@ interface SettingsFeatureController {
     fun openDebugLogs()
     fun setStatusBarLyricsAvailability(available: Boolean)
     fun setStatusBarLyricsEnabled(enabled: Boolean)
+    fun setBydInstrumentLyricsEnabled(enabled: Boolean)
     fun dismissFeedback(feedback: String)
 }
 
@@ -94,6 +100,7 @@ fun createSettingsFeatureController(
     debugLogViewerAvailable: Boolean,
     navigator: AppNavigator,
     scope: CoroutineScope,
+    bydInstrumentLyricsAvailable: Boolean = false,
 ): SettingsFeatureController {
     val owner = createSettingsFeatureOwner(
         preferences = BoundSettingsPreferencesPort(settingsRepository),
@@ -105,14 +112,30 @@ fun createSettingsFeatureController(
         debugLogViewerAvailable = debugLogViewerAvailable,
         scope = scope,
     )
-    return BoundSettingsFeatureController(owner, settingsRepository)
+    return BoundSettingsFeatureController(
+        owner = owner,
+        settingsRepository = settingsRepository,
+        scope = scope,
+        bydInstrumentLyricsAvailable = bydInstrumentLyricsAvailable,
+    )
 }
 
 private class BoundSettingsFeatureController(
     private val owner: BoundCoreOwner,
     private val settingsRepository: AppSettingsRepository,
+    private val scope: CoroutineScope,
+    private val bydInstrumentLyricsAvailable: Boolean,
 ) : SettingsFeatureController {
-    override val uiState: StateFlow<SettingsFeatureUiState> = owner.state.mapSettingsState(::toUiState)
+    override val uiState: StateFlow<SettingsFeatureUiState> = combine(
+        owner.state,
+        settingsRepository.state,
+    ) { state, settingsState ->
+        toUiState(state, settingsState.settings)
+    }.stateIn(
+        scope = scope,
+        started = SharingStarted.Eagerly,
+        initialValue = toUiState(owner.state.value, settingsRepository.state.value.settings),
+    )
 
     override fun close() = owner.close()
 
@@ -151,7 +174,7 @@ private class BoundSettingsFeatureController(
     override fun setAudioCacheLimitMb(value: Int) = owner.setAudioCacheLimitMb(value)
     override fun setImageCacheLimitMb(value: Int) = owner.setImageCacheLimitMb(value)
     override fun refreshLocalMusicDirectories() = owner.refreshLocalMusicDirectories()
-    override fun setLocalMusicDirectoryEnabled(directoryId: String, enabled: Boolean) = owner.setLocalMusicDirectoryEnabled(directoryId, enabled)
+    override fun setLocalMusicDirectoryEnabled(directoryId: String, enabled: Boolean) = owner.setDirectoryEnabled(directoryId, enabled)
     override fun setLocalMusicMinDurationSeconds(value: Int) = owner.setLocalMusicMinDurationSeconds(value)
     override fun clearCache() = owner.clearCache()
     override fun refreshCacheUsage() = owner.refreshCacheUsage()
@@ -159,14 +182,23 @@ private class BoundSettingsFeatureController(
     override fun openDebugLogs() = owner.openDebugLogs()
     override fun setStatusBarLyricsAvailability(available: Boolean) = owner.setStatusBarLyricsAvailability(available)
     override fun setStatusBarLyricsEnabled(enabled: Boolean) = owner.setStatusBarLyricsEnabled(enabled)
+    override fun setBydInstrumentLyricsEnabled(enabled: Boolean) {
+        scope.launch {
+            settingsRepository.update { settings -> settings.copy(bydInstrumentLyricsEnabled = enabled) }
+        }
+    }
     override fun dismissFeedback(feedback: String) = owner.dismissFeedback(feedback)
 
-    private fun toUiState(state: BoundCoreState): SettingsFeatureUiState = SettingsFeatureUiState(
-        settings = settingsRepository.state.value.settings,
+    private fun toUiState(
+        state: BoundCoreState,
+        appSettings: AppSettings,
+    ): SettingsFeatureUiState = SettingsFeatureUiState(
+        settings = appSettings,
         cacheUsage = state.cacheUsage,
         downloadTasks = state.downloadTasks,
         localMusic = state.localMusic,
         statusBarLyricsAvailable = state.statusBarLyricsAvailable,
+        bydInstrumentLyricsAvailable = bydInstrumentLyricsAvailable,
         debugLogViewerAvailable = state.debugLogViewerAvailable,
         isBusy = state.isBusy,
         feedback = state.feedback,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -99,7 +99,7 @@ private enum class FeatureSettingsCategory(
 ) {
     Sources("音源与账号", "音源启用、排序、登录与显示范围"),
     Playback("播放与音质", "网络音质、播放策略与智能替换"),
-    Appearance("外观与显示", "主题、歌词字号与状态栏歌词"),
+    Appearance("外观与显示", "主题、歌词字号与歌词同步"),
     LocalMusic("本地音乐", "媒体目录扫描与短音频过滤"),
     Storage("下载与存储", "下载行为、缓存上限与清理"),
     About("关于", "版本、项目链接与诊断信息"),
@@ -950,6 +950,16 @@ private fun AppearanceFeatureSettings(
                 checked = settings.statusBarLyricsEnabled,
                 enabled = enabled,
                 onCheckedChange = controller::setStatusBarLyricsEnabled,
+            )
+        }
+        if (state.bydInstrumentLyricsAvailable) {
+            SettingsDivider(startPadding = FuoSpacing.lg)
+            SettingsToggleRow(
+                title = "比亚迪仪表歌词",
+                supportingText = "将当前歌词同步到驾驶仪表的三行歌词区域",
+                checked = settings.bydInstrumentLyricsEnabled,
+                enabled = enabled,
+                onCheckedChange = controller::setBydInstrumentLyricsEnabled,
             )
         }
     }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/InstrumentLyricsWindowTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/InstrumentLyricsWindowTest.kt
@@ -1,0 +1,53 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class InstrumentLyricsWindowTest {
+    @Test
+    fun timedLyricsExposePreviousCurrentAndNextLines() {
+        val payload = StatusBarLyricsPayload.Timed(
+            listOf(
+                StatusBarLyricLine(0, 1_000, "第一行"),
+                StatusBarLyricLine(1_000, 2_000, "第二行"),
+                StatusBarLyricLine(2_000, 3_000, "第三行"),
+            ),
+        )
+
+        assertEquals(
+            InstrumentLyricsWindow("第一行", "第二行", "第三行"),
+            buildInstrumentLyricsWindow(payload, 1_500),
+        )
+    }
+
+    @Test
+    fun positionBeforeFirstTimestampUsesFirstLineAsCurrent() {
+        val payload = StatusBarLyricsPayload.Timed(
+            listOf(
+                StatusBarLyricLine(1_000, 2_000, "第一行"),
+                StatusBarLyricLine(2_000, 3_000, "第二行"),
+            ),
+        )
+
+        assertEquals(
+            InstrumentLyricsWindow("", "第一行", "第二行"),
+            buildInstrumentLyricsWindow(payload, 0),
+        )
+    }
+
+    @Test
+    fun untimedLyricsUseFirstLineAndFollowingLine() {
+        val payload = StatusBarLyricsPayload.Text("第一行\n第二行\n第三行")
+
+        assertEquals(
+            InstrumentLyricsWindow("", "第一行", "第二行"),
+            buildInstrumentLyricsWindow(payload, 10_000),
+        )
+    }
+
+    @Test
+    fun emptyPayloadHasNoWindow() {
+        assertNull(buildInstrumentLyricsWindow(StatusBarLyricsPayload.Empty, 0))
+    }
+}


### PR DESCRIPTION
## Summary

- add a BYD-only instrument lyrics switch under Appearance / playback display
- detect `android.hardware.bydauto.instrument.BYDAutoInstrumentDevice` at runtime so the option stays hidden on unsupported Android devices
- support both BYD instrument transports:
  - `sendThreeLineLyrics(String, String, String)` when the firmware exposes a working dedicated three-line API
  - DiLink 4-compatible `sendMusicName(String)` fallback, updating the current lyric through the instrument music-info channel and syncing available play/pause/source metadata
- if a firmware exposes `sendThreeLineLyrics` but the real call fails, automatically switch once to `sendMusicName` instead of latching publication as failed
- request the DiLink runtime `BYDAUTO_INSTRUMENT_COMMON` ("仪表信息") permission on startup when needed; keep `GET/SET` declared for the SDK while handling their client-side signature checks only inside the isolated BYD adapter
- feed runtime permission changes back into the publisher so granting "仪表信息" immediately retries the current lyric without requiring a playback/state toggle
- reuse the existing normalized lyric parser, including timed LRC/YRC data, and keep line transitions aligned with playback using an elapsed-realtime position anchor
- isolate BYD private-API access behind reflection and a dedicated instrument-only permission-compatible `ContextWrapper`; failures are logged and never affect playback
- clear instrument lyrics when the feature is disabled, playback ends/errors, lyrics disappear, or the Android container closes
- add focused common tests for three-line lyric window selection

## DiLink 4 compatibility

DiLink 4 firmware commonly exposes the instrument music API (`sendMusicName`, `sendMusicState`, `sendMusicSource`) rather than a usable `sendThreeLineLyrics`. Availability accepts either transport, so the settings switch appears on DiLink 4 instead of being hidden by the previous three-line-only capability check.

For DiLink 4 the current lyric line is written through `sendMusicName`. Optional music state/source calls use constants exposed by the runtime class via reflection; no undocumented numeric constants are hard-coded. If both transports are exposed but the three-line call rejects publication, the bridge switches to the verified DiLink 4 music-name path for subsequent lyrics.

## Permissions

The integration declares `BYDAUTO_INSTRUMENT_COMMON/GET/SET`. Startup dynamically requests only `BYDAUTO_INSTRUMENT_COMMON`, which is the user-visible/runtime "仪表信息" permission on applicable DiLink firmware. `GET/SET` are not requested as runtime permissions.

Permission grant/revoke state is refreshed from the Activity Result callback and when the Activity resumes. The publisher observes that state directly, so a newly granted permission clears any transient initialization/publication failure and retries the current playback snapshot immediately.

The permission compatibility wrapper is scoped strictly to `BYDAUTO_INSTRUMENT_COMMON/GET/SET`; it does not grant access to unrelated BYD vehicle APIs.

## Compatibility

The integration does not link against BYD framework classes at compile time. Non-BYD phones/tablets and unsupported head units continue through the normal Android path without creating the publisher. The switch defaults to off.

## Validation

- Android architecture checks, feature/playback/provider runtime tests, shared tests and coverage: passed
- signed multi-ABI release APK build, signing and artifact upload: passed
- shared Android + iOS tests and architecture checks: passed
- debug iOS simulator app build and artifact upload: passed
- all three Codex review threads addressed and resolved; latest-head re-review requested

Latest validated head: `085cef1ea7c799954afedf86665b29426ef88392`.