### PR TITLE
fix: refine app bar and snackbar spacing

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -222,6 +222,13 @@ fun AppRoot(
 
         BoxWithConstraints(Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) { appLayoutInfoFor(maxWidth, maxHeight) }
+            val snackbarBottomPadding = if (
+                playbackGraph.currentTrack != null && !playbackGraph.isFullPlayerOpen
+            ) {
+                if (layoutInfo.useWideLayout) 80.dp else 96.dp
+            } else {
+                16.dp
+            }
             CompositionLocalProvider(
                 LocalPlaybackSession provides appViewModel.playbackSession,
                 LocalPlaybackUiPort provides playbackGraph,
@@ -327,7 +334,15 @@ fun AppRoot(
                                 TrackArtistTargetFeatureDialog(appViewModel.providerTrackActionPort)
                                 SnackbarHost(
                                     hostState = snackbar,
-                                    modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding().padding(16.dp),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomCenter)
+                                        .navigationBarsPadding()
+                                        .padding(
+                                            start = 16.dp,
+                                            top = 16.dp,
+                                            end = 16.dp,
+                                            bottom = snackbarBottomPadding,
+                                        ),
                                 ) { data ->
                                     Snackbar(
                                         snackbarData = data,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -75,6 +75,31 @@ private data class SnackbarFeedbackEvent(
     val dismiss: () -> Unit,
 )
 
+private fun AppRoute.showsMiniPlayer(
+    hasCurrentTrack: Boolean,
+    hasQueueTrack: Boolean,
+    isVideoFullscreen: Boolean,
+): Boolean = when (this) {
+    AppRoute.Home -> hasCurrentTrack
+    AppRoute.LocalPlaylist,
+    AppRoute.LocalMusicCollection,
+    is AppRoute.FeatureDetail,
+    is AppRoute.PlaylistDetail,
+    is AppRoute.TrackDetail,
+    is AppRoute.MediaItemDetail -> hasQueueTrack
+    is AppRoute.VideoDetail -> hasQueueTrack && !isVideoFullscreen
+    AppRoute.Search,
+    AppRoute.AudioRecognition,
+    AppRoute.Settings,
+    AppRoute.DebugLogs,
+    AppRoute.DownloadManager,
+    AppRoute.Feature,
+    AppRoute.Playlist,
+    AppRoute.Track,
+    AppRoute.Video,
+    AppRoute.MediaItem -> false
+}
+
 private fun Flow<String?>.toSnackbarFeedbackEvents(
     lifecycle: Lifecycle,
     dismissFeedback: (String) -> Unit,
@@ -144,6 +169,7 @@ fun AppRoot(
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
     val localPlaylistState by appViewModel.localPlaylistFeatureController.uiState.collectAsStateWithLifecycle()
+    val videoDetailState by appViewModel.providerDetailOwners.video.uiState.collectAsStateWithLifecycle()
     val playbackGraph = appViewModel.playbackUiPort
 
     FuoTheme(
@@ -222,9 +248,13 @@ fun AppRoot(
 
         BoxWithConstraints(Modifier.fillMaxSize()) {
             val layoutInfo = remember(maxWidth, maxHeight) { appLayoutInfoFor(maxWidth, maxHeight) }
-            val snackbarBottomPadding = if (
-                playbackGraph.currentTrack != null && !playbackGraph.isFullPlayerOpen
-            ) {
+            val miniPlayerVisible = !playbackGraph.isFullPlayerOpen &&
+                appUiState.backStack.lastOrNull()?.showsMiniPlayer(
+                    hasCurrentTrack = playbackGraph.currentTrack != null,
+                    hasQueueTrack = playbackGraph.queue.currentQueueTrack != null,
+                    isVideoFullscreen = videoDetailState.isFullscreen,
+                ) == true
+            val snackbarBottomPadding = if (miniPlayerVisible) {
                 if (layoutInfo.useWideLayout) 80.dp else 96.dp
             } else {
                 16.dp

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -80,7 +80,7 @@ fun HomeScreen(
         topBar = {
             if (!layoutInfo.useWideLayout) {
                 CenterAlignedTopAppBar(
-                    title = { Text("FeelUOwn") },
+                    title = {},
                     navigationIcon = {
                         IconButton(onClick = { home.openSettings() }) {
                             Icon(Icons.Filled.Settings, contentDescription = "设置")


### PR DESCRIPTION
## Summary
- remove the `FeelUOwn` title from the compact home top app bar while keeping the app bar actions unchanged
- raise the global Snackbar above the MiniPlayer when a track is active
- use separate narrow/wide offsets matching the MiniPlayer layout height, while keeping the normal 16dp bottom spacing when the full player is open

## Verification
- diff is limited to `HomeScreen.kt` and `AppRoot.kt`
- Snackbar keeps navigation bar padding and existing horizontal/top spacing