### PR TITLE
feat: add manual lyric association

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -312,6 +312,7 @@ internal class AndroidAppContainer(
             playlistActionPort = playlistActionPort,
             providerTrackActionPort = providerTrackActionPort,
             localMusicActionPort = localMusicFeatureController,
+            playbackLyricsPort = playbackFeatureOwner.lyrics,
             replacementActionPort = playbackFeatureOwner.replacement,
             debugLogFeatureController = debugLogFeatureController,
             providerCatalogFeatureController = providerCatalogFeatureController,

--- a/persistence/settings/src/commonMain/kotlin/org/feeluown/mobile/SettingsPersistence.kt
+++ b/persistence/settings/src/commonMain/kotlin/org/feeluown/mobile/SettingsPersistence.kt
@@ -68,6 +68,7 @@ data class PersistedSettingsV1(
     val smartReplacementProviderIds: Set<String>? = null,
     val smartReplacementMinScore: Double? = null,
     val smartReplacementSelections: Map<String, PersistedSmartReplacementSelection>? = null,
+    val lyricsAssociations: Map<String, String>? = null,
     val pauseOnOtherAppPlayback: Boolean? = null,
     val lyricFontSize: String? = null,
     val statusBarLyricsEnabled: Boolean? = null,

--- a/persistence/settings/src/commonTest/kotlin/org/feeluown/mobile/SettingsPersistenceTest.kt
+++ b/persistence/settings/src/commonTest/kotlin/org/feeluown/mobile/SettingsPersistenceTest.kt
@@ -69,6 +69,7 @@ class SettingsPersistenceTest {
                     replacementScore = 0.9,
                 ),
             ),
+            lyricsAssociations = mapOf("bilibili:BVdemo" to "netease:1"),
             playlistPlaybackStats = mapOf(
                 "netease::playlist:1" to PersistedPlaylistPlaybackStat(2, 1234),
             ),

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
@@ -100,6 +100,24 @@ class BilibiliProvider(
         )
     }
 
