### PR TITLE
refactor: migrate business state off Compose snapshots

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
@@ -1,8 +1,5 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,7 +7,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class PlaylistControllerState {
     private var localPlaylistChangeListener: (() -> Unit)? = null
 
-    private var localPlaylistsState by mutableStateOf<List<LocalPlaylist>>(emptyList())
+    private var localPlaylistsState: List<LocalPlaylist> = emptyList()
     var localPlaylists: List<LocalPlaylist>
         get() = localPlaylistsState
         set(value) {
@@ -18,7 +15,7 @@ internal class PlaylistControllerState {
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistState by mutableStateOf<LocalPlaylist?>(null)
+    private var selectedLocalPlaylistState: LocalPlaylist? = null
     var selectedLocalPlaylist: LocalPlaylist?
         get() = selectedLocalPlaylistState
         set(value) {
@@ -26,7 +23,7 @@ internal class PlaylistControllerState {
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistTracksState by mutableStateOf<List<MusicTrack>>(emptyList())
+    private var selectedLocalPlaylistTracksState: List<MusicTrack> = emptyList()
     var selectedLocalPlaylistTracks: List<MusicTrack>
         get() = selectedLocalPlaylistTracksState
         set(value) {
@@ -34,7 +31,7 @@ internal class PlaylistControllerState {
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistErrorState by mutableStateOf<String?>(null)
+    private var selectedLocalPlaylistErrorState: String? = null
     var selectedLocalPlaylistError: String?
         get() = selectedLocalPlaylistErrorState
         set(value) {
@@ -42,7 +39,7 @@ internal class PlaylistControllerState {
             localPlaylistChanged()
         }
 
-    private var playlistTargetTrackState by mutableStateOf<MusicTrack?>(null)
+    private var playlistTargetTrackState: MusicTrack? = null
     var playlistTargetTrack: MusicTrack?
         get() = playlistTargetTrackState
         set(value) {
@@ -50,7 +47,7 @@ internal class PlaylistControllerState {
             playlistTargetPickerChanged()
         }
 
-    private var playlistTargetTypeState by mutableStateOf(PlaylistTargetType.Provider)
+    private var playlistTargetTypeState = PlaylistTargetType.Provider
     var playlistTargetType: PlaylistTargetType
         get() = playlistTargetTypeState
         set(value) {
@@ -58,7 +55,7 @@ internal class PlaylistControllerState {
             playlistTargetPickerChanged()
         }
 
-    private var playlistTargetPickerShowSwitcherState by mutableStateOf(true)
+    private var playlistTargetPickerShowSwitcherState = true
     var playlistTargetPickerShowSwitcher: Boolean
         get() = playlistTargetPickerShowSwitcherState
         set(value) {
@@ -66,7 +63,7 @@ internal class PlaylistControllerState {
             playlistTargetPickerChanged()
         }
 
-    private var playlistOperationTargetsState by mutableStateOf<List<ProviderPlaylist>>(emptyList())
+    private var playlistOperationTargetsState: List<ProviderPlaylist> = emptyList()
     var playlistOperationTargets: List<ProviderPlaylist>
         get() = playlistOperationTargetsState
         set(value) {
@@ -74,7 +71,7 @@ internal class PlaylistControllerState {
             playlistTargetPickerChanged()
         }
 
-    private var playlistOperationErrorState by mutableStateOf<String?>(null)
+    private var playlistOperationErrorState: String? = null
     var playlistOperationError: String?
         get() = playlistOperationErrorState
         set(value) {
@@ -86,17 +83,15 @@ internal class PlaylistControllerState {
     val playlistTargetPickerFlow: StateFlow<PlaylistTargetPickerUiState> =
         mutablePlaylistTargetPickerState.asStateFlow()
 
-    private val playlistOperationFeedbackState = mutableStateOf<String?>(null)
     private val mutablePlaylistOperationFeedback = MutableStateFlow<String?>(null)
     val playlistOperationFeedbackFlow: StateFlow<String?> = mutablePlaylistOperationFeedback.asStateFlow()
     var playlistOperationFeedback: String?
-        get() = playlistOperationFeedbackState.value
+        get() = mutablePlaylistOperationFeedback.value
         set(value) {
-            playlistOperationFeedbackState.value = value
             mutablePlaylistOperationFeedback.value = value
         }
 
-    private var localPlaylistOperationErrorState by mutableStateOf<String?>(null)
+    private var localPlaylistOperationErrorState: String? = null
     var localPlaylistOperationError: String?
         get() = localPlaylistOperationErrorState
         set(value) {
@@ -105,7 +100,7 @@ internal class PlaylistControllerState {
             playlistTargetPickerChanged()
         }
 
-    private var localPlaylistImportPreviewState by mutableStateOf<LocalPlaylistImportPreview?>(null)
+    private var localPlaylistImportPreviewState: LocalPlaylistImportPreview? = null
     var localPlaylistImportPreview: LocalPlaylistImportPreview?
         get() = localPlaylistImportPreviewState
         set(value) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/PlaylistControllerState.kt
@@ -3,79 +3,87 @@ package org.feeluown.mobile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+internal data class PlaylistControllerSnapshot(
+    val localPlaylists: List<LocalPlaylist> = emptyList(),
+    val selectedLocalPlaylist: LocalPlaylist? = null,
+    val selectedLocalPlaylistTracks: List<MusicTrack> = emptyList(),
+    val selectedLocalPlaylistError: String? = null,
+    val playlistTargetTrack: MusicTrack? = null,
+    val playlistTargetType: PlaylistTargetType = PlaylistTargetType.Provider,
+    val playlistTargetPickerShowSwitcher: Boolean = true,
+    val playlistOperationTargets: List<ProviderPlaylist> = emptyList(),
+    val playlistOperationError: String? = null,
+    val localPlaylistOperationError: String? = null,
+    val localPlaylistImportPreview: LocalPlaylistImportPreview? = null,
+)
 
 internal class PlaylistControllerState {
     private var localPlaylistChangeListener: (() -> Unit)? = null
+    private val mutableState = MutableStateFlow(PlaylistControllerSnapshot())
+    val state: StateFlow<PlaylistControllerSnapshot> = mutableState.asStateFlow()
 
-    private var localPlaylistsState: List<LocalPlaylist> = emptyList()
     var localPlaylists: List<LocalPlaylist>
-        get() = localPlaylistsState
+        get() = mutableState.value.localPlaylists
         set(value) {
-            localPlaylistsState = value
+            update { it.copy(localPlaylists = value) }
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistState: LocalPlaylist? = null
     var selectedLocalPlaylist: LocalPlaylist?
-        get() = selectedLocalPlaylistState
+        get() = mutableState.value.selectedLocalPlaylist
         set(value) {
-            selectedLocalPlaylistState = value
+            update { it.copy(selectedLocalPlaylist = value) }
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistTracksState: List<MusicTrack> = emptyList()
     var selectedLocalPlaylistTracks: List<MusicTrack>
-        get() = selectedLocalPlaylistTracksState
+        get() = mutableState.value.selectedLocalPlaylistTracks
         set(value) {
-            selectedLocalPlaylistTracksState = value
+            update { it.copy(selectedLocalPlaylistTracks = value) }
             localPlaylistChanged()
         }
 
-    private var selectedLocalPlaylistErrorState: String? = null
     var selectedLocalPlaylistError: String?
-        get() = selectedLocalPlaylistErrorState
+        get() = mutableState.value.selectedLocalPlaylistError
         set(value) {
-            selectedLocalPlaylistErrorState = value
+            update { it.copy(selectedLocalPlaylistError = value) }
             localPlaylistChanged()
         }
 
-    private var playlistTargetTrackState: MusicTrack? = null
     var playlistTargetTrack: MusicTrack?
-        get() = playlistTargetTrackState
+        get() = mutableState.value.playlistTargetTrack
         set(value) {
-            playlistTargetTrackState = value
+            update { it.copy(playlistTargetTrack = value) }
             playlistTargetPickerChanged()
         }
 
-    private var playlistTargetTypeState = PlaylistTargetType.Provider
     var playlistTargetType: PlaylistTargetType
-        get() = playlistTargetTypeState
+        get() = mutableState.value.playlistTargetType
         set(value) {
-            playlistTargetTypeState = value
+            update { it.copy(playlistTargetType = value) }
             playlistTargetPickerChanged()
         }
 
-    private var playlistTargetPickerShowSwitcherState = true
     var playlistTargetPickerShowSwitcher: Boolean
-        get() = playlistTargetPickerShowSwitcherState
+        get() = mutableState.value.playlistTargetPickerShowSwitcher
         set(value) {
-            playlistTargetPickerShowSwitcherState = value
+            update { it.copy(playlistTargetPickerShowSwitcher = value) }
             playlistTargetPickerChanged()
         }
 
-    private var playlistOperationTargetsState: List<ProviderPlaylist> = emptyList()
     var playlistOperationTargets: List<ProviderPlaylist>
-        get() = playlistOperationTargetsState
+        get() = mutableState.value.playlistOperationTargets
         set(value) {
-            playlistOperationTargetsState = value
+            update { it.copy(playlistOperationTargets = value) }
             playlistTargetPickerChanged()
         }
 
-    private var playlistOperationErrorState: String? = null
     var playlistOperationError: String?
-        get() = playlistOperationErrorState
+        get() = mutableState.value.playlistOperationError
         set(value) {
-            playlistOperationErrorState = value
+            update { it.copy(playlistOperationError = value) }
             playlistTargetPickerChanged()
         }
 
@@ -91,20 +99,18 @@ internal class PlaylistControllerState {
             mutablePlaylistOperationFeedback.value = value
         }
 
-    private var localPlaylistOperationErrorState: String? = null
     var localPlaylistOperationError: String?
-        get() = localPlaylistOperationErrorState
+        get() = mutableState.value.localPlaylistOperationError
         set(value) {
-            localPlaylistOperationErrorState = value
+            update { it.copy(localPlaylistOperationError = value) }
             localPlaylistChanged()
             playlistTargetPickerChanged()
         }
 
-    private var localPlaylistImportPreviewState: LocalPlaylistImportPreview? = null
     var localPlaylistImportPreview: LocalPlaylistImportPreview?
-        get() = localPlaylistImportPreviewState
+        get() = mutableState.value.localPlaylistImportPreview
         set(value) {
-            localPlaylistImportPreviewState = value
+            update { it.copy(localPlaylistImportPreview = value) }
             localPlaylistChanged()
         }
 
@@ -118,13 +124,18 @@ internal class PlaylistControllerState {
     }
 
     private fun playlistTargetPickerChanged() {
+        val current = mutableState.value
         mutablePlaylistTargetPickerState.value = PlaylistTargetPickerUiState(
-            track = playlistTargetTrackState,
-            targetType = playlistTargetTypeState,
-            showSwitcher = playlistTargetPickerShowSwitcherState,
-            providerTargets = playlistOperationTargetsState,
-            providerError = playlistOperationErrorState,
-            localError = localPlaylistOperationErrorState,
+            track = current.playlistTargetTrack,
+            targetType = current.playlistTargetType,
+            showSwitcher = current.playlistTargetPickerShowSwitcher,
+            providerTargets = current.playlistOperationTargets,
+            providerError = current.playlistOperationError,
+            localError = current.localPlaylistOperationError,
         )
+    }
+
+    private inline fun update(crossinline transform: (PlaylistControllerSnapshot) -> PlaylistControllerSnapshot) {
+        mutableState.update { current -> transform(current) }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-internal data class PlaybackQueueControllerSnapshot(
+data class PlaybackQueueState(
     val mainQueue: List<MusicTrack> = emptyList(),
     val originalMainQueue: List<MusicTrack> = emptyList(),
     val upNextQueue: List<MusicTrack> = emptyList(),
@@ -29,8 +29,8 @@ internal data class PlaybackQueueControllerSnapshot(
 internal class PlaybackQueueController {
     private var applyingStartupSnapshot = false
     private var startupDirty = false
-    private val mutableState = MutableStateFlow(PlaybackQueueControllerSnapshot())
-    val state: StateFlow<PlaybackQueueControllerSnapshot> = mutableState.asStateFlow()
+    private val mutableState = MutableStateFlow(PlaybackQueueState())
+    val state: StateFlow<PlaybackQueueState> = mutableState.asStateFlow()
 
     var mainQueue: List<MusicTrack>
         get() = mutableState.value.mainQueue
@@ -71,21 +71,9 @@ internal class PlaybackQueueController {
 
     private var pendingPlaybackStartReason: PlaybackStartReason? = null
 
-    fun currentTrack(): MusicTrack? =
-        if (currentIsUpNext) currentUpNextTrack else mainQueue.getOrNull(mainQueueIndex)
+    fun currentTrack(): MusicTrack? = mutableState.value.currentTrack()
 
-    fun displayQueue(): List<MusicTrack> = buildList {
-        currentTrack()?.let(::add)
-        addAll(upNextQueue)
-        val nextMainIndex = when {
-            currentIsUpNext -> mainQueueIndex + 1
-            mainQueueIndex >= 0 -> mainQueueIndex + 1
-            else -> 0
-        }
-        if (nextMainIndex in 0..mainQueue.size) {
-            addAll(mainQueue.drop(nextMainIndex))
-        }
-    }
+    fun displayQueue(): List<MusicTrack> = mutableState.value.displayQueue()
 
     fun displayQueueIndex(): Int = if (currentTrack() != null) 0 else -1
 
@@ -127,7 +115,7 @@ internal class PlaybackQueueController {
         if (startupDirty) return false
         applyingStartupSnapshot = true
         try {
-            mutableState.value = PlaybackQueueControllerSnapshot(
+            mutableState.value = PlaybackQueueState(
                 mainQueue = snapshot.mainQueue,
                 originalMainQueue = snapshot.originalMainQueue,
                 upNextQueue = snapshot.upNextQueue,
@@ -159,9 +147,25 @@ internal class PlaybackQueueController {
     }
 
     private inline fun update(
-        crossinline transform: (PlaybackQueueControllerSnapshot) -> PlaybackQueueControllerSnapshot,
+        crossinline transform: (PlaybackQueueState) -> PlaybackQueueState,
     ) {
         if (!applyingStartupSnapshot) startupDirty = true
         mutableState.update { current -> transform(current) }
+    }
+}
+
+internal fun PlaybackQueueState.currentTrack(): MusicTrack? =
+    if (currentIsUpNext) currentUpNextTrack else mainQueue.getOrNull(mainQueueIndex)
+
+internal fun PlaybackQueueState.displayQueue(): List<MusicTrack> = buildList {
+    currentTrack()?.let(::add)
+    addAll(upNextQueue)
+    val nextMainIndex = when {
+        currentIsUpNext -> mainQueueIndex + 1
+        mainQueueIndex >= 0 -> mainQueueIndex + 1
+        else -> 0
+    }
+    if (nextMainIndex in 0..mainQueue.size) {
+        addAll(mainQueue.drop(nextMainIndex))
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueController.kt
@@ -1,9 +1,24 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import kotlin.properties.ReadWriteProperty
-import kotlin.reflect.KProperty
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+internal data class PlaybackQueueControllerSnapshot(
+    val mainQueue: List<MusicTrack> = emptyList(),
+    val originalMainQueue: List<MusicTrack> = emptyList(),
+    val upNextQueue: List<MusicTrack> = emptyList(),
+    val mainQueueIndex: Int = -1,
+    val currentUpNextTrack: MusicTrack? = null,
+    val currentIsUpNext: Boolean = false,
+    val queueFeature: ProviderFeature? = null,
+    val queuePlaylistId: String? = null,
+    val shuffleEnabled: Boolean = false,
+    val repeatMode: RepeatMode = RepeatMode.QUEUE,
+    val isFmQueue: Boolean = false,
+    val shuffleBeforeFm: Boolean? = null,
+)
 
 /**
  * Owns the durable playback-queue state independently from the app controller.
@@ -14,19 +29,46 @@ import kotlin.reflect.KProperty
 internal class PlaybackQueueController {
     private var applyingStartupSnapshot = false
     private var startupDirty = false
+    private val mutableState = MutableStateFlow(PlaybackQueueControllerSnapshot())
+    val state: StateFlow<PlaybackQueueControllerSnapshot> = mutableState.asStateFlow()
 
-    var mainQueue by trackedStateOf<List<MusicTrack>>(emptyList())
-    var originalMainQueue by trackedStateOf<List<MusicTrack>>(emptyList())
-    var upNextQueue by trackedStateOf<List<MusicTrack>>(emptyList())
-    var mainQueueIndex by trackedStateOf(-1)
-    var currentUpNextTrack by trackedStateOf<MusicTrack?>(null)
-    var currentIsUpNext by trackedStateOf(false)
-    var queueFeature by trackedStateOf<ProviderFeature?>(null)
-    var queuePlaylistId by trackedStateOf<String?>(null)
-    var shuffleEnabled by trackedStateOf(false)
-    var repeatMode by trackedStateOf(RepeatMode.QUEUE)
-    var isFmQueue by trackedStateOf(false)
-    var shuffleBeforeFm by trackedStateOf<Boolean?>(null)
+    var mainQueue: List<MusicTrack>
+        get() = mutableState.value.mainQueue
+        set(value) = update { it.copy(mainQueue = value) }
+    var originalMainQueue: List<MusicTrack>
+        get() = mutableState.value.originalMainQueue
+        set(value) = update { it.copy(originalMainQueue = value) }
+    var upNextQueue: List<MusicTrack>
+        get() = mutableState.value.upNextQueue
+        set(value) = update { it.copy(upNextQueue = value) }
+    var mainQueueIndex: Int
+        get() = mutableState.value.mainQueueIndex
+        set(value) = update { it.copy(mainQueueIndex = value) }
+    var currentUpNextTrack: MusicTrack?
+        get() = mutableState.value.currentUpNextTrack
+        set(value) = update { it.copy(currentUpNextTrack = value) }
+    var currentIsUpNext: Boolean
+        get() = mutableState.value.currentIsUpNext
+        set(value) = update { it.copy(currentIsUpNext = value) }
+    var queueFeature: ProviderFeature?
+        get() = mutableState.value.queueFeature
+        set(value) = update { it.copy(queueFeature = value) }
+    var queuePlaylistId: String?
+        get() = mutableState.value.queuePlaylistId
+        set(value) = update { it.copy(queuePlaylistId = value) }
+    var shuffleEnabled: Boolean
+        get() = mutableState.value.shuffleEnabled
+        set(value) = update { it.copy(shuffleEnabled = value) }
+    var repeatMode: RepeatMode
+        get() = mutableState.value.repeatMode
+        set(value) = update { it.copy(repeatMode = value) }
+    var isFmQueue: Boolean
+        get() = mutableState.value.isFmQueue
+        set(value) = update { it.copy(isFmQueue = value) }
+    var shuffleBeforeFm: Boolean?
+        get() = mutableState.value.shuffleBeforeFm
+        set(value) = update { it.copy(shuffleBeforeFm = value) }
+
     private var pendingPlaybackStartReason: PlaybackStartReason? = null
 
     fun currentTrack(): MusicTrack? =
@@ -56,11 +98,19 @@ internal class PlaybackQueueController {
             ?: PlaybackStartReason.AUTO_NEXT
 
     fun updateCurrentTrack(track: MusicTrack) {
-        if (currentIsUpNext) {
-            currentUpNextTrack = track
-        } else if (mainQueueIndex in mainQueue.indices) {
-            mainQueue = mainQueue.mapIndexed { index, item -> if (index == mainQueueIndex) track else item }
-            originalMainQueue = originalMainQueue.map { item -> if (item.id == track.id) track else item }
+        val current = mutableState.value
+        when {
+            current.currentIsUpNext -> update { it.copy(currentUpNextTrack = track) }
+            current.mainQueueIndex in current.mainQueue.indices -> update { snapshot ->
+                snapshot.copy(
+                    mainQueue = snapshot.mainQueue.mapIndexed { index, item ->
+                        if (index == snapshot.mainQueueIndex) track else item
+                    },
+                    originalMainQueue = snapshot.originalMainQueue.map { item ->
+                        if (item.id == track.id) track else item
+                    },
+                )
+            }
         }
     }
 
@@ -77,16 +127,16 @@ internal class PlaybackQueueController {
         if (startupDirty) return false
         applyingStartupSnapshot = true
         try {
-            mainQueue = snapshot.mainQueue
-            originalMainQueue = snapshot.originalMainQueue
-            upNextQueue = snapshot.upNextQueue
-            mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex)
-            shuffleEnabled = snapshot.shuffleEnabled
-            repeatMode = snapshot.repeatMode
-            isFmQueue = snapshot.isFmQueue
-            shuffleBeforeFm = snapshot.shuffleBeforeFm
-            currentUpNextTrack = null
-            currentIsUpNext = false
+            mutableState.value = PlaybackQueueControllerSnapshot(
+                mainQueue = snapshot.mainQueue,
+                originalMainQueue = snapshot.originalMainQueue,
+                upNextQueue = snapshot.upNextQueue,
+                mainQueueIndex = snapshot.queueIndex.coerceIn(-1, snapshot.mainQueue.lastIndex),
+                shuffleEnabled = snapshot.shuffleEnabled,
+                repeatMode = snapshot.repeatMode,
+                isFmQueue = snapshot.isFmQueue,
+                shuffleBeforeFm = snapshot.shuffleBeforeFm,
+            )
             pendingPlaybackStartReason = null
         } finally {
             applyingStartupSnapshot = false
@@ -94,26 +144,24 @@ internal class PlaybackQueueController {
         return true
     }
 
-    fun snapshot(): PlaybackQueueSnapshot = PlaybackQueueSnapshot(
-        mainQueue = mainQueue,
-        originalMainQueue = originalMainQueue,
-        upNextQueue = upNextQueue,
-        queueIndex = mainQueueIndex,
-        shuffleEnabled = shuffleEnabled,
-        repeatMode = repeatMode,
-        isFmQueue = isFmQueue,
-        shuffleBeforeFm = shuffleBeforeFm,
-    )
+    fun snapshot(): PlaybackQueueSnapshot {
+        val current = mutableState.value
+        return PlaybackQueueSnapshot(
+            mainQueue = current.mainQueue,
+            originalMainQueue = current.originalMainQueue,
+            upNextQueue = current.upNextQueue,
+            queueIndex = current.mainQueueIndex,
+            shuffleEnabled = current.shuffleEnabled,
+            repeatMode = current.repeatMode,
+            isFmQueue = current.isFmQueue,
+            shuffleBeforeFm = current.shuffleBeforeFm,
+        )
+    }
 
-    private fun <T> trackedStateOf(initialValue: T): ReadWriteProperty<Any?, T> {
-        val state: MutableState<T> = mutableStateOf(initialValue)
-        return object : ReadWriteProperty<Any?, T> {
-            override fun getValue(thisRef: Any?, property: KProperty<*>): T = state.value
-
-            override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
-                if (!applyingStartupSnapshot) startupDirty = true
-                state.value = value
-            }
-        }
+    private inline fun update(
+        crossinline transform: (PlaybackQueueControllerSnapshot) -> PlaybackQueueControllerSnapshot,
+    ) {
+        if (!applyingStartupSnapshot) startupDirty = true
+        mutableState.update { current -> transform(current) }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackQueueCoordinator.kt
@@ -49,6 +49,7 @@ internal class PlaybackQueueCoordinator(
     override var trackChangeDirection by mutableStateOf(TrackChangeDirection.Next)
         private set
     override val feedback: StateFlow<String?> = mutableFeedback.asStateFlow()
+    override val queueStateFlow: StateFlow<PlaybackQueueState> = queueState.state
 
     override val currentQueueTrack: MusicTrack?
         get() = queueState.currentTrack()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackReplacementController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackReplacementController.kt
@@ -1,11 +1,11 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
@@ -21,8 +21,11 @@ internal class PlaybackReplacementController(
     private val openTrackDetail: (MusicTrack) -> Unit,
     private val failureMessage: (Throwable, String, String?) -> String,
 ) : ReplacementActionPort {
-    override var replacementCandidateState by mutableStateOf(ReplacementCandidateState())
-        private set
+    private val mutableReplacementCandidateState = MutableStateFlow(ReplacementCandidateState())
+    override val replacementCandidateStateFlow: StateFlow<ReplacementCandidateState> =
+        mutableReplacementCandidateState.asStateFlow()
+    override val replacementCandidateState: ReplacementCandidateState
+        get() = mutableReplacementCandidateState.value
 
     private var candidatesJob: Job? = null
 
@@ -30,7 +33,7 @@ internal class PlaybackReplacementController(
         val originalTrack = track.originalDetailTrackForNavigation()
         val trackId = originalTrack.id
         candidatesJob?.cancel()
-        replacementCandidateState = ReplacementCandidateState(
+        mutableReplacementCandidateState.value = ReplacementCandidateState(
             trackId = trackId,
             isLoading = true,
         )
@@ -45,7 +48,7 @@ internal class PlaybackReplacementController(
                 }
             }.onSuccess { candidates ->
                 if (replacementCandidateState.trackId == trackId) {
-                    replacementCandidateState = ReplacementCandidateState(
+                    mutableReplacementCandidateState.value = ReplacementCandidateState(
                         trackId = trackId,
                         candidates = candidates
                             .sortedByDescending { candidate -> candidate.score }
@@ -55,7 +58,7 @@ internal class PlaybackReplacementController(
             }.onFailure { throwable ->
                 if (throwable is CancellationException) return@onFailure
                 if (replacementCandidateState.trackId == trackId) {
-                    replacementCandidateState = ReplacementCandidateState(
+                    mutableReplacementCandidateState.value = ReplacementCandidateState(
                         trackId = trackId,
                         errorMessage = failureMessage(throwable, "查询失败", originalTrack.source),
                     )
@@ -68,7 +71,7 @@ internal class PlaybackReplacementController(
         val previousTrack = currentTrack() ?: return
         val originalTrack = track.originalDetailTrackForNavigation()
         val selection = candidate.toSmartReplacementSelection()
-        replacementCandidateState = replacementCandidateState.copy(isLoading = false)
+        mutableReplacementCandidateState.value = replacementCandidateState.copy(isLoading = false)
         startManualReplacement(
             originalTrack.withReplacementSelection(selection),
             selection,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackSleepTimerController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackSleepTimerController.kt
@@ -1,8 +1,5 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -18,13 +15,15 @@ internal class PlaybackSleepTimerController(
     private val nowMillis: () -> Long,
     private val onFeedback: (String) -> Unit,
 ) : PlaybackSleepTimerPort, PlaybackEndSleepTimer {
-    var state by mutableStateOf(SleepTimerState())
+    private val mutableState = MutableStateFlow(SleepTimerState())
+    override val sleepTimerStateFlow: StateFlow<SleepTimerState> = mutableState.asStateFlow()
+    override val sleepTimerState: SleepTimerState
+        get() = mutableState.value
+    val state: SleepTimerState
+        get() = mutableState.value
 
     private val mutableFeedback = MutableStateFlow<String?>(null)
     override val feedback: StateFlow<String?> = mutableFeedback.asStateFlow()
-
-    override val sleepTimerState: SleepTimerState
-        get() = state
 
     private var timerJob: Job? = null
     private var timerSerial: Long = 0L
@@ -81,7 +80,7 @@ internal class PlaybackSleepTimerController(
         timerSerial += 1L
         timerJob?.cancel()
         timerJob = null
-        state = SleepTimerState()
+        mutableState.value = SleepTimerState()
         playbackEngine.setStopAfterCurrentTrack(false)
     }
 
@@ -117,7 +116,7 @@ internal class PlaybackSleepTimerController(
 
     private fun replace(nextState: SleepTimerState) {
         clear()
-        state = nextState
+        mutableState.value = nextState
         playbackEngine.setStopAfterCurrentTrack(nextState.mode == SleepTimerMode.EndOfTrack)
         if (nextState.mode != SleepTimerMode.Duration) return
         val deadlineMs = nextState.deadlineMs ?: return
@@ -131,7 +130,7 @@ internal class PlaybackSleepTimerController(
                     publishFeedback("睡眠定时已结束，播放已暂停")
                     break
                 }
-                state = state.copy(remainingMs = remainingMs)
+                mutableState.value = state.copy(remainingMs = remainingMs)
                 delay(minOf(remainingMs, 1_000L))
             }
         }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -70,6 +70,13 @@ fun ProvideNarrowPlaybackUi(
     graph: PlaybackUiGraph = LocalPlaybackUiPort.current,
     content: @Composable () -> Unit,
 ) {
+    val queueStateFlow = graph.queue.queueStateFlow
+    val observedQueueState = if (queueStateFlow != null) {
+        val state by queueStateFlow.collectAsStateWithLifecycle()
+        state
+    } else {
+        null
+    }
     val sleepTimerStateFlow = graph.sleepTimer.sleepTimerStateFlow
     val observedSleepTimerState = if (sleepTimerStateFlow != null) {
         val state by sleepTimerStateFlow.collectAsStateWithLifecycle()
@@ -84,6 +91,18 @@ fun ProvideNarrowPlaybackUi(
     } else {
         graph.replacement.replacementCandidateState
     }
+    val observedQueue = observedQueueState?.let { queueState ->
+        remember(graph.queue, queueState) {
+            object : PlaybackQueueUiPort by graph.queue {
+                override val currentQueueTrack: MusicTrack? = queueState.currentTrack()
+                override val queue: List<MusicTrack> = queueState.displayQueue()
+                override val displayUpNextCount: Int = queueState.upNextQueue.size
+                override val isShuffleEnabled: Boolean = queueState.shuffleEnabled
+                override val repeatMode: RepeatMode = queueState.repeatMode
+                override val isFmQueueActive: Boolean = queueState.isFmQueue
+            }
+        }
+    } ?: graph.queue
     val observedSleepTimer = remember(graph.sleepTimer, observedSleepTimerState) {
         object : PlaybackSleepTimerPort by graph.sleepTimer {
             override val sleepTimerState: SleepTimerState = observedSleepTimerState
@@ -97,7 +116,7 @@ fun ProvideNarrowPlaybackUi(
     CompositionLocalProvider(
         LocalPlaybackNavigationPort provides graph.navigation,
         LocalPlaybackPresentationPort provides graph.presentation,
-        LocalPlaybackQueueUiPort provides graph.queue,
+        LocalPlaybackQueueUiPort provides observedQueue,
         LocalPlaybackSleepTimerPort provides observedSleepTimer,
         LocalDownloadActionPort provides graph.downloads,
         LocalPlaylistActionPort provides graph.playlists,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -2,7 +2,10 @@ package org.feeluown.mobile
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**
  * Composition-only wiring graph for playback UI dependencies.
@@ -67,17 +70,41 @@ fun ProvideNarrowPlaybackUi(
     graph: PlaybackUiGraph = LocalPlaybackUiPort.current,
     content: @Composable () -> Unit,
 ) {
+    val sleepTimerStateFlow = graph.sleepTimer.sleepTimerStateFlow
+    val observedSleepTimerState = if (sleepTimerStateFlow != null) {
+        val state by sleepTimerStateFlow.collectAsStateWithLifecycle()
+        state
+    } else {
+        graph.sleepTimer.sleepTimerState
+    }
+    val replacementCandidateStateFlow = graph.replacement.replacementCandidateStateFlow
+    val observedReplacementCandidateState = if (replacementCandidateStateFlow != null) {
+        val state by replacementCandidateStateFlow.collectAsStateWithLifecycle()
+        state
+    } else {
+        graph.replacement.replacementCandidateState
+    }
+    val observedSleepTimer = remember(graph.sleepTimer, observedSleepTimerState) {
+        object : PlaybackSleepTimerPort by graph.sleepTimer {
+            override val sleepTimerState: SleepTimerState = observedSleepTimerState
+        }
+    }
+    val observedReplacement = remember(graph.replacement, observedReplacementCandidateState) {
+        object : ReplacementActionPort by graph.replacement {
+            override val replacementCandidateState: ReplacementCandidateState = observedReplacementCandidateState
+        }
+    }
     CompositionLocalProvider(
         LocalPlaybackNavigationPort provides graph.navigation,
         LocalPlaybackPresentationPort provides graph.presentation,
         LocalPlaybackQueueUiPort provides graph.queue,
-        LocalPlaybackSleepTimerPort provides graph.sleepTimer,
+        LocalPlaybackSleepTimerPort provides observedSleepTimer,
         LocalDownloadActionPort provides graph.downloads,
         LocalPlaylistActionPort provides graph.playlists,
         LocalProviderTrackActionPort provides graph.providerTrackActions,
         LocalLocalMusicActionPort provides graph.localMusicActions,
         LocalPlaybackLyricsPort provides graph.lyrics,
-        LocalReplacementActionPort provides graph.replacement,
+        LocalReplacementActionPort provides observedReplacement,
         content = content,
     )
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -60,6 +60,8 @@ interface PlaybackQueueUiPort {
     val repeatMode: RepeatMode
     val isFmQueueActive: Boolean
     val trackChangeDirection: TrackChangeDirection
+    val queueStateFlow: StateFlow<PlaybackQueueState>?
+        get() = null
     val feedback: StateFlow<String?>
         get() = EMPTY_FEEDBACK_FLOW
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -104,6 +104,8 @@ interface PlaybackQueueUiPort {
 /** Sleep-timer state, commands and transient feedback owned by playback. */
 interface PlaybackSleepTimerPort {
     val sleepTimerState: SleepTimerState
+    val sleepTimerStateFlow: StateFlow<SleepTimerState>?
+        get() = null
     val feedback: StateFlow<String?>
         get() = EMPTY_FEEDBACK_FLOW
 
@@ -201,6 +203,8 @@ interface PlaybackLyricsPort {
 /** Smart-replacement state/actions used by the now-playing surface. */
 interface ReplacementActionPort {
     val replacementCandidateState: ReplacementCandidateState
+    val replacementCandidateStateFlow: StateFlow<ReplacementCandidateState>?
+        get() = null
 
     fun loadReplacementCandidates(track: MusicTrack)
     fun selectReplacementCandidate(track: MusicTrack, candidate: ReplacementCandidate)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderControllerState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderControllerState.kt
@@ -1,41 +1,90 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+internal data class ProviderControllerSnapshot(
+    val availableProviders: List<ProviderInfo> = emptyList(),
+    val providers: List<ProviderInfo> = emptyList(),
+    val features: List<ProviderFeature> = emptyList(),
+    val capabilities: Map<String, ProviderCapabilities> = emptyMap(),
+    val authStates: Map<String, ProviderAuthState> = emptyMap(),
+    val authOperations: Map<String, ProviderSessionOperation> = emptyMap(),
+    val authErrors: Map<String, String> = emptyMap(),
+    val recommendSections: List<ProviderContentSection> = emptyList(),
+    val musicSections: List<ProviderContentSection> = emptyList(),
+    val mineSections: List<ProviderContentSection> = emptyList(),
+    val minePlaylistSections: List<ProviderContentSection> = emptyList(),
+    val mineFavoritePlaylistSections: List<ProviderContentSection> = emptyList(),
+    val lastFailure: ProviderFailure? = null,
+)
 
 internal class ProviderControllerState {
-    var availableProviders by mutableStateOf<List<ProviderInfo>>(emptyList())
-    var providers by mutableStateOf<List<ProviderInfo>>(emptyList())
-    var features by mutableStateOf<List<ProviderFeature>>(emptyList())
-    var capabilities by mutableStateOf<Map<String, ProviderCapabilities>>(emptyMap())
-    var authStates by mutableStateOf<Map<String, ProviderAuthState>>(emptyMap())
-    var authOperations by mutableStateOf<Map<String, ProviderSessionOperation>>(emptyMap())
-    var authErrors by mutableStateOf<Map<String, String>>(emptyMap())
+    private val mutableState = MutableStateFlow(ProviderControllerSnapshot())
+    val state: StateFlow<ProviderControllerSnapshot> = mutableState.asStateFlow()
 
-    private var recommendSectionsState by mutableStateOf<List<ProviderContentSection>>(emptyList())
+    var availableProviders: List<ProviderInfo>
+        get() = mutableState.value.availableProviders
+        set(value) = update { it.copy(availableProviders = value) }
+
+    var providers: List<ProviderInfo>
+        get() = mutableState.value.providers
+        set(value) = update { it.copy(providers = value) }
+
+    var features: List<ProviderFeature>
+        get() = mutableState.value.features
+        set(value) = update { it.copy(features = value) }
+
+    var capabilities: Map<String, ProviderCapabilities>
+        get() = mutableState.value.capabilities
+        set(value) = update { it.copy(capabilities = value) }
+
+    var authStates: Map<String, ProviderAuthState>
+        get() = mutableState.value.authStates
+        set(value) = update { it.copy(authStates = value) }
+
+    var authOperations: Map<String, ProviderSessionOperation>
+        get() = mutableState.value.authOperations
+        set(value) = update { it.copy(authOperations = value) }
+
+    var authErrors: Map<String, String>
+        get() = mutableState.value.authErrors
+        set(value) = update { it.copy(authErrors = value) }
+
     var recommendSections: List<ProviderContentSection>
-        get() = recommendSectionsState
-        set(value) {
-            recommendSectionsState = value.groupedByContentType()
-        }
+        get() = mutableState.value.recommendSections
+        set(value) = update { it.copy(recommendSections = value.groupedByContentType()) }
 
-    private var musicSectionsState by mutableStateOf<List<ProviderContentSection>>(emptyList())
     var musicSections: List<ProviderContentSection>
-        get() = musicSectionsState
-        set(value) {
-            musicSectionsState = value.groupedByContentType()
-        }
+        get() = mutableState.value.musicSections
+        set(value) = update { it.copy(musicSections = value.groupedByContentType()) }
 
-    var mineSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
-    var minePlaylistSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
-    var mineFavoritePlaylistSections by mutableStateOf<List<ProviderContentSection>>(emptyList())
-    var lastFailure by mutableStateOf<ProviderFailure?>(null)
+    var mineSections: List<ProviderContentSection>
+        get() = mutableState.value.mineSections
+        set(value) = update { it.copy(mineSections = value) }
+
+    var minePlaylistSections: List<ProviderContentSection>
+        get() = mutableState.value.minePlaylistSections
+        set(value) = update { it.copy(minePlaylistSections = value) }
+
+    var mineFavoritePlaylistSections: List<ProviderContentSection>
+        get() = mutableState.value.mineFavoritePlaylistSections
+        set(value) = update { it.copy(mineFavoritePlaylistSections = value) }
+
+    var lastFailure: ProviderFailure?
+        get() = mutableState.value.lastFailure
+        set(value) = update { it.copy(lastFailure = value) }
 
     fun userMessage(throwable: Throwable, fallback: String, providerId: String? = null): String {
         val failure = throwable.providerFailureOrNull(providerId)
         lastFailure = failure
         return failure?.userMessage ?: throwable.message ?: fallback
+    }
+
+    private inline fun update(crossinline transform: (ProviderControllerSnapshot) -> ProviderControllerSnapshot) {
+        mutableState.update { current -> transform(current) }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderTrackActionController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderTrackActionController.kt
@@ -1,8 +1,5 @@
 package org.feeluown.mobile
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,11 +22,6 @@ internal class ProviderTrackActionController(
     private val setMessage: (String) -> Unit,
     private val onError: (Throwable) -> Unit,
 ) : ProviderTrackActionPort {
-    var artistTargetTrack by mutableStateOf<MusicTrack?>(null)
-        private set
-    var artistTargets by mutableStateOf<List<TrackArtistTarget>>(emptyList())
-        private set
-
     private val mutableArtistTargetPickerState = MutableStateFlow(ArtistTargetPickerUiState())
     override val artistTargetPickerState: StateFlow<ArtistTargetPickerUiState> =
         mutableArtistTargetPickerState.asStateFlow()
@@ -41,13 +33,11 @@ internal class ProviderTrackActionController(
     }
 
     override fun closeArtistTargetPicker() {
-        artistTargetTrack = null
-        artistTargets = emptyList()
-        publishArtistTargetPickerState()
+        mutableArtistTargetPickerState.value = ArtistTargetPickerUiState()
     }
 
     override fun openArtistTarget(target: TrackArtistTarget) {
-        val track = artistTargetTrack ?: return
+        val track = mutableArtistTargetPickerState.value.track ?: return
         closeArtistTargetPicker()
         navigation.closeFullPlayer()
         target.mediaItem?.let(openMediaItem)
@@ -120,9 +110,10 @@ internal class ProviderTrackActionController(
             return
         }
         if (targets.size > 1) {
-            artistTargetTrack = track
-            artistTargets = targets
-            publishArtistTargetPickerState()
+            mutableArtistTargetPickerState.value = ArtistTargetPickerUiState(
+                track = track,
+                targets = targets,
+            )
             return
         }
         targets.singleOrNull()?.mediaItem?.let {
@@ -193,13 +184,6 @@ internal class ProviderTrackActionController(
         return names.mapIndexed { index, name ->
             TrackArtistTarget(name, firstItem.takeIf { index == 0 })
         }
-    }
-
-    private fun publishArtistTargetPickerState() {
-        mutableArtistTargetPickerState.value = ArtistTargetPickerUiState(
-            track = artistTargetTrack,
-            targets = artistTargets,
-        )
     }
 
     private fun publishFeedback(message: String) {

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
@@ -37,6 +37,47 @@ class PlaybackQueueControllerTest {
     }
 
     @Test
+    fun stateFlowPublishesDurableQueueMutations() {
+        val first = track("netease:1", "First")
+        val second = track("netease:2", "Second")
+        val controller = PlaybackQueueController()
+
+        controller.mainQueue = listOf(first, second)
+        controller.mainQueueIndex = 1
+        controller.repeatMode = RepeatMode.SINGLE
+
+        assertEquals(listOf(first, second), controller.state.value.mainQueue)
+        assertEquals(1, controller.state.value.mainQueueIndex)
+        assertEquals(RepeatMode.SINGLE, controller.state.value.repeatMode)
+        assertEquals(second, controller.currentTrack())
+    }
+
+    @Test
+    fun restoredSnapshotIsPublishedAsSingleStateSnapshot() {
+        val first = track("netease:1", "First")
+        val second = track("netease:2", "Second")
+        val snapshot = PlaybackQueueSnapshot(
+            mainQueue = listOf(first, second),
+            originalMainQueue = listOf(second, first),
+            upNextQueue = emptyList(),
+            queueIndex = 1,
+            shuffleEnabled = true,
+            repeatMode = RepeatMode.SINGLE,
+            isFmQueue = false,
+            shuffleBeforeFm = null,
+        )
+        val controller = PlaybackQueueController()
+
+        assertTrue(controller.restore(snapshot))
+
+        assertEquals(listOf(first, second), controller.state.value.mainQueue)
+        assertEquals(listOf(second, first), controller.state.value.originalMainQueue)
+        assertEquals(1, controller.state.value.mainQueueIndex)
+        assertTrue(controller.state.value.shuffleEnabled)
+        assertEquals(RepeatMode.SINGLE, controller.state.value.repeatMode)
+    }
+
+    @Test
     fun delayedStartupRestoreDoesNotOverwriteNewPlaylistSelection() {
         val restoredTrack = track("netease:old", "Restored")
         val oldSnapshot = PlaybackQueueController().apply {


### PR DESCRIPTION
## Summary

- migrate durable playback queue state from Compose `MutableState` delegates to a `StateFlow` snapshot while preserving queue restore/startup race semantics
- migrate provider aggregate state, sleep timer state, and smart-replacement candidate state to `StateFlow`
- make playlist target/feedback and artist target picker flows the single observable source instead of mirroring Compose state
- observe the new sleep-timer/replacement flows at the playback composition boundary so existing player UI contracts remain behavior-compatible
- keep genuinely presentation-local Compose state (player navigation/presentation adapters, `remember` UI state, download snapshot UI adapter) unchanged

## Compatibility

- existing playback UI port value getters remain available
- legacy/fake port implementations do not need to provide the new optional state flows
- queue persistence schema and playback start reason behavior are unchanged

## Tests

- extend `PlaybackQueueControllerTest` to cover StateFlow mutation publication and restored snapshot publication
- existing queue restore/startup mutation regression tests remain in place

## Validation

GitHub Actions should run the repository shared/architecture/platform checks for this PR.