### PR TITLE
feat: refine manual lyrics association and alignment

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -104,7 +104,7 @@ internal class AndroidAppContainer(
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedProviderId = initialSettings.selectedSearchProviderId,
+                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -104,7 +104,7 @@ internal class AndroidAppContainer(
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
+                selectedProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }
@@ -382,8 +382,13 @@ internal class AndroidAppContainer(
         }
 
         appScope.launch {
-            session.state.map { it.currentTrack?.id to it.lyrics }.distinctUntilChanged().collect { (trackId, lyrics) ->
-                if (trackId != null) playbackEngine.publishLockScreenLyrics(trackId, lyrics)
+            session.state.map { state ->
+                Triple(state.currentTrack?.id, state.lyrics, state.lyricsAlignmentOffsetMs)
+            }.distinctUntilChanged().collect { (trackId, lyrics, alignmentOffsetMs) ->
+                if (trackId != null) {
+                    val platformLyrics = toTimedLineLrc(lyrics, alignmentOffsetMs) ?: lyrics
+                    playbackEngine.publishLockScreenLyrics(trackId, platformLyrics)
+                }
             }
         }
         appScope.launch {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
@@ -93,6 +93,7 @@ private fun PlaybackState.toPlaybackRuntimeOverlay(): PlaybackRuntimeOverlay =
     PlaybackRuntimeOverlay(
         currentTrack = currentTrack?.toTrackRef(),
         lyrics = lyrics,
+        lyricsAlignmentOffsetMs = lyricsAlignmentOffsetMs,
         queueTrackIds = queue.map(MusicTrack::id),
         queueIndex = queueIndex,
     )

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -72,7 +72,7 @@ internal class BydInstrumentLyricsPublisher(
                     permissionGranted = permissionGranted,
                     status = state.status,
                     track = state.currentTrack,
-                    positionMs = state.positionMs,
+                    positionMs = state.lyricsPositionMs,
                     durationMs = state.durationMs,
                     lyrics = state.lyrics,
                 )

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -81,7 +81,7 @@ internal class LyriconLyricsPublisher(
                     enabled = enabled,
                     status = state.status,
                     track = state.currentTrack,
-                    positionMs = state.positionMs,
+                    positionMs = state.lyricsPositionMs,
                     durationMs = state.durationMs,
                     lyrics = state.lyrics,
                 )

--- a/persistence/settings/src/commonMain/kotlin/org/feeluown/mobile/SettingsPersistence.kt
+++ b/persistence/settings/src/commonMain/kotlin/org/feeluown/mobile/SettingsPersistence.kt
@@ -69,6 +69,7 @@ data class PersistedSettingsV1(
     val smartReplacementMinScore: Double? = null,
     val smartReplacementSelections: Map<String, PersistedSmartReplacementSelection>? = null,
     val lyricsAssociations: Map<String, String>? = null,
+    val lyricsAlignmentOffsetsMs: Map<String, Long>? = null,
     val pauseOnOtherAppPlayback: Boolean? = null,
     val lyricFontSize: String? = null,
     val statusBarLyricsEnabled: Boolean? = null,

--- a/persistence/settings/src/commonTest/kotlin/org/feeluown/mobile/SettingsPersistenceTest.kt
+++ b/persistence/settings/src/commonTest/kotlin/org/feeluown/mobile/SettingsPersistenceTest.kt
@@ -39,6 +39,7 @@ class SettingsPersistenceTest {
         assertEquals("Highest", result.snapshot.wifiAudioQualityPolicy)
         assertEquals("Dark", result.snapshot.themeMode)
         assertEquals(true, result.snapshot.statusBarLyricsEnabled)
+        assertEquals(null, result.snapshot.lyricsAlignmentOffsetsMs)
     }
 
     @Test
@@ -70,6 +71,7 @@ class SettingsPersistenceTest {
                 ),
             ),
             lyricsAssociations = mapOf("bilibili:BVdemo" to "netease:1"),
+            lyricsAlignmentOffsetsMs = mapOf("bilibili:BVdemo" to -750L),
             playlistPlaybackStats = mapOf(
                 "netease::playlist:1" to PersistedPlaylistPlaybackStat(2, 1234),
             ),

--- a/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
+++ b/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
@@ -16,6 +16,7 @@ data class PlaybackSessionState(
     val status: PlaybackSessionStatus = PlaybackSessionStatus.Idle,
     val currentTrack: TrackRef? = null,
     val positionMs: Long = 0L,
+    val lyricsPositionMs: Long = positionMs,
     val durationMs: Long = 0L,
     val bufferedMs: Long = 0L,
     val lyrics: String? = null,

--- a/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
+++ b/playback/api/src/commonMain/kotlin/org/feeluown/mobile/playback/api/PlaybackSession.kt
@@ -17,6 +17,7 @@ data class PlaybackSessionState(
     val currentTrack: TrackRef? = null,
     val positionMs: Long = 0L,
     val lyricsPositionMs: Long = positionMs,
+    val lyricsAlignmentOffsetMs: Long = 0L,
     val durationMs: Long = 0L,
     val bufferedMs: Long = 0L,
     val lyrics: String? = null,

--- a/playback/runtime/src/commonMain/kotlin/org/feeluown/mobile/playback/runtime/PlaybackRuntime.kt
+++ b/playback/runtime/src/commonMain/kotlin/org/feeluown/mobile/playback/runtime/PlaybackRuntime.kt
@@ -116,6 +116,7 @@ private fun composeState(
     currentTrack = overlay.currentTrack,
     positionMs = engine.positionMs,
     lyricsPositionMs = (engine.positionMs - overlay.lyricsAlignmentOffsetMs).coerceAtLeast(0L),
+    lyricsAlignmentOffsetMs = overlay.lyricsAlignmentOffsetMs,
     durationMs = engine.durationMs,
     bufferedMs = engine.bufferedMs,
     lyrics = overlay.lyrics,

--- a/playback/runtime/src/commonMain/kotlin/org/feeluown/mobile/playback/runtime/PlaybackRuntime.kt
+++ b/playback/runtime/src/commonMain/kotlin/org/feeluown/mobile/playback/runtime/PlaybackRuntime.kt
@@ -23,6 +23,7 @@ data class PlaybackRuntimeEngineState(
 data class PlaybackRuntimeOverlay(
     val currentTrack: TrackRef? = null,
     val lyrics: String? = null,
+    val lyricsAlignmentOffsetMs: Long = 0L,
     val queueTrackIds: List<String> = emptyList(),
     val queueIndex: Int = -1,
 )
@@ -114,6 +115,7 @@ private fun composeState(
     status = engine.status,
     currentTrack = overlay.currentTrack,
     positionMs = engine.positionMs,
+    lyricsPositionMs = (engine.positionMs - overlay.lyricsAlignmentOffsetMs).coerceAtLeast(0L),
     durationMs = engine.durationMs,
     bufferedMs = engine.bufferedMs,
     lyrics = overlay.lyrics,

--- a/playback/runtime/src/commonTest/kotlin/org/feeluown/mobile/playback/runtime/DefaultPlaybackRuntimeTest.kt
+++ b/playback/runtime/src/commonTest/kotlin/org/feeluown/mobile/playback/runtime/DefaultPlaybackRuntimeTest.kt
@@ -37,6 +37,7 @@ class DefaultPlaybackRuntimeTest {
         assertEquals("a", runtime.state.value.currentTrack?.id)
         assertEquals(12_000, runtime.state.value.positionMs)
         assertEquals(10_750, runtime.state.value.lyricsPositionMs)
+        assertEquals(1_250, runtime.state.value.lyricsAlignmentOffsetMs)
         assertEquals(180_000, runtime.state.value.durationMs)
         assertEquals("merged lyrics", runtime.state.value.lyrics)
         assertEquals(listOf("a", "b"), runtime.state.value.queueTrackIds)
@@ -50,6 +51,7 @@ class DefaultPlaybackRuntimeTest {
 
         assertEquals("b", runtime.state.value.currentTrack?.id)
         assertEquals(12_500, runtime.state.value.lyricsPositionMs)
+        assertEquals(-500, runtime.state.value.lyricsAlignmentOffsetMs)
         assertEquals(null, runtime.state.value.lyrics)
         assertEquals(listOf("b"), runtime.state.value.queueTrackIds)
         scope.cancel()

--- a/playback/runtime/src/commonTest/kotlin/org/feeluown/mobile/playback/runtime/DefaultPlaybackRuntimeTest.kt
+++ b/playback/runtime/src/commonTest/kotlin/org/feeluown/mobile/playback/runtime/DefaultPlaybackRuntimeTest.kt
@@ -26,6 +26,7 @@ class DefaultPlaybackRuntimeTest {
             PlaybackRuntimeOverlay(
                 currentTrack = track("a"),
                 lyrics = "merged lyrics",
+                lyricsAlignmentOffsetMs = 1_250,
                 queueTrackIds = listOf("a", "b"),
                 queueIndex = 0,
             ),
@@ -35,6 +36,7 @@ class DefaultPlaybackRuntimeTest {
         assertEquals(PlaybackSessionStatus.Playing, runtime.state.value.status)
         assertEquals("a", runtime.state.value.currentTrack?.id)
         assertEquals(12_000, runtime.state.value.positionMs)
+        assertEquals(10_750, runtime.state.value.lyricsPositionMs)
         assertEquals(180_000, runtime.state.value.durationMs)
         assertEquals("merged lyrics", runtime.state.value.lyrics)
         assertEquals(listOf("a", "b"), runtime.state.value.queueTrackIds)
@@ -42,10 +44,12 @@ class DefaultPlaybackRuntimeTest {
         overlay.value = overlay.value.copy(
             currentTrack = track("b"),
             lyrics = null,
+            lyricsAlignmentOffsetMs = -500,
             queueTrackIds = listOf("b"),
         )
 
         assertEquals("b", runtime.state.value.currentTrack?.id)
+        assertEquals(12_500, runtime.state.value.lyricsPositionMs)
         assertEquals(null, runtime.state.value.lyrics)
         assertEquals(listOf("b"), runtime.state.value.queueTrackIds)
         scope.cancel()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppSettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppSettingsRepository.kt
@@ -135,6 +135,7 @@ internal fun AppSettings.toPersistedSettings(): PersistedSettingsV1 = PersistedS
     smartReplacementMinScore = smartReplacementMinScore,
     smartReplacementSelections = smartReplacementSelections.mapValues { (_, selection) -> selection.toPersisted() },
     lyricsAssociations = lyricsAssociations,
+    lyricsAlignmentOffsetsMs = lyricsAlignmentOffsetsMs,
     pauseOnOtherAppPlayback = pauseOnOtherAppPlayback,
     lyricFontSize = lyricFontSize.name,
     statusBarLyricsEnabled = statusBarLyricsEnabled,
@@ -184,6 +185,7 @@ internal fun PersistedSettingsV1.toAppSettings(): AppSettings {
             ?.mapValues { (_, selection) -> selection.toDomain() }
             ?: defaults.smartReplacementSelections,
         lyricsAssociations = lyricsAssociations ?: defaults.lyricsAssociations,
+        lyricsAlignmentOffsetsMs = lyricsAlignmentOffsetsMs ?: defaults.lyricsAlignmentOffsetsMs,
         pauseOnOtherAppPlayback = pauseOnOtherAppPlayback ?: defaults.pauseOnOtherAppPlayback,
         lyricFontSize = lyricFontSize.enumOr(defaults.lyricFontSize),
         statusBarLyricsEnabled = statusBarLyricsEnabled ?: defaults.statusBarLyricsEnabled,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/AppSettingsContracts.kt
@@ -89,6 +89,7 @@ data class AppSettings(
     val smartReplacementMinScore: Double = DEFAULT_SMART_REPLACEMENT_MIN_SCORE,
     val smartReplacementSelections: Map<String, SmartReplacementSelection> = emptyMap(),
     val lyricsAssociations: Map<String, String> = emptyMap(),
+    val lyricsAlignmentOffsetsMs: Map<String, Long> = emptyMap(),
     val pauseOnOtherAppPlayback: Boolean = DEFAULT_PAUSE_ON_OTHER_APP_PLAYBACK,
     val lyricFontSize: LyricFontSize = LyricFontSize.Small,
     val statusBarLyricsEnabled: Boolean = false,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/PlaybackApplicationContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/PlaybackApplicationContracts.kt
@@ -49,6 +49,7 @@ data class PlaybackState(
     val queueIndex: Int = -1,
     val playMode: PlayMode = PlayMode.ListLoop,
     val lyrics: String? = null,
+    val lyricsAlignmentOffsetMs: Long = 0L,
     val audioQuality: String? = null,
     val audioFormatInfo: AudioFormatInfo? = null,
     val audioDecoderInfo: AudioDecoderInfo? = null,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/TimedLineLyrics.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/TimedLineLyrics.kt
@@ -9,14 +9,17 @@ package org.feeluown.mobile
  * `rawLyric` is intentionally omitted until FuoEvolve can serialize a compatible
  * word timeline rather than passing provider-specific YRC through unchanged.
  */
-fun toTimedLineLrc(rawLyrics: String?): String? {
+fun toTimedLineLrc(
+    rawLyrics: String?,
+    alignmentOffsetMs: Long = 0L,
+): String? {
     val timedLines = parseLyrics(rawLyrics)
         .filter { it.timeMs != Long.MAX_VALUE && it.text.isNotBlank() }
     if (timedLines.isEmpty()) return null
 
     return buildString {
         timedLines.forEach { line ->
-            val timestamp = formatLrcTimestamp(line.timeMs)
+            val timestamp = formatLrcTimestamp(line.timeMs + alignmentOffsetMs)
             append(timestamp)
             append(line.text.trim())
             append('\n')

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -4,27 +4,38 @@ import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +49,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlin.math.roundToInt
 
 @Composable
 fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifier) {
@@ -45,13 +57,21 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
     val associationState by lyricsPort.associationState.collectAsStateWithLifecycle()
     val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
     val listState = rememberLazyListState()
+    val currentTrack = state.currentTrack
+    val lyricOffsetMs = remember(currentTrack?.id) { mutableLongStateOf(0L) }
+    var alignmentPanelOpen by remember(currentTrack?.id) { mutableStateOf(false) }
     val renderPositionMs = rememberKaraokePositionMs(
         positionMs = state.positionMs,
         isPlaying = state.status == PlayerStatus.Playing,
     )
-    val currentIndex by remember(lines, renderPositionMs) {
-        androidx.compose.runtime.derivedStateOf {
-            currentLyricIndex(lines, renderPositionMs.value)
+    val alignedPositionMs = remember(renderPositionMs, lyricOffsetMs) {
+        derivedStateOf {
+            (renderPositionMs.value - lyricOffsetMs.longValue).coerceAtLeast(0L)
+        }
+    }
+    val currentIndex by remember(lines, alignedPositionMs) {
+        derivedStateOf {
+            currentLyricIndex(lines, alignedPositionMs.value)
         }
     }
     val activeStyle = when (fontSize) {
@@ -79,7 +99,6 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         LyricFontSize.Medium -> 7.dp
         LyricFontSize.Large -> 8.dp
     }
-    val currentTrack = state.currentTrack
     val associationMatchesTrack = associationState.trackId == currentTrack?.id
 
     LaunchedEffect(currentIndex, lines.size) {
@@ -152,7 +171,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                                 if (active && !line.romanizationWords.isNullOrEmpty()) {
                                     KaraokeLyricText(
                                         words = line.romanizationWords,
-                                        positionMs = renderPositionMs,
+                                        positionMs = alignedPositionMs,
                                         style = romanizationStyle,
                                         activeColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.78f),
                                         inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f),
@@ -176,7 +195,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                             if (active && !line.words.isNullOrEmpty()) {
                                 KaraokeLyricText(
                                     words = line.words,
-                                    positionMs = renderPositionMs,
+                                    positionMs = alignedPositionMs,
                                     style = activeStyle,
                                     activeColor = MaterialTheme.colorScheme.primary,
                                     inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
@@ -216,13 +235,73 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                     associationMatchesTrack &&
                     associationState.isManualAssociation
                 ) {
-                    TextButton(
-                        onClick = { lyricsPort.openAssociationSearch(currentTrack) },
+                    Row(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .padding(FuoSpacing.sm),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("更换歌词")
+                        IconButton(onClick = { lyricsPort.openAssociationSearch(currentTrack) }) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "更换歌词",
+                            )
+                        }
+                        IconButton(onClick = { alignmentPanelOpen = !alignmentPanelOpen }) {
+                            Icon(
+                                imageVector = Icons.Default.Tune,
+                                contentDescription = "微调歌词对齐",
+                            )
+                        }
+                    }
+                    if (alignmentPanelOpen) {
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(top = 60.dp, end = FuoSpacing.sm)
+                                .width(280.dp),
+                            shape = MaterialTheme.shapes.medium,
+                            tonalElevation = 3.dp,
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(FuoSpacing.md),
+                                verticalArrangement = Arrangement.spacedBy(FuoSpacing.xs),
+                            ) {
+                                Text(
+                                    text = "歌词对齐：${lyricOffsetLabel(lyricOffsetMs.longValue)}",
+                                    style = MaterialTheme.typography.labelLarge,
+                                )
+                                Slider(
+                                    value = lyricOffsetMs.longValue.toFloat(),
+                                    onValueChange = { value ->
+                                        lyricOffsetMs.longValue =
+                                            ((value / 250f).roundToInt() * 250L).coerceIn(-3_000L, 3_000L)
+                                    },
+                                    valueRange = -3_000f..3_000f,
+                                    steps = 23,
+                                )
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = "提前 3 秒",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    TextButton(onClick = { lyricOffsetMs.longValue = 0L }) {
+                                        Text("归零")
+                                    }
+                                    Text(
+                                        text = "延后 3 秒",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -343,6 +422,20 @@ private fun LyricsAssociationDialog(
             }
         },
     )
+}
+
+private fun lyricOffsetLabel(offsetMs: Long): String {
+    if (offsetMs == 0L) return "0 秒"
+    val absolute = kotlin.math.abs(offsetMs)
+    val seconds = absolute / 1_000L
+    val remainder = absolute % 1_000L
+    val value = if (remainder == 0L) {
+        seconds.toString()
+    } else {
+        "$seconds.${remainder.toString().padStart(3, '0').trimEnd('0')}"
+    }
+    val direction = if (offsetMs > 0L) "延后" else "提前"
+    return "$direction $value 秒"
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -58,7 +58,8 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
     val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
     val listState = rememberLazyListState()
     val currentTrack = state.currentTrack
-    val lyricOffsetMs = remember(currentTrack?.id) { mutableLongStateOf(0L) }
+    val associationMatchesTrack = associationState.trackId == currentTrack?.id
+    val lyricOffsetMs = if (associationMatchesTrack) associationState.alignmentOffsetMs else 0L
     var alignmentPanelOpen by remember(currentTrack?.id) { mutableStateOf(false) }
     val renderPositionMs = rememberKaraokePositionMs(
         positionMs = state.positionMs,
@@ -66,7 +67,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
     )
     val alignedPositionMs = remember(renderPositionMs, lyricOffsetMs) {
         derivedStateOf {
-            (renderPositionMs.value - lyricOffsetMs.longValue).coerceAtLeast(0L)
+            (renderPositionMs.value - lyricOffsetMs).coerceAtLeast(0L)
         }
     }
     val currentIndex by remember(lines, alignedPositionMs) {
@@ -99,7 +100,6 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
         LyricFontSize.Medium -> 7.dp
         LyricFontSize.Large -> 8.dp
     }
-    val associationMatchesTrack = associationState.trackId == currentTrack?.id
 
     LaunchedEffect(currentIndex, lines.size) {
         if (currentIndex < 0) return@LaunchedEffect
@@ -269,14 +269,15 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                                 verticalArrangement = Arrangement.spacedBy(FuoSpacing.xs),
                             ) {
                                 Text(
-                                    text = "歌词对齐：${lyricOffsetLabel(lyricOffsetMs.longValue)}",
+                                    text = "歌词对齐：${lyricOffsetLabel(lyricOffsetMs)}",
                                     style = MaterialTheme.typography.labelLarge,
                                 )
                                 Slider(
-                                    value = lyricOffsetMs.longValue.toFloat(),
+                                    value = lyricOffsetMs.toFloat(),
                                     onValueChange = { value ->
-                                        lyricOffsetMs.longValue =
-                                            ((value / 250f).roundToInt() * 250L).coerceIn(-3_000L, 3_000L)
+                                        lyricsPort.updateAlignmentOffset(
+                                            ((value / 250f).roundToInt() * 250L).coerceIn(-3_000L, 3_000L),
+                                        )
                                     },
                                     valueRange = -3_000f..3_000f,
                                     steps = 23,
@@ -291,7 +292,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
-                                    TextButton(onClick = { lyricOffsetMs.longValue = 0L }) {
+                                    TextButton(onClick = { lyricsPort.updateAlignmentOffset(0L) }) {
                                         Text("归零")
                                     }
                                     Text(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -116,7 +116,11 @@ private class DefaultPlaybackFeatureOwner(
         playbackRepository = playbackRepository,
         scope = scope,
         currentPlaybackState = { playbackState.value },
-        publishPlaybackState = { mutablePlaybackState.value = it },
+        publishPlaybackState = { state ->
+            mutablePlaybackState.value = state.copy(
+                lyricsAlignmentOffsetMs = lyricsOwner.associationState.value.alignmentOffsetMs,
+            )
+        },
         prepareTrack = { track -> track.withRememberedReplacement().preferDownloaded() },
         unavailablePlaybackPolicy = { currentSettings().unavailablePlaybackPolicy },
         smartReplacementProviderIds = ::selectedSmartReplacementProviderIds,
@@ -231,6 +235,15 @@ private class DefaultPlaybackFeatureOwner(
             }
         }
         scope.launch {
+            lyricsOwner.associationState.collect { state ->
+                if (playbackState.value.lyricsAlignmentOffsetMs != state.alignmentOffsetMs) {
+                    updatePlaybackState { current ->
+                        current.copy(lyricsAlignmentOffsetMs = state.alignmentOffsetMs)
+                    }
+                }
+            }
+        }
+        scope.launch {
             playbackEngine.state.collect(::onEngineState)
         }
     }
@@ -270,6 +283,7 @@ private class DefaultPlaybackFeatureOwner(
                 currentQueueTrackId = currentQueueTrackId,
                 previousPlaybackState = previous,
             ),
+            lyricsAlignmentOffsetMs = lyricsOwner.associationState.value.alignmentOffsetMs,
         )
         lyricsOwner.maybeLoad(playbackState.value.currentTrack)
         if (engineState.playbackParts.isNotEmpty()) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -81,6 +81,7 @@ private class DefaultPlaybackFeatureOwner(
     private var lastRecoveredPlaybackErrorKey: String? = null
     private var smartReplacementSelections: Map<String, SmartReplacementSelection> = emptyMap()
     private var lyricsAssociations: Map<String, String> = emptyMap()
+    private var lyricsAlignmentOffsetsMs: Map<String, Long> = emptyMap()
     private var pendingManualReplacementSwitch: PlaybackOwnerPendingManualReplacement? = null
     private var suppressPlaybackRecoveryRequestSerial: Long? = null
     private var appendQueueFeatureTask: Deferred<Int>? = null
@@ -105,6 +106,8 @@ private class DefaultPlaybackFeatureOwner(
         updateLyrics = { lyrics -> updatePlaybackState { it.copy(lyrics = lyrics) } },
         associationForTrackId = { trackId -> lyricsAssociations[trackId] },
         rememberAssociation = ::rememberLyricsAssociation,
+        alignmentOffsetForTrackId = { trackId -> lyricsAlignmentOffsetsMs[trackId] ?: 0L },
+        rememberAlignmentOffset = ::rememberLyricsAlignmentOffset,
     )
 
     private val startOwner = PlaybackStartCoordinator(
@@ -212,14 +215,18 @@ private class DefaultPlaybackFeatureOwner(
             val settings = settingsRepository.awaitSettings()
             smartReplacementSelections = settings.smartReplacementSelections
             lyricsAssociations = settings.lyricsAssociations
+            lyricsAlignmentOffsetsMs = settings.lyricsAlignmentOffsetsMs
             runCatching { playbackQueueStore.load() }
                 .onSuccess(::restorePlaybackQueue)
+            lyricsOwner.refreshPersistentState(playbackState.value.currentTrack)
         }
         scope.launch {
             settingsRepository.state.collect { state ->
                 if (state.isLoaded) {
                     smartReplacementSelections = state.settings.smartReplacementSelections
                     lyricsAssociations = state.settings.lyricsAssociations
+                    lyricsAlignmentOffsetsMs = state.settings.lyricsAlignmentOffsetsMs
+                    lyricsOwner.refreshPersistentState(playbackState.value.currentTrack)
                 }
             }
         }
@@ -340,10 +347,23 @@ private class DefaultPlaybackFeatureOwner(
         } else {
             lyricsAssociations + (sourceTrackId to lyricsTrackId)
         }
-        val nextAssociations = lyricsAssociations
         scope.launch {
             settingsRepository.update { current ->
-                current.copy(lyricsAssociations = nextAssociations)
+                current.copy(lyricsAssociations = lyricsAssociations)
+            }
+        }
+    }
+
+    private fun rememberLyricsAlignmentOffset(sourceTrackId: String, offsetMs: Long) {
+        val clamped = offsetMs.coerceIn(-3_000L, 3_000L)
+        lyricsAlignmentOffsetsMs = if (clamped == 0L) {
+            lyricsAlignmentOffsetsMs - sourceTrackId
+        } else {
+            lyricsAlignmentOffsetsMs + (sourceTrackId to clamped)
+        }
+        scope.launch {
+            settingsRepository.update { current ->
+                current.copy(lyricsAlignmentOffsetsMs = lyricsAlignmentOffsetsMs)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -94,7 +94,10 @@ private class DefaultPlaybackFeatureOwner(
     )
 
     private val lyricsOwner = PlaybackLyricsController(
-        providerRepository = providerRepository,
+        providerRegistryRepository = providerRepository,
+        providerSearchRepository = providerRepository,
+        providerCatalogRepository = providerRepository,
+        providerPlaybackRepository = playbackRepository,
         scope = scope,
         currentRequestSerial = { playRequestSerial },
         currentTrackId = { queueState.currentTrack()?.id ?: playbackState.value.currentTrack?.id },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackFeatureOwner.kt
@@ -356,28 +356,30 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun rememberLyricsAssociation(sourceTrackId: String, lyricsTrackId: String?) {
-        lyricsAssociations = if (lyricsTrackId.isNullOrBlank()) {
+        val nextAssociations = if (lyricsTrackId.isNullOrBlank()) {
             lyricsAssociations - sourceTrackId
         } else {
             lyricsAssociations + (sourceTrackId to lyricsTrackId)
         }
+        lyricsAssociations = nextAssociations
         scope.launch {
             settingsRepository.update { current ->
-                current.copy(lyricsAssociations = lyricsAssociations)
+                current.copy(lyricsAssociations = nextAssociations)
             }
         }
     }
 
     private fun rememberLyricsAlignmentOffset(sourceTrackId: String, offsetMs: Long) {
         val clamped = offsetMs.coerceIn(-3_000L, 3_000L)
-        lyricsAlignmentOffsetsMs = if (clamped == 0L) {
+        val nextOffsets = if (clamped == 0L) {
             lyricsAlignmentOffsetsMs - sourceTrackId
         } else {
             lyricsAlignmentOffsetsMs + (sourceTrackId to clamped)
         }
+        lyricsAlignmentOffsetsMs = nextOffsets
         scope.launch {
             settingsRepository.update { current ->
-                current.copy(lyricsAlignmentOffsetsMs = lyricsAlignmentOffsetsMs)
+                current.copy(lyricsAlignmentOffsetsMs = nextOffsets)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+private val LYRICS_ASSOCIATION_PROVIDER_IDS = setOf("netease", "qqmusic", "ytmusic")
+
 internal interface PlaybackLyricsRepository {
     suspend fun lyrics(track: MusicTrack): String?
     suspend fun search(keyword: String): List<MusicTrack>
@@ -19,8 +21,17 @@ private class ProviderPlaybackLyricsRepository(
 ) : PlaybackLyricsRepository {
     override suspend fun lyrics(track: MusicTrack): String? = delegate.lyrics(track)
 
-    override suspend fun search(keyword: String): List<MusicTrack> =
-        delegate.search(keyword, providerId = null)
+    override suspend fun search(keyword: String): List<MusicTrack> {
+        val enabledProviderIds = delegate.providers().mapTo(mutableSetOf()) { it.providerId }
+        val results = mutableListOf<MusicTrack>()
+        for (providerId in LYRICS_ASSOCIATION_PROVIDER_IDS) {
+            if (providerId !in enabledProviderIds) continue
+            val providerResults = runCatching { delegate.search(keyword, providerId) }
+                .getOrDefault(emptyList())
+            results += providerResults
+        }
+        return results.distinctBy { it.id }
+    }
 
     override suspend fun trackDetail(trackId: String): MusicTrack? =
         runCatching { delegate.trackDetail(trackId) }.getOrNull()
@@ -172,10 +183,13 @@ internal class PlaybackLyricsController(
         searchJob?.cancel()
         searchJob = scope.launch {
             val sourceTrack = lyricSourceTrackForPlayback(track)
-            val keyword = runCatching { repository.searchKeyword(sourceTrack) }
+            val rawKeyword = runCatching { repository.searchKeyword(sourceTrack) }
                 .getOrNull()
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
+                ?: sourceTrack.title.trim()
+            val keyword = normalizeAssociationSearchKeyword(sourceTrack, rawKeyword)
+                .takeIf { it.isNotBlank() }
                 ?: sourceTrack.title.trim()
             if (associationSearchTrack?.id != track.id || currentTrackId() != track.id) return@launch
             if (associationQueryEdited) {
@@ -293,6 +307,21 @@ internal class PlaybackLyricsController(
 
     private fun isCurrent(track: MusicTrack, requestSerial: Long): Boolean =
         requestSerial == currentRequestSerial() && currentTrackId() == track.id
+
+    private fun normalizeAssociationSearchKeyword(track: MusicTrack, keyword: String): String {
+        val trimmed = keyword.trim()
+        if (track.source != "bilibili") return trimmed
+        val withoutDiscoveryPrefix = trimmed.removePrefix("发现").trim()
+        return if (
+            withoutDiscoveryPrefix.length >= 2 &&
+            withoutDiscoveryPrefix.startsWith('《') &&
+            withoutDiscoveryPrefix.endsWith('》')
+        ) {
+            withoutDiscoveryPrefix.substring(1, withoutDiscoveryPrefix.length - 1).trim()
+        } else {
+            withoutDiscoveryPrefix
+        }
+    }
 
     private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack {
         if (!track.isSmartReplacement) return track

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -17,16 +17,19 @@ internal interface PlaybackLyricsRepository {
 }
 
 private class ProviderPlaybackLyricsRepository(
-    private val delegate: ProviderMusicRepository,
+    private val registryRepository: ProviderRegistryRepository,
+    private val searchRepository: ProviderSearchRepository,
+    private val catalogRepository: ProviderCatalogRepository,
+    private val playbackRepository: ProviderPlaybackRepository,
 ) : PlaybackLyricsRepository {
-    override suspend fun lyrics(track: MusicTrack): String? = delegate.lyrics(track)
+    override suspend fun lyrics(track: MusicTrack): String? = playbackRepository.lyrics(track)
 
     override suspend fun search(keyword: String): List<MusicTrack> {
-        val enabledProviderIds = delegate.providers().mapTo(mutableSetOf()) { it.providerId }
+        val enabledProviderIds = registryRepository.providers().mapTo(mutableSetOf()) { it.providerId }
         val results = mutableListOf<MusicTrack>()
         for (providerId in LYRICS_ASSOCIATION_PROVIDER_IDS) {
             if (providerId !in enabledProviderIds) continue
-            val providerResults = runCatching { delegate.search(keyword, providerId) }
+            val providerResults = runCatching { searchRepository.search(keyword, providerId) }
                 .getOrDefault(emptyList())
             results += providerResults
         }
@@ -34,10 +37,10 @@ private class ProviderPlaybackLyricsRepository(
     }
 
     override suspend fun trackDetail(trackId: String): MusicTrack? =
-        runCatching { delegate.trackDetail(trackId) }.getOrNull()
+        runCatching { catalogRepository.trackDetail(trackId) }.getOrNull()
 
     override suspend fun searchKeyword(track: MusicTrack): String? =
-        delegate.lyricsSearchKeyword(track)
+        playbackRepository.lyricsSearchKeyword(track)
 }
 
 internal class PlaybackLyricsController(
@@ -51,7 +54,10 @@ internal class PlaybackLyricsController(
     private val rememberAssociation: (String, String?) -> Unit,
 ) : PlaybackLyricsPort {
     constructor(
-        providerRepository: ProviderMusicRepository,
+        providerRegistryRepository: ProviderRegistryRepository,
+        providerSearchRepository: ProviderSearchRepository,
+        providerCatalogRepository: ProviderCatalogRepository,
+        providerPlaybackRepository: ProviderPlaybackRepository,
         scope: CoroutineScope,
         currentRequestSerial: () -> Long,
         currentTrackId: () -> String?,
@@ -60,7 +66,12 @@ internal class PlaybackLyricsController(
         associationForTrackId: (String) -> String?,
         rememberAssociation: (String, String?) -> Unit,
     ) : this(
-        repository = ProviderPlaybackLyricsRepository(providerRepository),
+        repository = ProviderPlaybackLyricsRepository(
+            registryRepository = providerRegistryRepository,
+            searchRepository = providerSearchRepository,
+            catalogRepository = providerCatalogRepository,
+            playbackRepository = providerPlaybackRepository,
+        ),
         scope = scope,
         currentRequestSerial = currentRequestSerial,
         currentTrackId = currentTrackId,
@@ -177,6 +188,7 @@ internal class PlaybackLyricsController(
             isManualAssociation = previous?.isManualAssociation == true,
             associatedTrackId = previous?.associatedTrackId,
             associatedTrackTitle = previous?.associatedTrackTitle,
+            alignmentOffsetMs = previous?.alignmentOffsetMs ?: 0L,
             isSearchOpen = true,
             isSearching = true,
         )
@@ -250,6 +262,7 @@ internal class PlaybackLyricsController(
                 return@launch
             }
 
+            val alignmentOffsetMs = mutableAssociationState.value.alignmentOffsetMs
             rememberAssociation(sourceTrack.id, track.id)
             updateLyrics(lyrics)
             mutableAssociationState.value = LyricsAssociationUiState(
@@ -257,6 +270,7 @@ internal class PlaybackLyricsController(
                 isManualAssociation = true,
                 associatedTrackId = track.id,
                 associatedTrackTitle = track.title,
+                alignmentOffsetMs = alignmentOffsetMs,
             )
             associationSearchTrack = null
         }
@@ -274,6 +288,12 @@ internal class PlaybackLyricsController(
             isSearching = false,
             selectingTrackId = null,
             message = null,
+        )
+    }
+
+    override fun updateAlignmentOffset(offsetMs: Long) {
+        mutableAssociationState.value = mutableAssociationState.value.copy(
+            alignmentOffsetMs = offsetMs.coerceIn(-3_000L, 3_000L),
         )
     }
 
@@ -311,15 +331,19 @@ internal class PlaybackLyricsController(
     private fun normalizeAssociationSearchKeyword(track: MusicTrack, keyword: String): String {
         val trimmed = keyword.trim()
         if (track.source != "bilibili") return trimmed
-        val withoutDiscoveryPrefix = trimmed.removePrefix("发现").trim()
-        return if (
-            withoutDiscoveryPrefix.length >= 2 &&
-            withoutDiscoveryPrefix.startsWith('《') &&
-            withoutDiscoveryPrefix.endsWith('》')
-        ) {
-            withoutDiscoveryPrefix.substring(1, withoutDiscoveryPrefix.length - 1).trim()
+        val wrapped = if (trimmed.startsWith("发现《") && trimmed.endsWith('》')) {
+            trimmed.removePrefix("发现").trim()
         } else {
-            withoutDiscoveryPrefix
+            trimmed
+        }
+        return if (
+            wrapped.length >= 2 &&
+            wrapped.startsWith('《') &&
+            wrapped.endsWith('》')
+        ) {
+            wrapped.substring(1, wrapped.length - 1).trim()
+        } else {
+            wrapped
         }
     }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -52,6 +52,8 @@ internal class PlaybackLyricsController(
     private val updateLyrics: (String) -> Unit,
     private val associationForTrackId: (String) -> String?,
     private val rememberAssociation: (String, String?) -> Unit,
+    private val alignmentOffsetForTrackId: (String) -> Long = { 0L },
+    private val rememberAlignmentOffset: (String, Long) -> Unit = { _, _ -> },
 ) : PlaybackLyricsPort {
     constructor(
         providerRegistryRepository: ProviderRegistryRepository,
@@ -65,6 +67,8 @@ internal class PlaybackLyricsController(
         updateLyrics: (String) -> Unit,
         associationForTrackId: (String) -> String?,
         rememberAssociation: (String, String?) -> Unit,
+        alignmentOffsetForTrackId: (String) -> Long = { 0L },
+        rememberAlignmentOffset: (String, Long) -> Unit = { _, _ -> },
     ) : this(
         repository = ProviderPlaybackLyricsRepository(
             registryRepository = providerRegistryRepository,
@@ -79,6 +83,8 @@ internal class PlaybackLyricsController(
         updateLyrics = updateLyrics,
         associationForTrackId = associationForTrackId,
         rememberAssociation = rememberAssociation,
+        alignmentOffsetForTrackId = alignmentOffsetForTrackId,
+        rememberAlignmentOffset = rememberAlignmentOffset,
     )
 
     private val mutableAssociationState = MutableStateFlow(LyricsAssociationUiState())
@@ -88,6 +94,8 @@ internal class PlaybackLyricsController(
     private var searchJob: Job? = null
     private var selectionJob: Job? = null
     private var loadedForTrackId: String? = null
+    private var loadedAssociationTrackId: String? = null
+    private var currentSourceTrackId: String? = null
     private var associationSearchTrack: MusicTrack? = null
     private var associationQueryEdited = false
 
@@ -99,9 +107,15 @@ internal class PlaybackLyricsController(
         searchJob = null
         selectionJob = null
         loadedForTrackId = null
+        loadedAssociationTrackId = null
+        currentSourceTrackId = null
         associationSearchTrack = null
         associationQueryEdited = false
         mutableAssociationState.value = LyricsAssociationUiState()
+    }
+
+    fun refreshPersistentState(track: MusicTrack?) {
+        maybeLoad(track)
     }
 
     fun mergedLyrics(
@@ -124,77 +138,120 @@ internal class PlaybackLyricsController(
 
     fun maybeLoad(track: MusicTrack?) {
         if (track == null) return
-        if (!currentLyrics().isNullOrBlank()) {
-            loadedForTrackId = track.id
-            if (mutableAssociationState.value.trackId != track.id) {
-                mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
+        val lyricTrack = lyricSourceTrackForPlayback(track)
+        val associatedTrackId = associationForTrackId(lyricTrack.id)
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+        val alignmentOffsetMs = alignmentOffsetForTrackId(lyricTrack.id)
+            .coerceIn(-3_000L, 3_000L)
+        currentSourceTrackId = lyricTrack.id
+
+        if (loadedForTrackId == track.id && loadedAssociationTrackId == associatedTrackId) {
+            if (
+                mutableAssociationState.value.trackId == track.id &&
+                mutableAssociationState.value.alignmentOffsetMs != alignmentOffsetMs
+            ) {
+                mutableAssociationState.value = mutableAssociationState.value.copy(
+                    alignmentOffsetMs = alignmentOffsetMs,
+                )
             }
             return
         }
-        track.lyrics?.takeIf { it.isNotBlank() }?.let {
-            updateLyrics(it)
-            loadedForTrackId = track.id
-            mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
-            return
-        }
-        if (loadedForTrackId == track.id) return
 
         loadedForTrackId = track.id
+        loadedAssociationTrackId = associatedTrackId
         val requestSerial = currentRequestSerial()
-        val lyricTrack = lyricSourceTrackForPlayback(track)
         loadJob?.cancel()
-        loadJob = scope.launch {
-            val associatedTrackId = associationForTrackId(lyricTrack.id)
-            if (!associatedTrackId.isNullOrBlank()) {
+
+        if (associatedTrackId != null) {
+            mutableAssociationState.value = LyricsAssociationUiState(
+                trackId = track.id,
+                alignmentOffsetMs = alignmentOffsetMs,
+            )
+            loadJob = scope.launch {
                 val associatedTrack = repository.trackDetail(associatedTrackId)
                 val associatedLyrics = associatedTrack?.let { candidate ->
                     runCatching { repository.lyrics(candidate) }.getOrNull()
                 }?.takeIf { it.isNotBlank() }
-                if (isCurrent(track, requestSerial) && associatedTrack != null && associatedLyrics != null) {
+                if (!isCurrent(track, requestSerial)) return@launch
+                if (associatedTrack != null && associatedLyrics != null) {
                     updateLyrics(associatedLyrics)
                     mutableAssociationState.value = LyricsAssociationUiState(
                         trackId = track.id,
                         isManualAssociation = true,
                         associatedTrackId = associatedTrack.id,
                         associatedTrackTitle = associatedTrack.title,
+                        alignmentOffsetMs = alignmentOffsetMs,
                     )
                     return@launch
                 }
-            }
 
+                val fallbackLyrics = track.lyrics
+                    ?.takeIf { it.isNotBlank() }
+                    ?: runCatching { repository.lyrics(lyricTrack) }
+                        .getOrNull()
+                        ?.takeIf { it.isNotBlank() }
+                if (!isCurrent(track, requestSerial)) return@launch
+                if (fallbackLyrics != null) updateLyrics(fallbackLyrics)
+                mutableAssociationState.value = LyricsAssociationUiState(
+                    trackId = track.id,
+                    isLyricsUnavailable = fallbackLyrics == null,
+                    alignmentOffsetMs = alignmentOffsetMs,
+                )
+            }
+            return
+        }
+
+        currentLyrics()?.takeIf { it.isNotBlank() }?.let {
+            mutableAssociationState.value = LyricsAssociationUiState(
+                trackId = track.id,
+                alignmentOffsetMs = alignmentOffsetMs,
+            )
+            return
+        }
+        track.lyrics?.takeIf { it.isNotBlank() }?.let {
+            updateLyrics(it)
+            mutableAssociationState.value = LyricsAssociationUiState(
+                trackId = track.id,
+                alignmentOffsetMs = alignmentOffsetMs,
+            )
+            return
+        }
+
+        loadJob = scope.launch {
             val lyrics = runCatching {
                 repository.lyrics(lyricTrack)
             }.getOrNull()?.takeIf { it.isNotBlank() }
             if (!isCurrent(track, requestSerial)) return@launch
-            if (lyrics != null) {
-                updateLyrics(lyrics)
-                mutableAssociationState.value = LyricsAssociationUiState(trackId = track.id)
-            } else {
-                mutableAssociationState.value = LyricsAssociationUiState(
-                    trackId = track.id,
-                    isLyricsUnavailable = true,
-                )
-            }
+            if (lyrics != null) updateLyrics(lyrics)
+            mutableAssociationState.value = LyricsAssociationUiState(
+                trackId = track.id,
+                isLyricsUnavailable = lyrics == null,
+                alignmentOffsetMs = alignmentOffsetMs,
+            )
         }
     }
 
     override fun openAssociationSearch(track: MusicTrack) {
         associationSearchTrack = track
         associationQueryEdited = false
+        val sourceTrack = lyricSourceTrackForPlayback(track)
+        currentSourceTrackId = sourceTrack.id
         val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
+        val alignmentOffsetMs = previous?.alignmentOffsetMs
+            ?: alignmentOffsetForTrackId(sourceTrack.id).coerceIn(-3_000L, 3_000L)
         mutableAssociationState.value = LyricsAssociationUiState(
             trackId = track.id,
             isLyricsUnavailable = previous?.isLyricsUnavailable ?: currentLyrics().isNullOrBlank(),
             isManualAssociation = previous?.isManualAssociation == true,
             associatedTrackId = previous?.associatedTrackId,
             associatedTrackTitle = previous?.associatedTrackTitle,
-            alignmentOffsetMs = previous?.alignmentOffsetMs ?: 0L,
+            alignmentOffsetMs = alignmentOffsetMs,
             isSearchOpen = true,
             isSearching = true,
         )
         searchJob?.cancel()
         searchJob = scope.launch {
-            val sourceTrack = lyricSourceTrackForPlayback(track)
             val rawKeyword = runCatching { repository.searchKeyword(sourceTrack) }
                 .getOrNull()
                 ?.trim()
@@ -241,6 +298,7 @@ internal class PlaybackLyricsController(
     override fun selectAssociation(track: MusicTrack) {
         val playbackTrack = associationSearchTrack ?: return
         val sourceTrack = lyricSourceTrackForPlayback(playbackTrack)
+        currentSourceTrackId = sourceTrack.id
         val requestSerial = currentRequestSerial()
         selectionJob?.cancel()
         mutableAssociationState.value = mutableAssociationState.value.copy(
@@ -264,6 +322,8 @@ internal class PlaybackLyricsController(
 
             val alignmentOffsetMs = mutableAssociationState.value.alignmentOffsetMs
             rememberAssociation(sourceTrack.id, track.id)
+            loadedForTrackId = playbackTrack.id
+            loadedAssociationTrackId = track.id
             updateLyrics(lyrics)
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = playbackTrack.id,
@@ -292,9 +352,15 @@ internal class PlaybackLyricsController(
     }
 
     override fun updateAlignmentOffset(offsetMs: Long) {
-        mutableAssociationState.value = mutableAssociationState.value.copy(
-            alignmentOffsetMs = offsetMs.coerceIn(-3_000L, 3_000L),
-        )
+        val clamped = offsetMs.coerceIn(-3_000L, 3_000L)
+        val current = mutableAssociationState.value
+        if (current.alignmentOffsetMs == clamped) return
+        mutableAssociationState.value = current.copy(alignmentOffsetMs = clamped)
+        if (current.isManualAssociation) {
+            currentSourceTrackId?.let { sourceTrackId ->
+                rememberAlignmentOffset(sourceTrackId, clamped)
+            }
+        }
     }
 
     private suspend fun performSearch(track: MusicTrack, keyword: String) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.launch
 
 private val LYRICS_ASSOCIATION_PROVIDER_IDS = setOf("netease", "qqmusic", "ytmusic")
 
+internal fun lyricsAlignmentPersistenceKey(sourceTrackId: String, lyricsTrackId: String): String =
+    "${sourceTrackId.length}:$sourceTrackId$lyricsTrackId"
+
 internal interface PlaybackLyricsRepository {
     suspend fun lyrics(track: MusicTrack): String?
     suspend fun search(keyword: String): List<MusicTrack>
@@ -27,11 +30,25 @@ private class ProviderPlaybackLyricsRepository(
     override suspend fun search(keyword: String): List<MusicTrack> {
         val enabledProviderIds = registryRepository.providers().mapTo(mutableSetOf()) { it.providerId }
         val results = mutableListOf<MusicTrack>()
+        var attemptedProviders = 0
+        var successfulProviders = 0
+        var firstFailure: Throwable? = null
         for (providerId in LYRICS_ASSOCIATION_PROVIDER_IDS) {
             if (providerId !in enabledProviderIds) continue
-            val providerResults = runCatching { searchRepository.search(keyword, providerId) }
-                .getOrDefault(emptyList())
-            results += providerResults
+            attemptedProviders += 1
+            runCatching { searchRepository.search(keyword, providerId) }
+                .fold(
+                    onSuccess = { providerResults ->
+                        successfulProviders += 1
+                        results += providerResults
+                    },
+                    onFailure = { throwable ->
+                        if (firstFailure == null) firstFailure = throwable
+                    },
+                )
+        }
+        if (attemptedProviders > 0 && successfulProviders == 0) {
+            throw firstFailure ?: IllegalStateException("歌词搜索失败")
         }
         return results.distinctBy { it.id }
     }
@@ -127,13 +144,22 @@ internal class PlaybackLyricsController(
         val currentId = currentQueueTrackId
             ?: engineTrackId
             ?: previousPlaybackState.currentTrack?.id
+        val previousTrackId = previousPlaybackState.currentTrack?.id
+        val previousLyrics = previousPlaybackState.lyrics?.takeIf {
+            it.isNotBlank() && previousTrackId != null && previousTrackId == currentId
+        }
+        val association = mutableAssociationState.value
+        if (
+            association.isManualAssociation &&
+            association.trackId == currentId &&
+            previousLyrics != null
+        ) {
+            return previousLyrics
+        }
         engineState.lyrics?.takeIf {
             it.isNotBlank() && (engineTrackId == null || engineTrackId == currentId)
         }?.let { return it }
-        val previousTrackId = previousPlaybackState.currentTrack?.id
-        return previousPlaybackState.lyrics?.takeIf {
-            it.isNotBlank() && previousTrackId != null && previousTrackId == currentId
-        }
+        return previousLyrics
     }
 
     fun maybeLoad(track: MusicTrack?) {
@@ -142,8 +168,11 @@ internal class PlaybackLyricsController(
         val associatedTrackId = associationForTrackId(lyricTrack.id)
             ?.trim()
             ?.takeIf { it.isNotBlank() }
-        val alignmentOffsetMs = alignmentOffsetForTrackId(lyricTrack.id)
-            .coerceIn(-3_000L, 3_000L)
+        val alignmentOffsetMs = associatedTrackId?.let { lyricsTrackId ->
+            alignmentOffsetForTrackId(
+                lyricsAlignmentPersistenceKey(lyricTrack.id, lyricsTrackId),
+            ).coerceIn(-3_000L, 3_000L)
+        } ?: 0L
         currentSourceTrackId = lyricTrack.id
 
         if (loadedForTrackId == track.id && loadedAssociationTrackId == associatedTrackId) {
@@ -239,8 +268,16 @@ internal class PlaybackLyricsController(
         val sourceTrack = lyricSourceTrackForPlayback(track)
         currentSourceTrackId = sourceTrack.id
         val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
+        val persistedAssociationTrackId = associationForTrackId(sourceTrack.id)
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
         val alignmentOffsetMs = previous?.alignmentOffsetMs
-            ?: alignmentOffsetForTrackId(sourceTrack.id).coerceIn(-3_000L, 3_000L)
+            ?: persistedAssociationTrackId?.let { lyricsTrackId ->
+                alignmentOffsetForTrackId(
+                    lyricsAlignmentPersistenceKey(sourceTrack.id, lyricsTrackId),
+                ).coerceIn(-3_000L, 3_000L)
+            }
+            ?: 0L
         mutableAssociationState.value = LyricsAssociationUiState(
             trackId = track.id,
             isLyricsUnavailable = previous?.isLyricsUnavailable ?: currentLyrics().isNullOrBlank(),
@@ -321,12 +358,10 @@ internal class PlaybackLyricsController(
                 return@launch
             }
 
-            val currentAssociation = mutableAssociationState.value
-            val associationChanged = currentAssociation.associatedTrackId != null &&
-                currentAssociation.associatedTrackId != track.id
-            val alignmentOffsetMs = if (associationChanged) 0L else currentAssociation.alignmentOffsetMs
+            val alignmentOffsetMs = alignmentOffsetForTrackId(
+                lyricsAlignmentPersistenceKey(sourceTrack.id, track.id),
+            ).coerceIn(-3_000L, 3_000L)
             rememberAssociation(sourceTrack.id, track.id)
-            if (associationChanged) rememberAlignmentOffset(sourceTrack.id, 0L)
             loadedForTrackId = playbackTrack.id
             loadedAssociationTrackId = track.id
             updateLyrics(lyrics)
@@ -362,8 +397,13 @@ internal class PlaybackLyricsController(
         if (current.alignmentOffsetMs == clamped) return
         mutableAssociationState.value = current.copy(alignmentOffsetMs = clamped)
         if (current.isManualAssociation) {
-            currentSourceTrackId?.let { sourceTrackId ->
-                rememberAlignmentOffset(sourceTrackId, clamped)
+            val sourceTrackId = currentSourceTrackId
+            val lyricsTrackId = current.associatedTrackId
+            if (sourceTrackId != null && lyricsTrackId != null) {
+                rememberAlignmentOffset(
+                    lyricsAlignmentPersistenceKey(sourceTrackId, lyricsTrackId),
+                    clamped,
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -321,8 +321,12 @@ internal class PlaybackLyricsController(
                 return@launch
             }
 
-            val alignmentOffsetMs = mutableAssociationState.value.alignmentOffsetMs
+            val currentAssociation = mutableAssociationState.value
+            val associationChanged = currentAssociation.associatedTrackId != null &&
+                currentAssociation.associatedTrackId != track.id
+            val alignmentOffsetMs = if (associationChanged) 0L else currentAssociation.alignmentOffsetMs
             rememberAssociation(sourceTrack.id, track.id)
+            if (associationChanged) rememberAlignmentOffset(sourceTrack.id, 0L)
             loadedForTrackId = playbackTrack.id
             loadedAssociationTrackId = track.id
             updateLyrics(lyrics)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackLyricsController.kt
@@ -147,12 +147,14 @@ internal class PlaybackLyricsController(
         currentSourceTrackId = lyricTrack.id
 
         if (loadedForTrackId == track.id && loadedAssociationTrackId == associatedTrackId) {
+            val current = mutableAssociationState.value
+            val effectiveAlignmentOffsetMs = if (current.isManualAssociation) alignmentOffsetMs else 0L
             if (
-                mutableAssociationState.value.trackId == track.id &&
-                mutableAssociationState.value.alignmentOffsetMs != alignmentOffsetMs
+                current.trackId == track.id &&
+                current.alignmentOffsetMs != effectiveAlignmentOffsetMs
             ) {
-                mutableAssociationState.value = mutableAssociationState.value.copy(
-                    alignmentOffsetMs = alignmentOffsetMs,
+                mutableAssociationState.value = current.copy(
+                    alignmentOffsetMs = effectiveAlignmentOffsetMs,
                 )
             }
             return
@@ -166,7 +168,6 @@ internal class PlaybackLyricsController(
         if (associatedTrackId != null) {
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
-                alignmentOffsetMs = alignmentOffsetMs,
             )
             loadJob = scope.launch {
                 val associatedTrack = repository.trackDetail(associatedTrackId)
@@ -196,7 +197,7 @@ internal class PlaybackLyricsController(
                 mutableAssociationState.value = LyricsAssociationUiState(
                     trackId = track.id,
                     isLyricsUnavailable = fallbackLyrics == null,
-                    alignmentOffsetMs = alignmentOffsetMs,
+                    alignmentOffsetMs = 0L,
                 )
             }
             return
@@ -205,7 +206,7 @@ internal class PlaybackLyricsController(
         currentLyrics()?.takeIf { it.isNotBlank() }?.let {
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
-                alignmentOffsetMs = alignmentOffsetMs,
+                alignmentOffsetMs = 0L,
             )
             return
         }
@@ -213,7 +214,7 @@ internal class PlaybackLyricsController(
             updateLyrics(it)
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
-                alignmentOffsetMs = alignmentOffsetMs,
+                alignmentOffsetMs = 0L,
             )
             return
         }
@@ -227,7 +228,7 @@ internal class PlaybackLyricsController(
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
                 isLyricsUnavailable = lyrics == null,
-                alignmentOffsetMs = alignmentOffsetMs,
+                alignmentOffsetMs = 0L,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -177,6 +177,7 @@ data class LyricsAssociationUiState(
     val isManualAssociation: Boolean = false,
     val associatedTrackId: String? = null,
     val associatedTrackTitle: String? = null,
+    val alignmentOffsetMs: Long = 0L,
     val isSearchOpen: Boolean = false,
     val query: String = "",
     val results: List<MusicTrack> = emptyList(),
@@ -194,6 +195,7 @@ interface PlaybackLyricsPort {
     fun searchAssociation()
     fun selectAssociation(track: MusicTrack)
     fun closeAssociationSearch()
+    fun updateAlignmentOffset(offsetMs: Long)
 }
 
 /** Smart-replacement state/actions used by the now-playing surface. */

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
@@ -176,7 +176,7 @@ private fun RuntimeMiniPlayerProgress(
 @Composable
 private fun RuntimeMiniPlayerLyricLine(state: PlaybackSessionState) {
     val lines = remember(state.lyrics) { parseLyrics(state.lyrics) }
-    val currentIndex = currentLyricIndex(lines, state.positionMs)
+    val currentIndex = currentLyricIndex(lines, state.lyricsPositionMs)
     val currentLine = lines.getOrNull(currentIndex)?.text?.takeIf { it.isNotBlank() } ?: return
 
     AnimatedContent(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppSettingsRepositoryTest.kt
@@ -100,6 +100,7 @@ class AppSettingsRepositoryTest {
         assertFalse(settings.statusBarLyricsEnabled)
         assertTrue(settings.pauseOnOtherAppPlayback)
         assertTrue(settings.smartReplacementSelections.isEmpty())
+        assertTrue(settings.lyricsAlignmentOffsetsMs.isEmpty())
     }
 
     @Test
@@ -180,7 +181,7 @@ class AppSettingsRepositoryTest {
     }
 
     @Test
-    fun lyricsAssociationsRoundTrip() = runTest {
+    fun lyricsAssociationsAndAlignmentOffsetsRoundTrip() = runTest {
         val store = FakeSettingsSnapshotStore()
         val first = PersistentAppSettingsRepository(
             store = store,
@@ -189,7 +190,10 @@ class AppSettingsRepositoryTest {
         )
         first.awaitSettings()
         first.update {
-            it.copy(lyricsAssociations = mapOf("bilibili:BVdemo" to "netease:123"))
+            it.copy(
+                lyricsAssociations = mapOf("bilibili:BVdemo" to "netease:123"),
+                lyricsAlignmentOffsetsMs = mapOf("bilibili:BVdemo" to 1_250L),
+            )
         }
 
         val restored = PersistentAppSettingsRepository(
@@ -199,6 +203,7 @@ class AppSettingsRepositoryTest {
         ).awaitSettings()
 
         assertEquals("netease:123", restored.lyricsAssociations["bilibili:BVdemo"])
+        assertEquals(1_250L, restored.lyricsAlignmentOffsetsMs["bilibili:BVdemo"])
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -31,6 +31,7 @@ class PlaybackLyricsControllerTest {
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { if (it == source.id) target.id else null },
             rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
         )
 
         controller.maybeLoad(source)
@@ -38,6 +39,7 @@ class PlaybackLyricsControllerTest {
 
         assertEquals("[00:00.00]关联歌词", currentLyrics)
         assertEquals(target.id, controller.associationState.value.associatedTrackId)
+        assertEquals(1_250L, controller.associationState.value.alignmentOffsetMs)
         assertTrue(controller.associationState.value.isManualAssociation)
         assertEquals(listOf(target.id), repository.lyricRequests)
     }
@@ -80,6 +82,73 @@ class PlaybackLyricsControllerTest {
         assertEquals("[00:00.00]目标歌词", currentLyrics)
         assertTrue(controller.associationState.value.isManualAssociation)
         assertFalse(controller.associationState.value.isSearchOpen)
+    }
+
+    @Test
+    fun alignmentOffsetChangeIsRememberedForAssociatedSource() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val target = providerTrack("netease:123", "歌词歌曲", "netease")
+        val repository = FakePlaybackLyricsRepository(
+            details = mapOf(target.id to target),
+            lyrics = mapOf(target.id to "[00:00.00]关联歌词"),
+        )
+        val rememberedOffsets = mutableListOf<Pair<String, Long>>()
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { if (it == source.id) target.id else null },
+            rememberAssociation = { _, _ -> },
+            rememberAlignmentOffset = { sourceId, offsetMs -> rememberedOffsets += sourceId to offsetMs },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        controller.updateAlignmentOffset(-750L)
+
+        assertEquals(listOf(source.id to -750L), rememberedOffsets)
+        assertEquals(-750L, controller.associationState.value.alignmentOffsetMs)
+    }
+
+    @Test
+    fun persistentStateRefreshRestoresAssociationLoadedAfterPlaybackState() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val target = providerTrack("netease:123", "歌词歌曲", "netease")
+        val repository = FakePlaybackLyricsRepository(
+            details = mapOf(target.id to target),
+            lyrics = mapOf(target.id to "[00:00.00]恢复歌词"),
+        )
+        var persistedAssociation: String? = null
+        var persistedOffsetMs = 0L
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { persistedAssociation },
+            rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { persistedOffsetMs },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        assertTrue(controller.associationState.value.isLyricsUnavailable)
+
+        persistedAssociation = target.id
+        persistedOffsetMs = 500L
+        controller.refreshPersistentState(source)
+        advanceUntilIdle()
+
+        assertEquals("[00:00.00]恢复歌词", currentLyrics)
+        assertEquals(target.id, controller.associationState.value.associatedTrackId)
+        assertEquals(500L, controller.associationState.value.alignmentOffsetMs)
+        assertTrue(controller.associationState.value.isManualAssociation)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -83,6 +83,30 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
+    fun bilibiliBgmKeywordRemovesDiscoveryPrefixAndBookTitleMarks() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val repository = FakePlaybackLyricsRepository(
+            searchKeyword = "发现《春を告げる》",
+        )
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+
+        assertEquals("春を告げる", controller.associationState.value.query)
+        assertEquals(listOf("春を告げる"), repository.searchRequests)
+    }
+
+    @Test
     fun rememberedAssociationIsPreservedWhenLookupFails() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val repository = FakePlaybackLyricsRepository()

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -107,6 +107,56 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
+    fun bilibiliBgmKeywordKeepsLegitimateDiscoveryPrefix() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val repository = FakePlaybackLyricsRepository(
+            searchKeyword = "发现爱",
+        )
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+
+        assertEquals("发现爱", controller.associationState.value.query)
+        assertEquals(listOf("发现爱"), repository.searchRequests)
+    }
+
+    @Test
+    fun alignmentOffsetSurvivesAssociationPanelOpenAndClose() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val repository = FakePlaybackLyricsRepository()
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        controller.updateAlignmentOffset(1_250L)
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+        controller.closeAssociationSearch()
+
+        assertEquals(1_250L, controller.associationState.value.alignmentOffsetMs)
+    }
+
+    @Test
     fun rememberedAssociationIsPreservedWhenLookupFails() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val repository = FakePlaybackLyricsRepository()

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -45,6 +45,36 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
+    fun unavailableRememberedAssociationDoesNotShiftNativeFallbackLyrics() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili").copy(
+            lyrics = "[00:00.00]原始歌词",
+        )
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = FakePlaybackLyricsRepository(),
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { if (it == source.id) "netease:missing" else null },
+            rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+
+        assertEquals("[00:00.00]原始歌词", currentLyrics)
+        assertFalse(controller.associationState.value.isManualAssociation)
+        assertEquals(0L, controller.associationState.value.alignmentOffsetMs)
+
+        controller.refreshPersistentState(source)
+        advanceUntilIdle()
+        assertEquals(0L, controller.associationState.value.alignmentOffsetMs)
+    }
+
+    @Test
     fun unavailableLyricsCanSearchSelectAndRememberAssociation() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val target = providerTrack("qqmusic:42", "BGM 歌曲", "qqmusic")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -144,6 +144,46 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
+    fun changingAssociatedLyricsResetsAndPersistsAlignmentOffset() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val currentTarget = providerTrack("netease:123", "旧歌词歌曲", "netease")
+        val replacementTarget = providerTrack("qqmusic:456", "新歌词歌曲", "qqmusic")
+        val repository = FakePlaybackLyricsRepository(
+            details = mapOf(currentTarget.id to currentTarget),
+            lyrics = mapOf(
+                currentTarget.id to "[00:00.00]旧歌词",
+                replacementTarget.id to "[00:00.00]新歌词",
+            ),
+        )
+        val rememberedOffsets = mutableListOf<Pair<String, Long>>()
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { null },
+            updateLyrics = {},
+            associationForTrackId = { if (it == source.id) currentTarget.id else null },
+            rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
+            rememberAlignmentOffset = { sourceId, offsetMs -> rememberedOffsets += sourceId to offsetMs },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        assertEquals(1_250L, controller.associationState.value.alignmentOffsetMs)
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+        controller.selectAssociation(replacementTarget)
+        advanceUntilIdle()
+
+        assertEquals(replacementTarget.id, controller.associationState.value.associatedTrackId)
+        assertEquals(0L, controller.associationState.value.alignmentOffsetMs)
+        assertEquals(listOf(source.id to 0L), rememberedOffsets)
+    }
+
+    @Test
     fun persistentStateRefreshRestoresAssociationLoadedAfterPlaybackState() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val target = providerTrack("netease:123", "歌词歌曲", "netease")

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsControllerTest.kt
@@ -31,7 +31,9 @@ class PlaybackLyricsControllerTest {
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { if (it == source.id) target.id else null },
             rememberAssociation = { _, _ -> },
-            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
+            alignmentOffsetForTrackId = {
+                if (it == lyricsAlignmentPersistenceKey(source.id, target.id)) 1_250L else 0L
+            },
         )
 
         controller.maybeLoad(source)
@@ -49,6 +51,7 @@ class PlaybackLyricsControllerTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili").copy(
             lyrics = "[00:00.00]原始歌词",
         )
+        val missingAssociationId = "netease:missing"
         var currentLyrics: String? = null
         val controller = PlaybackLyricsController(
             repository = FakePlaybackLyricsRepository(),
@@ -57,9 +60,11 @@ class PlaybackLyricsControllerTest {
             currentTrackId = { source.id },
             currentLyrics = { currentLyrics },
             updateLyrics = { currentLyrics = it },
-            associationForTrackId = { if (it == source.id) "netease:missing" else null },
+            associationForTrackId = { if (it == source.id) missingAssociationId else null },
             rememberAssociation = { _, _ -> },
-            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
+            alignmentOffsetForTrackId = {
+                if (it == lyricsAlignmentPersistenceKey(source.id, missingAssociationId)) 1_250L else 0L
+            },
         )
 
         controller.maybeLoad(source)
@@ -115,7 +120,7 @@ class PlaybackLyricsControllerTest {
     }
 
     @Test
-    fun alignmentOffsetChangeIsRememberedForAssociatedSource() = runTest {
+    fun alignmentOffsetChangeIsRememberedForSpecificAssociation() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val target = providerTrack("netease:123", "歌词歌曲", "netease")
         val repository = FakePlaybackLyricsRepository(
@@ -132,19 +137,22 @@ class PlaybackLyricsControllerTest {
             updateLyrics = {},
             associationForTrackId = { if (it == source.id) target.id else null },
             rememberAssociation = { _, _ -> },
-            rememberAlignmentOffset = { sourceId, offsetMs -> rememberedOffsets += sourceId to offsetMs },
+            rememberAlignmentOffset = { associationKey, offsetMs -> rememberedOffsets += associationKey to offsetMs },
         )
 
         controller.maybeLoad(source)
         advanceUntilIdle()
         controller.updateAlignmentOffset(-750L)
 
-        assertEquals(listOf(source.id to -750L), rememberedOffsets)
+        assertEquals(
+            listOf(lyricsAlignmentPersistenceKey(source.id, target.id) to -750L),
+            rememberedOffsets,
+        )
         assertEquals(-750L, controller.associationState.value.alignmentOffsetMs)
     }
 
     @Test
-    fun changingAssociatedLyricsResetsAndPersistsAlignmentOffset() = runTest {
+    fun changingAssociatedLyricsRestoresEachLyricsOwnAlignmentOffset() = runTest {
         val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
         val currentTarget = providerTrack("netease:123", "旧歌词歌曲", "netease")
         val replacementTarget = providerTrack("qqmusic:456", "新歌词歌曲", "qqmusic")
@@ -155,7 +163,12 @@ class PlaybackLyricsControllerTest {
                 replacementTarget.id to "[00:00.00]新歌词",
             ),
         )
+        var persistedAssociation: String? = currentTarget.id
         val rememberedOffsets = mutableListOf<Pair<String, Long>>()
+        val savedOffsets = mapOf(
+            lyricsAlignmentPersistenceKey(source.id, currentTarget.id) to 1_250L,
+            lyricsAlignmentPersistenceKey(source.id, replacementTarget.id) to -500L,
+        )
         val controller = PlaybackLyricsController(
             repository = repository,
             scope = this,
@@ -163,10 +176,10 @@ class PlaybackLyricsControllerTest {
             currentTrackId = { source.id },
             currentLyrics = { null },
             updateLyrics = {},
-            associationForTrackId = { if (it == source.id) currentTarget.id else null },
-            rememberAssociation = { _, _ -> },
-            alignmentOffsetForTrackId = { if (it == source.id) 1_250L else 0L },
-            rememberAlignmentOffset = { sourceId, offsetMs -> rememberedOffsets += sourceId to offsetMs },
+            associationForTrackId = { if (it == source.id) persistedAssociation else null },
+            rememberAssociation = { _, targetId -> persistedAssociation = targetId },
+            alignmentOffsetForTrackId = { savedOffsets[it] ?: 0L },
+            rememberAlignmentOffset = { associationKey, offsetMs -> rememberedOffsets += associationKey to offsetMs },
         )
 
         controller.maybeLoad(source)
@@ -179,8 +192,58 @@ class PlaybackLyricsControllerTest {
         advanceUntilIdle()
 
         assertEquals(replacementTarget.id, controller.associationState.value.associatedTrackId)
-        assertEquals(0L, controller.associationState.value.alignmentOffsetMs)
-        assertEquals(listOf(source.id to 0L), rememberedOffsets)
+        assertEquals(-500L, controller.associationState.value.alignmentOffsetMs)
+        assertTrue(rememberedOffsets.isEmpty())
+
+        controller.openAssociationSearch(source)
+        advanceUntilIdle()
+        controller.selectAssociation(currentTarget)
+        advanceUntilIdle()
+
+        assertEquals(currentTarget.id, controller.associationState.value.associatedTrackId)
+        assertEquals(1_250L, controller.associationState.value.alignmentOffsetMs)
+        assertTrue(rememberedOffsets.isEmpty())
+    }
+
+    @Test
+    fun activeManualAssociationKeepsAssociatedLyricsOverEngineLyrics() = runTest {
+        val source = providerTrack("bilibili:BVdemo", "视频标题", "bilibili")
+        val target = providerTrack("netease:123", "歌词歌曲", "netease")
+        val associatedLyrics = "[00:00.00]手动关联歌词"
+        val repository = FakePlaybackLyricsRepository(
+            details = mapOf(target.id to target),
+            lyrics = mapOf(target.id to associatedLyrics),
+        )
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = repository,
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { source.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { if (it == source.id) target.id else null },
+            rememberAssociation = { _, _ -> },
+        )
+
+        controller.maybeLoad(source)
+        advanceUntilIdle()
+        assertEquals(associatedLyrics, currentLyrics)
+        assertTrue(controller.associationState.value.isManualAssociation)
+
+        val merged = controller.mergedLyrics(
+            engineState = PlaybackState(
+                currentTrack = source,
+                lyrics = "[00:00.00]引擎原生歌词",
+            ),
+            currentQueueTrackId = source.id,
+            previousPlaybackState = PlaybackState(
+                currentTrack = source,
+                lyrics = associatedLyrics,
+            ),
+        )
+
+        assertEquals(associatedLyrics, merged)
     }
 
     @Test
@@ -203,7 +266,17 @@ class PlaybackLyricsControllerTest {
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { persistedAssociation },
             rememberAssociation = { _, _ -> },
-            alignmentOffsetForTrackId = { persistedOffsetMs },
+            alignmentOffsetForTrackId = { key ->
+                val associationId = persistedAssociation
+                if (
+                    associationId != null &&
+                    key == lyricsAlignmentPersistenceKey(source.id, associationId)
+                ) {
+                    persistedOffsetMs
+                } else {
+                    0L
+                }
+            },
         )
 
         controller.maybeLoad(source)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/TimedLineLyricsTest.kt
@@ -48,6 +48,23 @@ class TimedLineLyricsTest {
     }
 
     @Test
+    fun appliesAlignmentOffsetToPlatformTimeline() {
+        val lyrics = """
+            [00:01.000]First
+            [00:03.000]Second
+        """.trimIndent()
+
+        assertEquals(
+            "[00:02.250]First\n[00:04.250]Second",
+            toTimedLineLrc(lyrics, alignmentOffsetMs = 1_250L),
+        )
+        assertEquals(
+            "[00:00.000]First\n[00:01.500]Second",
+            toTimedLineLrc(lyrics, alignmentOffsetMs = -1_500L),
+        )
+    }
+
+    @Test
     fun ignoresUntimedLyricsForLockScreenTimeline() {
         assertNull(toTimedLineLrc("plain lyrics without timestamps"))
     }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackRuntime.kt
@@ -100,6 +100,7 @@ private fun PlaybackState.toPlaybackRuntimeOverlay(): PlaybackRuntimeOverlay =
     PlaybackRuntimeOverlay(
         currentTrack = currentTrack?.toTrackRef(),
         lyrics = lyrics,
+        lyricsAlignmentOffsetMs = lyricsAlignmentOffsetMs,
         queueTrackIds = queue.map(MusicTrack::id),
         queueIndex = queueIndex,
     )


### PR DESCRIPTION
## Summary
- restrict manual lyrics association search to enabled providers that currently support lyrics (NetEase, QQ Music, YouTube Music)
- inject provider registry/search/catalog/playback as narrow ports at the playback composition root
- clean Bilibili BGM hints before searching, e.g. `发现《春を告げる》` -> `春を告げる`, while preserving legitimate titles such as `发现爱`
- replace the manual association text action with an edit icon
- add a neighboring lyrics-alignment icon with an inline ±3s adjustment control at 250ms steps
- apply the alignment offset to line selection and karaoke word progress in the full player
- persist manual lyrics associations in app settings and restore them on later playback/app startup
- persist lyrics alignment per `(original source track, associated lyrics track)` relationship, so corrections for one lyric source never affect another and switching back restores that lyric's own correction
- refresh persisted lyrics state after settings/queue restoration so a restored paused session also recovers its association and offset
- keep an active restored manual association authoritative when the playback engine later publishes native lyrics
- preserve partial provider search results, but surface a search failure when every attempted lyrics provider fails
- publish the aligned lyric position through `PlaybackSession` so mini-player, Lyricon status-bar lyrics, and BYD instrument lyrics use the same timing as the full player
- shift ColorOS/OPlus lock-screen LRC timestamps by the saved alignment offset so platform media-session lyrics stay consistent too

## Validation
- `PlaybackLyricsControllerTest.rememberedAssociationLoadsBeforeNativeLyrics`
- `PlaybackLyricsControllerTest.unavailableRememberedAssociationDoesNotShiftNativeFallbackLyrics`
- `PlaybackLyricsControllerTest.alignmentOffsetChangeIsRememberedForSpecificAssociation`
- `PlaybackLyricsControllerTest.changingAssociatedLyricsRestoresEachLyricsOwnAlignmentOffset`
- `PlaybackLyricsControllerTest.activeManualAssociationKeepsAssociatedLyricsOverEngineLyrics`
- `PlaybackLyricsControllerTest.persistentStateRefreshRestoresAssociationLoadedAfterPlaybackState`
- `PlaybackLyricsControllerTest.bilibiliBgmKeywordRemovesDiscoveryPrefixAndBookTitleMarks`
- `PlaybackLyricsControllerTest.bilibiliBgmKeywordKeepsLegitimateDiscoveryPrefix`
- `PlaybackLyricsControllerTest.alignmentOffsetSurvivesAssociationPanelOpenAndClose`
- `AppSettingsRepositoryTest.lyricsAssociationsAndAlignmentOffsetsRoundTrip`
- `SettingsPersistenceTest.snapshotRoundTripsThroughDataStore`
- `DefaultPlaybackRuntimeTest.mergesEngineAndQueuePresentationIntoSessionState` verifies shared aligned lyric position/offset propagation
- `TimedLineLyricsTest.appliesAlignmentOffsetToPlatformTimeline` verifies shifted ColorOS/OPlus timestamps
- GitHub Actions Android/iOS validation runs on the latest head.