### PR TITLE
fix: keep BYD instrument lyrics visible

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -416,12 +416,11 @@ private class BydInstrumentLyricsBridge(
         private const val MUSIC_NAME_REFRESH_BASE_MS = 2_800L
         private const val MUSIC_NAME_REFRESH_PER_CHAR_MS = 140L
         private const val MUSIC_NAME_REFRESH_MIN_MS = 4_000L
-        private const val MUSIC_NAME_REFRESH_MAX_MS = 7_500L
 
         private fun musicNameRefreshIntervalMs(text: String): Long {
             val charCount = text.codePointCount(0, text.length).coerceAtLeast(1)
             return (MUSIC_NAME_REFRESH_BASE_MS + charCount * MUSIC_NAME_REFRESH_PER_CHAR_MS)
-                .coerceIn(MUSIC_NAME_REFRESH_MIN_MS, MUSIC_NAME_REFRESH_MAX_MS)
+                .coerceAtLeast(MUSIC_NAME_REFRESH_MIN_MS)
         }
 
         fun create(context: Context): Result<BydInstrumentLyricsBridge> = runCatching {

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -182,6 +182,7 @@ internal class BydInstrumentLyricsPublisher(
                 }
                 if (!publishAtPosition(snapshot, estimatedPositionMs())) break
                 bridge?.refreshSessionLease(snapshot.status)
+                bridge?.refreshLyricDisplayLease(snapshot.status)
                 delay(POSITION_SYNC_INTERVAL_MS)
             }
         }
