### PR TITLE
feat: backup and restore provider credentials

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -104,7 +104,7 @@ internal class AndroidAppContainer(
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedProviderId = initialSettings.selectedSearchProviderId,
+                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -23,11 +23,22 @@ internal class AndroidAppContainer(
     private var lyriconLyricsPublisher: LyriconLyricsPublisher? = null
     private var bydInstrumentLyricsPublisher: BydInstrumentLyricsPublisher? = null
 
+    private val providerCredentialStore: AndroidProviderCredentialStore by lazy {
+        AndroidProviderCredentialStore(context)
+    }
+
     val providerRepository: ProviderMusicRepository by lazy {
         createFuoProviderRepository(
-            credentials = AndroidProviderCredentialStore(context),
+            credentials = providerCredentialStore,
             persistentCache = AndroidProviderCacheStore(context),
             isCellularConnection = ::isCellularConnection,
+        )
+    }
+
+    val providerCredentialBackup: AndroidProviderCredentialBackup by lazy {
+        AndroidProviderCredentialBackup(
+            credentialStore = providerCredentialStore,
+            providerRepository = providerRepository,
         )
     }
 
@@ -358,7 +369,7 @@ internal class AndroidAppContainer(
                     .map { state -> state.settings.bydInstrumentLyricsEnabled }
                     .distinctUntilChanged(),
                 scope = appScope,
-            ).also(BydInstrumentLyricsPublisher::start)
+            ).also(LydInstrumentLyricsPublisher::start)
         }
 
         FuoPlaybackService.transportControls = object : FuoPlaybackService.TransportControls {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -104,7 +104,7 @@ internal class AndroidAppContainer(
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
+                selectedProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }
@@ -369,7 +369,7 @@ internal class AndroidAppContainer(
                     .map { state -> state.settings.bydInstrumentLyricsEnabled }
                     .distinctUntilChanged(),
                 scope = appScope,
-            ).also(LydInstrumentLyricsPublisher::start)
+            ).also(BydInstrumentLyricsPublisher::start)
         }
 
         FuoPlaybackService.transportControls = object : FuoPlaybackService.TransportControls {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -174,11 +174,56 @@ internal class AndroidProviderCredentialBackup(
         require(restorable.isNotEmpty()) { "备份中没有当前版本支持的音源凭证" }
 
         restorable.forEach { (providerId, credentials) -> credentialStore.write(providerId, credentials) }
+        restorable.forEach { (providerId, credentials) ->
+            refreshProviderCredentialState(providerId, credentials)
+        }
 
         ProviderCredentialRestoreResult(
             restoredProviderIds = restorable.keys.toList(),
             ignoredProviderIds = ignored,
         )
+    }
+
+    /**
+     * Re-enter the provider-owned authentication path after the durable credential write. Providers
+     * can invalidate cached identity/session state here (for example YouTube Music's account name).
+     * The durable restore remains successful even if a provider refresh needs network access and
+     * fails while the device is offline.
+     */
+    private suspend fun refreshProviderCredentialState(providerId: String, credentials: ProviderCredentials) {
+        runCatching {
+            when {
+                !credentials.headerFileJson.isNullOrBlank() -> providerRepository.loginWithHeaderFile(
+                    providerId = providerId,
+                    headerFileJson = credentials.headerFileJson,
+                )
+                credentials.hasOAuthAccess() &&
+                    !credentials.oauthClientId.isNullOrBlank() &&
+                    !credentials.oauthClientSecret.isNullOrBlank() -> providerRepository.loginWithOAuth(
+                    providerId = providerId,
+                    accessToken = credentials.oauthAccessToken.orEmpty(),
+                    refreshToken = credentials.oauthRefreshToken.orEmpty(),
+                    expiresAtMillis = credentials.oauthExpiresAtMillis,
+                    scope = credentials.oauthScope,
+                    clientId = credentials.oauthClientId,
+                    clientSecret = credentials.oauthClientSecret,
+                )
+                !credentials.authorization.isNullOrBlank() && !credentials.cookieHeader.isNullOrBlank() ->
+                    providerRepository.loginWithHeaders(
+                        providerId = providerId,
+                        authorization = credentials.authorization,
+                        cookie = credentials.cookieHeader,
+                    )
+                credentials.cookies.isNotEmpty() -> providerRepository.loginWithCookies(
+                    providerId = providerId,
+                    cookiesJson = JsonObject(credentials.cookies.mapValues { JsonPrimitive(it.value) }).toString(),
+                )
+                !credentials.cookieHeader.isNullOrBlank() -> providerRepository.loginWithCookies(
+                    providerId = providerId,
+                    cookiesJson = credentials.cookieHeader,
+                )
+            }
+        }
     }
 
     private fun encodePlaintext(credentials: Map<String, ProviderCredentials>): String {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -46,6 +46,11 @@ internal data class ProviderCredentialRestoreResult(
     val ignoredProviderIds: List<String>,
 )
 
+internal data class ProviderCredentialBackupTarget(
+    val providerId: String?,
+    val providerName: String,
+)
+
 /**
  * Portable provider credential backup owned by the Android app container.
  *
@@ -94,25 +99,38 @@ internal class AndroidProviderCredentialBackup(
     suspend fun export(
         mode: ProviderCredentialExportMode,
         password: String = "",
+        providerId: String? = null,
     ): ProviderCredentialBackupFile = withContext(Dispatchers.IO) {
         val providers = providerRepository.availableProviders()
+        val selectedProviders = if (providerId == null) {
+            providers
+        } else {
+            val provider = providers.firstOrNull { it.providerId == providerId }
+                ?: throw IllegalArgumentException("当前版本不支持该音源")
+            listOf(provider)
+        }
         val credentials = buildMap {
-            providers.forEach { provider ->
+            selectedProviders.forEach { provider ->
                 credentialStore.read(provider.providerId)?.let { put(provider.providerId, it) }
             }
         }
-        require(credentials.isNotEmpty()) { "没有可备份的登录凭证" }
+        if (providerId == null) {
+            require(credentials.isNotEmpty()) { "没有可备份的登录凭证" }
+        } else {
+            val providerName = selectedProviders.first().providerName
+            require(credentials.isNotEmpty()) { "$providerName 没有可导出的登录凭证" }
+        }
 
         val plaintext = encodePlaintext(credentials)
         when (mode) {
             ProviderCredentialExportMode.Plaintext -> ProviderCredentialBackupFile(
-                fileName = PLAINTEXT_FILE_NAME,
+                fileName = backupFileName(providerId, encrypted = false),
                 content = plaintext,
             )
             ProviderCredentialExportMode.Encrypted -> {
                 require(password.length >= MIN_PASSWORD_LENGTH) { "备份密码至少需要 $MIN_PASSWORD_LENGTH 位" }
                 ProviderCredentialBackupFile(
-                    fileName = ENCRYPTED_FILE_NAME,
+                    fileName = backupFileName(providerId, encrypted = true),
                     content = encrypt(plaintext, password),
                 )
             }
@@ -274,6 +292,18 @@ internal class AndroidProviderCredentialBackup(
         } finally {
             passwordBytes.fill(0)
             blockInput.fill(0)
+        }
+    }
+
+    private fun backupFileName(providerId: String?, encrypted: Boolean): String {
+        if (providerId == null) return if (encrypted) ENCRYPTED_FILE_NAME else PLAINTEXT_FILE_NAME
+        val safeProviderId = providerId.map { character ->
+            if (character.isLetterOrDigit() || character == '-' || character == '_' || character == '.') character else '_'
+        }.joinToString("").ifBlank { "provider" }
+        return if (encrypted) {
+            "fuoevolve-provider-credentials-$safeProviderId.fuoauth.json"
+        } else {
+            "fuoevolve-provider-credentials-$safeProviderId.plain.json"
         }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -218,10 +218,6 @@ internal class AndroidProviderCredentialBackup(
                     providerId = providerId,
                     cookiesJson = JsonObject(credentials.cookies.mapValues { JsonPrimitive(it.value) }).toString(),
                 )
-                !credentials.cookieHeader.isNullOrBlank() -> providerRepository.loginWithCookies(
-                    providerId = providerId,
-                    cookiesJson = credentials.cookieHeader,
-                )
             }
         }
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -1,0 +1,299 @@
+package org.feeluown.mobile
+
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.ProviderCredentials
+import java.security.SecureRandom
+import javax.crypto.AEADBadTagException
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+internal enum class ProviderCredentialExportMode {
+    Encrypted,
+    Plaintext,
+}
+
+internal data class ProviderCredentialBackupFile(
+    val fileName: String,
+    val content: String,
+)
+
+internal data class ProviderCredentialBackupInspection(
+    val encrypted: Boolean,
+    val providerCount: Int?,
+)
+
+internal data class ProviderCredentialRestoreResult(
+    val restoredProviderIds: List<String>,
+    val ignoredProviderIds: List<String>,
+)
+
+/**
+ * Portable provider credential backup used by the Android settings surface.
+ *
+ * The normal on-device credential store remains protected by Android Keystore. Exported encrypted
+ * backups deliberately use a password-derived key instead so the file can be restored on another
+ * device. Plaintext export exists only for interoperability and is guarded by an explicit UI risk
+ * acknowledgement.
+ */
+internal class AndroidProviderCredentialBackup(
+    private val credentialStore: ProviderCredentialStore,
+    private val providerRepository: ProviderRegistryRepository,
+    private val sessionRepository: ProviderSessionRepository,
+    private val onRestored: () -> Unit = {},
+) {
+    private val json = Json {
+        prettyPrint = true
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    suspend fun export(
+        mode: ProviderCredentialExportMode,
+        password: String = "",
+    ): ProviderCredentialBackupFile = withContext(Dispatchers.IO) {
+        val providers = providerRepository.availableProviders()
+        val credentials = buildMap {
+            providers.forEach { provider ->
+                credentialStore.read(provider.providerId)?.let { put(provider.providerId, it) }
+            }
+        }
+        require(credentials.isNotEmpty()) { "没有可备份的登录凭证" }
+
+        val plaintext = encodePlaintext(credentials)
+        when (mode) {
+            ProviderCredentialExportMode.Plaintext -> ProviderCredentialBackupFile(
+                fileName = PLAINTEXT_FILE_NAME,
+                content = plaintext,
+            )
+            ProviderCredentialExportMode.Encrypted -> {
+                require(password.length >= MIN_PASSWORD_LENGTH) { "备份密码至少需要 $MIN_PASSWORD_LENGTH 位" }
+                ProviderCredentialBackupFile(
+                    fileName = ENCRYPTED_FILE_NAME,
+                    content = encrypt(plaintext, password),
+                )
+            }
+        }
+    }
+
+    suspend fun inspect(content: String): ProviderCredentialBackupInspection = withContext(Dispatchers.Default) {
+        val root = parseRoot(content)
+        validateHeader(root)
+        val encrypted = root.boolean(ENCRYPTED_FIELD)
+        ProviderCredentialBackupInspection(
+            encrypted = encrypted,
+            providerCount = if (encrypted) null else providersObject(root).size,
+        )
+    }
+
+    suspend fun restore(
+        content: String,
+        password: String = "",
+    ): ProviderCredentialRestoreResult = withContext(Dispatchers.IO) {
+        val outer = parseRoot(content)
+        validateHeader(outer)
+        val plaintextRoot = if (outer.boolean(ENCRYPTED_FIELD)) {
+            require(password.isNotBlank()) { "请输入备份密码" }
+            parseRoot(decrypt(outer, password))
+        } else {
+            outer
+        }
+        validateHeader(plaintextRoot)
+        require(!plaintextRoot.boolean(ENCRYPTED_FIELD)) { "备份文件结构无效" }
+
+        val providers = providersObject(plaintextRoot)
+        require(providers.isNotEmpty()) { "备份中没有登录凭证" }
+        val knownProviderIds = providerRepository.availableProviders().mapTo(linkedSetOf()) { it.providerId }
+        val decoded = providers.mapValues { (providerId, element) ->
+            require(element is JsonObject) { "$providerId 登录凭证格式无效" }
+            json.decodeFromJsonElement(ProviderCredentials.serializer(), element)
+        }
+        val restorable = decoded.filterKeys(knownProviderIds::contains)
+        val ignored = decoded.keys.filterNot(knownProviderIds::contains)
+        require(restorable.isNotEmpty()) { "备份中没有当前版本支持的音源凭证" }
+
+        restorable.forEach { (providerId, credentials) -> credentialStore.write(providerId, credentials) }
+        restorable.keys.forEach { providerId ->
+            runCatching { sessionRepository.refresh(providerId, refreshUserInfo = true) }
+        }
+        onRestored()
+
+        ProviderCredentialRestoreResult(
+            restoredProviderIds = restorable.keys.toList(),
+            ignoredProviderIds = ignored,
+        )
+    }
+
+    private fun encodePlaintext(credentials: Map<String, ProviderCredentials>): String {
+        val root = buildJsonObject {
+            put(FORMAT_FIELD, JsonPrimitive(FORMAT))
+            put(VERSION_FIELD, JsonPrimitive(VERSION))
+            put(ENCRYPTED_FIELD, JsonPrimitive(false))
+            put(
+                PROVIDERS_FIELD,
+                JsonObject(
+                    credentials.mapValues { (_, value) ->
+                        json.encodeToJsonElement(ProviderCredentials.serializer(), value)
+                    },
+                ),
+            )
+        }
+        return json.encodeToString(JsonObject.serializer(), root)
+    }
+
+    private fun encrypt(plaintext: String, password: String): String {
+        val salt = ByteArray(SALT_BYTES).also(SecureRandom()::nextBytes)
+        val iv = ByteArray(GCM_IV_BYTES).also(SecureRandom()::nextBytes)
+        val keyBytes = deriveKey(password, salt, PBKDF2_ITERATIONS)
+        try {
+            val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(keyBytes, "AES"), GCMParameterSpec(GCM_TAG_BITS, iv))
+            cipher.updateAAD(AAD)
+            val payload = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+            val root = buildJsonObject {
+                put(FORMAT_FIELD, JsonPrimitive(FORMAT))
+                put(VERSION_FIELD, JsonPrimitive(VERSION))
+                put(ENCRYPTED_FIELD, JsonPrimitive(true))
+                put(KDF_FIELD, buildJsonObject {
+                    put(NAME_FIELD, JsonPrimitive(PBKDF2_NAME))
+                    put(ITERATIONS_FIELD, JsonPrimitive(PBKDF2_ITERATIONS))
+                    put(SALT_FIELD, JsonPrimitive(base64(salt)))
+                })
+                put(CIPHER_FIELD, buildJsonObject {
+                    put(NAME_FIELD, JsonPrimitive(AES_GCM_NAME))
+                    put(IV_FIELD, JsonPrimitive(base64(iv)))
+                    put(TAG_BITS_FIELD, JsonPrimitive(GCM_TAG_BITS))
+                })
+                put(PAYLOAD_FIELD, JsonPrimitive(base64(payload)))
+            }
+            return json.encodeToString(JsonObject.serializer(), root)
+        } finally {
+            keyBytes.fill(0)
+        }
+    }
+
+    private fun decrypt(root: JsonObject, password: String): String {
+        val kdf = root.objectValue(KDF_FIELD)
+        require(kdf.string(NAME_FIELD) == PBKDF2_NAME) { "不支持的备份密钥派生算法" }
+        val iterations = kdf.int(ITERATIONS_FIELD)
+        require(iterations in MIN_ACCEPTED_ITERATIONS..MAX_ACCEPTED_ITERATIONS) { "备份密钥派生参数无效" }
+        val salt = decodeBase64(kdf.string(SALT_FIELD), "备份盐值无效")
+        require(salt.size in 16..64) { "备份盐值无效" }
+
+        val cipherInfo = root.objectValue(CIPHER_FIELD)
+        require(cipherInfo.string(NAME_FIELD) == AES_GCM_NAME) { "不支持的备份加密算法" }
+        require(cipherInfo.int(TAG_BITS_FIELD) == GCM_TAG_BITS) { "备份认证标签参数无效" }
+        val iv = decodeBase64(cipherInfo.string(IV_FIELD), "备份 IV 无效")
+        require(iv.size == GCM_IV_BYTES) { "备份 IV 无效" }
+        val encrypted = decodeBase64(root.string(PAYLOAD_FIELD), "备份内容无效")
+
+        val keyBytes = deriveKey(password, salt, iterations)
+        try {
+            val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(keyBytes, "AES"), GCMParameterSpec(GCM_TAG_BITS, iv))
+            cipher.updateAAD(AAD)
+            return try {
+                String(cipher.doFinal(encrypted), Charsets.UTF_8)
+            } catch (_: AEADBadTagException) {
+                throw IllegalArgumentException("密码错误或备份文件已损坏")
+            }
+        } finally {
+            keyBytes.fill(0)
+        }
+    }
+
+    private fun deriveKey(password: String, salt: ByteArray, iterations: Int): ByteArray {
+        val spec = PBEKeySpec(password.toCharArray(), salt, iterations, AES_KEY_BITS)
+        return try {
+            SecretKeyFactory.getInstance(PBKDF2_JCA_NAME).generateSecret(spec).encoded
+        } finally {
+            spec.clearPassword()
+        }
+    }
+
+    private fun parseRoot(content: String): JsonObject = try {
+        json.parseToJsonElement(content).jsonObject
+    } catch (_: Throwable) {
+        throw IllegalArgumentException("无法识别登录凭证备份文件")
+    }
+
+    private fun validateHeader(root: JsonObject) {
+        require(root.string(FORMAT_FIELD) == FORMAT) { "不是 FuoEvolve 登录凭证备份" }
+        require(root.int(VERSION_FIELD) == VERSION) { "暂不支持此版本的登录凭证备份" }
+        require(root[ENCRYPTED_FIELD]?.jsonPrimitive?.booleanOrNull != null) { "备份文件缺少加密标记" }
+    }
+
+    private fun providersObject(root: JsonObject): JsonObject =
+        root[PROVIDERS_FIELD] as? JsonObject ?: throw IllegalArgumentException("备份文件缺少音源登录凭证")
+
+    private fun JsonObject.objectValue(name: String): JsonObject =
+        this[name] as? JsonObject ?: throw IllegalArgumentException("备份文件缺少 $name")
+
+    private fun JsonObject.string(name: String): String =
+        this[name]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: throw IllegalArgumentException("备份文件缺少 $name")
+
+    private fun JsonObject.int(name: String): Int =
+        this[name]?.jsonPrimitive?.intOrNull ?: throw IllegalArgumentException("备份文件缺少 $name")
+
+    private fun JsonObject.boolean(name: String): Boolean =
+        this[name]?.jsonPrimitive?.booleanOrNull ?: throw IllegalArgumentException("备份文件缺少 $name")
+
+    private fun base64(value: ByteArray): String = Base64.encodeToString(value, Base64.NO_WRAP)
+
+    private fun decodeBase64(value: String, error: String): ByteArray = try {
+        Base64.decode(value, Base64.NO_WRAP)
+    } catch (_: IllegalArgumentException) {
+        throw IllegalArgumentException(error)
+    }
+
+    private companion object {
+        const val FORMAT = "fuoevolve-provider-credentials"
+        const val VERSION = 1
+        const val FORMAT_FIELD = "format"
+        const val VERSION_FIELD = "version"
+        const val ENCRYPTED_FIELD = "encrypted"
+        const val PROVIDERS_FIELD = "providers"
+        const val KDF_FIELD = "kdf"
+        const val CIPHER_FIELD = "cipher"
+        const val PAYLOAD_FIELD = "payload"
+        const val NAME_FIELD = "name"
+        const val ITERATIONS_FIELD = "iterations"
+        const val SALT_FIELD = "salt"
+        const val IV_FIELD = "iv"
+        const val TAG_BITS_FIELD = "tagBits"
+        const val PBKDF2_NAME = "PBKDF2-HMAC-SHA256"
+        const val PBKDF2_JCA_NAME = "PBKDF2WithHmacSHA256"
+        const val PBKDF2_ITERATIONS = 210_000
+        const val MIN_ACCEPTED_ITERATIONS = 100_000
+        const val MAX_ACCEPTED_ITERATIONS = 2_000_000
+        const val AES_GCM_NAME = "AES-256-GCM"
+        const val AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding"
+        const val AES_KEY_BITS = 256
+        const val GCM_TAG_BITS = 128
+        const val SALT_BYTES = 16
+        const val GCM_IV_BYTES = 12
+        const val MIN_PASSWORD_LENGTH = 8
+        const val ENCRYPTED_FILE_NAME = "fuoevolve-provider-credentials.fuoauth.json"
+        const val PLAINTEXT_FILE_NAME = "fuoevolve-provider-credentials.plain.json"
+        val AAD = "$FORMAT:$VERSION".toByteArray(Charsets.UTF_8)
+    }
+}

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -2,6 +2,9 @@ package org.feeluown.mobile
 
 import android.util.Base64
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -44,22 +47,48 @@ internal data class ProviderCredentialRestoreResult(
 )
 
 /**
- * Portable provider credential backup used by the Android settings surface.
+ * Portable provider credential backup owned by the Android app container.
  *
  * The normal on-device credential store remains protected by Android Keystore. Exported encrypted
  * backups deliberately use a password-derived key instead so the file can be restored on another
  * device. Plaintext export exists only for interoperability and is guarded by an explicit UI risk
  * acknowledgement.
+ *
+ * Pending picker payloads live here rather than in Activity composition. This object is process
+ * scoped, so an Activity recreation while Android's document picker is open cannot discard a
+ * selected import or leave a newly created export document empty.
  */
 internal class AndroidProviderCredentialBackup(
     private val credentialStore: ProviderCredentialStore,
-    private val providerRepository: ProviderRegistryRepository,
+    private val providerRepository: ProviderMusicRepository,
 ) {
     private val json = Json {
         prettyPrint = true
         encodeDefaults = true
         ignoreUnknownKeys = true
         explicitNulls = false
+    }
+    private val _pendingImportContent = MutableStateFlow<String?>(null)
+    val pendingImportContent: StateFlow<String?> = _pendingImportContent.asStateFlow()
+    private val pendingExportLock = Any()
+    private var pendingExportFile: ProviderCredentialBackupFile? = null
+
+    fun stageImport(content: String) {
+        _pendingImportContent.value = content
+    }
+
+    fun clearPendingImport() {
+        _pendingImportContent.value = null
+    }
+
+    fun stageExport(file: ProviderCredentialBackupFile) {
+        synchronized(pendingExportLock) {
+            pendingExportFile = file
+        }
+    }
+
+    fun consumePendingExport(): ProviderCredentialBackupFile? = synchronized(pendingExportLock) {
+        pendingExportFile.also { pendingExportFile = null }
     }
 
     suspend fun export(
@@ -227,16 +256,20 @@ internal class AndroidProviderCredentialBackup(
         try {
             mac.init(SecretKeySpec(passwordBytes, HMAC_SHA256))
             var u = mac.doFinal(blockInput)
+            var next = ByteArray(u.size)
             val derived = u.copyOf()
             repeat(iterations - 1) {
-                val next = mac.doFinal(u)
-                u.fill(0)
-                u = next
+                mac.update(u)
+                mac.doFinal(next, 0)
                 for (index in derived.indices) {
-                    derived[index] = (derived[index].toInt() xor u[index].toInt()).toByte()
+                    derived[index] = (derived[index].toInt() xor next[index].toInt()).toByte()
                 }
+                val previous = u
+                u = next
+                next = previous
             }
             u.fill(0)
+            next.fill(0)
             return derived
         } finally {
             passwordBytes.fill(0)
@@ -301,7 +334,7 @@ internal class AndroidProviderCredentialBackup(
         const val PASSWORD_ENCODING = "UTF-8"
         const val PBKDF2_ITERATIONS = 210_000
         const val MIN_ACCEPTED_ITERATIONS = 100_000
-        const val MAX_ACCEPTED_ITERATIONS = 2_000_000
+        const val MAX_ACCEPTED_ITERATIONS = 1_000_000
         const val PBKDF2_BLOCK_INDEX_BYTES = 4
         const val HMAC_SHA256 = "HmacSHA256"
         const val AES_GCM_NAME = "AES-256-GCM"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -19,9 +19,8 @@ import org.feeluown.mobile.provider.core.ProviderCredentials
 import java.security.SecureRandom
 import javax.crypto.AEADBadTagException
 import javax.crypto.Cipher
-import javax.crypto.SecretKeyFactory
+import javax.crypto.Mac
 import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
 
 internal enum class ProviderCredentialExportMode {
@@ -169,6 +168,8 @@ internal class AndroidProviderCredentialBackup(
                     put(NAME_FIELD, JsonPrimitive(PBKDF2_NAME))
                     put(ITERATIONS_FIELD, JsonPrimitive(PBKDF2_ITERATIONS))
                     put(SALT_FIELD, JsonPrimitive(base64(salt)))
+                    put(PASSWORD_ENCODING_FIELD, JsonPrimitive(PASSWORD_ENCODING))
+                    put(KEY_BITS_FIELD, JsonPrimitive(AES_KEY_BITS))
                 })
                 put(CIPHER_FIELD, buildJsonObject {
                     put(NAME_FIELD, JsonPrimitive(AES_GCM_NAME))
@@ -186,6 +187,8 @@ internal class AndroidProviderCredentialBackup(
     private fun decrypt(root: JsonObject, password: String): String {
         val kdf = root.objectValue(KDF_FIELD)
         require(kdf.string(NAME_FIELD) == PBKDF2_NAME) { "不支持的备份密钥派生算法" }
+        require(kdf.string(PASSWORD_ENCODING_FIELD) == PASSWORD_ENCODING) { "不支持的备份密码编码" }
+        require(kdf.int(KEY_BITS_FIELD) == AES_KEY_BITS) { "备份密钥长度无效" }
         val iterations = kdf.int(ITERATIONS_FIELD)
         require(iterations in MIN_ACCEPTED_ITERATIONS..MAX_ACCEPTED_ITERATIONS) { "备份密钥派生参数无效" }
         val salt = decodeBase64(kdf.string(SALT_FIELD), "备份盐值无效")
@@ -213,12 +216,31 @@ internal class AndroidProviderCredentialBackup(
         }
     }
 
+    /** PBKDF2-HMAC-SHA256 implemented with HmacSHA256 so it also works on API 24-25. */
     private fun deriveKey(password: String, salt: ByteArray, iterations: Int): ByteArray {
-        val spec = PBEKeySpec(password.toCharArray(), salt, iterations, AES_KEY_BITS)
-        return try {
-            SecretKeyFactory.getInstance(PBKDF2_JCA_NAME).generateSecret(spec).encoded
+        require(iterations > 0) { "PBKDF2 iterations must be positive" }
+        val passwordBytes = password.toByteArray(Charsets.UTF_8)
+        val blockInput = ByteArray(salt.size + PBKDF2_BLOCK_INDEX_BYTES)
+        salt.copyInto(blockInput)
+        blockInput[blockInput.lastIndex] = 1
+        val mac = Mac.getInstance(HMAC_SHA256)
+        try {
+            mac.init(SecretKeySpec(passwordBytes, HMAC_SHA256))
+            var u = mac.doFinal(blockInput)
+            val derived = u.copyOf()
+            repeat(iterations - 1) {
+                val next = mac.doFinal(u)
+                u.fill(0)
+                u = next
+                for (index in derived.indices) {
+                    derived[index] = (derived[index].toInt() xor u[index].toInt()).toByte()
+                }
+            }
+            u.fill(0)
+            return derived
         } finally {
-            spec.clearPassword()
+            passwordBytes.fill(0)
+            blockInput.fill(0)
         }
     }
 
@@ -271,13 +293,17 @@ internal class AndroidProviderCredentialBackup(
         const val NAME_FIELD = "name"
         const val ITERATIONS_FIELD = "iterations"
         const val SALT_FIELD = "salt"
+        const val PASSWORD_ENCODING_FIELD = "passwordEncoding"
+        const val KEY_BITS_FIELD = "keyBits"
         const val IV_FIELD = "iv"
         const val TAG_BITS_FIELD = "tagBits"
         const val PBKDF2_NAME = "PBKDF2-HMAC-SHA256"
-        const val PBKDF2_JCA_NAME = "PBKDF2WithHmacSHA256"
+        const val PASSWORD_ENCODING = "UTF-8"
         const val PBKDF2_ITERATIONS = 210_000
         const val MIN_ACCEPTED_ITERATIONS = 100_000
         const val MAX_ACCEPTED_ITERATIONS = 2_000_000
+        const val PBKDF2_BLOCK_INDEX_BYTES = 4
+        const val HMAC_SHA256 = "HmacSHA256"
         const val AES_GCM_NAME = "AES-256-GCM"
         const val AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding"
         const val AES_KEY_BITS = 256

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -191,29 +191,32 @@ internal class AndroidProviderCredentialBackup(
      * fails while the device is offline.
      */
     private suspend fun refreshProviderCredentialState(providerId: String, credentials: ProviderCredentials) {
+        val headerFileJson = credentials.headerFileJson
+        val oauthClientId = credentials.oauthClientId
+        val oauthClientSecret = credentials.oauthClientSecret
+        val authorization = credentials.authorization
+        val cookieHeader = credentials.cookieHeader
         runCatching {
             when {
-                !credentials.headerFileJson.isNullOrBlank() -> providerRepository.loginWithHeaderFile(
+                !headerFileJson.isNullOrBlank() -> providerRepository.loginWithHeaderFile(
                     providerId = providerId,
-                    headerFileJson = credentials.headerFileJson,
+                    headerFileJson = headerFileJson,
                 )
-                credentials.hasOAuthAccess() &&
-                    !credentials.oauthClientId.isNullOrBlank() &&
-                    !credentials.oauthClientSecret.isNullOrBlank() -> providerRepository.loginWithOAuth(
-                    providerId = providerId,
-                    accessToken = credentials.oauthAccessToken.orEmpty(),
-                    refreshToken = credentials.oauthRefreshToken.orEmpty(),
-                    expiresAtMillis = credentials.oauthExpiresAtMillis,
-                    scope = credentials.oauthScope,
-                    clientId = credentials.oauthClientId,
-                    clientSecret = credentials.oauthClientSecret,
-                )
-                !credentials.authorization.isNullOrBlank() && !credentials.cookieHeader.isNullOrBlank() ->
-                    providerRepository.loginWithHeaders(
+                credentials.hasOAuthAccess() && !oauthClientId.isNullOrBlank() && !oauthClientSecret.isNullOrBlank() ->
+                    providerRepository.loginWithOAuth(
                         providerId = providerId,
-                        authorization = credentials.authorization,
-                        cookie = credentials.cookieHeader,
+                        accessToken = credentials.oauthAccessToken.orEmpty(),
+                        refreshToken = credentials.oauthRefreshToken.orEmpty(),
+                        expiresAtMillis = credentials.oauthExpiresAtMillis,
+                        scope = credentials.oauthScope,
+                        clientId = oauthClientId,
+                        clientSecret = oauthClientSecret,
                     )
+                !authorization.isNullOrBlank() && !cookieHeader.isNullOrBlank() -> providerRepository.loginWithHeaders(
+                    providerId = providerId,
+                    authorization = authorization,
+                    cookie = cookieHeader,
+                )
                 credentials.cookies.isNotEmpty() -> providerRepository.loginWithCookies(
                     providerId = providerId,
                     cookiesJson = JsonObject(credentials.cookies.mapValues { JsonPrimitive(it.value) }).toString(),

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCredentialBackup.kt
@@ -4,7 +4,6 @@ import android.util.Base64
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -56,8 +55,6 @@ internal data class ProviderCredentialRestoreResult(
 internal class AndroidProviderCredentialBackup(
     private val credentialStore: ProviderCredentialStore,
     private val providerRepository: ProviderRegistryRepository,
-    private val sessionRepository: ProviderSessionRepository,
-    private val onRestored: () -> Unit = {},
 ) {
     private val json = Json {
         prettyPrint = true
@@ -131,10 +128,6 @@ internal class AndroidProviderCredentialBackup(
         require(restorable.isNotEmpty()) { "备份中没有当前版本支持的音源凭证" }
 
         restorable.forEach { (providerId, credentials) -> credentialStore.write(providerId, credentials) }
-        restorable.keys.forEach { providerId ->
-            runCatching { sessionRepository.refresh(providerId, refreshUserInfo = true) }
-        }
-        onRestored()
 
         ProviderCredentialRestoreResult(
             restoredProviderIds = restorable.keys.toList(),

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -17,6 +17,9 @@ class FuoEvolveApplication : Application() {
     internal val providerRepository: ProviderMusicRepository
         get() = container().providerRepository
 
+    internal val providerCredentialBackup: AndroidProviderCredentialBackup
+        get() = container().providerCredentialBackup
+
     internal val settingsRepository: AppSettingsRepository
         get() = container().settingsRepository
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -16,9 +16,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -27,10 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
@@ -43,6 +38,7 @@ private data class PendingLocalPlaylistExport(val fileName: String, val content:
 private data class PendingLocalPlaylistImport(val fileName: String, val content: String)
 private const val LOCAL_PLAYLIST_MIME_TYPE = "application/x-fuo"
 private const val PROVIDER_CREDENTIAL_BACKUP_MIME_TYPE = "application/json"
+private const val ALL_PROVIDER_CREDENTIALS_TARGET = "__all_provider_credentials__"
 private const val CONTENT_URI_SCHEME = "content"
 private const val FILE_URI_SCHEME = "file"
 private const val BYD_INSTRUMENT_PERMISSION_REQUEST_CODE = 4104
@@ -149,6 +145,31 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
+            var providerCredentialExportTargetKey by rememberSaveable { mutableStateOf<String?>(null) }
+            var providerCredentialExportTargetName by rememberSaveable { mutableStateOf("") }
+            val providerCredentialExportTarget = providerCredentialExportTargetKey?.let { key ->
+                ProviderCredentialBackupTarget(
+                    providerId = key.takeUnless { it == ALL_PROVIDER_CREDENTIALS_TARGET },
+                    providerName = providerCredentialExportTargetName.ifBlank {
+                        if (key == ALL_PROVIDER_CREDENTIALS_TARGET) "全部已登录音源" else key
+                    },
+                )
+            }
+            val credentialBackupActions = ProviderCredentialBackupActions(
+                exportAll = {
+                    providerCredentialExportTargetKey = ALL_PROVIDER_CREDENTIALS_TARGET
+                    providerCredentialExportTargetName = "全部已登录音源"
+                },
+                exportProvider = { provider ->
+                    providerCredentialExportTargetKey = provider.providerId
+                    providerCredentialExportTargetName = provider.providerName
+                },
+                importBackup = {
+                    providerCredentialImportLauncher.launch(
+                        arrayOf("application/json", "text/plain", "application/octet-stream", "*/*"),
+                    )
+                },
+            )
 
             var pendingLocalPlaylistExport by remember { mutableStateOf<PendingLocalPlaylistExport?>(null) }
             val localPlaylistFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
@@ -188,7 +209,7 @@ class MainActivity : ComponentActivity() {
                 launchSharedText?.let(appViewModel.sharedResourceActionPort::open)
             }
 
-            Box(Modifier.fillMaxSize()) {
+            CompositionLocalProvider(LocalProviderCredentialBackupActions provides credentialBackupActions) {
                 AppRoot(
                     appViewModel = appViewModel,
                     hasAudioPermission = hasAudioPermission,
@@ -231,27 +252,22 @@ class MainActivity : ComponentActivity() {
                     onShareText = ::shareText,
                 )
 
-                if (appUiState.backStack.lastOrNull() == AppRoute.Settings) {
-                    ProviderCredentialBackupOverlay(
-                        backup = providerCredentialBackup,
-                        onImportFile = {
-                            providerCredentialImportLauncher.launch(
-                                arrayOf("application/json", "text/plain", "application/octet-stream", "*/*"),
-                            )
-                        },
-                        onExportFile = { fileName ->
-                            providerCredentialExportLauncher.launch(fileName)
-                        },
-                        onRestored = { restoredProviderIds ->
-                            val restored = restoredProviderIds.toSet()
-                            val providers = appViewModel.providerCatalogFeatureController.uiState.value.availableProviders
-                                .filter { provider -> provider.providerId in restored }
-                            appViewModel.providerAuthFeatureController.refreshAll(providers, refreshUserInfo = true)
-                        },
-                        onFeedback = appViewModel::showFeedback,
-                        modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
-                    )
-                }
+                ProviderCredentialBackupDialogs(
+                    backup = providerCredentialBackup,
+                    exportTarget = providerCredentialExportTarget,
+                    onDismissExport = {
+                        providerCredentialExportTargetKey = null
+                        providerCredentialExportTargetName = ""
+                    },
+                    onExportFile = providerCredentialExportLauncher::launch,
+                    onRestored = { restoredProviderIds ->
+                        val restored = restoredProviderIds.toSet()
+                        val providers = appViewModel.providerCatalogFeatureController.uiState.value.availableProviders
+                            .filter { provider -> provider.providerId in restored }
+                        appViewModel.providerAuthFeatureController.refreshAll(providers, refreshUserInfo = true)
+                    },
+                    onFeedback = appViewModel::showFeedback,
+                )
             }
 
             BackHandler(

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -16,6 +16,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -24,7 +27,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
@@ -36,6 +42,7 @@ import java.io.File
 private data class PendingLocalPlaylistExport(val fileName: String, val content: String)
 private data class PendingLocalPlaylistImport(val fileName: String, val content: String)
 private const val LOCAL_PLAYLIST_MIME_TYPE = "application/x-fuo"
+private const val PROVIDER_CREDENTIAL_BACKUP_MIME_TYPE = "application/json"
 private const val CONTENT_URI_SCHEME = "content"
 private const val FILE_URI_SCHEME = "file"
 private const val BYD_INSTRUMENT_PERMISSION_REQUEST_CODE = 4104
@@ -55,6 +62,12 @@ class MainActivity : ComponentActivity() {
             var hasImagePermission by remember { mutableStateOf(hasImagePermission()) }
             var hasMicrophonePermission by remember { mutableStateOf(hasMicrophonePermission()) }
             val appViewModel = fuoApplication.appViewModel
+            val providerCredentialBackup = remember(fuoApplication) {
+                AndroidProviderCredentialBackup(
+                    credentialStore = AndroidProviderCredentialStore(this@MainActivity),
+                    providerRepository = fuoApplication.providerRepository,
+                )
+            }
             remember { AndroidPredictiveBackPreference.initialize(this@MainActivity); Unit }
             val predictiveBackEnabled by AndroidPredictiveBackPreference.enabled
 
@@ -118,6 +131,35 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            var providerCredentialImportHandler by remember { mutableStateOf<((String) -> Unit)?>(null) }
+            var pendingProviderCredentialExport by remember { mutableStateOf<ProviderCredentialBackupFile?>(null) }
+            val providerCredentialImportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+                val handler = providerCredentialImportHandler
+                providerCredentialImportHandler = null
+                if (uri != null && handler != null) {
+                    val content = readText(uri)
+                    if (content.isBlank()) appViewModel.showFeedback("无法读取登录凭证备份文件")
+                    else handler(content)
+                }
+            }
+            val providerCredentialExportLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.CreateDocument(PROVIDER_CREDENTIAL_BACKUP_MIME_TYPE),
+            ) { uri ->
+                val pending = pendingProviderCredentialExport
+                if (uri != null && pending != null) {
+                    runCatching {
+                        contentResolver.openOutputStream(uri)?.use { output ->
+                            output.write(pending.content.toByteArray(Charsets.UTF_8))
+                        } ?: error("无法打开导出目标")
+                    }.onSuccess {
+                        appViewModel.showFeedback("登录凭证备份已导出")
+                    }.onFailure {
+                        appViewModel.showFeedback(it.message ?: "导出登录凭证失败")
+                    }
+                }
+                pendingProviderCredentialExport = null
+            }
+
             var pendingLocalPlaylistExport by remember { mutableStateOf<PendingLocalPlaylistExport?>(null) }
             val localPlaylistFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
                 if (uri != null) {
@@ -156,47 +198,73 @@ class MainActivity : ComponentActivity() {
                 launchSharedText?.let(appViewModel.sharedResourceActionPort::open)
             }
 
-            AppRoot(
-                appViewModel = appViewModel,
-                hasAudioPermission = hasAudioPermission,
-                hasImagePermission = hasImagePermission,
-                appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                onRequestAudioPermission = { permissionLauncher.launch(mediaPermissions()) },
-                onRequestImagePermission = { permissionLauncher.launch(imagePermissions()) },
-                hasMicrophonePermission = hasMicrophonePermission,
-                onRequestMicrophonePermission = { microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
-                onOpenProviderWebLogin = { provider ->
-                    if (provider.loginConfig != null) {
-                        pendingWebLoginProviderId = provider.providerId
-                        webLoginLauncher.launch(ProviderWebLoginActivity.createIntent(this@MainActivity, provider))
-                    }
-                },
-                onLogoutProvider = { provider ->
-                    ProviderWebLoginActivity.clearWebLoginState()
-                    appViewModel.providerAuthFeatureController.logout(provider.providerId)
-                },
-                onImportYtmusicHeaderFile = { ytmusicHeaderFileLauncher.launch(arrayOf("application/json")) },
-                onImportYtmusicOAuthFile = { ytmusicOAuthFileLauncher.launch(arrayOf("application/json")) },
-                onStartYtmusicOAuth = {
-                    val oauthInput = appViewModel.providerAuthFeatureController.oauthInput("ytmusic")
-                    val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                        ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
-                    if (oauthInput.clientId.isNotBlank() && oauthInput.clientSecret.isNotBlank() && needsPermission) {
-                        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    } else {
-                        appViewModel.providerAuthFeatureController.startYtmusicTvOAuthLogin()
-                    }
-                },
-                onImportLocalPlaylistFile = {
-                    localPlaylistFileLauncher.launch(arrayOf("text/plain", "application/octet-stream", "application/x-fuo", "*/*"))
-                },
-                onExportLocalPlaylistFile = { fileName, content ->
-                    pendingLocalPlaylistExport = PendingLocalPlaylistExport(fileName, content)
-                    localPlaylistExportLauncher.launch(fileName)
-                },
-                onShareLocalPlaylistFile = ::shareLocalPlaylistFile,
-                onShareText = ::shareText,
-            )
+            Box(Modifier.fillMaxSize()) {
+                AppRoot(
+                    appViewModel = appViewModel,
+                    hasAudioPermission = hasAudioPermission,
+                    hasImagePermission = hasImagePermission,
+                    appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                    onRequestAudioPermission = { permissionLauncher.launch(mediaPermissions()) },
+                    onRequestImagePermission = { permissionLauncher.launch(imagePermissions()) },
+                    hasMicrophonePermission = hasMicrophonePermission,
+                    onRequestMicrophonePermission = { microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+                    onOpenProviderWebLogin = { provider ->
+                        if (provider.loginConfig != null) {
+                            pendingWebLoginProviderId = provider.providerId
+                            webLoginLauncher.launch(ProviderWebLoginActivity.createIntent(this@MainActivity, provider))
+                        }
+                    },
+                    onLogoutProvider = { provider ->
+                        ProviderWebLoginActivity.clearWebLoginState()
+                        appViewModel.providerAuthFeatureController.logout(provider.providerId)
+                    },
+                    onImportYtmusicHeaderFile = { ytmusicHeaderFileLauncher.launch(arrayOf("application/json")) },
+                    onImportYtmusicOAuthFile = { ytmusicOAuthFileLauncher.launch(arrayOf("application/json")) },
+                    onStartYtmusicOAuth = {
+                        val oauthInput = appViewModel.providerAuthFeatureController.oauthInput("ytmusic")
+                        val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                            ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+                        if (oauthInput.clientId.isNotBlank() && oauthInput.clientSecret.isNotBlank() && needsPermission) {
+                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        } else {
+                            appViewModel.providerAuthFeatureController.startYtmusicTvOAuthLogin()
+                        }
+                    },
+                    onImportLocalPlaylistFile = {
+                        localPlaylistFileLauncher.launch(arrayOf("text/plain", "application/octet-stream", "application/x-fuo", "*/*"))
+                    },
+                    onExportLocalPlaylistFile = { fileName, content ->
+                        pendingLocalPlaylistExport = PendingLocalPlaylistExport(fileName, content)
+                        localPlaylistExportLauncher.launch(fileName)
+                    },
+                    onShareLocalPlaylistFile = ::shareLocalPlaylistFile,
+                    onShareText = ::shareText,
+                )
+
+                if (appUiState.backStack.lastOrNull() == AppRoute.Settings) {
+                    ProviderCredentialBackupOverlay(
+                        backup = providerCredentialBackup,
+                        onImportFile = { handler ->
+                            providerCredentialImportHandler = handler
+                            providerCredentialImportLauncher.launch(
+                                arrayOf("application/json", "text/plain", "application/octet-stream", "*/*"),
+                            )
+                        },
+                        onExportFile = { fileName, content ->
+                            pendingProviderCredentialExport = ProviderCredentialBackupFile(fileName, content)
+                            providerCredentialExportLauncher.launch(fileName)
+                        },
+                        onRestored = { restoredProviderIds ->
+                            val restored = restoredProviderIds.toSet()
+                            val providers = appViewModel.providerCatalogFeatureController.uiState.value.availableProviders
+                                .filter { provider -> provider.providerId in restored }
+                            appViewModel.providerAuthFeatureController.refreshAll(providers, refreshUserInfo = true)
+                        },
+                        onFeedback = appViewModel::showFeedback,
+                        modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+                    )
+                }
+            }
 
             BackHandler(
                 enabled = !appShellHandlesBack && AndroidPredictiveBackPreference.isSupported && !predictiveBackEnabled &&

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -259,7 +259,7 @@ class MainActivity : ComponentActivity() {
                         providerCredentialExportTargetKey = null
                         providerCredentialExportTargetName = ""
                     },
-                    onExportFile = providerCredentialExportLauncher::launch,
+                    onExportFile = { fileName -> providerCredentialExportLauncher.launch(fileName) },
                     onRestored = { restoredProviderIds ->
                         val restored = restoredProviderIds.toSet()
                         val providers = appViewModel.providerCatalogFeatureController.uiState.value.availableProviders

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -62,12 +62,7 @@ class MainActivity : ComponentActivity() {
             var hasImagePermission by remember { mutableStateOf(hasImagePermission()) }
             var hasMicrophonePermission by remember { mutableStateOf(hasMicrophonePermission()) }
             val appViewModel = fuoApplication.appViewModel
-            val providerCredentialBackup = remember(fuoApplication) {
-                AndroidProviderCredentialBackup(
-                    credentialStore = AndroidProviderCredentialStore(this@MainActivity),
-                    providerRepository = fuoApplication.providerRepository,
-                )
-            }
+            val providerCredentialBackup = fuoApplication.providerCredentialBackup
             remember { AndroidPredictiveBackPreference.initialize(this@MainActivity); Unit }
             val predictiveBackEnabled by AndroidPredictiveBackPreference.enabled
 
@@ -131,21 +126,17 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            var providerCredentialImportHandler by remember { mutableStateOf<((String) -> Unit)?>(null) }
-            var pendingProviderCredentialExport by remember { mutableStateOf<ProviderCredentialBackupFile?>(null) }
             val providerCredentialImportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-                val handler = providerCredentialImportHandler
-                providerCredentialImportHandler = null
-                if (uri != null && handler != null) {
+                if (uri != null) {
                     val content = readText(uri)
                     if (content.isBlank()) appViewModel.showFeedback("无法读取登录凭证备份文件")
-                    else handler(content)
+                    else providerCredentialBackup.stageImport(content)
                 }
             }
             val providerCredentialExportLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.CreateDocument(PROVIDER_CREDENTIAL_BACKUP_MIME_TYPE),
             ) { uri ->
-                val pending = pendingProviderCredentialExport
+                val pending = providerCredentialBackup.consumePendingExport()
                 if (uri != null && pending != null) {
                     runCatching {
                         contentResolver.openOutputStream(uri)?.use { output ->
@@ -157,7 +148,6 @@ class MainActivity : ComponentActivity() {
                         appViewModel.showFeedback(it.message ?: "导出登录凭证失败")
                     }
                 }
-                pendingProviderCredentialExport = null
             }
 
             var pendingLocalPlaylistExport by remember { mutableStateOf<PendingLocalPlaylistExport?>(null) }
@@ -244,14 +234,12 @@ class MainActivity : ComponentActivity() {
                 if (appUiState.backStack.lastOrNull() == AppRoute.Settings) {
                     ProviderCredentialBackupOverlay(
                         backup = providerCredentialBackup,
-                        onImportFile = { handler ->
-                            providerCredentialImportHandler = handler
+                        onImportFile = {
                             providerCredentialImportLauncher.launch(
                                 arrayOf("application/json", "text/plain", "application/octet-stream", "*/*"),
                             )
                         },
-                        onExportFile = { fileName, content ->
-                            pendingProviderCredentialExport = ProviderCredentialBackupFile(fileName, content)
+                        onExportFile = { fileName ->
                             providerCredentialExportLauncher.launch(fileName)
                         },
                         onRestored = { restoredProviderIds ->

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,18 +36,36 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun ProviderCredentialBackupOverlay(
     backup: AndroidProviderCredentialBackup,
-    onImportFile: (((String) -> Unit) -> Unit),
-    onExportFile: (String, String) -> Unit,
+    onImportFile: () -> Unit,
+    onExportFile: (String) -> Unit,
     onRestored: (List<String>) -> Unit,
     onFeedback: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showActions by remember { mutableStateOf(false) }
     var showExport by remember { mutableStateOf(false) }
-    var pendingImport by remember { mutableStateOf<String?>(null) }
+    val pendingImport by backup.pendingImportContent.collectAsState()
     var importInspection by remember { mutableStateOf<ProviderCredentialBackupInspection?>(null) }
     var importError by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(pendingImport) {
+        val content = pendingImport
+        if (content == null) {
+            importInspection = null
+            return@LaunchedEffect
+        }
+        runCatching { backup.inspect(content) }
+            .onSuccess {
+                importInspection = it
+                importError = null
+            }
+            .onFailure {
+                backup.clearPendingImport()
+                importInspection = null
+                importError = it.message ?: "无法读取备份文件"
+            }
+    }
 
     ExtendedFloatingActionButton(
         modifier = modifier,
@@ -75,17 +95,7 @@ internal fun ProviderCredentialBackupOverlay(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = {
                             showActions = false
-                            onImportFile { content ->
-                                scope.launch {
-                                    runCatching { backup.inspect(content) }
-                                        .onSuccess {
-                                            pendingImport = content
-                                            importInspection = it
-                                            importError = null
-                                        }
-                                        .onFailure { importError = it.message ?: "无法读取备份文件" }
-                                }
-                            }
+                            onImportFile()
                         },
                     ) { Text("从文件恢复") }
                 }
@@ -108,14 +118,14 @@ internal fun ProviderCredentialBackupOverlay(
             ProviderCredentialImportDialog(
                 inspection = inspection,
                 onDismiss = {
-                    pendingImport = null
+                    backup.clearPendingImport()
                     importInspection = null
                 },
                 onRestore = { password ->
                     scope.launch {
                         runCatching { backup.restore(content, password) }
                             .onSuccess { result ->
-                                pendingImport = null
+                                backup.clearPendingImport()
                                 importInspection = null
                                 onRestored(result.restoredProviderIds)
                                 val ignored = if (result.ignoredProviderIds.isEmpty()) "" else
@@ -143,7 +153,7 @@ internal fun ProviderCredentialBackupOverlay(
 private fun ProviderCredentialExportDialog(
     backup: AndroidProviderCredentialBackup,
     onDismiss: () -> Unit,
-    onExportFile: (String, String) -> Unit,
+    onExportFile: (String) -> Unit,
 ) {
     var mode by remember { mutableStateOf(ProviderCredentialExportMode.Encrypted) }
     var password by remember { mutableStateOf("") }
@@ -252,9 +262,10 @@ private fun ProviderCredentialExportDialog(
                                 password = if (mode == ProviderCredentialExportMode.Encrypted) password else "",
                             )
                         }.onSuccess { file ->
+                            backup.stageExport(file)
                             isBusy = false
                             onDismiss()
-                            onExportFile(file.fileName, file.content)
+                            onExportFile(file.fileName)
                         }.onFailure {
                             isBusy = false
                             error = it.message ?: "导出登录凭证失败"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
@@ -36,6 +36,7 @@ internal fun ProviderCredentialBackupOverlay(
     backup: AndroidProviderCredentialBackup,
     onImportFile: (((String) -> Unit) -> Unit),
     onExportFile: (String, String) -> Unit,
+    onRestored: (List<String>) -> Unit,
     onFeedback: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -116,6 +117,7 @@ internal fun ProviderCredentialBackupOverlay(
                             .onSuccess { result ->
                                 pendingImport = null
                                 importInspection = null
+                                onRestored(result.restoredProviderIds)
                                 val ignored = if (result.ignoredProviderIds.isEmpty()) "" else
                                     "，另有 ${result.ignoredProviderIds.size} 个当前版本不支持的音源已跳过"
                                 onFeedback("已恢复 ${result.restoredProviderIds.size} 个音源登录凭证$ignored")

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
@@ -3,9 +3,7 @@ package org.feeluown.mobile
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -86,8 +84,8 @@ internal fun ProviderCredentialBackupDialogs(
                                 importInspection = null
                                 onRestored(result.restoredProviderIds)
                                 val ignored = if (result.ignoredProviderIds.isEmpty()) "" else
-                                    "，另有 ${result.ignoredProviderIds.size} 个当前版本不支持的音源已跳过"
-                                onFeedback("已恢复 ${result.restoredProviderIds.size} 个音源登录凭证$ignored")
+                                    "，${result.ignoredProviderIds.size} 个音源已跳过"
+                                onFeedback("已恢复 ${result.restoredProviderIds.size} 个音源$ignored")
                             }
                             .onFailure { importError = it.message ?: "恢复登录凭证失败" }
                     }
@@ -99,7 +97,7 @@ internal fun ProviderCredentialBackupDialogs(
     importError?.let { message ->
         AlertDialog(
             onDismissRequest = { importError = null },
-            title = { Text("登录凭证备份") },
+            title = { Text("登录凭证") },
             text = { Text(message) },
             confirmButton = { TextButton(onClick = { importError = null }) { Text("确定") } },
         )
@@ -126,22 +124,15 @@ private fun ProviderCredentialExportDialog(
         ProviderCredentialExportMode.Encrypted -> encryptedReady
         ProviderCredentialExportMode.Plaintext -> plaintextRiskAccepted
     }
-    val targetDescription = if (target.providerId == null) {
-        "导出全部已保存的音源登录凭证"
-    } else {
-        "仅导出 ${target.providerName} 的登录凭证"
-    }
 
     AlertDialog(
         onDismissRequest = { if (!isBusy) onDismiss() },
         title = { Text(if (target.providerId == null) "导出全部登录凭证" else "导出 ${target.providerName}") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text("$targetDescription。默认推荐加密备份；只有第三方应用明确需要读取凭证时才使用明文导出。")
                 ExportModeRow(
                     selected = mode == ProviderCredentialExportMode.Encrypted,
-                    title = "加密备份（推荐）",
-                    description = "使用备份密码加密，可在其他设备恢复。",
+                    title = "加密备份",
                     onClick = {
                         mode = ProviderCredentialExportMode.Encrypted
                         plaintextRiskAccepted = false
@@ -149,8 +140,7 @@ private fun ProviderCredentialExportDialog(
                 )
                 ExportModeRow(
                     selected = mode == ProviderCredentialExportMode.Plaintext,
-                    title = "明文 JSON（第三方应用）",
-                    description = "不做任何加密，第三方程序可直接读取。",
+                    title = "明文 JSON",
                     onClick = { mode = ProviderCredentialExportMode.Plaintext },
                 )
 
@@ -159,7 +149,7 @@ private fun ProviderCredentialExportDialog(
                         modifier = Modifier.fillMaxWidth(),
                         value = password,
                         onValueChange = { password = it; error = null },
-                        label = { Text("备份密码（至少 8 位）") },
+                        label = { Text("密码（至少 8 位）") },
                         singleLine = true,
                         visualTransformation = PasswordVisualTransformation(),
                     )
@@ -167,15 +157,10 @@ private fun ProviderCredentialExportDialog(
                         modifier = Modifier.fillMaxWidth(),
                         value = confirmation,
                         onValueChange = { confirmation = it; error = null },
-                        label = { Text("确认备份密码") },
+                        label = { Text("确认密码") },
                         singleLine = true,
                         visualTransformation = PasswordVisualTransformation(),
                         isError = confirmation.isNotEmpty() && confirmation != password,
-                    )
-                    Text(
-                        "请妥善保存备份密码。密码不会写入文件，遗失后无法恢复加密备份。",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 } else {
                     Surface(
@@ -183,13 +168,11 @@ private fun ProviderCredentialExportDialog(
                         contentColor = MaterialTheme.colorScheme.onErrorContainer,
                         shape = MaterialTheme.shapes.medium,
                     ) {
-                        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("明文导出存在高风险", style = MaterialTheme.typography.titleSmall)
-                            Text(
-                                "文件会直接包含 Cookie、访问令牌、Refresh Token、Authorization 以及 OAuth client_secret。任何拿到文件的人或应用都可能利用这些凭证访问你的账号。仅向你完全信任的第三方应用提供，不要上传到网盘、聊天、Issue 或其他公共位置，使用完成后请及时删除。",
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
+                        Text(
+                            "明文文件包含登录凭证，请仅用于可信应用。",
+                            modifier = Modifier.padding(12.dp),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
                     }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -200,7 +183,7 @@ private fun ProviderCredentialExportDialog(
                             onCheckedChange = { plaintextRiskAccepted = it },
                         )
                         Text(
-                            "我已了解明文导出的风险，并确认仍要继续",
+                            "我确认导出明文凭证",
                             modifier = Modifier.weight(1f),
                             style = MaterialTheme.typography.bodyMedium,
                         )
@@ -246,19 +229,14 @@ private fun ProviderCredentialExportDialog(
 private fun ExportModeRow(
     selected: Boolean,
     title: String,
-    description: String,
     onClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         RadioButton(selected = selected, onClick = onClick)
-        Column(Modifier.weight(1f).padding(top = 8.dp)) {
-            Text(title, style = MaterialTheme.typography.bodyLarge)
-            Spacer(Modifier.height(2.dp))
-            Text(description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
+        Text(title, style = MaterialTheme.typography.bodyLarge)
     }
 }
 
@@ -277,7 +255,6 @@ private fun ProviderCredentialImportDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (inspection.encrypted) {
-                    Text("这是加密备份。恢复会覆盖备份中对应音源当前保存的登录凭证。")
                     OutlinedTextField(
                         modifier = Modifier.fillMaxWidth(),
                         value = password,
@@ -293,16 +270,15 @@ private fun ProviderCredentialImportDialog(
                         shape = MaterialTheme.shapes.medium,
                     ) {
                         Text(
-                            "检测到明文凭证文件。文件内容未加密，恢复前请确认文件来自你信任的来源。",
+                            "这是明文凭证文件，请确认来源可信。",
                             modifier = Modifier.padding(12.dp),
                             style = MaterialTheme.typography.bodySmall,
                         )
                     }
-                    inspection.providerCount?.let { Text("备份包含 $it 个音源的登录凭证。") }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Checkbox(checked = confirmed, onCheckedChange = { confirmed = it })
-                    Text("我确认覆盖备份中对应音源的现有登录凭证", Modifier.weight(1f))
+                    Text("覆盖现有登录凭证", Modifier.weight(1f))
                 }
             }
         },

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
@@ -7,12 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -34,16 +30,14 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun ProviderCredentialBackupOverlay(
+internal fun ProviderCredentialBackupDialogs(
     backup: AndroidProviderCredentialBackup,
-    onImportFile: () -> Unit,
+    exportTarget: ProviderCredentialBackupTarget?,
+    onDismissExport: () -> Unit,
     onExportFile: (String) -> Unit,
     onRestored: (List<String>) -> Unit,
     onFeedback: (String) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    var showActions by remember { mutableStateOf(false) }
-    var showExport by remember { mutableStateOf(false) }
     val pendingImport by backup.pendingImportContent.collectAsState()
     var importInspection by remember { mutableStateOf<ProviderCredentialBackupInspection?>(null) }
     var importError by remember { mutableStateOf<String?>(null) }
@@ -67,48 +61,11 @@ internal fun ProviderCredentialBackupOverlay(
             }
     }
 
-    ExtendedFloatingActionButton(
-        modifier = modifier,
-        onClick = { showActions = true },
-        icon = { androidx.compose.material3.Icon(Icons.Filled.Lock, contentDescription = null) },
-        text = { Text("登录凭证备份") },
-    )
-
-    if (showActions) {
-        AlertDialog(
-            onDismissRequest = { showActions = false },
-            title = { Text("登录凭证备份与恢复") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text(
-                        "备份会包含已登录音源的 Cookie、访问令牌和 OAuth 凭证。默认使用密码加密导出。",
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                    Button(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = {
-                            showActions = false
-                            showExport = true
-                        },
-                    ) { Text("导出登录凭证") }
-                    Button(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = {
-                            showActions = false
-                            onImportFile()
-                        },
-                    ) { Text("从文件恢复") }
-                }
-            },
-            confirmButton = {},
-            dismissButton = { TextButton(onClick = { showActions = false }) { Text("取消") } },
-        )
-    }
-
-    if (showExport) {
+    exportTarget?.let { target ->
         ProviderCredentialExportDialog(
             backup = backup,
-            onDismiss = { showExport = false },
+            target = target,
+            onDismiss = onDismissExport,
             onExportFile = onExportFile,
         )
     }
@@ -152,15 +109,16 @@ internal fun ProviderCredentialBackupOverlay(
 @Composable
 private fun ProviderCredentialExportDialog(
     backup: AndroidProviderCredentialBackup,
+    target: ProviderCredentialBackupTarget,
     onDismiss: () -> Unit,
     onExportFile: (String) -> Unit,
 ) {
-    var mode by remember { mutableStateOf(ProviderCredentialExportMode.Encrypted) }
-    var password by remember { mutableStateOf("") }
-    var confirmation by remember { mutableStateOf("") }
-    var plaintextRiskAccepted by remember { mutableStateOf(false) }
-    var error by remember { mutableStateOf<String?>(null) }
-    var isBusy by remember { mutableStateOf(false) }
+    var mode by remember(target.providerId) { mutableStateOf(ProviderCredentialExportMode.Encrypted) }
+    var password by remember(target.providerId) { mutableStateOf("") }
+    var confirmation by remember(target.providerId) { mutableStateOf("") }
+    var plaintextRiskAccepted by remember(target.providerId) { mutableStateOf(false) }
+    var error by remember(target.providerId) { mutableStateOf<String?>(null) }
+    var isBusy by remember(target.providerId) { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     val encryptedReady = password.length >= 8 && password == confirmation
@@ -168,13 +126,18 @@ private fun ProviderCredentialExportDialog(
         ProviderCredentialExportMode.Encrypted -> encryptedReady
         ProviderCredentialExportMode.Plaintext -> plaintextRiskAccepted
     }
+    val targetDescription = if (target.providerId == null) {
+        "导出全部已保存的音源登录凭证"
+    } else {
+        "仅导出 ${target.providerName} 的登录凭证"
+    }
 
     AlertDialog(
         onDismissRequest = { if (!isBusy) onDismiss() },
-        title = { Text("导出登录凭证") },
+        title = { Text(if (target.providerId == null) "导出全部登录凭证" else "导出 ${target.providerName}") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text("默认推荐加密备份；只有第三方应用明确需要读取凭证时才使用明文导出。")
+                Text("$targetDescription。默认推荐加密备份；只有第三方应用明确需要读取凭证时才使用明文导出。")
                 ExportModeRow(
                     selected = mode == ProviderCredentialExportMode.Encrypted,
                     title = "加密备份（推荐）",
@@ -260,6 +223,7 @@ private fun ProviderCredentialExportDialog(
                             backup.export(
                                 mode = mode,
                                 password = if (mode == ProviderCredentialExportMode.Encrypted) password else "",
+                                providerId = target.providerId,
                             )
                         }.onSuccess { file ->
                             backup.stageExport(file)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/ProviderCredentialBackupUi.kt
@@ -1,0 +1,340 @@
+package org.feeluown.mobile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+@Composable
+internal fun ProviderCredentialBackupOverlay(
+    backup: AndroidProviderCredentialBackup,
+    onImportFile: (((String) -> Unit) -> Unit),
+    onExportFile: (String, String) -> Unit,
+    onFeedback: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showActions by remember { mutableStateOf(false) }
+    var showExport by remember { mutableStateOf(false) }
+    var pendingImport by remember { mutableStateOf<String?>(null) }
+    var importInspection by remember { mutableStateOf<ProviderCredentialBackupInspection?>(null) }
+    var importError by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    ExtendedFloatingActionButton(
+        modifier = modifier,
+        onClick = { showActions = true },
+        icon = { androidx.compose.material3.Icon(Icons.Filled.Lock, contentDescription = null) },
+        text = { Text("登录凭证备份") },
+    )
+
+    if (showActions) {
+        AlertDialog(
+            onDismissRequest = { showActions = false },
+            title = { Text("登录凭证备份与恢复") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(
+                        "备份会包含已登录音源的 Cookie、访问令牌和 OAuth 凭证。默认使用密码加密导出。",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            showActions = false
+                            showExport = true
+                        },
+                    ) { Text("导出登录凭证") }
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            showActions = false
+                            onImportFile { content ->
+                                scope.launch {
+                                    runCatching { backup.inspect(content) }
+                                        .onSuccess {
+                                            pendingImport = content
+                                            importInspection = it
+                                            importError = null
+                                        }
+                                        .onFailure { importError = it.message ?: "无法读取备份文件" }
+                                }
+                            }
+                        },
+                    ) { Text("从文件恢复") }
+                }
+            },
+            confirmButton = {},
+            dismissButton = { TextButton(onClick = { showActions = false }) { Text("取消") } },
+        )
+    }
+
+    if (showExport) {
+        ProviderCredentialExportDialog(
+            backup = backup,
+            onDismiss = { showExport = false },
+            onExportFile = onExportFile,
+        )
+    }
+
+    pendingImport?.let { content ->
+        importInspection?.let { inspection ->
+            ProviderCredentialImportDialog(
+                inspection = inspection,
+                onDismiss = {
+                    pendingImport = null
+                    importInspection = null
+                },
+                onRestore = { password ->
+                    scope.launch {
+                        runCatching { backup.restore(content, password) }
+                            .onSuccess { result ->
+                                pendingImport = null
+                                importInspection = null
+                                val ignored = if (result.ignoredProviderIds.isEmpty()) "" else
+                                    "，另有 ${result.ignoredProviderIds.size} 个当前版本不支持的音源已跳过"
+                                onFeedback("已恢复 ${result.restoredProviderIds.size} 个音源登录凭证$ignored")
+                            }
+                            .onFailure { importError = it.message ?: "恢复登录凭证失败" }
+                    }
+                },
+            )
+        }
+    }
+
+    importError?.let { message ->
+        AlertDialog(
+            onDismissRequest = { importError = null },
+            title = { Text("登录凭证备份") },
+            text = { Text(message) },
+            confirmButton = { TextButton(onClick = { importError = null }) { Text("确定") } },
+        )
+    }
+}
+
+@Composable
+private fun ProviderCredentialExportDialog(
+    backup: AndroidProviderCredentialBackup,
+    onDismiss: () -> Unit,
+    onExportFile: (String, String) -> Unit,
+) {
+    var mode by remember { mutableStateOf(ProviderCredentialExportMode.Encrypted) }
+    var password by remember { mutableStateOf("") }
+    var confirmation by remember { mutableStateOf("") }
+    var plaintextRiskAccepted by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var isBusy by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    val encryptedReady = password.length >= 8 && password == confirmation
+    val canExport = !isBusy && when (mode) {
+        ProviderCredentialExportMode.Encrypted -> encryptedReady
+        ProviderCredentialExportMode.Plaintext -> plaintextRiskAccepted
+    }
+
+    AlertDialog(
+        onDismissRequest = { if (!isBusy) onDismiss() },
+        title = { Text("导出登录凭证") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("默认推荐加密备份；只有第三方应用明确需要读取凭证时才使用明文导出。")
+                ExportModeRow(
+                    selected = mode == ProviderCredentialExportMode.Encrypted,
+                    title = "加密备份（推荐）",
+                    description = "使用备份密码加密，可在其他设备恢复。",
+                    onClick = {
+                        mode = ProviderCredentialExportMode.Encrypted
+                        plaintextRiskAccepted = false
+                    },
+                )
+                ExportModeRow(
+                    selected = mode == ProviderCredentialExportMode.Plaintext,
+                    title = "明文 JSON（第三方应用）",
+                    description = "不做任何加密，第三方程序可直接读取。",
+                    onClick = { mode = ProviderCredentialExportMode.Plaintext },
+                )
+
+                if (mode == ProviderCredentialExportMode.Encrypted) {
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = password,
+                        onValueChange = { password = it; error = null },
+                        label = { Text("备份密码（至少 8 位）") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = confirmation,
+                        onValueChange = { confirmation = it; error = null },
+                        label = { Text("确认备份密码") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        isError = confirmation.isNotEmpty() && confirmation != password,
+                    )
+                    Text(
+                        "请妥善保存备份密码。密码不会写入文件，遗失后无法恢复加密备份。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Surface(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text("明文导出存在高风险", style = MaterialTheme.typography.titleSmall)
+                            Text(
+                                "文件会直接包含 Cookie、访问令牌、Refresh Token、Authorization 以及 OAuth client_secret。任何拿到文件的人或应用都可能利用这些凭证访问你的账号。仅向你完全信任的第三方应用提供，不要上传到网盘、聊天、Issue 或其他公共位置，使用完成后请及时删除。",
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = plaintextRiskAccepted,
+                            onCheckedChange = { plaintextRiskAccepted = it },
+                        )
+                        Text(
+                            "我已了解明文导出的风险，并确认仍要继续",
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+
+                error?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = canExport,
+                onClick = {
+                    isBusy = true
+                    error = null
+                    scope.launch {
+                        runCatching {
+                            backup.export(
+                                mode = mode,
+                                password = if (mode == ProviderCredentialExportMode.Encrypted) password else "",
+                            )
+                        }.onSuccess { file ->
+                            isBusy = false
+                            onDismiss()
+                            onExportFile(file.fileName, file.content)
+                        }.onFailure {
+                            isBusy = false
+                            error = it.message ?: "导出登录凭证失败"
+                        }
+                    }
+                },
+            ) { Text(if (isBusy) "正在生成…" else "导出") }
+        },
+        dismissButton = { TextButton(enabled = !isBusy, onClick = onDismiss) { Text("取消") } },
+    )
+}
+
+@Composable
+private fun ExportModeRow(
+    selected: Boolean,
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Column(Modifier.weight(1f).padding(top = 8.dp)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Spacer(Modifier.height(2.dp))
+            Text(description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ProviderCredentialImportDialog(
+    inspection: ProviderCredentialBackupInspection,
+    onDismiss: () -> Unit,
+    onRestore: (String) -> Unit,
+) {
+    var password by remember(inspection) { mutableStateOf("") }
+    var confirmed by remember(inspection) { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("恢复登录凭证") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                if (inspection.encrypted) {
+                    Text("这是加密备份。恢复会覆盖备份中对应音源当前保存的登录凭证。")
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        value = password,
+                        onValueChange = { password = it },
+                        label = { Text("备份密码") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+                } else {
+                    Surface(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Text(
+                            "检测到明文凭证文件。文件内容未加密，恢复前请确认文件来自你信任的来源。",
+                            modifier = Modifier.padding(12.dp),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    inspection.providerCount?.let { Text("备份包含 $it 个音源的登录凭证。") }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(checked = confirmed, onCheckedChange = { confirmed = it })
+                    Text("我确认覆盖备份中对应音源的现有登录凭证", Modifier.weight(1f))
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = confirmed && (!inspection.encrypted || password.isNotBlank()),
+                onClick = { onRestore(password) },
+            ) { Text("恢复") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } },
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/ProviderCredentialBackupActions.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/ProviderCredentialBackupActions.kt
@@ -1,0 +1,15 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/** Platform capability surfaced inside the shared settings UI. */
+data class ProviderCredentialBackupActions(
+    val exportAll: (() -> Unit)? = null,
+    val exportProvider: ((ProviderInfo) -> Unit)? = null,
+    val importBackup: (() -> Unit)? = null,
+) {
+    val isAvailable: Boolean
+        get() = exportAll != null && exportProvider != null && importBackup != null
+}
+
+val LocalProviderCredentialBackupActions = staticCompositionLocalOf { ProviderCredentialBackupActions() }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -226,7 +226,7 @@ fun SettingsFeatureScreen(
                         }
                     }
                     FeatureSettingsRoute.CredentialBackup -> SettingsScaffold(
-                        title = "登录凭证备份与恢复",
+                        title = "登录凭证",
                         onBack = ::pop,
                         isLoading = catalogState.isLoading,
                     ) { bodyModifier ->
@@ -653,8 +653,7 @@ private fun ProviderCatalogSettings(
     if (credentialBackupActions.isAvailable) {
         SettingsGroup(title = "登录凭证") {
             SettingsRow(
-                title = "登录凭证备份与恢复",
-                supportingText = "加密备份全部或单个音源，也可从备份文件恢复",
+                title = "备份与恢复",
                 leadingContent = { Icon(Icons.Filled.ManageAccounts, contentDescription = null) },
                 trailingContent = {
                     Icon(
@@ -700,12 +699,8 @@ private fun ProviderCredentialBackupSettings(
 
     SettingsGroup(title = "备份") {
         SettingsRow(
-            title = "导出全部登录凭证",
-            supportingText = if (orderedLoggedInProviders.isEmpty()) {
-                "当前没有已登录的音源"
-            } else {
-                "${orderedLoggedInProviders.size} 个已登录音源 · 默认使用密码加密"
-            },
+            title = "导出全部",
+            supportingText = orderedLoggedInProviders.takeIf { it.isNotEmpty() }?.let { "${it.size} 个音源" },
             enabled = exportAll != null && orderedLoggedInProviders.isNotEmpty(),
             leadingContent = { Icon(Icons.Filled.Download, contentDescription = null) },
             trailingContent = {
@@ -721,17 +716,13 @@ private fun ProviderCredentialBackupSettings(
 
     SettingsGroup(title = "单独导出") {
         if (orderedLoggedInProviders.isEmpty()) {
-            SettingsRow(
-                title = "暂无可导出的音源",
-                supportingText = "登录音源后可在这里单独备份对应凭证",
-            )
+            SettingsRow(title = "暂无已登录音源")
         } else {
             orderedLoggedInProviders.forEachIndexed { index, provider ->
                 val auth = state.sessions.authStates[provider.providerId]
                 SettingsRow(
                     title = provider.providerName,
-                    supportingText = auth?.userName?.takeIf { it.isNotBlank() }?.let { "已登录 · $it" }
-                        ?: "仅导出此音源的登录凭证",
+                    supportingText = auth?.userName?.takeIf { it.isNotBlank() },
                     enabled = exportProvider != null,
                     leadingContent = { Icon(Icons.Filled.ManageAccounts, contentDescription = null) },
                     trailingContent = {
@@ -750,8 +741,7 @@ private fun ProviderCredentialBackupSettings(
 
     SettingsGroup(title = "恢复") {
         SettingsRow(
-            title = "从备份文件恢复",
-            supportingText = "支持全部音源备份和单个音源备份；恢复前会再次确认覆盖",
+            title = "从文件恢复",
             enabled = importBackup != null,
             leadingContent = { Icon(Icons.Filled.Settings, contentDescription = null) },
             trailingContent = {
@@ -762,13 +752,6 @@ private fun ProviderCredentialBackupSettings(
                 )
             },
             onClick = importBackup,
-        )
-    }
-
-    SettingsGroup(title = "安全说明") {
-        SettingsRow(
-            title = "默认使用加密备份",
-            supportingText = "备份可能包含 Cookie、访问令牌、Refresh Token、Authorization 和 OAuth client_secret。明文导出仅用于可信第三方应用，并需要额外风险确认。",
         )
     }
 }
@@ -1349,8 +1332,7 @@ private fun ProviderAccountSettings(
     if (auth.isLoggedIn && credentialBackupActions.exportProvider != null) {
         SettingsGroup(title = "登录凭证") {
             SettingsRow(
-                title = "导出此音源登录凭证",
-                supportingText = "仅备份 ${provider.providerName}，默认使用密码加密",
+                title = "导出登录凭证",
                 enabled = !busy,
                 leadingContent = { Icon(Icons.Filled.Download, contentDescription = null) },
                 trailingContent = {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -110,6 +110,7 @@ private sealed interface FeatureSettingsRoute : NavKey {
     @Serializable data object Main : FeatureSettingsRoute
     @Serializable data class Category(val category: FeatureSettingsCategory) : FeatureSettingsRoute
     @Serializable data object Theme : FeatureSettingsRoute
+    @Serializable data object CredentialBackup : FeatureSettingsRoute
     @Serializable data class Provider(val providerId: String) : FeatureSettingsRoute
 }
 
@@ -150,6 +151,7 @@ fun SettingsFeatureScreen(
     val settingsState by settingsController.uiState.collectAsStateWithLifecycle()
     val catalogState by providerCatalog.uiState.collectAsStateWithLifecycle()
     val authState by providerAuth.uiState.collectAsStateWithLifecycle()
+    val credentialBackupActions = LocalProviderCredentialBackupActions.current
     val layoutInfo = LocalAppLayoutInfo.current
     val predictiveBackPreference = rememberPredictiveBackPreference()
     var backStack by remember { mutableStateOf<List<FeatureSettingsRoute>>(listOf(FeatureSettingsRoute.Main)) }
@@ -193,6 +195,7 @@ fun SettingsFeatureScreen(
                         },
                         onOpenTheme = { push(FeatureSettingsRoute.Theme) },
                         onOpenProvider = { push(FeatureSettingsRoute.Provider(it.providerId)) },
+                        onOpenCredentialBackup = { push(FeatureSettingsRoute.CredentialBackup) },
                         onBack = settingsController::close,
                         settingsController = settingsController,
                         providerCatalog = providerCatalog,
@@ -206,6 +209,7 @@ fun SettingsFeatureScreen(
                         providerCatalog = providerCatalog,
                         onOpenTheme = { push(FeatureSettingsRoute.Theme) },
                         onOpenProvider = { push(FeatureSettingsRoute.Provider(it.providerId)) },
+                        onOpenCredentialBackup = { push(FeatureSettingsRoute.CredentialBackup) },
                         onBack = ::pop,
                     )
                     FeatureSettingsRoute.Theme -> SettingsScaffold(
@@ -218,6 +222,18 @@ fun SettingsFeatureScreen(
                                 state = settingsState,
                                 controller = settingsController,
                                 predictiveBackPreference = predictiveBackPreference,
+                            )
+                        }
+                    }
+                    FeatureSettingsRoute.CredentialBackup -> SettingsScaffold(
+                        title = "登录凭证备份与恢复",
+                        onBack = ::pop,
+                        isLoading = catalogState.isLoading,
+                    ) { bodyModifier ->
+                        SettingsDetailColumn(modifier = bodyModifier) {
+                            ProviderCredentialBackupSettings(
+                                state = catalogState,
+                                actions = credentialBackupActions,
                             )
                         }
                     }
@@ -270,6 +286,7 @@ private fun SettingsMainPage(
     onSelectCategory: (FeatureSettingsCategory) -> Unit,
     onOpenTheme: () -> Unit,
     onOpenProvider: (ProviderInfo) -> Unit,
+    onOpenCredentialBackup: () -> Unit,
     onBack: () -> Unit,
     settingsController: SettingsFeatureController,
     providerCatalog: ProviderCatalogFeatureController,
@@ -322,6 +339,7 @@ private fun SettingsMainPage(
                             providerCatalog = providerCatalog,
                             onOpenTheme = onOpenTheme,
                             onOpenProvider = onOpenProvider,
+                            onOpenCredentialBackup = onOpenCredentialBackup,
                         )
                     }
                 }
@@ -349,6 +367,7 @@ private fun SettingsCategoryPage(
     providerCatalog: ProviderCatalogFeatureController,
     onOpenTheme: () -> Unit,
     onOpenProvider: (ProviderInfo) -> Unit,
+    onOpenCredentialBackup: () -> Unit,
     onBack: () -> Unit,
 ) {
     SettingsScaffold(
@@ -366,6 +385,7 @@ private fun SettingsCategoryPage(
             providerCatalog = providerCatalog,
             onOpenTheme = onOpenTheme,
             onOpenProvider = onOpenProvider,
+            onOpenCredentialBackup = onOpenCredentialBackup,
             modifier = bodyModifier,
         )
     }
@@ -486,6 +506,7 @@ private fun SettingsCategoryDetail(
     providerCatalog: ProviderCatalogFeatureController,
     onOpenTheme: () -> Unit,
     onOpenProvider: (ProviderInfo) -> Unit,
+    onOpenCredentialBackup: () -> Unit,
     modifier: Modifier = Modifier.fillMaxSize(),
 ) {
     SettingsDetailColumn(modifier = modifier) {
@@ -504,6 +525,7 @@ private fun SettingsCategoryDetail(
                 state = catalog,
                 controller = providerCatalog,
                 onOpenProvider = onOpenProvider,
+                onOpenCredentialBackup = onOpenCredentialBackup,
             )
             FeatureSettingsCategory.Playback -> PlaybackFeatureSettings(
                 state = settings,
@@ -542,7 +564,9 @@ private fun ProviderCatalogSettings(
     state: ProviderCatalogUiState,
     controller: ProviderCatalogFeatureController,
     onOpenProvider: (ProviderInfo) -> Unit,
+    onOpenCredentialBackup: () -> Unit,
 ) {
+    val credentialBackupActions = LocalProviderCredentialBackupActions.current
     val ordered = remember(state.availableProviders, state.providerOrderIds) {
         val order = state.providerOrderIds.withIndex().associate { it.value to it.index }
         state.availableProviders.sortedBy { order[it.providerId] ?: Int.MAX_VALUE }
@@ -626,6 +650,23 @@ private fun ProviderCatalogSettings(
             if (index < ordered.lastIndex) SettingsDivider()
         }
     }
+    if (credentialBackupActions.isAvailable) {
+        SettingsGroup(title = "登录凭证") {
+            SettingsRow(
+                title = "登录凭证备份与恢复",
+                supportingText = "加密备份全部或单个音源，也可从备份文件恢复",
+                leadingContent = { Icon(Icons.Filled.ManageAccounts, contentDescription = null) },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                onClick = onOpenCredentialBackup,
+            )
+        }
+    }
     SettingsGroup(title = "说明") {
         SettingsRow(
             title = "长按拖动调整音源优先级",
@@ -638,6 +679,96 @@ private fun ProviderCatalogSettings(
             controller = controller,
             provider = provider,
             onDismissRequest = { configuringProvider = null },
+        )
+    }
+}
+
+@Composable
+private fun ProviderCredentialBackupSettings(
+    state: ProviderCatalogUiState,
+    actions: ProviderCredentialBackupActions,
+) {
+    val orderedLoggedInProviders = remember(state.availableProviders, state.providerOrderIds, state.sessions.authStates) {
+        val order = state.providerOrderIds.withIndex().associate { it.value to it.index }
+        state.availableProviders
+            .filter { provider -> state.sessions.authStates[provider.providerId]?.isLoggedIn == true }
+            .sortedBy { provider -> order[provider.providerId] ?: Int.MAX_VALUE }
+    }
+    val exportAll = actions.exportAll
+    val exportProvider = actions.exportProvider
+    val importBackup = actions.importBackup
+
+    SettingsGroup(title = "备份") {
+        SettingsRow(
+            title = "导出全部登录凭证",
+            supportingText = if (orderedLoggedInProviders.isEmpty()) {
+                "当前没有已登录的音源"
+            } else {
+                "${orderedLoggedInProviders.size} 个已登录音源 · 默认使用密码加密"
+            },
+            enabled = exportAll != null && orderedLoggedInProviders.isNotEmpty(),
+            leadingContent = { Icon(Icons.Filled.Download, contentDescription = null) },
+            trailingContent = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            onClick = exportAll,
+        )
+    }
+
+    SettingsGroup(title = "单独导出") {
+        if (orderedLoggedInProviders.isEmpty()) {
+            SettingsRow(
+                title = "暂无可导出的音源",
+                supportingText = "登录音源后可在这里单独备份对应凭证",
+            )
+        } else {
+            orderedLoggedInProviders.forEachIndexed { index, provider ->
+                val auth = state.sessions.authStates[provider.providerId]
+                SettingsRow(
+                    title = provider.providerName,
+                    supportingText = auth?.userName?.takeIf { it.isNotBlank() }?.let { "已登录 · $it" }
+                        ?: "仅导出此音源的登录凭证",
+                    enabled = exportProvider != null,
+                    leadingContent = { Icon(Icons.Filled.ManageAccounts, contentDescription = null) },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    onClick = exportProvider?.let { action -> { action(provider) } },
+                )
+                if (index < orderedLoggedInProviders.lastIndex) SettingsDivider()
+            }
+        }
+    }
+
+    SettingsGroup(title = "恢复") {
+        SettingsRow(
+            title = "从备份文件恢复",
+            supportingText = "支持全部音源备份和单个音源备份；恢复前会再次确认覆盖",
+            enabled = importBackup != null,
+            leadingContent = { Icon(Icons.Filled.Settings, contentDescription = null) },
+            trailingContent = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            onClick = importBackup,
+        )
+    }
+
+    SettingsGroup(title = "安全说明") {
+        SettingsRow(
+            title = "默认使用加密备份",
+            supportingText = "备份可能包含 Cookie、访问令牌、Refresh Token、Authorization 和 OAuth client_secret。明文导出仅用于可信第三方应用，并需要额外风险确认。",
         )
     }
 }
@@ -1188,6 +1319,7 @@ private fun ProviderAccountSettings(
     onStartYtmusicOAuth: (() -> Unit)?,
 ) {
     val uriHandler = LocalUriHandler.current
+    val credentialBackupActions = LocalProviderCredentialBackupActions.current
     val auth = authController.authStateFor(provider)
     val busy = authController.isBusy(provider.providerId)
     val modes = provider.supportedLoginModes.toList().ifEmpty { listOf(ProviderLoginMode.Cookie) }
@@ -1211,6 +1343,25 @@ private fun ProviderAccountSettings(
                     modifier = Modifier.fillMaxWidth(),
                 ) { Text("退出登录") }
             }
+        }
+    }
+
+    if (auth.isLoggedIn && credentialBackupActions.exportProvider != null) {
+        SettingsGroup(title = "登录凭证") {
+            SettingsRow(
+                title = "导出此音源登录凭证",
+                supportingText = "仅备份 ${provider.providerName}，默认使用密码加密",
+                enabled = !busy,
+                leadingContent = { Icon(Icons.Filled.Download, contentDescription = null) },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                onClick = { credentialBackupActions.exportProvider.invoke(provider) },
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

- add provider credential backup and restore
- move the entry to Settings → 音源与账号 → 登录凭证
- support exporting all logged-in providers or a single provider
- default to password-encrypted backup, with optional plaintext JSON export
- restore credentials and refresh provider auth state
- keep pending file operations safe across Activity recreation

## Notes

Plaintext export requires an explicit confirmation. Android provides the file import/export implementation; unsupported platforms hide the entry.