### PR TITLE
fix: refresh BYD instrument music session

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -181,6 +181,7 @@ internal class BydInstrumentLyricsPublisher(
                     break
                 }
                 if (!publishAtPosition(snapshot, estimatedPositionMs())) break
+                bridge?.refreshSessionLease(snapshot.status)
                 delay(POSITION_SYNC_INTERVAL_MS)
             }
         }
@@ -276,6 +277,7 @@ private class BydInstrumentLyricsBridge(
 
     private var useMusicNameTransport = threeLineLyricsMethod == null
     private var lastMusicStateValue: Int? = null
+    private var lastMusicSessionRefreshRealtimeMs = 0L
 
     fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
         if (!useMusicNameTransport) {
@@ -293,6 +295,20 @@ private class BydInstrumentLyricsBridge(
         return invokeRequired(nameMethod, window.current)
     }
 
+    fun refreshSessionLease(
+        status: PlaybackSessionStatus,
+        realtimeMs: Long = SystemClock.elapsedRealtime(),
+    ) {
+        if (!useMusicNameTransport || status != PlaybackSessionStatus.Playing) return
+        if (
+            lastMusicSessionRefreshRealtimeMs != 0L &&
+            realtimeMs - lastMusicSessionRefreshRealtimeMs < MUSIC_SESSION_LEASE_INTERVAL_MS
+        ) {
+            return
+        }
+        refreshMusicSession(status, realtimeMs)
+    }
+
     fun clear() {
         if (!useMusicNameTransport) {
             val method = threeLineLyricsMethod
@@ -301,13 +317,17 @@ private class BydInstrumentLyricsBridge(
         musicNameMethod?.let { invokeOptional(it, "") }
         publishMusicStateValueIfAvailable(musicStopValue, force = true)
         lastMusicStateValue = null
+        lastMusicSessionRefreshRealtimeMs = 0L
     }
 
-    private fun refreshMusicSession(status: PlaybackSessionStatus) {
-        // The publisher suppresses identical track/window/status snapshots, so this runs only
-        // for a lyric transition or playback lifecycle change. Reasserting source/state here
-        // lets DiLink reclaim third-party music display after firmware/media interruptions
-        // without introducing a high-frequency heartbeat.
+    private fun refreshMusicSession(
+        status: PlaybackSessionStatus,
+        realtimeMs: Long = SystemClock.elapsedRealtime(),
+    ) {
+        // Reassert source/state on actual lyric/status changes, then maintain the same ownership
+        // with a low-frequency lease while playing. The lease intentionally never resends
+        // sendMusicName, so long scrolling lyrics are not restarted.
+        lastMusicSessionRefreshRealtimeMs = realtimeMs
         publishMusicSourceIfAvailable()
         publishMusicStateIfAvailable(status, force = true)
     }
@@ -360,6 +380,7 @@ private class BydInstrumentLyricsBridge(
 
     companion object {
         private const val TAG = "BydInstrumentLyrics"
+        private const val MUSIC_SESSION_LEASE_INTERVAL_MS = 5_000L
 
         fun create(context: Context): Result<BydInstrumentLyricsBridge> = runCatching {
             val instrumentClass = Class.forName(BYD_INSTRUMENT_DEVICE_CLASS)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -276,7 +276,6 @@ private class BydInstrumentLyricsBridge(
 
     private var useMusicNameTransport = threeLineLyricsMethod == null
     private var lastMusicStateValue: Int? = null
-    private var musicSourceInitialized = false
 
     fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
         if (!useMusicNameTransport) {
@@ -290,8 +289,7 @@ private class BydInstrumentLyricsBridge(
         }
 
         val nameMethod = musicNameMethod ?: return false
-        initializeMusicSourceIfAvailable()
-        publishMusicStateIfAvailable(status)
+        refreshMusicSession(status)
         return invokeRequired(nameMethod, window.current)
     }
 
@@ -301,18 +299,26 @@ private class BydInstrumentLyricsBridge(
             if (method != null && invokeOptional(method, "", "", "")) return
         }
         musicNameMethod?.let { invokeOptional(it, "") }
-        publishMusicStateValueIfAvailable(musicStopValue)
+        publishMusicStateValueIfAvailable(musicStopValue, force = true)
+        lastMusicStateValue = null
     }
 
-    private fun initializeMusicSourceIfAvailable() {
-        if (musicSourceInitialized) return
-        musicSourceInitialized = true
+    private fun refreshMusicSession(status: PlaybackSessionStatus) {
+        // The publisher suppresses identical track/window/status snapshots, so this runs only
+        // for a lyric transition or playback lifecycle change. Reasserting source/state here
+        // lets DiLink reclaim third-party music display after firmware/media interruptions
+        // without introducing a high-frequency heartbeat.
+        publishMusicSourceIfAvailable()
+        publishMusicStateIfAvailable(status, force = true)
+    }
+
+    private fun publishMusicSourceIfAvailable() {
         val method = musicSourceMethod ?: return
         val value = musicSourceOthersValue ?: return
         invokeOptional(method, value)
     }
 
-    private fun publishMusicStateIfAvailable(status: PlaybackSessionStatus) {
+    private fun publishMusicStateIfAvailable(status: PlaybackSessionStatus, force: Boolean = false) {
         val value = when (status) {
             PlaybackSessionStatus.Playing -> musicPlayValue
             PlaybackSessionStatus.Paused -> musicPauseValue
@@ -322,13 +328,13 @@ private class BydInstrumentLyricsBridge(
             -> musicStopValue
             PlaybackSessionStatus.Loading -> null
         }
-        publishMusicStateValueIfAvailable(value)
+        publishMusicStateValueIfAvailable(value, force)
     }
 
-    private fun publishMusicStateValueIfAvailable(value: Int?) {
+    private fun publishMusicStateValueIfAvailable(value: Int?, force: Boolean = false) {
         val method = musicStateMethod ?: return
         val stateValue = value ?: return
-        if (lastMusicStateValue == stateValue) return
+        if (!force && lastMusicStateValue == stateValue) return
         if (invokeOptional(method, stateValue)) lastMusicStateValue = stateValue
     }
 


### PR DESCRIPTION
## Summary

- treat the DiLink `sendMusicName` path as an instrument music session rather than a one-shot fallback
- on each real lyric/track/status update, reassert `MUSIC_SOURCE_OTHERS` and the current PLAY/PAUSE state before publishing the current lyric through `sendMusicName`
- while playing, maintain a 5-second session lease that reasserts only `MUSIC_SOURCE_OTHERS` + PLAY; the lease never resends `sendMusicName`
- keep STOP cleanup when lyrics are cleared or playback ends
- preserve the existing three-line transport and automatic fallback behavior

## Why

BYD exposes `sendMusicSource`, `sendMusicState`, `sendMusicPlaybackProgress`, and `sendMusicName` as the instrument music-info API. Third-party BYD music-assistant compatibility reports also show that newer firmware can lose or only display third-party instrument information once after media/navigation interruptions.

The lease gives DiLink 4 a low-frequency ownership recovery path even for untimed lyrics or unusually long lyric lines. Because it only refreshes source/state and never the lyric text, it does not restart the instrument's scrolling text.

## Scope

This PR intentionally does not attempt to fix the separate behavior where a lyric finishes scrolling and the instrument temporarily restores the song title before the next lyric line. It also does not use `sendMusicPlaybackProgress`, because public material confirms the API exists but does not document reliable units/update semantics across firmware.

## Validation

- shared tests, architecture checks and coverage: passed
- signed multi-ABI release APK build, signing and artifact upload: passed
- Codex P2 for untimed-lyrics recovery addressed and resolved

Latest validated head: `73503e21089253fff31fef9ca90103464b242b83`.