@@ -278,6 +279,8 @@ private class BydInstrumentLyricsBridge(
     private var useMusicNameTransport = threeLineLyricsMethod == null
     private var lastMusicStateValue: Int? = null
     private var lastMusicSessionRefreshRealtimeMs = 0L
+    private var lastPublishedMusicName: String? = null
+    private var lastMusicNameRefreshRealtimeMs = 0L
 
     fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
         if (!useMusicNameTransport) {
@@ -291,8 +294,14 @@ private class BydInstrumentLyricsBridge(
         }
 
         val nameMethod = musicNameMethod ?: return false
-        refreshMusicSession(status)
-        return invokeRequired(nameMethod, window.current)
+        val realtimeMs = SystemClock.elapsedRealtime()
+        refreshMusicSession(status, realtimeMs)
+        val success = invokeRequired(nameMethod, window.current)
+        if (success) {
+            lastPublishedMusicName = window.current
+            lastMusicNameRefreshRealtimeMs = realtimeMs
+        }
+        return success
     }
 
     fun refreshSessionLease(
@@ -309,6 +318,27 @@ private class BydInstrumentLyricsBridge(
         refreshMusicSession(status, realtimeMs)
     }
 
+    fun refreshLyricDisplayLease(
+        status: PlaybackSessionStatus,
+        realtimeMs: Long = SystemClock.elapsedRealtime(),
+    ) {
+        if (!useMusicNameTransport || status != PlaybackSessionStatus.Playing) return
+        val lyric = lastPublishedMusicName?.takeIf { it.isNotBlank() } ?: return
+        val intervalMs = musicNameRefreshIntervalMs(lyric)
+        if (
+            lastMusicNameRefreshRealtimeMs != 0L &&
+            realtimeMs - lastMusicNameRefreshRealtimeMs < intervalMs
+        ) {
+            return
+        }
+
+        // DiLink 4 restores the native media title after one marquee cycle. Refresh only after
+        // the estimated display cycle has elapsed, so the current lyric is restored without
+        // repeatedly restarting a long line while it is still scrolling.
+        lastMusicNameRefreshRealtimeMs = realtimeMs
+        musicNameMethod?.let { invokeOptional(it, lyric) }
+    }
+
     fun clear() {
         if (!useMusicNameTransport) {
             val method = threeLineLyricsMethod
@@ -318,6 +348,8 @@ private class BydInstrumentLyricsBridge(
         publishMusicStateValueIfAvailable(musicStopValue, force = true)
         lastMusicStateValue = null
         lastMusicSessionRefreshRealtimeMs = 0L
+        lastPublishedMusicName = null
+        lastMusicNameRefreshRealtimeMs = 0L
     }
 
     private fun refreshMusicSession(
@@ -325,8 +357,8 @@ private class BydInstrumentLyricsBridge(
         realtimeMs: Long = SystemClock.elapsedRealtime(),
     ) {
         // Reassert source/state on actual lyric/status changes, then maintain the same ownership
-        // with a low-frequency lease while playing. The lease intentionally never resends
-        // sendMusicName, so long scrolling lyrics are not restarted.
+        // with a low-frequency lease while playing. The text display has a separate adaptive
+        // keepalive because DiLink can restore the native title after a completed marquee cycle.
         lastMusicSessionRefreshRealtimeMs = realtimeMs
         publishMusicSourceIfAvailable()
         publishMusicStateIfAvailable(status, force = true)
@@ -381,6 +413,16 @@ private class BydInstrumentLyricsBridge(
     companion object {
         private const val TAG = "BydInstrumentLyrics"
         private const val MUSIC_SESSION_LEASE_INTERVAL_MS = 5_000L
+        private const val MUSIC_NAME_REFRESH_BASE_MS = 2_800L
+        private const val MUSIC_NAME_REFRESH_PER_CHAR_MS = 140L
+        private const val MUSIC_NAME_REFRESH_MIN_MS = 4_000L
+        private const val MUSIC_NAME_REFRESH_MAX_MS = 7_500L
+
+        private fun musicNameRefreshIntervalMs(text: String): Long {
+            val charCount = text.codePointCount(0, text.length).coerceAtLeast(1)
+            return (MUSIC_NAME_REFRESH_BASE_MS + charCount * MUSIC_NAME_REFRESH_PER_CHAR_MS)
+                .coerceIn(MUSIC_NAME_REFRESH_MIN_MS, MUSIC_NAME_REFRESH_MAX_MS)
+        }
 
         fun create(context: Context): Result<BydInstrumentLyricsBridge> = runCatching {
             val instrumentClass = Class.forName(BYD_INSTRUMENT_DEVICE_CLASS)

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -281,6 +281,7 @@ private class BydInstrumentLyricsBridge(
     private var lastMusicSessionRefreshRealtimeMs = 0L
     private var lastPublishedMusicName: String? = null
     private var lastMusicNameRefreshRealtimeMs = 0L
+    private var lastMusicNameRefreshAttemptRealtimeMs = 0L
 
     fun publish(window: InstrumentLyricsWindow, status: PlaybackSessionStatus): Boolean {
         if (!useMusicNameTransport) {
@@ -300,6 +301,7 @@ private class BydInstrumentLyricsBridge(
         if (success) {
             lastPublishedMusicName = window.current
             lastMusicNameRefreshRealtimeMs = realtimeMs
+            lastMusicNameRefreshAttemptRealtimeMs = 0L
         }
         return success
     }
@@ -331,12 +333,23 @@ private class BydInstrumentLyricsBridge(
         ) {
             return
         }
+        if (
+            lastMusicNameRefreshAttemptRealtimeMs != 0L &&
+            realtimeMs - lastMusicNameRefreshAttemptRealtimeMs < MUSIC_NAME_REFRESH_FAILURE_RETRY_MS
+        ) {
+            return
+        }
 
         // DiLink 4 restores the native media title after one marquee cycle. Refresh only after
         // the estimated display cycle has elapsed, so the current lyric is restored without
-        // repeatedly restarting a long line while it is still scrolling.
-        lastMusicNameRefreshRealtimeMs = realtimeMs
-        musicNameMethod?.let { invokeOptional(it, lyric) }
+        // repeatedly restarting a long line while it is still scrolling. Failed keepalives use
+        // a short bounded retry instead of consuming the full display interval or retrying at 100 ms.
+        lastMusicNameRefreshAttemptRealtimeMs = realtimeMs
+        val success = musicNameMethod?.let { invokeOptional(it, lyric) } ?: false
+        if (success) {
+            lastMusicNameRefreshRealtimeMs = realtimeMs
+            lastMusicNameRefreshAttemptRealtimeMs = 0L
+        }
     }
 
     fun clear() {
@@ -350,6 +363,7 @@ private class BydInstrumentLyricsBridge(
         lastMusicSessionRefreshRealtimeMs = 0L
         lastPublishedMusicName = null
         lastMusicNameRefreshRealtimeMs = 0L
+        lastMusicNameRefreshAttemptRealtimeMs = 0L
     }
 
     private fun refreshMusicSession(
@@ -416,6 +430,7 @@ private class BydInstrumentLyricsBridge(
         private const val MUSIC_NAME_REFRESH_BASE_MS = 2_800L
         private const val MUSIC_NAME_REFRESH_PER_CHAR_MS = 140L
         private const val MUSIC_NAME_REFRESH_MIN_MS = 4_000L
+        private const val MUSIC_NAME_REFRESH_FAILURE_RETRY_MS = 1_000L
 
         private fun musicNameRefreshIntervalMs(text: String): Long {
             val charCount = text.codePointCount(0, text.length).coerceAtLeast(1)


### PR DESCRIPTION
## Summary

- keep the existing 5-second DiLink music-session lease for instrument ownership
- add a separate `sendMusicName` display keepalive for DiLink 4, because the instrument restores the native song title after one marquee cycle even when session ownership is still valid
- reset the display timer whenever a new lyric/track/status update is published
- use a length-scaled refresh interval with a 4-second minimum and no upper clamp, so long lyric lines can finish their marquee before the same text is resent
- retry failed display keepalives after a bounded 1-second delay without advancing the last-success timestamp
- keep the dedicated three-line lyrics transport unchanged

## Behavior

The playing sync loop still runs every 100 ms, but both BYD leases are independently rate-limited inside the bridge:

- session lease: every 5 seconds, reasserts only `MUSIC_SOURCE_OTHERS` + PLAY
- display lease: repeats the current `sendMusicName` only after the estimated marquee interval has elapsed

The display interval is estimated from Unicode code-point count using `2.8s + 140ms/character`, with a 4-second minimum and no maximum. A normal lyric transition publishes immediately and resets the display timer. If a keepalive call fails, it retries after 1 second rather than waiting the full display interval or retrying at the 100 ms sync cadence.

## Why

Real DiLink 4 testing confirms that reasserting `MUSIC_SOURCE_OTHERS` + PLAY prevents ownership loss but does not stop the instrument UI from restoring the original track title after the lyric marquee finishes. This PR handles that separate display lifecycle directly.

## Validation

- shared tests, architecture checks and coverage: passed
- signed multi-ABI release APK build, signing and artifact upload: passed
- Codex P1 for long marquee truncation: addressed and resolved
- Codex P2 for failed keepalive retry timing: addressed and resolved
- final Codex review on `d88ecfa721`: no major issues found

Latest validated head: `d88ecfa721f8a62316f3dbd7ee85874916e4b843`.