+    override suspend fun lyricsSearchKeyword(track: org.feeluown.mobile.MusicTrack): String? {
+        val fallback = track.title.trim().takeIf { it.isNotBlank() }
+        val (bvid, page) = parsePaged(rawIdentifier(track.providerId ?: track.id))
+        return runCatching {
+            val info = videoInfo(bvid).obj("data") ?: return@runCatching fallback
+            val pages = info.array("pages")
+            if (page != null && page !in 1..pages.size) return@runCatching fallback
+            val pageInfo = pages.getOrNull((page ?: 1) - 1)?.asObject()
+            val cid = pageInfo?.long("cid") ?: info.long("cid") ?: return@runCatching fallback
+            playerInfoData(bvid, cid)
+                ?.obj("bgm_info")
+                ?.stringOrNull("music_title")
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: fallback
+        }.getOrNull() ?: fallback
+    }
+
     override suspend fun resolve(track: org.feeluown.mobile.MusicTrack, qualityPolicy: String): PlaybackPayload? {
         val (bvid, page) = parsePaged(rawIdentifier(track.providerId ?: track.id))
         val info = videoInfo(bvid).obj("data") ?: return null
@@ -362,6 +380,27 @@ class BilibiliProvider(
         cacheKey = "bilibili:view:$bvid",
         cachePolicy = ProviderCachePolicies.detail,
     ).value.let { providerJson.parseToJsonElement(it).asObject() }
+
+    private suspend fun playerInfoData(
+        bvid: String,
+        cid: Long,
+    ): kotlinx.serialization.json.JsonObject? {
+        val response = http.getText(
+            ID,
+            queryUrl(
+                "$BASE/x/player/wbi/v2",
+                mapOf(
+                    "bvid" to bvid,
+                    "cid" to cid.toString(),
+                ),
+            ),
+            headers(),
+            cacheKey = "bilibili:player-info:$bvid:$cid",
+            cachePolicy = ProviderCachePolicies.detail,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        if (response.int("code") != null && response.int("code") != 0) return null
+        return response.obj("data")
+    }
 
     private suspend fun playUrlData(
         bvid: String,

--- a/provider/bilibili/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
+++ b/provider/bilibili/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
@@ -39,6 +39,76 @@ class BilibiliProviderTest {
     }
 
     @Test
+    fun lyricSearchKeywordPrefersBgmTitle() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/x/web-interface/view" -> respond(
+                                """{"code":0,"data":{"bvid":"BVdemo","cid":123,"title":"视频标题","pages":[{"cid":123,"page":1,"part":"正片"}]}}""",
+                            )
+                            "/x/player/wbi/v2" -> {
+                                assertEquals("BVdemo", request.url.parameters["bvid"])
+                                assertEquals("123", request.url.parameters["cid"])
+                                respond(
+                                    """{"code":0,"data":{"bgm_info":{"music_id":"MA1","music_title":"Unwelcome school"}}}""",
+                                )
+                            }
+                            else -> error("unexpected Bilibili request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = BilibiliProvider(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "bilibili:BVdemo",
+            title = "视频标题",
+            artists = "UP",
+            album = "",
+            source = "bilibili",
+            sourceType = TrackSourceType.Provider,
+            providerId = "bilibili:BVdemo",
+        )
+
+        assertEquals("Unwelcome school", provider.lyricsSearchKeyword(track))
+        client.close()
+    }
+
+    @Test
+    fun lyricSearchKeywordFallsBackToTrackTitleWithoutBgm() = runTest {
+        val client = ProviderHttpClient(
+            HttpClient(MockEngine) {
+                engine {
+                    addHandler { request ->
+                        when (request.url.encodedPath) {
+                            "/x/web-interface/view" -> respond(
+                                """{"code":0,"data":{"bvid":"BVdemo","cid":123,"title":"接口标题","pages":[{"cid":123,"page":1,"part":"正片"}]}}""",
+                            )
+                            "/x/player/wbi/v2" -> respond("""{"code":0,"data":{"bgm_info":null}}""")
+                            else -> error("unexpected Bilibili request: ${request.url.encodedPath}")
+                        }
+                    }
+                }
+            },
+        )
+        val provider = BilibiliProvider(client, InMemoryProviderCredentialStore())
+        val track = MusicTrack(
+            id = "bilibili:BVdemo",
+            title = "当前视频标题",
+            artists = "UP",
+            album = "",
+            source = "bilibili",
+            sourceType = TrackSourceType.Provider,
+            providerId = "bilibili:BVdemo",
+        )
+
+        assertEquals("当前视频标题", provider.lyricsSearchKeyword(track))
+        client.close()
+    }
+
+    @Test
     fun resolveSelectsBilibiliAudioQualityAndPreservesPlayableParts() = runTest {
         val playUrlRequests = mutableListOf<Pair<String, String?>>()
         val client = ProviderHttpClient(

--- a/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/provider/core/ProviderSupport.kt
+++ b/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/provider/core/ProviderSupport.kt
@@ -431,6 +431,7 @@ interface KotlinMusicProvider {
     suspend fun trackDetail(identifier: String): MusicTrack?
     suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload?
     suspend fun lyrics(track: MusicTrack): String? = null
+    suspend fun lyricsSearchKeyword(track: MusicTrack): String? = null
     suspend fun authState(): ProviderAuthState
     suspend fun loginWithCookies(cookiesJson: String): ProviderAuthState
     suspend fun loginWithHeaders(authorization: String, cookie: String): ProviderAuthState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppSettingsRepository.kt
@@ -134,6 +134,7 @@ internal fun AppSettings.toPersistedSettings(): PersistedSettingsV1 = PersistedS
     smartReplacementProviderIds = smartReplacementProviderIds,
     smartReplacementMinScore = smartReplacementMinScore,
     smartReplacementSelections = smartReplacementSelections.mapValues { (_, selection) -> selection.toPersisted() },
+    lyricsAssociations = lyricsAssociations,
     pauseOnOtherAppPlayback = pauseOnOtherAppPlayback,
     lyricFontSize = lyricFontSize.name,
     statusBarLyricsEnabled = statusBarLyricsEnabled,
@@ -182,6 +183,7 @@ internal fun PersistedSettingsV1.toAppSettings(): AppSettings {
         smartReplacementSelections = smartReplacementSelections
             ?.mapValues { (_, selection) -> selection.toDomain() }
             ?: defaults.smartReplacementSelections,
+        lyricsAssociations = lyricsAssociations ?: defaults.lyricsAssociations,
         pauseOnOtherAppPlayback = pauseOnOtherAppPlayback ?: defaults.pauseOnOtherAppPlayback,
         lyricFontSize = lyricFontSize.enumOr(defaults.lyricFontSize),
         statusBarLyricsEnabled = statusBarLyricsEnabled ?: defaults.statusBarLyricsEnabled,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
@@ -137,6 +137,7 @@ class FuoAppViewModel(
     val playlistActionPort: PlaylistActionPort,
     val providerTrackActionPort: ProviderTrackActionPort,
     val localMusicActionPort: LocalMusicActionPort,
+    val playbackLyricsPort: PlaybackLyricsPort,
     val replacementActionPort: ReplacementActionPort,
     val debugLogFeatureController: DebugLogFeatureController,
     val providerCatalogFeatureController: ProviderCatalogFeatureController,
@@ -170,6 +171,7 @@ class FuoAppViewModel(
         playlists = playlistActionPort,
         providerTrackActions = providerTrackActionPort,
         localMusicActions = localMusicActionPort,
+        lyrics = playbackLyricsPort,
         replacement = replacementActionPort,
     )
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
@@ -88,6 +88,7 @@ data class AppSettings(
     val smartReplacementProviderIds: Set<String> = emptySet(),
     val smartReplacementMinScore: Double = DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
     val smartReplacementSelections: Map<String, SmartReplacementSelection> = emptyMap(),
+    val lyricsAssociations: Map<String, String> = emptyMap(),
     val pauseOnOtherAppPlayback: Boolean = DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
     val statusBarLyricsEnabled: Boolean = false,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -79,7 +79,8 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         LyricFontSize.Medium -> 7.dp
         LyricFontSize.Large -> 8.dp
     }
-    val associationMatchesTrack = associationState.trackId == state.currentTrack?.id
+    val currentTrack = state.currentTrack
+    val associationMatchesTrack = associationState.trackId == currentTrack?.id
 
     LaunchedEffect(currentIndex, lines.size) {
         if (currentIndex < 0) return@LaunchedEffect
@@ -118,11 +119,11 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 if (
-                    state.currentTrack != null &&
+                    currentTrack != null &&
                     associationMatchesTrack &&
                     associationState.isLyricsUnavailable
                 ) {
-                    TextButton(onClick = { lyricsPort.openAssociationSearch(state.currentTrack) }) {
+                    TextButton(onClick = { lyricsPort.openAssociationSearch(currentTrack) }) {
                         Text("搜索并关联歌词")
                     }
                 }
@@ -211,12 +212,12 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                     }
                 }
                 if (
-                    state.currentTrack != null &&
+                    currentTrack != null &&
                     associationMatchesTrack &&
                     associationState.isManualAssociation
                 ) {
                     TextButton(
-                        onClick = { lyricsPort.openAssociationSearch(state.currentTrack) },
+                        onClick = { lyricsPort.openAssociationSearch(currentTrack) },
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .padding(FuoSpacing.sm),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -8,19 +8,25 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
@@ -28,13 +34,16 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifier) {
+    val lyricsPort = LocalPlaybackLyricsPort.current
+    val associationState by lyricsPort.associationState.collectAsStateWithLifecycle()
     val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
-    val displayLines = lines.takeIf { it.isNotEmpty() } ?: listOf(LyricLine(0, "暂无歌词"))
     val listState = rememberLazyListState()
     val renderPositionMs = rememberKaraokePositionMs(
         positionMs = state.positionMs,
@@ -70,6 +79,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         LyricFontSize.Medium -> 7.dp
         LyricFontSize.Large -> 8.dp
     }
+    val associationMatchesTrack = associationState.trackId == state.currentTrack?.id
 
     LaunchedEffect(currentIndex, lines.size) {
         if (currentIndex < 0) return@LaunchedEffect
@@ -94,90 +104,244 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         color = MaterialTheme.colorScheme.surfaceContainer,
         shape = MaterialTheme.shapes.medium,
     ) {
-        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-            val edgeSpacerHeight = maxHeight / 2
-            LazyColumn(
-                state = listState,
+        if (lines.isEmpty()) {
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = FuoSpacing.lg),
+                    .padding(FuoSpacing.lg),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                item(key = "lyrics-top-spacer") {
-                    Spacer(modifier = Modifier.height(edgeSpacerHeight))
+                Text(
+                    text = "暂无歌词",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (
+                    state.currentTrack != null &&
+                    associationMatchesTrack &&
+                    associationState.isLyricsUnavailable
+                ) {
+                    TextButton(onClick = { lyricsPort.openAssociationSearch(state.currentTrack) }) {
+                        Text("搜索并关联歌词")
+                    }
                 }
-                itemsIndexed(displayLines) { index, line ->
-                    val active = index == currentIndex
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = linePadding),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                    ) {
-                        line.romanization?.takeIf { it.isNotBlank() }?.let { romanization ->
-                            if (active && !line.romanizationWords.isNullOrEmpty()) {
+            }
+        } else {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val edgeSpacerHeight = maxHeight / 2
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = FuoSpacing.lg),
+                ) {
+                    item(key = "lyrics-top-spacer") {
+                        Spacer(modifier = Modifier.height(edgeSpacerHeight))
+                    }
+                    itemsIndexed(lines) { index, line ->
+                        val active = index == currentIndex
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = linePadding),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            line.romanization?.takeIf { it.isNotBlank() }?.let { romanization ->
+                                if (active && !line.romanizationWords.isNullOrEmpty()) {
+                                    KaraokeLyricText(
+                                        words = line.romanizationWords,
+                                        positionMs = renderPositionMs,
+                                        style = romanizationStyle,
+                                        activeColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
+                                        inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f),
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier.fillMaxWidth(),
+                                    )
+                                } else {
+                                    Text(
+                                        text = romanization,
+                                        style = romanizationStyle,
+                                        color = if (active) {
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f)
+                                        },
+                                        fontWeight = if (active) FontWeight.Medium else FontWeight.Normal,
+                                        modifier = Modifier.fillMaxWidth(),
+                                    )
+                                }
+                            }
+                            if (active && !line.words.isNullOrEmpty()) {
                                 KaraokeLyricText(
-                                    words = line.romanizationWords,
+                                    words = line.words,
                                     positionMs = renderPositionMs,
-                                    style = romanizationStyle,
-                                    activeColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
-                                    inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f),
-                                    fontWeight = FontWeight.Medium,
+                                    style = activeStyle,
+                                    activeColor = MaterialTheme.colorScheme.primary,
+                                    inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                             } else {
                                 Text(
-                                    text = romanization,
-                                    style = romanizationStyle,
+                                    text = line.text,
+                                    style = if (active) activeStyle else inactiveStyle,
                                     color = if (active) {
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+                                        MaterialTheme.colorScheme.primary
                                     } else {
-                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f)
+                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.46f)
                                     },
-                                    fontWeight = if (active) FontWeight.Medium else FontWeight.Normal,
+                                    fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                            line.translation?.takeIf { it.isNotBlank() }?.let { translation ->
+                                Text(
+                                    text = translation,
+                                    style = translationStyle,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(
+                                        alpha = if (active) 0.52f else 0.38f,
+                                    ),
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                             }
                         }
-                        if (active && !line.words.isNullOrEmpty()) {
-                            KaraokeLyricText(
-                                words = line.words,
-                                positionMs = renderPositionMs,
-                                style = activeStyle,
-                                activeColor = MaterialTheme.colorScheme.primary,
-                                inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        } else {
-                            Text(
-                                text = line.text,
-                                style = if (active) activeStyle else inactiveStyle,
-                                color = if (active) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.46f)
-                                },
-                                fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                        line.translation?.takeIf { it.isNotBlank() }?.let { translation ->
-                            Text(
-                                text = translation,
-                                style = translationStyle,
-                                color = MaterialTheme.colorScheme.onSurface.copy(
-                                    alpha = if (active) 0.52f else 0.38f,
-                                ),
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
+                    }
+                    item(key = "lyrics-bottom-spacer") {
+                        Spacer(modifier = Modifier.height(edgeSpacerHeight))
                     }
                 }
-                item(key = "lyrics-bottom-spacer") {
-                    Spacer(modifier = Modifier.height(edgeSpacerHeight))
+                if (
+                    state.currentTrack != null &&
+                    associationMatchesTrack &&
+                    associationState.isManualAssociation
+                ) {
+                    TextButton(
+                        onClick = { lyricsPort.openAssociationSearch(state.currentTrack) },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(FuoSpacing.sm),
+                    ) {
+                        Text("更换歌词")
+                    }
                 }
             }
         }
     }
+
+    if (associationMatchesTrack && associationState.isSearchOpen) {
+        LyricsAssociationDialog(
+            state = associationState,
+            onQueryChange = lyricsPort::updateAssociationQuery,
+            onSearch = lyricsPort::searchAssociation,
+            onSelect = lyricsPort::selectAssociation,
+            onDismiss = lyricsPort::closeAssociationSearch,
+        )
+    }
+}
+
+@Composable
+private fun LyricsAssociationDialog(
+    state: LyricsAssociationUiState,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onSelect: (MusicTrack) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("关联歌词") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                state.associatedTrackTitle?.takeIf { state.isManualAssociation }?.let { title ->
+                    Text(
+                        text = "当前关联：$title",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                OutlinedTextField(
+                    value = state.query,
+                    onValueChange = onQueryChange,
+                    label = { Text("搜索歌曲") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                when {
+                    state.isSearching -> CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    )
+                    state.message != null -> Text(
+                        text = state.message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (state.results.isNotEmpty()) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 360.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        itemsIndexed(state.results, key = { _, track -> track.id }) { _, track ->
+                            TextButton(
+                                onClick = { onSelect(track) },
+                                enabled = state.selectingTrackId == null,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Column(modifier = Modifier.fillMaxWidth()) {
+                                    Text(
+                                        text = track.title,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    val detail = listOf(
+                                        track.artists.takeIf { it.isNotBlank() },
+                                        (track.providerName ?: track.source).takeIf { it.isNotBlank() },
+                                    ).filterNotNull().joinToString(" · ")
+                                    if (detail.isNotBlank()) {
+                                        Text(
+                                            text = detail,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    }
+                                    if (state.selectingTrackId == track.id) {
+                                        Text(
+                                            text = "正在读取歌词…",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.primary,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onSearch,
+                enabled = !state.isSearching && state.selectingTrackId == null,
+            ) {
+                Text("搜索")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("取消")
+            }
+        },
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -32,6 +32,7 @@ interface PlaybackFeatureOwner {
     val startFailureSource: PlaybackStartFailureSource
     val navigation: PlaybackNavigationPort
     val sleepTimer: PlaybackSleepTimerPort
+    val lyrics: PlaybackLyricsPort
     val replacement: ReplacementActionPort
 
     fun updateTrackCopies(trackId: String, updatedTrack: MusicTrack)
@@ -79,6 +80,7 @@ private class DefaultPlaybackFeatureOwner(
     private var playRequestSerial = 0L
     private var lastRecoveredPlaybackErrorKey: String? = null
     private var smartReplacementSelections: Map<String, SmartReplacementSelection> = emptyMap()
+    private var lyricsAssociations: Map<String, String> = emptyMap()
     private var pendingManualReplacementSwitch: PlaybackOwnerPendingManualReplacement? = null
     private var suppressPlaybackRecoveryRequestSerial: Long? = null
     private var appendQueueFeatureTask: Deferred<Int>? = null
@@ -98,6 +100,8 @@ private class DefaultPlaybackFeatureOwner(
         currentTrackId = { queueState.currentTrack()?.id ?: playbackState.value.currentTrack?.id },
         currentLyrics = { playbackState.value.lyrics },
         updateLyrics = { lyrics -> updatePlaybackState { it.copy(lyrics = lyrics) } },
+        associationForTrackId = { trackId -> lyricsAssociations[trackId] },
+        rememberAssociation = ::rememberLyricsAssociation,
     )
 
     private val startOwner = PlaybackStartCoordinator(
@@ -197,18 +201,23 @@ private class DefaultPlaybackFeatureOwner(
     override val startFailureSource: PlaybackStartFailureSource = startOwner
     override val navigation: PlaybackNavigationPort = navigationOwner
     override val sleepTimer: PlaybackSleepTimerPort = sleepTimerOwner
+    override val lyrics: PlaybackLyricsPort = lyricsOwner
     override val replacement: ReplacementActionPort = replacementOwner
 
     init {
         scope.launch {
             val settings = settingsRepository.awaitSettings()
             smartReplacementSelections = settings.smartReplacementSelections
+            lyricsAssociations = settings.lyricsAssociations
             runCatching { playbackQueueStore.load() }
                 .onSuccess(::restorePlaybackQueue)
         }
         scope.launch {
             settingsRepository.state.collect { state ->
-                if (state.isLoaded) smartReplacementSelections = state.settings.smartReplacementSelections
+                if (state.isLoaded) {
+                    smartReplacementSelections = state.settings.smartReplacementSelections
+                    lyricsAssociations = state.settings.lyricsAssociations
+                }
             }
         }
         scope.launch {
@@ -320,6 +329,20 @@ private class DefaultPlaybackFeatureOwner(
             return if (isSmartReplacement) originalTrack else this
         }
         return originalTrack.withReplacementSelection(selection)
+    }
+
+    private fun rememberLyricsAssociation(sourceTrackId: String, lyricsTrackId: String?) {
+        lyricsAssociations = if (lyricsTrackId.isNullOrBlank()) {
+            lyricsAssociations - sourceTrackId
+        } else {
+            lyricsAssociations + (sourceTrackId to lyricsTrackId)
+        }
+        val nextAssociations = lyricsAssociations
+        scope.launch {
+            settingsRepository.update { current ->
+                current.copy(lyricsAssociations = nextAssociations)
+            }
+        }
     }
 
     private fun commitManualReplacementIfReady(engineState: PlaybackState) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -67,6 +67,7 @@ internal class PlaybackLyricsController(
     private var selectionJob: Job? = null
     private var loadedForTrackId: String? = null
     private var associationSearchTrack: MusicTrack? = null
+    private var associationQueryEdited = false
 
     fun resetForPlaybackRequest() {
         loadJob?.cancel()
@@ -77,6 +78,7 @@ internal class PlaybackLyricsController(
         selectionJob = null
         loadedForTrackId = null
         associationSearchTrack = null
+        associationQueryEdited = false
         mutableAssociationState.value = LyricsAssociationUiState()
     }
 
@@ -156,6 +158,7 @@ internal class PlaybackLyricsController(
 
     override fun openAssociationSearch(track: MusicTrack) {
         associationSearchTrack = track
+        associationQueryEdited = false
         val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
         mutableAssociationState.value = LyricsAssociationUiState(
             trackId = track.id,
@@ -175,12 +178,17 @@ internal class PlaybackLyricsController(
                 ?.takeIf { it.isNotBlank() }
                 ?: sourceTrack.title.trim()
             if (associationSearchTrack?.id != track.id || currentTrackId() != track.id) return@launch
+            if (associationQueryEdited) {
+                mutableAssociationState.value = mutableAssociationState.value.copy(isSearching = false)
+                return@launch
+            }
             mutableAssociationState.value = mutableAssociationState.value.copy(query = keyword)
             performSearch(track, keyword)
         }
     }
 
     override fun updateAssociationQuery(query: String) {
+        associationQueryEdited = true
         mutableAssociationState.value = mutableAssociationState.value.copy(
             query = query,
             message = null,
@@ -246,6 +254,7 @@ internal class PlaybackLyricsController(
         searchJob = null
         selectionJob = null
         associationSearchTrack = null
+        associationQueryEdited = false
         mutableAssociationState.value = mutableAssociationState.value.copy(
             isSearchOpen = false,
             isSearching = false,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -136,9 +136,6 @@ internal class PlaybackLyricsController(
                     )
                     return@launch
                 }
-                if (associatedTrack == null || associatedLyrics == null) {
-                    rememberAssociation(lyricTrack.id, null)
-                }
             }
 
             val lyrics = runCatching {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -2,24 +2,82 @@ package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+internal interface PlaybackLyricsRepository {
+    suspend fun lyrics(track: MusicTrack): String?
+    suspend fun search(keyword: String): List<MusicTrack>
+    suspend fun trackDetail(trackId: String): MusicTrack?
+    suspend fun searchKeyword(track: MusicTrack): String?
+}
+
+private class ProviderPlaybackLyricsRepository(
+    private val delegate: ProviderMusicRepository,
+) : PlaybackLyricsRepository {
+    override suspend fun lyrics(track: MusicTrack): String? = delegate.lyrics(track)
+
+    override suspend fun search(keyword: String): List<MusicTrack> =
+        delegate.search(keyword, providerId = null)
+
+    override suspend fun trackDetail(trackId: String): MusicTrack? =
+        runCatching { delegate.trackDetail(trackId) }.getOrNull()
+
+    override suspend fun searchKeyword(track: MusicTrack): String? =
+        delegate.lyricsSearchKeyword(track)
+}
+
 internal class PlaybackLyricsController(
-    providerRepository: ProviderMusicRepository,
+    private val repository: PlaybackLyricsRepository,
     private val scope: CoroutineScope,
     private val currentRequestSerial: () -> Long,
     private val currentTrackId: () -> String?,
     private val currentLyrics: () -> String?,
     private val updateLyrics: (String) -> Unit,
-) {
-    private val providerRepository: ProviderPlaybackRepository = ProviderPlaybackRepositoryView(providerRepository)
+    private val associationForTrackId: (String) -> String?,
+    private val rememberAssociation: (String, String?) -> Unit,
+) : PlaybackLyricsPort {
+    constructor(
+        providerRepository: ProviderMusicRepository,
+        scope: CoroutineScope,
+        currentRequestSerial: () -> Long,
+        currentTrackId: () -> String?,
+        currentLyrics: () -> String?,
+        updateLyrics: (String) -> Unit,
+        associationForTrackId: (String) -> String?,
+        rememberAssociation: (String, String?) -> Unit,
+    ) : this(
+        repository = ProviderPlaybackLyricsRepository(providerRepository),
+        scope = scope,
+        currentRequestSerial = currentRequestSerial,
+        currentTrackId = currentTrackId,
+        currentLyrics = currentLyrics,
+        updateLyrics = updateLyrics,
+        associationForTrackId = associationForTrackId,
+        rememberAssociation = rememberAssociation,
+    )
+
+    private val mutableAssociationState = MutableStateFlow(LyricsAssociationUiState())
+    override val associationState: StateFlow<LyricsAssociationUiState> = mutableAssociationState.asStateFlow()
+
     private var loadJob: Job? = null
+    private var searchJob: Job? = null
+    private var selectionJob: Job? = null
     private var loadedForTrackId: String? = null
+    private var associationSearchTrack: MusicTrack? = null
 
     fun resetForPlaybackRequest() {
         loadJob?.cancel()
+        searchJob?.cancel()
+        selectionJob?.cancel()
         loadJob = null
+        searchJob = null
+        selectionJob = null
         loadedForTrackId = null
+        associationSearchTrack = null
+        mutableAssociationState.value = LyricsAssociationUiState()
     }
 
     fun mergedLyrics(
@@ -44,28 +102,191 @@ internal class PlaybackLyricsController(
         if (track == null) return
         if (!currentLyrics().isNullOrBlank()) {
             loadedForTrackId = track.id
+            if (mutableAssociationState.value.trackId != track.id) {
+                mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
+            }
             return
         }
         track.lyrics?.takeIf { it.isNotBlank() }?.let {
             updateLyrics(it)
             loadedForTrackId = track.id
+            mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
             return
         }
         if (loadedForTrackId == track.id) return
+
         loadedForTrackId = track.id
         val requestSerial = currentRequestSerial()
+        val lyricTrack = lyricSourceTrackForPlayback(track)
         loadJob?.cancel()
         loadJob = scope.launch {
+            val associatedTrackId = associationForTrackId(lyricTrack.id)
+            if (!associatedTrackId.isNullOrBlank()) {
+                val associatedTrack = repository.trackDetail(associatedTrackId)
+                val associatedLyrics = associatedTrack?.let { candidate ->
+                    runCatching { repository.lyrics(candidate) }.getOrNull()
+                }?.takeIf { it.isNotBlank() }
+                if (isCurrent(track, requestSerial) && associatedTrack != null && associatedLyrics != null) {
+                    updateLyrics(associatedLyrics)
+                    mutableAssociationState.value = LyricsAssociationUiState(
+                        trackId = track.id,
+                        isManualAssociation = true,
+                        associatedTrackId = associatedTrack.id,
+                        associatedTrackTitle = associatedTrack.title,
+                    )
+                    return@launch
+                }
+                if (associatedTrack == null || associatedLyrics == null) {
+                    rememberAssociation(lyricTrack.id, null)
+                }
+            }
+
             val lyrics = runCatching {
-                providerRepository.lyrics(lyricSourceTrackForPlayback(track))
+                repository.lyrics(lyricTrack)
             }.getOrNull()?.takeIf { it.isNotBlank() }
-            if (requestSerial != currentRequestSerial()) return@launch
-            if (currentTrackId() != track.id) return@launch
-            if (!lyrics.isNullOrBlank()) {
+            if (!isCurrent(track, requestSerial)) return@launch
+            if (lyrics != null) {
                 updateLyrics(lyrics)
+                mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
+            } else {
+                mutableAssociationState.value = LyricsAssociationUiState(
+                    trackId = track.id,
+                    isLyricsUnavailable = true,
+                )
             }
         }
     }
+
+    override fun openAssociationSearch(track: MusicTrack) {
+        associationSearchTrack = track
+        val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
+        mutableAssociationState.value = LyricsAssociationUiState(
+            trackId = track.id,
+            isLyricsUnavailable = previous?.isLyricsUnavailable ?: currentLyrics().isNullOrBlank(),
+            isManualAssociation = previous?.isManualAssociation == true,
+            associatedTrackId = previous?.associatedTrackId,
+            associatedTrackTitle = previous?.associatedTrackTitle,
+            isSearchOpen = true,
+            isSearching = true,
+        )
+        searchJob?.cancel()
+        searchJob = scope.launch {
+            val sourceTrack = lyricSourceTrackForPlayback(track)
+            val keyword = runCatching { repository.searchKeyword(sourceTrack) }
+                .getOrNull()
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: sourceTrack.title.trim()
+            if (associationSearchTrack?.id != track.id || currentTrackId() != track.id) return@launch
+            mutableAssociationState.value = mutableAssociationState.value.copy(query = keyword)
+            performSearch(track, keyword)
+        }
+    }
+
+    override fun updateAssociationQuery(query: String) {
+        mutableAssociationState.value = mutableAssociationState.value.copy(
+            query = query,
+            message = null,
+        )
+    }
+
+    override fun searchAssociation() {
+        val track = associationSearchTrack ?: return
+        val keyword = mutableAssociationState.value.query.trim()
+        if (keyword.isBlank()) {
+            mutableAssociationState.value = mutableAssociationState.value.copy(
+                results = emptyList(),
+                isSearching = false,
+                message = "请输入搜索关键词",
+            )
+            return
+        }
+        searchJob?.cancel()
+        searchJob = scope.launch {
+            performSearch(track, keyword)
+        }
+    }
+
+    override fun selectAssociation(track: MusicTrack) {
+        val playbackTrack = associationSearchTrack ?: return
+        val sourceTrack = lyricSourceTrackForPlayback(playbackTrack)
+        val requestSerial = currentRequestSerial()
+        selectionJob?.cancel()
+        mutableAssociationState.value = mutableAssociationState.value.copy(
+            selectingTrackId = track.id,
+            message = null,
+        )
+        selectionJob = scope.launch {
+            val lyrics = runCatching { repository.lyrics(track) }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
+            if (!isCurrent(playbackTrack, requestSerial) || associationSearchTrack?.id != playbackTrack.id) {
+                return@launch
+            }
+            if (lyrics == null) {
+                mutableAssociationState.value = mutableAssociationState.value.copy(
+                    selectingTrackId = null,
+                    message = "该搜索结果没有可用歌词，请选择其他结果",
+                )
+                return@launch
+            }
+
+            rememberAssociation(sourceTrack.id, track.id)
+            updateLyrics(lyrics)
+            mutableAssociationState.value = LyricsAssociationUiState(
+                trackId = playbackTrack.id,
+                isManualAssociation = true,
+                associatedTrackId = track.id,
+                associatedTrackTitle = track.title,
+            )
+            associationSearchTrack = null
+        }
+    }
+
+    override fun closeAssociationSearch() {
+        searchJob?.cancel()
+        selectionJob?.cancel()
+        searchJob = null
+        selectionJob = null
+        associationSearchTrack = null
+        mutableAssociationState.value = mutableAssociationState.value.copy(
+            isSearchOpen = false,
+            isSearching = false,
+            selectingTrackId = null,
+            message = null,
+        )
+    }
+
+    private suspend fun performSearch(track: MusicTrack, keyword: String) {
+        mutableAssociationState.value = mutableAssociationState.value.copy(
+            isSearching = true,
+            results = emptyList(),
+            message = null,
+        )
+        val sourceTrack = lyricSourceTrackForPlayback(track)
+        val result = runCatching { repository.search(keyword) }
+        if (associationSearchTrack?.id != track.id || currentTrackId() != track.id) return
+        result.onSuccess { tracks ->
+            val candidates = tracks
+                .asSequence()
+                .filter { it.id != sourceTrack.id }
+                .distinctBy { it.id }
+                .toList()
+            mutableAssociationState.value = mutableAssociationState.value.copy(
+                isSearching = false,
+                results = candidates,
+                message = if (candidates.isEmpty()) "没有找到可关联的歌曲" else null,
+            )
+        }.onFailure { throwable ->
+            mutableAssociationState.value = mutableAssociationState.value.copy(
+                isSearching = false,
+                message = throwable.message ?: "搜索歌词失败",
+            )
+        }
+    }
+
+    private fun isCurrent(track: MusicTrack, requestSerial: Long): Boolean =
+        requestSerial == currentRequestSerial() && currentTrackId() == track.id
 
     private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack {
         if (!track.isSmartReplacement) return track

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -19,6 +19,7 @@ data class PlaybackUiGraph(
     val playlists: PlaylistActionPort,
     val providerTrackActions: ProviderTrackActionPort,
     val localMusicActions: LocalMusicActionPort,
+    val lyrics: PlaybackLyricsPort,
     val replacement: ReplacementActionPort,
 ) {
     val isFullPlayerOpen: Boolean
@@ -54,6 +55,9 @@ val LocalProviderTrackActionPort = staticCompositionLocalOf<ProviderTrackActionP
 val LocalLocalMusicActionPort = staticCompositionLocalOf<LocalMusicActionPort> {
     error("LocalMusicActionPort is not provided")
 }
+val LocalPlaybackLyricsPort = staticCompositionLocalOf<PlaybackLyricsPort> {
+    error("PlaybackLyricsPort is not provided")
+}
 val LocalReplacementActionPort = staticCompositionLocalOf<ReplacementActionPort> {
     error("ReplacementActionPort is not provided")
 }
@@ -72,6 +76,7 @@ fun ProvideNarrowPlaybackUi(
         LocalPlaylistActionPort provides graph.playlists,
         LocalProviderTrackActionPort provides graph.providerTrackActions,
         LocalLocalMusicActionPort provides graph.localMusicActions,
+        LocalPlaybackLyricsPort provides graph.lyrics,
         LocalReplacementActionPort provides graph.replacement,
         content = content,
     )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -171,6 +171,31 @@ interface LocalMusicActionPort {
     fun openLocalMetadataEditor(track: MusicTrack)
 }
 
+data class LyricsAssociationUiState(
+    val trackId: String? = null,
+    val isLyricsUnavailable: Boolean = false,
+    val isManualAssociation: Boolean = false,
+    val associatedTrackId: String? = null,
+    val associatedTrackTitle: String? = null,
+    val isSearchOpen: Boolean = false,
+    val query: String = "",
+    val results: List<MusicTrack> = emptyList(),
+    val isSearching: Boolean = false,
+    val selectingTrackId: String? = null,
+    val message: String? = null,
+)
+
+/** Manual lyric lookup/association state owned by playback. */
+interface PlaybackLyricsPort {
+    val associationState: StateFlow<LyricsAssociationUiState>
+
+    fun openAssociationSearch(track: MusicTrack)
+    fun updateAssociationQuery(query: String)
+    fun searchAssociation()
+    fun selectAssociation(track: MusicTrack)
+    fun closeAssociationSearch()
+}
+
 /** Smart-replacement state/actions used by the now-playing surface. */
 interface ReplacementActionPort {
     val replacementCandidateState: ReplacementCandidateState

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
@@ -271,6 +271,15 @@ class KotlinProviderRepository : ProviderMusicRepository {
         return providerMap[providerId]?.lyrics(lyricTrack)?.takeIf { it.isNotBlank() }
     }
 
+    override suspend fun lyricsSearchKeyword(track: MusicTrack): String? {
+        initialize()
+        val lyricTrack = track.asOriginalMediaTrack()
+        val providerId = lyricTrack.source.ifBlank {
+            splitResourceId(lyricTrack.providerId ?: lyricTrack.id).first
+        }
+        return providerMap[providerId]?.lyricsSearchKeyword(lyricTrack)?.takeIf { it.isNotBlank() }
+    }
+
     override suspend fun authState(providerId: String): ProviderAuthState = requireProvider(providerId).authState()
 
     override suspend fun refreshAuthState(providerId: String): ProviderAuthState = requireProvider(providerId).authState()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderRepositoryCapabilities.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderRepositoryCapabilities.kt
@@ -31,6 +31,8 @@ interface ProviderPlaybackRepository {
     )
 
     suspend fun lyrics(track: MusicTrack): String? = null
+
+    suspend fun lyricsSearchKeyword(track: MusicTrack): String? = null
 }
 
 /** Compatibility adapters while the application aggregate repository is being retired. */
@@ -86,6 +88,9 @@ internal class ProviderPlaybackRepositoryView(
     )
 
     override suspend fun lyrics(track: MusicTrack): String? = delegate.lyrics(track)
+
+    override suspend fun lyricsSearchKeyword(track: MusicTrack): String? =
+        delegate.lyricsSearchKeyword(track)
 }
 
 internal class ProviderAuthRepositoryView(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -180,6 +180,28 @@ class AppSettingsRepositoryTest {
     }
 
     @Test
+    fun lyricsAssociationsRoundTrip() = runTest {
+        val store = FakeSettingsSnapshotStore()
+        val first = PersistentAppSettingsRepository(
+            store = store,
+            legacyLoader = null,
+            scope = backgroundScope,
+        )
+        first.awaitSettings()
+        first.update {
+            it.copy(lyricsAssociations = mapOf("bilibili:BVdemo" to "netease:123"))
+        }
+
+        val restored = PersistentAppSettingsRepository(
+            store = store,
+            legacyLoader = null,
+            scope = backgroundScope,
+        ).awaitSettings()
+
+        assertEquals("netease:123", restored.lyricsAssociations["bilibili:BVdemo"])
+    }
+
+    @Test
     fun incompatibleOrInvalidPlaylistPlaybackStatsAreDiscarded() {
         val legacy = AppSettings(
             playlistPlaybackStats = mapOf(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -22,7 +22,7 @@ class PlaybackLyricsControllerTest {
         var currentLyrics: String? = null
         val controller = PlaybackLyricsController(
             repository = repository,
-            scope = backgroundScope,
+            scope = this,
             currentRequestSerial = { 1L },
             currentTrackId = { source.id },
             currentLyrics = { currentLyrics },
@@ -53,7 +53,7 @@ class PlaybackLyricsControllerTest {
         var remembered: Pair<String, String?>? = null
         val controller = PlaybackLyricsController(
             repository = repository,
-            scope = backgroundScope,
+            scope = this,
             currentRequestSerial = { 7L },
             currentTrackId = { source.id },
             currentLyrics = { currentLyrics },
@@ -88,7 +88,7 @@ class PlaybackLyricsControllerTest {
         )
         val controller = PlaybackLyricsController(
             repository = repository,
-            scope = backgroundScope,
+            scope = this,
             currentRequestSerial = { 1L },
             currentTrackId = { source.id },
             currentLyrics = { null },

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -1,6 +1,8 @@
 package org.feeluown.mobile
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -81,6 +83,56 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
+    fun rememberedAssociationIsPreservedWhenLookupFails() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val repository = FakePlaybackLyricsRepository()
+        val rememberedCalls = mutableListOf<Pair<String, String?>>()
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { if (it == source.id) "netease:missing" else null },
+            rememberAssociation = { sourceId, targetId -> rememberedCalls += sourceId to targetId },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+
+        assertTrue(controller.associationState.value.isLyricsUnavailable)
+        assertTrue(rememberedCalls.isEmpty())
+    }
+
+    @Test
+    fun userQueryIsNotOverwrittenWhileDefaultKeywordLoads() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val keywordGate = CompletableDeferred<String?>()
+        val repository = FakePlaybackLyricsRepository(searchKeywordGate = keywordGate)
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.openAssociationSearch(source)
+        runCurrent()
+        controller.updateAssociationQuery("用户输入")
+        keywordGate.complete("异步 BGM 标题")
+        advanceUntilIdle()
+
+        assertEquals("用户输入", controller.associationState.value.query)
+        assertFalse(controller.associationState.value.isSearching)
+        assertTrue(repository.searchRequests.isEmpty())
+    }
+
+    @Test
     fun searchFallsBackToTrackTitleWhenProviderHasNoHint() = runTest {
         val source = providerTrack("other:1", "原始标题", "other")
         val repository = FakePlaybackLyricsRepository(
@@ -120,6 +172,7 @@ class PlaybackLyricsControllerTest {
         private val lyrics: Map<String, String> = emptyMap(),
         private val searchKeyword: String? = null,
         private val searchResults: List<MusicTrack> = emptyList(),
+        private val searchKeywordGate: CompletableDeferred<String?>? = null,
     ) : PlaybackLyricsRepository {
         val lyricRequests = mutableListOf<String>()
         val searchRequests = mutableListOf<String>()
@@ -136,6 +189,7 @@ class PlaybackLyricsControllerTest {
 
         override suspend fun trackDetail(trackId: String): MusicTrack? = details[trackId]
 
-        override suspend fun searchKeyword(track: MusicTrack): String? = searchKeyword
+        override suspend fun searchKeyword(track: MusicTrack): String? =
+            searchKeywordGate?.await() ?: searchKeyword
     }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -1,0 +1,141 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackLyricsControllerTest {
+    @Test
+    fun rememberedAssociationLoadsBeforeNativeLyrics() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val target = providerTrack("netease:123", "歌词歌曲", "netease")
+        val repository = FakePlaybackLyricsRepository(
+            details = mapOf(target.id to target),
+            lyrics = mapOf(
+                target.id to "[00:00.00]关联歌词",
+                source.id to "[00:00.00]不应优先使用",
+            ),
+        )
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = backgroundScope,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { if (it == source.id) target.id else null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+
+        assertEquals("[00:00.00]关联歌词", currentLyrics)
+        assertEquals(target.id, controller.associationState.value.associatedTrackId)
+        assertTrue(controller.associationState.value.isManualAssociation)
+        assertEquals(listOf(target.id), repository.lyricRequests)
+    }
+
+    @Test
+    fun unavailableLyricsCanSearchSelectAndRememberAssociation() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val target = providerTrack("qqmusic:42", "BGM 歌曲", "qqmusic")
+        val repository = FakePlaybackLyricsRepository(
+            searchKeyword = "BGM 歌曲",
+            searchResults = listOf(target),
+            lyrics = mapOf(target.id to "[00:00.00]目标歌词"),
+        )
+        var currentLyrics: String? = null
+        var remembered: Pair<String, String?>? = null
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = backgroundScope,
+            currentRequestSerial = { 7L },
+            currentTrackId = { source.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { null },
+            rememberAssociation = { sourceId, targetId -> remembered = sourceId to targetId },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        assertTrue(controller.associationState.value.isLyricsUnavailable)
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+        assertEquals("BGM 歌曲", controller.associationState.value.query)
+        assertEquals(listOf(target), controller.associationState.value.results)
+
+        controller.selectAssociation(target)
+        advanceUntilIdle()
+
+        assertEquals(source.id to target.id, remembered)
+        assertEquals("[00:00.00]目标歌词", currentLyrics)
+        assertTrue(controller.associationState.value.isManualAssociation)
+        assertFalse(controller.associationState.value.isSearchOpen)
+    }
+
+    @Test
+    fun searchFallsBackToTrackTitleWhenProviderHasNoHint() = runTest {
+        val source = providerTrack("other:1", "原始标题", "other")
+        val repository = FakePlaybackLyricsRepository(
+            searchResults = emptyList(),
+        )
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = backgroundScope,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+
+        assertEquals("原始标题", controller.associationState.value.query)
+        assertEquals(listOf("原始标题"), repository.searchRequests)
+    }
+
+    private fun providerTrack(id: String, title: String, source: String) = MusicTrack(
+        id = id,
+        title = title,
+        artists = "artist",
+        album = "",
+        source = source,
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+        providerName = source,
+    )
+
+    private class FakePlaybackLyricsRepository(
+        private val details: Map<String, MusicTrack> = emptyMap(),
+        private val lyrics: Map<String, String> = emptyMap(),
+        private val searchKeyword: String? = null,
+        private val searchResults: List<MusicTrack> = emptyList(),
+    ) : PlaybackLyricsRepository {
+        val lyricRequests = mutableListOf<String>()
+        val searchRequests = mutableListOf<String>()
+
+        override suspend fun lyrics(track: MusicTrack): String? {
+            lyricRequests += track.id
+            return lyrics[track.id]
+        }
+
+        override suspend fun search(keyword: String): List<MusicTrack> {
+            searchRequests += keyword
+            return searchResults
+        }
+
+        override suspend fun trackDetail(trackId: String): MusicTrack? = details[trackId]
+
+        override suspend fun searchKeyword(track: MusicTrack): String? = searchKeyword
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -376,6 +376,7 @@ private class IosAppContainer(
         playlistActionPort = playlistActionPort,
         providerTrackActionPort = providerTrackActionPort,
         localMusicActionPort = localMusicFeatureController,
+        playbackLyricsPort = playbackFeatureOwner.lyrics,
         replacementActionPort = playbackFeatureOwner.replacement,
         debugLogFeatureController = debugLogFeatureController,
         providerCatalogFeatureController = providerCatalogFeatureController,


### PR DESCRIPTION
## Summary
- add a playback-owned manual lyric search/association flow for tracks whose source cannot provide lyrics
- remember lyric associations locally as original track ID -> selected lyric track ID and restore them on later playback
- let Bilibili derive the default lyric search keyword from `/x/player/wbi/v2` `bgm_info.music_title`, falling back to the current video title
- keep smart-replacement lyric association keyed to the original source track
- allow replacing an existing manual lyric association from the lyrics panel

## Behavior
- native/embedded lyrics continue to work as before
- after native lyric lookup returns no lyrics, the lyrics page exposes “搜索并关联歌词”
- search uses the existing cross-provider search path; selecting a result verifies that it actually has lyrics before saving
- remembered associations survive transient lookup/network failures and are retried on later playback

## Tests
- AppSettings lyric-association persistence round trip
- settings snapshot serialization round trip
- playback lyric controller remembered association / search / selection / title fallback
- Bilibili BGM keyword preference and title fallback
