### PR TITLE
feat: add provider resource favorite actions

### DIFF
--- a/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
+++ b/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
@@ -496,6 +496,16 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
                     playlist = playlist,
                     category = category,
                     isLoading = true,
+                    favoriteState = if (before.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
+                        before.favoriteState
+                    } else {
+                        ProviderDetailFavoriteState()
+                    },
+                    isFavoriteLoading = if (before.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
+                        before.isFavoriteLoading
+                    } else {
+                        false
+                    },
                     message = "正在加载：${port.playlistTitle(playlist)}",
                 )
             } else {
@@ -528,6 +538,7 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     }
 
     private fun refreshFavoriteState(playlist: Playlist) {
+        if (favoriteMutationJob?.isActive == true) return
         favoriteStateJob?.cancel()
         favoriteStateJob = scope.launch {
             val favoriteState = runCatching { port.loadFavoriteState(playlist) }.getOrNull() ?: return@launch
@@ -871,9 +882,20 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
         tracksJob?.cancel()
         albumsJob?.cancel()
         tracksJob = scope.launch {
+            val before = state.value
             mutableState.value = ProviderMediaItemDetailFeatureState(
                 item = item,
                 isLoading = true,
+                favoriteState = if (before.item?.let(port::itemId) == port.itemId(item)) {
+                    before.favoriteState
+                } else {
+                    ProviderDetailFavoriteState()
+                },
+                isFavoriteLoading = if (before.item?.let(port::itemId) == port.itemId(item)) {
+                    before.isFavoriteLoading
+                } else {
+                    false
+                },
                 message = "正在加载：${port.itemTitle(item)}",
             )
             runCatching {
@@ -907,6 +929,7 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     }
 
     private fun refreshFavoriteState(item: Item) {
+        if (favoriteMutationJob?.isActive == true) return
         favoriteStateJob?.cancel()
         favoriteStateJob = scope.launch {
             val favoriteState = runCatching { port.loadFavoriteState(item) }.getOrNull() ?: return@launch

--- a/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
+++ b/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
@@ -56,6 +56,8 @@ interface ProviderFeatureDetailFeatureOwner<Feature, Content, Track> {
     fun prefetchIfNeeded(visibleIndex: Int)
     fun play(index: Int)
     fun playAll()
+    fun canToggleFavorite(): Boolean
+    fun toggleFavorite()
 }
 
 fun <Feature, Content, Track> createProviderFeatureDetailFeatureOwner(
@@ -224,6 +226,12 @@ data class ProviderDetailMutationResult(
     val message: String = "",
 )
 
+data class ProviderDetailFavoriteState(
+    val isFavorite: Boolean = false,
+    val canFavorite: Boolean = false,
+    val canUnfavorite: Boolean = false,
+)
+
 data class ProviderPlaylistDetailFeatureState<Playlist, Category, Track>(
     val playlist: Playlist? = null,
     val category: Category? = null,
@@ -231,6 +239,8 @@ data class ProviderPlaylistDetailFeatureState<Playlist, Category, Track>(
     val nextOffset: Int = 0,
     val hasMore: Boolean = false,
     val isLoading: Boolean = false,
+    val favoriteState: ProviderDetailFavoriteState = ProviderDetailFavoriteState(),
+    val isFavoriteLoading: Boolean = false,
     val message: String? = null,
     val errorMessage: String? = null,
 )
@@ -239,6 +249,9 @@ interface ProviderPlaylistDetailPort<Playlist, Category, Track> {
     suspend fun loadPage(playlist: Playlist, offset: Int): ProviderPlaylistDetailPage<Playlist, Track>
     suspend fun removeTrack(playlist: Playlist, track: Track): ProviderDetailMutationResult
     suspend fun deletePlaylist(playlist: Playlist): ProviderDetailMutationResult
+    suspend fun loadFavoriteState(playlist: Playlist): ProviderDetailFavoriteState = ProviderDetailFavoriteState()
+    suspend fun setFavorite(playlist: Playlist, favorite: Boolean): ProviderDetailMutationResult =
+        ProviderDetailMutationResult(false)
     suspend fun recordPlayback(playlist: Playlist)
     fun playlistId(playlist: Playlist): String
     fun playlistTitle(playlist: Playlist): String
@@ -273,6 +286,8 @@ interface ProviderPlaylistDetailFeatureOwner<Playlist, Category, Track> {
     fun remove(track: Track)
     fun canDelete(): Boolean
     fun delete()
+    fun canToggleFavorite(): Boolean
+    fun toggleFavorite()
 }
 
 fun <Playlist, Category, Track> createProviderPlaylistDetailFeatureOwner(
@@ -289,6 +304,7 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     override val state: StateFlow<ProviderPlaylistDetailFeatureState<Playlist, Category, Track>> = mutableState.asStateFlow()
     private var loadJob: Job? = null
     private var playbackPaginationJob: Job? = null
+    private var favoriteJob: Job? = null
 
     override fun open(playlist: Playlist, category: Category?) {
         port.open(playlist, category)
@@ -307,6 +323,7 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     override fun close() {
         loadJob?.cancel()
         playbackPaginationJob?.cancel()
+        favoriteJob?.cancel()
         mutableState.value = ProviderPlaylistDetailFeatureState()
         port.close()
     }
@@ -414,6 +431,61 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
         }
     }
 
+    override fun canToggleFavorite(): Boolean {
+        val current = state.value
+        return !current.isFavoriteLoading && when {
+            current.favoriteState.isFavorite -> current.favoriteState.canUnfavorite
+            else -> current.favoriteState.canFavorite
+        }
+    }
+
+    override fun toggleFavorite() {
+        val playlist = state.value.playlist ?: return
+        if (!canToggleFavorite()) return
+        val favorite = !state.value.favoriteState.isFavorite
+        favoriteJob?.cancel()
+        favoriteJob = scope.launch {
+            mutableState.value = state.value.copy(isFavoriteLoading = true, errorMessage = null)
+            runCatching { port.setFavorite(playlist, favorite) }
+                .onSuccess { result ->
+                    if (state.value.playlist?.let(port::playlistId) != port.playlistId(playlist)) return@onSuccess
+                    if (result.success) {
+                        mutableState.value = state.value.copy(
+                            favoriteState = ProviderDetailFavoriteState(
+                                isFavorite = favorite,
+                                canFavorite = !favorite,
+                                canUnfavorite = favorite,
+                            ),
+                            isFavoriteLoading = false,
+                            message = result.message.ifBlank { if (favorite) "收藏成功" else "已取消收藏" },
+                            errorMessage = null,
+                        )
+                        port.onProviderMutation(port.playlistProviderId(playlist))
+                    } else {
+                        val error = result.message.ifBlank { if (favorite) "收藏失败" else "取消收藏失败" }
+                        mutableState.value = state.value.copy(
+                            isFavoriteLoading = false,
+                            message = error,
+                            errorMessage = error,
+                        )
+                    }
+                }
+                .onFailure {
+                    if (state.value.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
+                        mutableState.value = state.value.copy(
+                            isFavoriteLoading = false,
+                            errorMessage = port.errorMessage(
+                                it,
+                                if (favorite) "收藏失败" else "取消收藏失败",
+                                port.playlistProviderId(playlist),
+                            ),
+                        )
+                    }
+                }
+        }
+    }
+
+
     private fun load(playlist: Playlist, category: Category?, reset: Boolean) {
         if (reset) loadJob?.cancel()
         loadJob = scope.launch {
@@ -443,6 +515,7 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
                     message = if (tracks.isEmpty()) "歌单暂无歌曲" else "${port.playlistTitle(page.playlist)} · ${tracks.size} 首",
                     errorMessage = null,
                 )
+                refreshFavoriteState(page.playlist)
             }.onFailure { throwable ->
                 if (state.value.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
                     mutableState.value = state.value.copy(
@@ -450,6 +523,19 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
                         errorMessage = port.errorMessage(throwable, "加载失败", port.playlistProviderId(playlist)),
                     )
                 }
+            }
+        }
+    }
+
+    private fun refreshFavoriteState(playlist: Playlist) {
+        favoriteJob?.cancel()
+        favoriteJob = scope.launch {
+            val favoriteState = runCatching { port.loadFavoriteState(playlist) }.getOrNull() ?: return@launch
+            if (state.value.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
+                mutableState.value = state.value.copy(
+                    favoriteState = favoriteState,
+                    isFavoriteLoading = false,
+                )
             }
         }
     }
@@ -622,12 +708,17 @@ data class ProviderMediaItemDetailFeatureState<Item, Track>(
     val albumsNextOffset: Int = 0,
     val albumsHasMore: Boolean = false,
     val isLoading: Boolean = false,
+    val favoriteState: ProviderDetailFavoriteState = ProviderDetailFavoriteState(),
+    val isFavoriteLoading: Boolean = false,
     val message: String? = null,
     val errorMessage: String? = null,
 )
 
 interface ProviderMediaItemDetailPort<Item, Track> {
     suspend fun loadPage(item: Item, tracksOffset: Int, albumsOffset: Int): ProviderMediaItemDetailPage<Item, Track>
+    suspend fun loadFavoriteState(item: Item): ProviderDetailFavoriteState = ProviderDetailFavoriteState()
+    suspend fun setFavorite(item: Item, favorite: Boolean): ProviderDetailMutationResult =
+        ProviderDetailMutationResult(false)
     fun itemId(item: Item): String
     fun itemTitle(item: Item): String
     fun itemProviderId(item: Item): String?
@@ -636,6 +727,7 @@ interface ProviderMediaItemDetailPort<Item, Track> {
     fun open(item: Item)
     fun close()
     fun playTracks(tracks: List<Track>, index: Int)
+    fun onProviderMutation(providerId: String) = Unit
 }
 
 interface ProviderMediaItemDetailFeatureOwner<Item, Track> {

--- a/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
+++ b/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
@@ -302,7 +302,8 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     override val state: StateFlow<ProviderPlaylistDetailFeatureState<Playlist, Category, Track>> = mutableState.asStateFlow()
     private var loadJob: Job? = null
     private var playbackPaginationJob: Job? = null
-    private var favoriteJob: Job? = null
+    private var favoriteStateJob: Job? = null
+    private var favoriteMutationJob: Job? = null
 
     override fun open(playlist: Playlist, category: Category?) {
         port.open(playlist, category)
@@ -321,7 +322,8 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     override fun close() {
         loadJob?.cancel()
         playbackPaginationJob?.cancel()
-        favoriteJob?.cancel()
+        favoriteStateJob?.cancel()
+        favoriteMutationJob?.cancel()
         mutableState.value = ProviderPlaylistDetailFeatureState()
         port.close()
     }
@@ -441,8 +443,8 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
         val playlist = state.value.playlist ?: return
         if (!canToggleFavorite()) return
         val favorite = !state.value.favoriteState.isFavorite
-        favoriteJob?.cancel()
-        favoriteJob = scope.launch {
+        favoriteMutationJob?.cancel()
+        favoriteMutationJob = scope.launch {
             mutableState.value = state.value.copy(isFavoriteLoading = true, errorMessage = null)
             runCatching { port.setFavorite(playlist, favorite) }
                 .onSuccess { result ->
@@ -526,8 +528,8 @@ private class DefaultProviderPlaylistDetailFeatureOwner<Playlist, Category, Trac
     }
 
     private fun refreshFavoriteState(playlist: Playlist) {
-        favoriteJob?.cancel()
-        favoriteJob = scope.launch {
+        favoriteStateJob?.cancel()
+        favoriteStateJob = scope.launch {
             val favoriteState = runCatching { port.loadFavoriteState(playlist) }.getOrNull() ?: return@launch
             if (state.value.playlist?.let(port::playlistId) == port.playlistId(playlist)) {
                 mutableState.value = state.value.copy(
@@ -755,7 +757,8 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     override val state: StateFlow<ProviderMediaItemDetailFeatureState<Item, Track>> = mutableState.asStateFlow()
     private var tracksJob: Job? = null
     private var albumsJob: Job? = null
-    private var favoriteJob: Job? = null
+    private var favoriteStateJob: Job? = null
+    private var favoriteMutationJob: Job? = null
 
     override fun open(item: Item) {
         port.open(item)
@@ -773,7 +776,8 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     override fun close() {
         tracksJob?.cancel()
         albumsJob?.cancel()
-        favoriteJob?.cancel()
+        favoriteStateJob?.cancel()
+        favoriteMutationJob?.cancel()
         mutableState.value = ProviderMediaItemDetailFeatureState()
         port.close()
     }
@@ -820,8 +824,8 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
         val item = state.value.item ?: return
         if (!canToggleFavorite()) return
         val favorite = !state.value.favoriteState.isFavorite
-        favoriteJob?.cancel()
-        favoriteJob = scope.launch {
+        favoriteMutationJob?.cancel()
+        favoriteMutationJob = scope.launch {
             mutableState.value = state.value.copy(isFavoriteLoading = true, errorMessage = null)
             runCatching { port.setFavorite(item, favorite) }
                 .onSuccess { result ->
@@ -903,8 +907,8 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     }
 
     private fun refreshFavoriteState(item: Item) {
-        favoriteJob?.cancel()
-        favoriteJob = scope.launch {
+        favoriteStateJob?.cancel()
+        favoriteStateJob = scope.launch {
             val favoriteState = runCatching { port.loadFavoriteState(item) }.getOrNull() ?: return@launch
             if (state.value.item?.let(port::itemId) == port.itemId(item)) {
                 mutableState.value = state.value.copy(

--- a/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
+++ b/feature/providerdetail/src/commonMain/kotlin/org/feeluown/mobile/ProviderDetailFeature.kt
@@ -56,8 +56,6 @@ interface ProviderFeatureDetailFeatureOwner<Feature, Content, Track> {
     fun prefetchIfNeeded(visibleIndex: Int)
     fun play(index: Int)
     fun playAll()
-    fun canToggleFavorite(): Boolean
-    fun toggleFavorite()
 }
 
 fun <Feature, Content, Track> createProviderFeatureDetailFeatureOwner(
@@ -740,6 +738,8 @@ interface ProviderMediaItemDetailFeatureOwner<Item, Track> {
     fun prefetchAlbumsIfNeeded(visibleIndex: Int)
     fun play(index: Int)
     fun playAll()
+    fun canToggleFavorite(): Boolean
+    fun toggleFavorite()
 }
 
 fun <Item, Track> createProviderMediaItemDetailFeatureOwner(
@@ -755,6 +755,7 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     override val state: StateFlow<ProviderMediaItemDetailFeatureState<Item, Track>> = mutableState.asStateFlow()
     private var tracksJob: Job? = null
     private var albumsJob: Job? = null
+    private var favoriteJob: Job? = null
 
     override fun open(item: Item) {
         port.open(item)
@@ -772,6 +773,7 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
     override fun close() {
         tracksJob?.cancel()
         albumsJob?.cancel()
+        favoriteJob?.cancel()
         mutableState.value = ProviderMediaItemDetailFeatureState()
         port.close()
     }
@@ -806,6 +808,61 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
         }
     }
 
+    override fun canToggleFavorite(): Boolean {
+        val current = state.value
+        return !current.isFavoriteLoading && when {
+            current.favoriteState.isFavorite -> current.favoriteState.canUnfavorite
+            else -> current.favoriteState.canFavorite
+        }
+    }
+
+    override fun toggleFavorite() {
+        val item = state.value.item ?: return
+        if (!canToggleFavorite()) return
+        val favorite = !state.value.favoriteState.isFavorite
+        favoriteJob?.cancel()
+        favoriteJob = scope.launch {
+            mutableState.value = state.value.copy(isFavoriteLoading = true, errorMessage = null)
+            runCatching { port.setFavorite(item, favorite) }
+                .onSuccess { result ->
+                    if (state.value.item?.let(port::itemId) != port.itemId(item)) return@onSuccess
+                    if (result.success) {
+                        mutableState.value = state.value.copy(
+                            favoriteState = ProviderDetailFavoriteState(
+                                isFavorite = favorite,
+                                canFavorite = !favorite,
+                                canUnfavorite = favorite,
+                            ),
+                            isFavoriteLoading = false,
+                            message = result.message.ifBlank { if (favorite) "收藏成功" else "已取消收藏" },
+                            errorMessage = null,
+                        )
+                        port.itemProviderId(item)?.let(port::onProviderMutation)
+                    } else {
+                        val error = result.message.ifBlank { if (favorite) "收藏失败" else "取消收藏失败" }
+                        mutableState.value = state.value.copy(
+                            isFavoriteLoading = false,
+                            message = error,
+                            errorMessage = error,
+                        )
+                    }
+                }
+                .onFailure {
+                    if (state.value.item?.let(port::itemId) == port.itemId(item)) {
+                        mutableState.value = state.value.copy(
+                            isFavoriteLoading = false,
+                            errorMessage = port.errorMessage(
+                                it,
+                                if (favorite) "收藏失败" else "取消收藏失败",
+                                port.itemProviderId(item),
+                            ),
+                        )
+                    }
+                }
+        }
+    }
+
+
     private fun loadInitial(item: Item) {
         tracksJob?.cancel()
         albumsJob?.cancel()
@@ -833,6 +890,7 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
                         if (page.albums.isNotEmpty()) add("${page.albums.size} 张专辑")
                     }.joinToString(" · ").ifBlank { "${port.itemTitle(page.item)} 暂无内容" },
                 )
+                refreshFavoriteState(page.item)
             }.onFailure {
                 if (state.value.item?.let(port::itemId) == port.itemId(item)) {
                     mutableState.value = state.value.copy(
@@ -840,6 +898,19 @@ private class DefaultProviderMediaItemDetailFeatureOwner<Item, Track>(
                         errorMessage = port.errorMessage(it, "加载失败", port.itemProviderId(item)),
                     )
                 }
+            }
+        }
+    }
+
+    private fun refreshFavoriteState(item: Item) {
+        favoriteJob?.cancel()
+        favoriteJob = scope.launch {
+            val favoriteState = runCatching { port.loadFavoriteState(item) }.getOrNull() ?: return@launch
+            if (state.value.item?.let(port::itemId) == port.itemId(item)) {
+                mutableState.value = state.value.copy(
+                    favoriteState = favoriteState,
+                    isFavoriteLoading = false,
+                )
             }
         }
     }

--- a/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
+++ b/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
@@ -207,8 +207,8 @@ class ProviderDetailFeatureTest {
             albumsOffset: Int,
         ) = ProviderMediaItemDetailPage(
             item = item,
-            tracks = emptyList(),
-            albums = emptyList(),
+            tracks = emptyList<FakeTrack>(),
+            albums = emptyList<FakeMediaItem>(),
             tracksNextOffset = 0,
             tracksHasMore = false,
             albumsNextOffset = 0,

--- a/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
+++ b/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
@@ -52,6 +52,44 @@ class ProviderDetailFeatureTest {
     }
 
     @Test
+    fun playlistFavoriteStateAndMutationStayOwnedByFeature() = runTest {
+        val port = PlaylistPort()
+        val owner = createProviderPlaylistDetailFeatureOwner(port, backgroundScope)
+        val playlist = FakePlaylist("p1", "收藏歌单", "qqmusic")
+
+        owner.activate(playlist, FakeCategory.Other)
+        runCurrent()
+
+        assertTrue(owner.canToggleFavorite())
+        assertFalse(owner.state.value.favoriteState.isFavorite)
+
+        owner.toggleFavorite()
+        runCurrent()
+
+        assertTrue(owner.state.value.favoriteState.isFavorite)
+        assertEquals(listOf(true), port.favoriteMutations)
+        assertEquals(listOf("qqmusic"), port.mutations)
+    }
+
+    @Test
+    fun mediaItemFavoriteStateAndMutationStayOwnedByFeature() = runTest {
+        val port = MediaPort()
+        val owner = createProviderMediaItemDetailFeatureOwner(port, backgroundScope)
+        val item = FakeMediaItem("artist:qqmusic:mid", "歌手", "qqmusic")
+
+        owner.activate(item)
+        runCurrent()
+
+        assertTrue(owner.canToggleFavorite())
+        owner.toggleFavorite()
+        runCurrent()
+
+        assertTrue(owner.state.value.favoriteState.isFavorite)
+        assertEquals(listOf(true), port.favoriteMutations)
+        assertEquals(listOf("qqmusic"), port.mutations)
+    }
+
+    @Test
     fun videoFullscreenIsFeatureLocalState() = runTest {
         val port = VideoPort()
         val owner = createProviderVideoDetailFeatureOwner(port, backgroundScope)
@@ -73,6 +111,7 @@ class ProviderDetailFeatureTest {
         val hasMore: Boolean,
     )
     private data class FakePlaylist(val id: String, val title: String, val providerId: String)
+    private data class FakeMediaItem(val id: String, val title: String, val providerId: String)
     private enum class FakeCategory { Mine, Other }
     private data class FakeVideo(val id: String, val title: String, val providerId: String)
 
@@ -114,6 +153,7 @@ class ProviderDetailFeatureTest {
 
     private class PlaylistPort : ProviderPlaylistDetailPort<FakePlaylist, FakeCategory, FakeTrack> {
         val mutations = mutableListOf<String>()
+        val favoriteMutations = mutableListOf<Boolean>()
 
         override suspend fun loadPage(
             playlist: FakePlaylist,
@@ -128,6 +168,12 @@ class ProviderDetailFeatureTest {
         override suspend fun removeTrack(playlist: FakePlaylist, track: FakeTrack) =
             ProviderDetailMutationResult(true, "已移除")
         override suspend fun deletePlaylist(playlist: FakePlaylist) = ProviderDetailMutationResult(true)
+        override suspend fun loadFavoriteState(playlist: FakePlaylist) =
+            ProviderDetailFavoriteState(canFavorite = true)
+        override suspend fun setFavorite(playlist: FakePlaylist, favorite: Boolean): ProviderDetailMutationResult {
+            favoriteMutations += favorite
+            return ProviderDetailMutationResult(true, if (favorite) "收藏成功" else "已取消收藏")
+        }
         override suspend fun recordPlayback(playlist: FakePlaylist) = Unit
         override fun playlistId(playlist: FakePlaylist) = playlist.id
         override fun playlistTitle(playlist: FakePlaylist) = playlist.title
@@ -146,6 +192,45 @@ class ProviderDetailFeatureTest {
         override fun playPlaylistTracks(tracks: List<FakeTrack>, index: Int, playlistId: String) = Unit
         override fun playAllPlaylistTracks(tracks: List<FakeTrack>, playlistId: String) = Unit
         override fun appendPlaylistTracks(playlistId: String, tracks: List<FakeTrack>) = Unit
+        override fun onProviderMutation(providerId: String) {
+            mutations += providerId
+        }
+    }
+
+    private class MediaPort : ProviderMediaItemDetailPort<FakeMediaItem, FakeTrack> {
+        val mutations = mutableListOf<String>()
+        val favoriteMutations = mutableListOf<Boolean>()
+
+        override suspend fun loadPage(
+            item: FakeMediaItem,
+            tracksOffset: Int,
+            albumsOffset: Int,
+        ) = ProviderMediaItemDetailPage(
+            item = item,
+            tracks = emptyList(),
+            albums = emptyList(),
+            tracksNextOffset = 0,
+            tracksHasMore = false,
+            albumsNextOffset = 0,
+            albumsHasMore = false,
+        )
+
+        override suspend fun loadFavoriteState(item: FakeMediaItem) =
+            ProviderDetailFavoriteState(canFavorite = true)
+
+        override suspend fun setFavorite(item: FakeMediaItem, favorite: Boolean): ProviderDetailMutationResult {
+            favoriteMutations += favorite
+            return ProviderDetailMutationResult(true, if (favorite) "收藏成功" else "已取消收藏")
+        }
+
+        override fun itemId(item: FakeMediaItem) = item.id
+        override fun itemTitle(item: FakeMediaItem) = item.title
+        override fun itemProviderId(item: FakeMediaItem) = item.providerId
+        override fun trackId(track: FakeTrack) = track.id
+        override fun errorMessage(throwable: Throwable, fallback: String, providerId: String?) = fallback
+        override fun open(item: FakeMediaItem) = Unit
+        override fun close() = Unit
+        override fun playTracks(tracks: List<FakeTrack>, index: Int) = Unit
         override fun onProviderMutation(providerId: String) {
             mutations += providerId
         }

--- a/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
+++ b/feature/providerdetail/src/commonTest/kotlin/org/feeluown/mobile/feature/providerdetail/ProviderDetailFeatureTest.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile.feature.providerdetail
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -68,6 +69,35 @@ class ProviderDetailFeatureTest {
 
         assertTrue(owner.state.value.favoriteState.isFavorite)
         assertEquals(listOf(true), port.favoriteMutations)
+        assertEquals(listOf("qqmusic"), port.mutations)
+    }
+
+    @Test
+    fun playlistRefreshDoesNotCancelFavoriteMutation() = runTest {
+        val port = PlaylistPort()
+        val owner = createProviderPlaylistDetailFeatureOwner(port, backgroundScope)
+        val playlist = FakePlaylist("p1", "收藏歌单", "qqmusic")
+        val gate = CompletableDeferred<Unit>()
+        port.favoriteGate = gate
+
+        owner.activate(playlist, FakeCategory.Other)
+        runCurrent()
+
+        owner.toggleFavorite()
+        runCurrent()
+        assertTrue(owner.state.value.isFavoriteLoading)
+
+        owner.refresh()
+        runCurrent()
+
+        assertTrue(owner.state.value.isFavoriteLoading)
+        assertEquals(listOf(true), port.favoriteMutations)
+
+        gate.complete(Unit)
+        runCurrent()
+
+        assertTrue(owner.state.value.favoriteState.isFavorite)
+        assertFalse(owner.state.value.isFavoriteLoading)
         assertEquals(listOf("qqmusic"), port.mutations)
     }
 
@@ -154,6 +184,7 @@ class ProviderDetailFeatureTest {
     private class PlaylistPort : ProviderPlaylistDetailPort<FakePlaylist, FakeCategory, FakeTrack> {
         val mutations = mutableListOf<String>()
         val favoriteMutations = mutableListOf<Boolean>()
+        var favoriteGate: CompletableDeferred<Unit>? = null
 
         override suspend fun loadPage(
             playlist: FakePlaylist,
@@ -172,6 +203,7 @@ class ProviderDetailFeatureTest {
             ProviderDetailFavoriteState(canFavorite = true)
         override suspend fun setFavorite(playlist: FakePlaylist, favorite: Boolean): ProviderDetailMutationResult {
             favoriteMutations += favorite
+            favoriteGate?.await()
             return ProviderDetailMutationResult(true, if (favorite) "收藏成功" else "已取消收藏")
         }
         override suspend fun recordPlayback(playlist: FakePlaylist) = Unit

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -23,6 +23,7 @@ import org.feeluown.mobile.ProviderMediaItemType
 import org.feeluown.mobile.ProviderMutationResult
 import org.feeluown.mobile.ProviderPlaylist
 import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderResourceState
 import org.feeluown.mobile.ProviderSearchResults
 import org.feeluown.mobile.ProviderVideo
 import org.feeluown.mobile.VideoPlaybackPayload
@@ -364,6 +365,123 @@ class NeteaseProvider(
             }
         }
         return result
+    }
+
+    override suspend fun resourceState(resourceType: String, resourceId: String): ProviderResourceState {
+        val type = normalizeFavoriteResourceType(resourceType)
+            ?: return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        if (!authState().isLoggedIn) {
+            return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        }
+        val identifier = favoriteResourceIdentifier(type, resourceId)
+        if (identifier.isBlank()) {
+            return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        }
+        val isFavorite = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> {
+                val uid = currentUserId() ?: return ProviderResourceState(providerId = ID, resourceId = resourceId)
+                val playlist = userPlaylistObjects(uid).firstOrNull { it.string("id") == identifier }
+                if (playlist != null && !playlist.boolean("subscribed")) {
+                    return ProviderResourceState(providerId = ID, resourceId = resourceId)
+                }
+                playlist?.boolean("subscribed") == true
+            }
+            FAVORITE_RESOURCE_ARTIST,
+            FAVORITE_RESOURCE_ALBUM,
+            -> isResourceSubscribed(type, identifier)
+            else -> false
+        }
+        return ProviderResourceState(
+            providerId = ID,
+            resourceId = resourceId,
+            isFavorite = isFavorite,
+            canFavorite = !isFavorite,
+            canUnfavorite = isFavorite,
+        )
+    }
+
+    override suspend fun setResourceFavorite(
+        resourceType: String,
+        resourceId: String,
+        favorite: Boolean,
+    ): ProviderMutationResult {
+        val type = normalizeFavoriteResourceType(resourceType)
+            ?: return ProviderMutationResult(false, "网易云音乐暂不支持该收藏操作")
+        if (!authState().isLoggedIn) return ProviderMutationResult(false, "请先登录网易云音乐")
+        val identifier = favoriteResourceIdentifier(type, resourceId)
+        if (identifier.isBlank()) return ProviderMutationResult(false, "无法读取网易云音乐资源编号")
+        if (type == FAVORITE_RESOURCE_PLAYLIST) {
+            val uid = currentUserId()
+            val ownPlaylist = uid?.let { userId ->
+                userPlaylistObjects(userId).firstOrNull {
+                    it.string("id") == identifier && !it.boolean("subscribed")
+                }
+            }
+            if (ownPlaylist != null) return ProviderMutationResult(false, "自己的歌单无需收藏")
+        }
+        val endpoint = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> "playlist/${if (favorite) "subscribe" else "unsubscribe"}"
+            FAVORITE_RESOURCE_ARTIST -> "artist/${if (favorite) "sub" else "unsub"}"
+            FAVORITE_RESOURCE_ALBUM -> "album/${if (favorite) "sub" else "unsub"}"
+            else -> return ProviderMutationResult(false, "网易云音乐暂不支持该收藏操作")
+        }
+        val payload = when (type) {
+            FAVORITE_RESOURCE_ARTIST ->
+                """{"artistId":"$identifier","artistIds":"[$identifier]","csrf_token":"${csrfToken().jsonString()}"}"""
+            else ->
+                """{"id":"$identifier","csrf_token":"${csrfToken().jsonString()}"}"""
+        }
+        val root = neteaseWeApiPost(
+            "$BASE/weapi/$endpoint",
+            payload,
+            ProviderRequestKind.Mutation,
+        )
+        val success = root.int("code") == 200 || root.boolean("success")
+        return ProviderMutationResult(
+            success = success,
+            message = if (success) {
+                if (favorite) "收藏成功" else "已取消收藏"
+            } else {
+                root.string("message").ifBlank { if (favorite) "收藏失败" else "取消收藏失败" }
+            },
+        )
+    }
+
+    private suspend fun isResourceSubscribed(type: String, identifier: String): Boolean {
+        val endpoint = when (type) {
+            FAVORITE_RESOURCE_ARTIST -> "artist/sublist"
+            FAVORITE_RESOURCE_ALBUM -> "album/sublist"
+            else -> return false
+        }
+        var offset = 0
+        repeat(FAVORITE_STATE_MAX_PAGES) {
+            val root = neteaseWeApiPost(
+                "$BASE/weapi/$endpoint",
+                """{"limit":$FAVORITE_STATE_PAGE_SIZE,"offset":$offset,"total":true,"csrf_token":"${csrfToken().jsonString()}"}""",
+            )
+            val values = root.array("data")
+            if (values.any { value -> value.asObject().string("id") == identifier }) return true
+            if (values.size < FAVORITE_STATE_PAGE_SIZE) return false
+            offset += values.size
+        }
+        return false
+    }
+
+    private fun normalizeFavoriteResourceType(resourceType: String): String? = when (resourceType.lowercase()) {
+        "playlist", "playlists" -> FAVORITE_RESOURCE_PLAYLIST
+        "artist", "artists" -> FAVORITE_RESOURCE_ARTIST
+        "album", "albums" -> FAVORITE_RESOURCE_ALBUM
+        else -> null
+    }
+
+    private fun favoriteResourceIdentifier(type: String, resourceId: String): String {
+        val expectedPrefix = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> "playlist"
+            FAVORITE_RESOURCE_ARTIST -> "artist"
+            FAVORITE_RESOURCE_ALBUM -> "album"
+            else -> null
+        }
+        return splitResourceId(resourceId, expectedPrefix).second.ifBlank { resourceId.substringAfterLast(':') }
     }
 
     override suspend fun loadFeature(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection {
@@ -1262,6 +1380,11 @@ class NeteaseProvider(
         const val BASE = "https://music.163.com"
         const val PLAYLIST_MUTATION_SYNC_ATTEMPTS = 6
         const val PLAYLIST_MUTATION_SYNC_DELAY_MS = 200L
+        const val FAVORITE_RESOURCE_PLAYLIST = "playlist"
+        const val FAVORITE_RESOURCE_ARTIST = "artist"
+        const val FAVORITE_RESOURCE_ALBUM = "album"
+        const val FAVORITE_STATE_PAGE_SIZE = 200
+        const val FAVORITE_STATE_MAX_PAGES = 10
         val STYLE_KINDS = setOf("songs", "playlists", "albums", "artists")
         val INFO = ProviderInfo(
             providerId = ID,
@@ -1276,6 +1399,12 @@ class NeteaseProvider(
             canRemoveSongFromPlaylist = true,
             canCreatePlaylist = true,
             canDeletePlaylist = true,
+            canFavoritePlaylist = true,
+            canUnfavoritePlaylist = true,
+            canFavoriteArtist = true,
+            canUnfavoriteArtist = true,
+            canFavoriteAlbum = true,
+            canUnfavoriteAlbum = true,
         )
         val FEATURES = listOf(
             ProviderFeature("netease_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),

--- a/provider/netease/src/commonTest/kotlin/org/feeluown/mobile/NeteaseResourceFavoriteTest.kt
+++ b/provider/netease/src/commonTest/kotlin/org/feeluown/mobile/NeteaseResourceFavoriteTest.kt
@@ -1,0 +1,83 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.netease.NeteaseProvider
+
+class NeteaseResourceFavoriteTest {
+    @Test
+    fun resourceFavoritesExposeStateAndMutationsForPlaylistArtistAndAlbum() = runTest {
+        val requestedPaths = mutableListOf<String>()
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        val path = request.url.encodedPath
+                        requestedPaths += path
+                        when (path) {
+                            "/api/user/level" -> respond("""{"code":200,"data":{"userId":12345}}""")
+                            "/weapi/share/userprofile/info" -> respond("""{"code":200,"nickname":"tester"}""")
+                            "/api/user/playlist/" -> respond(
+                                """
+                                {
+                                  "code":200,
+                                  "playlist":[
+                                    {"id":1,"name":"我的歌单","subscribed":false},
+                                    {"id":2,"name":"收藏歌单","subscribed":true}
+                                  ]
+                                }
+                                """.trimIndent(),
+                            )
+                            "/weapi/artist/sublist" -> respond(
+                                """{"code":200,"data":[{"id":9,"name":"收藏歌手"}],"hasMore":false}""",
+                            )
+                            "/weapi/album/sublist" -> respond(
+                                """{"code":200,"data":[{"id":10,"name":"收藏专辑"}],"hasMore":false}""",
+                            )
+                            "/weapi/playlist/unsubscribe",
+                            "/weapi/artist/unsub",
+                            "/weapi/album/unsub",
+                            -> respond("""{"code":200}""")
+                            else -> error("unexpected NetEase request: $path")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = NeteaseProvider(http, InMemoryProviderCredentialStore())
+        provider.loginWithCookies("""{"MUSIC_U":"music-cookie","__csrf":"csrf"}""")
+
+        val ownPlaylist = provider.resourceState("playlist", "playlist:netease:1")
+        val favoritePlaylist = provider.resourceState("playlist", "playlist:netease:2")
+        val favoriteArtist = provider.resourceState("artist", "artist:netease:9")
+        val favoriteAlbum = provider.resourceState("album", "album:netease:10")
+
+        assertFalse(ownPlaylist.canFavorite)
+        assertFalse(ownPlaylist.canUnfavorite)
+        assertTrue(favoritePlaylist.isFavorite)
+        assertTrue(favoritePlaylist.canUnfavorite)
+        assertTrue(favoriteArtist.isFavorite)
+        assertTrue(favoriteArtist.canUnfavorite)
+        assertTrue(favoriteAlbum.isFavorite)
+        assertTrue(favoriteAlbum.canUnfavorite)
+
+        assertTrue(provider.setResourceFavorite("playlist", "playlist:netease:2", false).success)
+        assertTrue(provider.setResourceFavorite("artist", "artist:netease:9", false).success)
+        assertTrue(provider.setResourceFavorite("album", "album:netease:10", false).success)
+
+        assertTrue("/weapi/playlist/unsubscribe" in requestedPaths)
+        assertTrue("/weapi/artist/unsub" in requestedPaths)
+        assertTrue("/weapi/album/unsub" in requestedPaths)
+        assertTrue(provider.capabilities.canFavoritePlaylist)
+        assertTrue(provider.capabilities.canUnfavoriteArtist)
+        assertTrue(provider.capabilities.canFavoriteAlbum)
+        http.close()
+    }
+}

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicCompositeProvider.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicCompositeProvider.kt
@@ -29,7 +29,14 @@ internal class QQMusicCompositeProvider(
     override val id: String get() = content.id
     override val name: String get() = content.name
     override val info get() = content.info
-    override val capabilities get() = content.capabilities
+    override val capabilities get() = content.capabilities.copy(
+        canFavoritePlaylist = true,
+        canUnfavoritePlaylist = true,
+        canFavoriteArtist = true,
+        canUnfavoriteArtist = true,
+        canFavoriteAlbum = true,
+        canUnfavoriteAlbum = true,
+    )
     override val features: List<ProviderFeature> = (content.features + MINE_FEATURES).distinctBy { it.id }
 
     override suspend fun initialize() = content.initialize()
@@ -156,9 +163,10 @@ internal class QQMusicCompositeProvider(
     override suspend fun hotComments(track: MusicTrack) = content.hotComments(track)
     override suspend fun trackVideo(track: MusicTrack) = content.trackVideo(track)
     override suspend fun videoPlaybackPayload(video: org.feeluown.mobile.ProviderVideo) = content.videoPlaybackPayload(video)
-    override suspend fun resourceState(resourceType: String, resourceId: String) = content.resourceState(resourceType, resourceId)
+    override suspend fun resourceState(resourceType: String, resourceId: String) =
+        userLibrary.resourceState(resourceType, resourceId)
     override suspend fun setResourceFavorite(resourceType: String, resourceId: String, favorite: Boolean) =
-        content.setResourceFavorite(resourceType, resourceId, favorite)
+        userLibrary.setResourceFavorite(resourceType, resourceId, favorite)
 
     private suspend fun enrichAuth(base: ProviderAuthState): ProviderAuthState {
         if (!base.isLoggedIn) return base

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -54,7 +54,7 @@ internal class QQMusicUserLibrary(
             return ProviderResourceState(providerId = ID, resourceId = resourceId)
         }
         val identifier = favoriteResourceIdentifier(type, resourceId)
-        if (identifier.isBlank()) {
+        if (identifier.isBlank() || !favoriteWriteSupported(type, identifier)) {
             return ProviderResourceState(providerId = ID, resourceId = resourceId)
         }
         if (type == FAVORITE_RESOURCE_PLAYLIST) {
@@ -88,6 +88,9 @@ internal class QQMusicUserLibrary(
         if (credentials.read(ID) == null) return ProviderMutationResult(false, "请先登录 QQ 音乐")
         val identifier = favoriteResourceIdentifier(type, resourceId)
         if (identifier.isBlank()) return ProviderMutationResult(false, "无法读取 QQ 音乐资源编号")
+        if (!favoriteWriteSupported(type, identifier)) {
+            return ProviderMutationResult(false, "QQ 音乐暂不支持收藏该资源")
+        }
         if (type == FAVORITE_RESOURCE_PLAYLIST) {
             val isOwned = runCatching {
                 snapshot().playlists.any { favoriteResourceIdentifier(type, it.id) == identifier }
@@ -188,10 +191,16 @@ internal class QQMusicUserLibrary(
     }
 
     private suspend fun mutateFavoriteAlbum(identifier: String, favorite: Boolean): Boolean {
-        val albumId = identifier.toLongOrNull() ?: return false
         val key = "favoriteAlbumWrite"
+        val uin = currentAccountIds().firstOrNull().orEmpty()
+        val target = identifier.toLongOrNull()?.let { albumId ->
+            "\"v_albumId\":[$albumId]"
+        } ?: "\"v_albumMid\":[${jsonString(identifier)}]"
+        val uinParam = uin.takeIf(String::isNotBlank)
+            ?.let { "\"uin\":${jsonString(it)}," }
+            .orEmpty()
         val root = rpc(
-            """{"$key":{"module":"music.musicasset.AlbumFavWrite","method":"${if (favorite) "FavAlbum" else "CancelFavAlbum"}","param":{"v_albumId":[$albumId]}}}""",
+            """{"$key":{"module":"music.musicasset.AlbumFavWrite","method":"${if (favorite) "FavAlbum" else "CancelFavAlbum"}","param":{$uinParam$target}}}""",
             ProviderRequestKind.Mutation,
         )
         return rpcMutationSucceeded(root, key)
@@ -245,6 +254,14 @@ internal class QQMusicUserLibrary(
         item.string("singerId"),
         item.string("id"),
     ).filter(String::isNotBlank).toSet()
+
+    private fun favoriteWriteSupported(type: String, identifier: String): Boolean = when (type) {
+        FAVORITE_RESOURCE_PLAYLIST -> identifier.toLongOrNull() != null
+        FAVORITE_RESOURCE_ARTIST,
+        FAVORITE_RESOURCE_ALBUM,
+        -> identifier.isNotBlank()
+        else -> false
+    }
 
     private fun normalizeFavoriteResourceType(resourceType: String): String? = when (resourceType.lowercase()) {
         "playlist", "playlists" -> FAVORITE_RESOURCE_PLAYLIST

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicUserLibrary.kt
@@ -7,7 +7,9 @@ import org.feeluown.mobile.ProviderContentSection
 import org.feeluown.mobile.ProviderFeature
 import org.feeluown.mobile.ProviderMediaItem
 import org.feeluown.mobile.ProviderMediaItemType
+import org.feeluown.mobile.ProviderMutationResult
 import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderResourceState
 import org.feeluown.mobile.providerBusinessException
 import org.feeluown.mobile.providerContractException
 import org.feeluown.mobile.providerFailureOrNull
@@ -27,6 +29,7 @@ import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.string
 import org.feeluown.mobile.provider.core.stringOrNull
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
 import org.feeluown.mobile.provider.core.network.currentTimeMillis
 import kotlin.random.Random
 
@@ -43,6 +46,224 @@ internal class QQMusicUserLibrary(
     private val credentials: ProviderCredentialStore,
 ) {
     suspend fun userName(): String? = runCatching { snapshot().userName }.getOrNull()
+
+    suspend fun resourceState(resourceType: String, resourceId: String): ProviderResourceState {
+        val type = normalizeFavoriteResourceType(resourceType)
+            ?: return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        if (credentials.read(ID) == null) {
+            return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        }
+        val identifier = favoriteResourceIdentifier(type, resourceId)
+        if (identifier.isBlank()) {
+            return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        }
+        if (type == FAVORITE_RESOURCE_PLAYLIST) {
+            val isOwned = runCatching {
+                snapshot().playlists.any { favoriteResourceIdentifier(type, it.id) == identifier }
+            }.getOrDefault(false)
+            if (isOwned) return ProviderResourceState(providerId = ID, resourceId = resourceId)
+        }
+        val favorite = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> isFavoritePlaylist(identifier)
+            FAVORITE_RESOURCE_ARTIST -> isFollowedArtist(identifier)
+            FAVORITE_RESOURCE_ALBUM -> isFavoriteAlbum(identifier)
+            else -> false
+        }
+        return ProviderResourceState(
+            providerId = ID,
+            resourceId = resourceId,
+            isFavorite = favorite,
+            canFavorite = !favorite,
+            canUnfavorite = favorite,
+        )
+    }
+
+    suspend fun setResourceFavorite(
+        resourceType: String,
+        resourceId: String,
+        favorite: Boolean,
+    ): ProviderMutationResult {
+        val type = normalizeFavoriteResourceType(resourceType)
+            ?: return ProviderMutationResult(false, "QQ 音乐暂不支持该收藏操作")
+        if (credentials.read(ID) == null) return ProviderMutationResult(false, "请先登录 QQ 音乐")
+        val identifier = favoriteResourceIdentifier(type, resourceId)
+        if (identifier.isBlank()) return ProviderMutationResult(false, "无法读取 QQ 音乐资源编号")
+        if (type == FAVORITE_RESOURCE_PLAYLIST) {
+            val isOwned = runCatching {
+                snapshot().playlists.any { favoriteResourceIdentifier(type, it.id) == identifier }
+            }.getOrDefault(false)
+            if (isOwned) return ProviderMutationResult(false, "自己的歌单无需收藏")
+        }
+        val success = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> mutateFavoritePlaylist(identifier, favorite)
+            FAVORITE_RESOURCE_ARTIST -> mutateFollowedArtist(identifier, favorite)
+            FAVORITE_RESOURCE_ALBUM -> mutateFavoriteAlbum(identifier, favorite)
+            else -> false
+        }
+        return ProviderMutationResult(
+            success = success,
+            message = if (success) {
+                if (favorite) "收藏成功" else "已取消收藏"
+            } else {
+                if (favorite) "QQ 音乐收藏失败" else "QQ 音乐取消收藏失败"
+            },
+        )
+    }
+
+    private suspend fun isFavoritePlaylist(identifier: String): Boolean {
+        val euin = encryptedUin()
+        var offset = 0
+        repeat(FAVORITE_STATE_MAX_PAGES) {
+            val root = rpc(
+                """{"favoritePlaylists":{"module":"music.musicasset.PlaylistFavRead","method":"CgiGetPlaylistFavInfo","param":{"uin":${jsonString(euin)},"offset":$offset,"size":$FAVORITE_STATE_PAGE_SIZE}}}""",
+            )
+            val data = rpcData(root, "favoritePlaylists")
+            val values = firstNonEmpty(data.array("v_list"), data.array("v_playlist"), data.array("list"))
+            if (values.any { value -> qqPlaylistIdentifier(value.asObject()) == identifier }) return true
+            val nextOffset = offset + values.size
+            val total = data.int("total")
+            val hasMore = data.int("hasmore")?.let { it != 0 }
+                ?: total?.let { nextOffset < it }
+                ?: (values.size >= FAVORITE_STATE_PAGE_SIZE)
+            if (!hasMore || values.isEmpty()) return false
+            offset = nextOffset
+        }
+        return false
+    }
+
+    private suspend fun isFavoriteAlbum(identifier: String): Boolean {
+        val euin = encryptedUin()
+        var offset = 0
+        repeat(FAVORITE_STATE_MAX_PAGES) {
+            val root = rpc(
+                """{"favoriteAlbums":{"module":"music.musicasset.AlbumFavRead","method":"CgiGetAlbumFavInfo","param":{"euin":${jsonString(euin)},"offset":$offset,"size":$FAVORITE_STATE_PAGE_SIZE}}}""",
+            )
+            val data = rpcData(root, "favoriteAlbums")
+            val values = firstNonEmpty(data.array("v_list"), data.array("v_album"), data.array("list"))
+            if (values.any { value -> qqAlbumIdentifiers(value.asObject()).contains(identifier) }) return true
+            val nextOffset = offset + values.size
+            val total = data.int("total")
+            val hasMore = data.int("hasmore")?.let { it != 0 }
+                ?: total?.let { nextOffset < it }
+                ?: (values.size >= FAVORITE_STATE_PAGE_SIZE)
+            if (!hasMore || values.isEmpty()) return false
+            offset = nextOffset
+        }
+        return false
+    }
+
+    private suspend fun isFollowedArtist(identifier: String): Boolean {
+        val euin = encryptedUin()
+        var offset = 0
+        repeat(FAVORITE_STATE_MAX_PAGES) {
+            val root = rpc(
+                """{"followedArtists":{"module":"music.concern.RelationList","method":"GetFollowSingerList","param":{"HostUin":${jsonString(euin)},"From":$offset,"Size":$FAVORITE_STATE_PAGE_SIZE}}}""",
+            )
+            val data = rpcData(root, "followedArtists")
+            val values = firstNonEmpty(data.array("List"), data.array("list"), data.array("singerList"))
+            if (values.any { value -> qqArtistIdentifiers(value.asObject()).contains(identifier) }) return true
+            val nextOffset = offset + values.size
+            val total = data.int("Total") ?: data.int("total")
+            val hasMore = when {
+                data.containsKey("HasMore") -> data.boolean("HasMore")
+                data.containsKey("hasMore") -> data.boolean("hasMore")
+                total != null -> nextOffset < total
+                else -> values.size >= FAVORITE_STATE_PAGE_SIZE
+            }
+            if (!hasMore || values.isEmpty()) return false
+            offset = nextOffset
+        }
+        return false
+    }
+
+    private suspend fun mutateFavoritePlaylist(identifier: String, favorite: Boolean): Boolean {
+        val playlistId = identifier.toLongOrNull() ?: return false
+        val euin = encryptedUin()
+        val key = "favoritePlaylistWrite"
+        val root = rpc(
+            """{"$key":{"module":"music.musicasset.PlaylistFavWrite","method":"${if (favorite) "FavPlaylist" else "CancelFavPlaylist"}","param":{"uin":${jsonString(euin)},"v_playlistId":[$playlistId]}}}""",
+            ProviderRequestKind.Mutation,
+        )
+        return rpcMutationSucceeded(root, key)
+    }
+
+    private suspend fun mutateFavoriteAlbum(identifier: String, favorite: Boolean): Boolean {
+        val albumId = identifier.toLongOrNull() ?: return false
+        val key = "favoriteAlbumWrite"
+        val root = rpc(
+            """{"$key":{"module":"music.musicasset.AlbumFavWrite","method":"${if (favorite) "FavAlbum" else "CancelFavAlbum"}","param":{"v_albumId":[$albumId]}}}""",
+            ProviderRequestKind.Mutation,
+        )
+        return rpcMutationSucceeded(root, key)
+    }
+
+    private suspend fun mutateFollowedArtist(identifier: String, favorite: Boolean): Boolean {
+        val root = http.getText(
+            providerId = ID,
+            url = queryUrl(
+                "$BASE/rsc/fcgi-bin/fcg_order_singer_${if (favorite) "add" else "del"}.fcg",
+                mapOf(
+                    "g_tk" to qqToken().toString(),
+                    "format" to "json",
+                    "singermid" to identifier,
+                ),
+            ),
+            headers = authenticatedHeaders("https://y.qq.com/"),
+            kind = ProviderRequestKind.Mutation,
+            cacheKey = null,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        return root.int("code") == 0
+    }
+
+    private fun rpcMutationSucceeded(root: JsonObject, key: String): Boolean {
+        val envelope = root.obj(key) ?: root
+        val code = envelope.int("code")
+        val data = envelope.obj("data") ?: envelope
+        val result = data.int("result") ?: data.int("retCode") ?: data.int("retcode")
+        return (code == null || code == 0) && (result == null || result == 0)
+    }
+
+    private fun qqPlaylistIdentifier(item: JsonObject): String =
+        item.string("tid").ifBlank { item.string("dissid") }.ifBlank { item.string("id") }
+
+    private fun qqAlbumIdentifiers(item: JsonObject): Set<String> = setOf(
+        item.string("id"),
+        item.string("albumID"),
+        item.string("albumId"),
+        item.string("mid"),
+        item.string("albumMid"),
+        item.string("albumMID"),
+        item.string("pmid"),
+    ).filter(String::isNotBlank).toSet()
+
+    private fun qqArtistIdentifiers(item: JsonObject): Set<String> = setOf(
+        item.string("MID"),
+        item.string("mid"),
+        item.string("SingerMid"),
+        item.string("singerMid"),
+        item.string("SingerID"),
+        item.string("singerId"),
+        item.string("id"),
+    ).filter(String::isNotBlank).toSet()
+
+    private fun normalizeFavoriteResourceType(resourceType: String): String? = when (resourceType.lowercase()) {
+        "playlist", "playlists" -> FAVORITE_RESOURCE_PLAYLIST
+        "artist", "artists" -> FAVORITE_RESOURCE_ARTIST
+        "album", "albums" -> FAVORITE_RESOURCE_ALBUM
+        else -> null
+    }
+
+    private fun favoriteResourceIdentifier(type: String, resourceId: String): String {
+        val expectedPrefix = when (type) {
+            FAVORITE_RESOURCE_PLAYLIST -> "playlist"
+            FAVORITE_RESOURCE_ARTIST -> "artist"
+            FAVORITE_RESOURCE_ALBUM -> "album"
+            else -> null
+        }
+        return org.feeluown.mobile.provider.core.splitResourceId(resourceId, expectedPrefix).second
+            .ifBlank { resourceId.substringAfterLast(':') }
+    }
+
 
     suspend fun loadPlaylists(
         feature: ProviderFeature,
@@ -549,6 +770,22 @@ internal class QQMusicUserLibrary(
         return parseCookies(stored.cookieHeader.orEmpty()) + stored.cookies
     }
 
+    private suspend fun qqToken(): Long = qqToken(qqCookies())
+
+    private fun qqToken(values: Map<String, String>): Long {
+        val tokenSource = listOf("qqmusic_key", "p_skey", "skey", "p_lskey", "lskey")
+            .asSequence()
+            .mapNotNull { values[it] }
+            .firstOrNull()
+            .orEmpty()
+        if (tokenSource.isBlank()) return 5_381L
+        var hash = 5_381L
+        tokenSource.forEach { character ->
+            hash = (hash * 33 + character.code) and 0xffff_ffffL
+        }
+        return hash and 0x7fff_ffffL
+    }
+
     private fun normalizeAccountId(raw: String?): String? {
         val value = raw?.trim()?.takeIf { it.isNotBlank() } ?: return null
         val digits = when {
@@ -562,7 +799,10 @@ internal class QQMusicUserLibrary(
     private fun isLikelyQqNumber(value: String): Boolean =
         value.length in MIN_QQ_UIN_LENGTH..MAX_QQ_UIN_LENGTH && value.all(Char::isDigit)
 
-    private suspend fun rpc(payload: String): JsonObject {
+    private suspend fun rpc(
+        payload: String,
+        kind: ProviderRequestKind = ProviderRequestKind.SafeRead,
+    ): JsonObject {
         val request = qqRpcPayload(payload)
         return http.getText(
             providerId = ID,
@@ -575,6 +815,7 @@ internal class QQMusicUserLibrary(
                 ),
             ),
             headers = authenticatedHeaders("https://y.qq.com/"),
+            kind = kind,
             cacheKey = null,
         ).value.let { providerJson.parseToJsonElement(it).asObject() }
     }
@@ -587,20 +828,7 @@ internal class QQMusicUserLibrary(
             ?: values["str_musicid"]?.takeIf(String::isNotBlank)
             ?: values["musicid"]?.takeIf(String::isNotBlank)
             ?: "0"
-        val tokenSource = listOf("qqmusic_key", "p_skey", "skey", "p_lskey", "lskey")
-            .asSequence()
-            .mapNotNull { values[it] }
-            .firstOrNull()
-            .orEmpty()
-        val token = if (tokenSource.isBlank()) {
-            5_381L
-        } else {
-            var hash = 5_381L
-            tokenSource.forEach { character ->
-                hash = (hash * 33 + character.code) and 0xffff_ffffL
-            }
-            hash and 0x7fff_ffffL
-        }
+        val token = qqToken(values)
         val common = mapOf(
             "loginUin" to JsonPrimitive(uin),
             "hostUin" to JsonPrimitive(0),
@@ -713,6 +941,11 @@ internal class QQMusicUserLibrary(
         const val WECHAT_LOGIN_TYPE = 2
         const val MIN_QQ_UIN_LENGTH = 5
         const val MAX_QQ_UIN_LENGTH = 12
+        const val FAVORITE_RESOURCE_PLAYLIST = "playlist"
+        const val FAVORITE_RESOURCE_ARTIST = "artist"
+        const val FAVORITE_RESOURCE_ALBUM = "album"
+        const val FAVORITE_STATE_PAGE_SIZE = 100
+        const val FAVORITE_STATE_MAX_PAGES = 20
         const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36"
         const val CONTENT_SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
     }

--- a/provider/qqmusic/src/commonTest/kotlin/org/feeluown/mobile/QQMusicResourceFavoriteTest.kt
+++ b/provider/qqmusic/src/commonTest/kotlin/org/feeluown/mobile/QQMusicResourceFavoriteTest.kt
@@ -1,0 +1,117 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.ProviderCredentials
+import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.qqmusic.QQMusicCompositeProvider
+
+class QQMusicResourceFavoriteTest {
+    @Test
+    fun resourceFavoritesUseLibraryStateAndWriteEndpoints() = runTest {
+        val requestedOperations = mutableListOf<String>()
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/rsc/fcgi-bin/fcg_get_profile_homepage.fcg" -> respond(
+                                """
+                                {
+                                  "code":0,
+                                  "data":{
+                                    "creator":{
+                                      "nick":"测试用户",
+                                      "encrypt_uin":"encrypted-user"
+                                    },
+                                    "mymusic":[],
+                                    "mydiss":{"list":[]}
+                                  }
+                                }
+                                """.trimIndent(),
+                            )
+                            "/cgi-bin/musicu.fcg" -> {
+                                val data = request.url.parameters["data"].orEmpty()
+                                when {
+                                    data.contains("CgiGetPlaylistFavInfo") -> respond(
+                                        """
+                                        {"favoritePlaylists":{"code":0,"data":{"total":1,"hasmore":0,"v_list":[{"tid":7001,"title":"收藏歌单"}]}}}
+                                        """.trimIndent(),
+                                    )
+                                    data.contains("GetFollowSingerList") -> respond(
+                                        """
+                                        {"followedArtists":{"code":0,"data":{"Total":1,"HasMore":false,"List":[{"MID":"artist-mid","Name":"关注歌手"}]}}}
+                                        """.trimIndent(),
+                                    )
+                                    data.contains("CgiGetAlbumFavInfo") -> respond(
+                                        """
+                                        {"favoriteAlbums":{"code":0,"data":{"total":1,"hasmore":0,"v_list":[{"id":9001,"mid":"album-mid","name":"收藏专辑"}]}}}
+                                        """.trimIndent(),
+                                    )
+                                    data.contains("FavPlaylist") || data.contains("CancelFavPlaylist") -> {
+                                        requestedOperations += if (data.contains("CancelFavPlaylist")) "playlist-unfavorite" else "playlist-favorite"
+                                        respond("""{"favoritePlaylistWrite":{"code":0,"data":{"result":0}}}""")
+                                    }
+                                    data.contains("FavAlbum") || data.contains("CancelFavAlbum") -> {
+                                        requestedOperations += if (data.contains("CancelFavAlbum")) "album-unfavorite" else "album-favorite"
+                                        respond("""{"favoriteAlbumWrite":{"code":0,"data":{"result":0}}}""")
+                                    }
+                                    else -> error("unexpected QQ Music RPC: $data")
+                                }
+                            }
+                            "/rsc/fcgi-bin/fcg_order_singer_del.fcg" -> {
+                                assertEquals("artist-mid", request.url.parameters["singermid"])
+                                requestedOperations += "artist-unfavorite"
+                                respond("""{"code":0}""")
+                            }
+                            else -> error("unexpected QQ Music request: ${request.url}")
+                        }
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            ProviderCredentials(
+                cookies = mapOf(
+                    "uin" to "123456",
+                    "encryptUin" to "encrypted-user",
+                    "qqmusic_key" to "test-key",
+                ),
+            ),
+        )
+        val provider = QQMusicCompositeProvider(ProviderRuntimeDependencies(http, credentials))
+
+        val playlist = provider.resourceState("playlist", "playlist:qqmusic:7001")
+        val artist = provider.resourceState("artist", "artist:qqmusic:artist-mid")
+        val album = provider.resourceState("album", "album:qqmusic:9001")
+
+        assertTrue(playlist.isFavorite)
+        assertTrue(artist.isFavorite)
+        assertTrue(album.isFavorite)
+        assertTrue(playlist.canUnfavorite)
+        assertTrue(artist.canUnfavorite)
+        assertTrue(album.canUnfavorite)
+
+        assertTrue(provider.setResourceFavorite("playlist", "playlist:qqmusic:7001", false).success)
+        assertTrue(provider.setResourceFavorite("artist", "artist:qqmusic:artist-mid", false).success)
+        assertTrue(provider.setResourceFavorite("album", "album:qqmusic:9001", false).success)
+
+        assertEquals(
+            setOf("playlist-unfavorite", "artist-unfavorite", "album-unfavorite"),
+            requestedOperations.toSet(),
+        )
+        assertTrue(provider.capabilities.canFavoritePlaylist)
+        assertTrue(provider.capabilities.canUnfavoriteArtist)
+        assertTrue(provider.capabilities.canFavoriteAlbum)
+        http.close()
+    }
+}

--- a/provider/qqmusic/src/commonTest/kotlin/org/feeluown/mobile/QQMusicResourceFavoriteTest.kt
+++ b/provider/qqmusic/src/commonTest/kotlin/org/feeluown/mobile/QQMusicResourceFavoriteTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.mock.respond
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
 import org.feeluown.mobile.provider.core.ProviderCredentials
@@ -60,6 +61,8 @@ class QQMusicResourceFavoriteTest {
                                         respond("""{"favoritePlaylistWrite":{"code":0,"data":{"result":0}}}""")
                                     }
                                     data.contains("FavAlbum") || data.contains("CancelFavAlbum") -> {
+                                        assertTrue(data.contains("\"v_albumMid\":[\"album-mid\"]"))
+                                        assertFalse(data.contains("\"v_albumId\""))
                                         requestedOperations += if (data.contains("CancelFavAlbum")) "album-unfavorite" else "album-favorite"
                                         respond("""{"favoriteAlbumWrite":{"code":0,"data":{"result":0}}}""")
                                     }
@@ -92,7 +95,7 @@ class QQMusicResourceFavoriteTest {
 
         val playlist = provider.resourceState("playlist", "playlist:qqmusic:7001")
         val artist = provider.resourceState("artist", "artist:qqmusic:artist-mid")
-        val album = provider.resourceState("album", "album:qqmusic:9001")
+        val album = provider.resourceState("album", "album:qqmusic:album-mid")
 
         assertTrue(playlist.isFavorite)
         assertTrue(artist.isFavorite)
@@ -103,7 +106,7 @@ class QQMusicResourceFavoriteTest {
 
         assertTrue(provider.setResourceFavorite("playlist", "playlist:qqmusic:7001", false).success)
         assertTrue(provider.setResourceFavorite("artist", "artist:qqmusic:artist-mid", false).success)
-        assertTrue(provider.setResourceFavorite("album", "album:qqmusic:9001", false).success)
+        assertTrue(provider.setResourceFavorite("album", "album:qqmusic:album-mid", false).success)
 
         assertEquals(
             setOf("playlist-unfavorite", "artist-unfavorite", "album-unfavorite"),
@@ -112,6 +115,38 @@ class QQMusicResourceFavoriteTest {
         assertTrue(provider.capabilities.canFavoritePlaylist)
         assertTrue(provider.capabilities.canUnfavoriteArtist)
         assertTrue(provider.capabilities.canFavoriteAlbum)
+        http.close()
+    }
+
+    @Test
+    fun syntheticToplistDoesNotExposeFavoriteCapability() = runTest {
+        val http = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        error("synthetic toplist should not issue favorite requests: ${request.url}")
+                    }
+                }
+            },
+        )
+        val credentials = InMemoryProviderCredentialStore()
+        credentials.write(
+            "qqmusic",
+            ProviderCredentials(cookies = mapOf("uin" to "123456", "qqmusic_key" to "test-key")),
+        )
+        val provider = QQMusicCompositeProvider(ProviderRuntimeDependencies(http, credentials))
+
+        val state = provider.resourceState("playlist", "playlist:qqmusic:toplist:4:2026-08-24")
+        val mutation = provider.setResourceFavorite(
+            "playlist",
+            "playlist:qqmusic:toplist:4:2026-08-24",
+            true,
+        )
+
+        assertFalse(state.isFavorite)
+        assertFalse(state.canFavorite)
+        assertFalse(state.canUnfavorite)
+        assertFalse(mutation.success)
         http.close()
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailOwners.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailOwners.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.StateFlow
+import org.feeluown.mobile.feature.providerdetail.ProviderDetailFavoriteState
 import org.feeluown.mobile.feature.providerdetail.ProviderDetailMutationResult
 import org.feeluown.mobile.feature.providerdetail.ProviderFeatureDetailFeatureOwner as CoreFeatureOwner
 import org.feeluown.mobile.feature.providerdetail.ProviderFeatureDetailFeatureState as CoreFeatureState
@@ -62,6 +63,8 @@ data class ProviderPlaylistDetailUiState(
     val nextOffset: Int = 0,
     val hasMore: Boolean = false,
     val isLoading: Boolean = false,
+    val favoriteState: ProviderDetailFavoriteState = ProviderDetailFavoriteState(),
+    val isFavoriteLoading: Boolean = false,
     val message: String? = null,
     val errorMessage: String? = null,
 )
@@ -80,6 +83,8 @@ interface ProviderPlaylistDetailController {
     fun remove(track: MusicTrack)
     fun canDelete(): Boolean
     fun delete()
+    fun canToggleFavorite(): Boolean
+    fun toggleFavorite()
 }
 
 data class ProviderTrackDetailUiState(
@@ -113,6 +118,8 @@ data class ProviderMediaItemDetailUiState(
     val albumsNextOffset: Int = 0,
     val albumsHasMore: Boolean = false,
     val isLoading: Boolean = false,
+    val favoriteState: ProviderDetailFavoriteState = ProviderDetailFavoriteState(),
+    val isFavoriteLoading: Boolean = false,
     val message: String? = null,
     val errorMessage: String? = null,
 )
@@ -127,6 +134,8 @@ interface ProviderMediaItemDetailController {
     fun prefetchAlbumsIfNeeded(visibleIndex: Int)
     fun play(index: Int)
     fun playAll()
+    fun canToggleFavorite(): Boolean
+    fun toggleFavorite()
 }
 
 data class ProviderVideoDetailUiState(
@@ -204,7 +213,12 @@ fun createProviderDetailOwners(
         ),
         mediaItem = BoundProviderMediaItemDetailController(
             createProviderMediaItemDetailFeatureOwner(
-                port = BoundProviderMediaItemDetailPort(providerRepository, playbackQueue, navigator),
+                port = BoundProviderMediaItemDetailPort(
+                    providerRepository = providerRepository,
+                    playbackQueue = playbackQueue,
+                    navigator = navigator,
+                    onProviderMutation = onProviderMutation,
+                ),
                 scope = scope,
             ),
         ),
@@ -242,6 +256,8 @@ private class BoundProviderPlaylistDetailController(
     override fun remove(track: MusicTrack) = owner.remove(track)
     override fun canDelete() = owner.canDelete()
     override fun delete() = owner.delete()
+    override fun canToggleFavorite() = owner.canToggleFavorite()
+    override fun toggleFavorite() = owner.toggleFavorite()
 }
 
 private class BoundProviderTrackDetailController(
@@ -269,6 +285,8 @@ private class BoundProviderMediaItemDetailController(
     override fun prefetchAlbumsIfNeeded(visibleIndex: Int) = owner.prefetchAlbumsIfNeeded(visibleIndex)
     override fun play(index: Int) = owner.play(index)
     override fun playAll() = owner.playAll()
+    override fun canToggleFavorite() = owner.canToggleFavorite()
+    override fun toggleFavorite() = owner.toggleFavorite()
 }
 
 private class BoundProviderVideoDetailController(
@@ -335,6 +353,16 @@ private class BoundProviderPlaylistDetailPort(
 
     override suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderDetailMutationResult =
         providerRepository.deletePlaylist(playlist).let { ProviderDetailMutationResult(it.success, it.message) }
+
+    override suspend fun loadFavoriteState(playlist: ProviderPlaylist): ProviderDetailFavoriteState =
+        providerRepository.resourceState("playlist", playlist.id).toDetailFavoriteState()
+
+    override suspend fun setFavorite(
+        playlist: ProviderPlaylist,
+        favorite: Boolean,
+    ): ProviderDetailMutationResult = providerRepository
+        .setResourceFavorite("playlist", playlist.id, favorite)
+        .let { ProviderDetailMutationResult(it.success, it.message) }
 
     override suspend fun recordPlayback(playlist: ProviderPlaylist) {
         settingsRepository.update { settings ->
@@ -419,6 +447,7 @@ private class BoundProviderMediaItemDetailPort(
     private val providerRepository: ProviderMusicRepository,
     private val playbackQueue: PlaybackQueueUiPort,
     private val navigator: AppNavigator,
+    private val onProviderMutation: (String) -> Unit,
 ) : CoreMediaItemPort<ProviderMediaItem, MusicTrack> {
     override suspend fun loadPage(
         item: ProviderMediaItem,
@@ -437,6 +466,16 @@ private class BoundProviderMediaItemDetailPort(
         )
     }
 
+    override suspend fun loadFavoriteState(item: ProviderMediaItem): ProviderDetailFavoriteState =
+        providerRepository.resourceState(item.favoriteResourceType(), item.id).toDetailFavoriteState()
+
+    override suspend fun setFavorite(
+        item: ProviderMediaItem,
+        favorite: Boolean,
+    ): ProviderDetailMutationResult = providerRepository
+        .setResourceFavorite(item.favoriteResourceType(), item.id, favorite)
+        .let { ProviderDetailMutationResult(it.success, it.message) }
+
     override fun itemId(item: ProviderMediaItem) = item.id
     override fun itemTitle(item: ProviderMediaItem) = item.title
     override fun itemProviderId(item: ProviderMediaItem) = item.providerId
@@ -448,6 +487,7 @@ private class BoundProviderMediaItemDetailPort(
         navigator.pop(AppRoute.MediaItem)
     }
     override fun playTracks(tracks: List<MusicTrack>, index: Int) = playbackQueue.playTracks(tracks, index)
+    override fun onProviderMutation(providerId: String) = onProviderMutation.invoke(providerId)
 }
 
 private class BoundProviderVideoDetailPort(
@@ -487,6 +527,8 @@ private fun CorePlaylistState<ProviderPlaylist, ProviderFeatureCategory, MusicTr
     nextOffset = nextOffset,
     hasMore = hasMore,
     isLoading = isLoading,
+    favoriteState = favoriteState,
+    isFavoriteLoading = isFavoriteLoading,
     message = message,
     errorMessage = errorMessage,
 )
@@ -511,6 +553,8 @@ private fun CoreMediaItemState<ProviderMediaItem, MusicTrack>.toUiState() = Prov
     albumsNextOffset = albumsNextOffset,
     albumsHasMore = albumsHasMore,
     isLoading = isLoading,
+    favoriteState = favoriteState,
+    isFavoriteLoading = isFavoriteLoading,
     message = message,
     errorMessage = errorMessage,
 )
@@ -582,3 +626,15 @@ private fun providerDetailError(throwable: Throwable, fallback: String, provider
     throwable.providerFailureOrNull(providerId)?.userMessage
         ?: throwable.message
         ?: throwable::class.simpleName.orEmpty().ifBlank { fallback }
+
+
+private fun ProviderResourceState.toDetailFavoriteState() = ProviderDetailFavoriteState(
+    isFavorite = isFavorite,
+    canFavorite = canFavorite,
+    canUnfavorite = canUnfavorite,
+)
+
+private fun ProviderMediaItem.favoriteResourceType(): String = when (type) {
+    ProviderMediaItemType.Artist -> "artist"
+    ProviderMediaItemType.Album -> "album"
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailRoutes.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailRoutes.kt
@@ -309,6 +309,20 @@ fun ProviderPlaylistDetailRoute(playlist: ProviderPlaylist, category: ProviderFe
                 placeholder = CoverPlaceholder.Playlist,
                 action = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (
+                            state.favoriteState.isFavorite ||
+                            state.favoriteState.canFavorite ||
+                            state.favoriteState.canUnfavorite
+                        ) {
+                            ProviderFavoriteButton(
+                                isFavorite = state.favoriteState.isFavorite,
+                                isLoading = state.isFavoriteLoading,
+                                enabled = owner.canToggleFavorite(),
+                                favoriteLabel = "收藏",
+                                unfavoriteLabel = "已收藏",
+                                onClick = owner::toggleFavorite,
+                            )
+                        }
                         if (state.tracks.isNotEmpty()) PlayAllButton(onClick = owner::playAll)
                         ShareTextButton(sharePayload)
                     }
@@ -484,6 +498,20 @@ fun ProviderMediaItemDetailRoute(item: ProviderMediaItem) {
                 placeholder = if (isArtist) CoverPlaceholder.Artist else CoverPlaceholder.Album,
                 action = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        if (
+                            state.favoriteState.isFavorite ||
+                            state.favoriteState.canFavorite ||
+                            state.favoriteState.canUnfavorite
+                        ) {
+                            ProviderFavoriteButton(
+                                isFavorite = state.favoriteState.isFavorite,
+                                isLoading = state.isFavoriteLoading,
+                                enabled = owner.canToggleFavorite(),
+                                favoriteLabel = if (isArtist) "关注" else "收藏",
+                                unfavoriteLabel = if (isArtist) "已关注" else "已收藏",
+                                onClick = owner::toggleFavorite,
+                            )
+                        }
                         if (state.tracks.isNotEmpty()) PlayAllButton(onClick = owner::playAll)
                         ShareTextButton(sharePayload)
                     }
@@ -526,6 +554,20 @@ fun ProviderMediaItemDetailRoute(item: ProviderMediaItem) {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ProviderFavoriteButton(
+    isFavorite: Boolean,
+    isLoading: Boolean,
+    enabled: Boolean,
+    favoriteLabel: String,
+    unfavoriteLabel: String,
+    onClick: () -> Unit,
+) {
+    TextButton(onClick = onClick, enabled = enabled && !isLoading) {
+        Text(if (isFavorite) unfavoriteLabel else favoriteLabel)
     }
 }
 


### PR DESCRIPTION
## Summary
- add playlist / artist / album favorite state and mutations for NetEase Cloud Music
- add QQ Music playlist favorites, artist follow/unfollow, and album favorites using the existing user-library identity flow
- expose favorite/unfavorite capabilities from both providers
- integrate resource favorite state into playlist and artist/album detail feature owners
- add 收藏/已收藏 and 关注/已关注 actions to provider detail UI
- refresh provider content after successful mutations

## Behavior
- owned playlists do not expose a redundant favorite action
- favorite state is loaded independently from detail content so a favorite-state failure does not block the detail page
- mutations update detail state immediately and then notify provider catalog content to refresh

## Validation
- added focused NetEase resource-favorite request/state tests
- added focused QQ Music resource-favorite request/state tests
- added provider-detail owner tests for favorite state and mutation ownership

## Deferred
- song like/dislike is intentionally not included in this PR; it has different semantics from resource subscription and should be handled separately
