### PR TITLE
fix: keep smart replacement from advancing multipart sources

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
@@ -229,7 +229,7 @@ class KotlinProviderRepository : ProviderMusicRepository {
         ).copy(replacementStrategy = track.replacementStrategy ?: "title_artist_duration")
     }
 
-    private fun annotateSmartReplacement(
+    internal fun annotateSmartReplacement(
         payload: PlaybackPayload,
         original: MusicTrack,
         candidate: MusicTrack,
@@ -237,6 +237,12 @@ class KotlinProviderRepository : ProviderMusicRepository {
         useOriginalMetadata: Boolean,
         useOriginalLyrics: Boolean,
     ): PlaybackPayload = payload.copy(
+        // A replacement substitutes exactly one logical queue track. Provider multipart metadata
+        // belongs to the replacement container (for example a Bilibili multi-P video); carrying it
+        // forward makes Next advance to P2 instead of the next queue track. Keep the already-resolved
+        // current-part URL, but do not expose provider-internal parts as queue-local continuation.
+        parts = emptyList(),
+        currentPartIndex = -1,
         isSmartReplacement = true,
         originalId = original.id,
         originalTitle = original.title,

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/KotlinProviderRepositoryReplacementTest.kt
@@ -178,6 +178,50 @@ class KotlinProviderRepositoryReplacementTest {
     }
 
     @Test
+    fun smartReplacementTreatsMultipartCandidateAsSingleQueueTrack() {
+        val original = track(
+            source = "netease",
+            title = "Night Song",
+            artists = "Alice",
+            id = "netease:night-song",
+        )
+        val candidate = track(
+            source = "bilibili",
+            title = "Night Song",
+            artists = "Alice",
+            id = "bilibili:BV1multi",
+        )
+        val multipartPayload = PlaybackPayload(
+            url = "https://example.test/p1.m4a",
+            title = candidate.title,
+            artists = candidate.artists,
+            album = candidate.album,
+            source = candidate.source,
+            parts = listOf(
+                PlaybackPart("bilibili:paged_BV1multi__1", "P1", 200_000),
+                PlaybackPart("bilibili:paged_BV1multi__2", "P2", 180_000),
+            ),
+            currentPartIndex = 0,
+        )
+
+        val annotated = KotlinProviderRepository().annotateSmartReplacement(
+            payload = multipartPayload,
+            original = original,
+            candidate = candidate,
+            score = 0.9,
+            useOriginalMetadata = true,
+            useOriginalLyrics = true,
+        )
+
+        assertEquals("https://example.test/p1.m4a", annotated.url)
+        assertTrue(annotated.parts.isEmpty())
+        assertEquals(-1, annotated.currentPartIndex)
+        assertTrue(annotated.isSmartReplacement)
+        assertEquals(original.id, annotated.originalId)
+        assertEquals(candidate.id, annotated.replacementId)
+    }
+
+    @Test
     fun replacementSelectionResolvesInScoreOrderAndStopsAtFirstPlayableCandidate() = runTest {
         val low = track("bilibili", "Low", "Uploader", id = "low")
         val medium = track("ytmusic", "Medium", "Artist", id = "medium")


### PR DESCRIPTION
## Summary
- treat smart replacement as exactly one logical queue track even when the replacement provider returns multipart playback metadata
- keep the already-resolved current-part URL, but clear `parts` and `currentPartIndex` from annotated smart-replacement payloads
- add regression coverage for a Bilibili-style multi-P replacement payload

## Root cause
Bilibili multi-P resolution returns `PlaybackPayload.parts` and a `currentPartIndex`. Smart replacement preserved that metadata, so shared queue `next()` preferred `playPlaybackPartOffset(1)` over advancing the logical queue. On Android, the playback service also inserted remaining parts ahead of subsequent playback-plan requests.

A replacement substitutes one logical source track, so provider-internal multipart continuation must not escape into the queue transport model.

## Behavior
- direct Bilibili multi-P playback remains multipart
- smart/manual/remembered replacements keep the resolved audio URL for the selected/current part
- next/auto-next advances to the next logical queue track instead of P2

## Tests
- added a multipart smart-replacement regression in `KotlinProviderRepositoryReplacementTest`