### PR TITLE
fix: keep Mine page at top after initial load

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -143,7 +143,7 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
         }
         if (!initialPlaylistLoadStarted) return@LaunchedEffect
 
-        if (listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0) {
+        if (state.playlistFilter != PlaylistFilter.Local) {
             listState.scrollToItem(0)
         }
         initialPlaylistLoadPending = false

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -110,7 +110,10 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
     val fileActions = LocalLocalPlaylistFileActions.current
     val listState = rememberLazyListState()
     var initialPlaylistLoadPending by remember {
-        mutableStateOf(state.minePlaylistSections.isEmpty() && state.mineFavoritePlaylistSections.isEmpty())
+        mutableStateOf(
+            state.isLoading ||
+                (state.minePlaylistSections.isEmpty() && state.mineFavoritePlaylistSections.isEmpty()),
+        )
     }
     var initialPlaylistLoadStarted by remember { mutableStateOf(false) }
     var createLocal by remember { mutableStateOf(false) }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -21,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -106,6 +108,11 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
     val local by graph.localPlaylist.uiState.collectAsStateWithLifecycle()
     val catalog by graph.providerCatalog.uiState.collectAsStateWithLifecycle()
     val fileActions = LocalLocalPlaylistFileActions.current
+    val listState = rememberLazyListState()
+    var initialPlaylistLoadPending by remember {
+        mutableStateOf(state.minePlaylistSections.isEmpty() && state.mineFavoritePlaylistSections.isEmpty())
+    }
+    var initialPlaylistLoadStarted by remember { mutableStateOf(false) }
     var createLocal by remember { mutableStateOf(false) }
     var createProvider by remember { mutableStateOf<String?>(null) }
     var name by remember { mutableStateOf("") }
@@ -124,9 +131,31 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
         it.category == ProviderFeatureCategory.Mine && it.contentType == ProviderContentType.Songs && it.providerId in selectedMineIds
     }
 
+    LaunchedEffect(state.homeSection, state.mineSection, state.isLoading) {
+        if (!initialPlaylistLoadPending || state.homeSection != HomeSection.Mine ||
+            (state.mineSection != MineSection.Playlists && state.mineSection != MineSection.Songs)
+        ) {
+            return@LaunchedEffect
+        }
+        if (state.isLoading) {
+            initialPlaylistLoadStarted = true
+            return@LaunchedEffect
+        }
+        if (!initialPlaylistLoadStarted) return@LaunchedEffect
+
+        if (listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 0) {
+            listState.scrollToItem(0)
+        }
+        initialPlaylistLoadPending = false
+    }
+
     Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
         if (showFilter) MineFilterChips(home)
-        LazyColumn(Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             if (state.playlistFilter == PlaylistFilter.UserPlaylists && frequent.isNotEmpty()) {
                 item("mine-frequent") {
                     Text("我的常听", style = MaterialTheme.typography.titleMedium)


### PR DESCRIPTION
## Summary
- keep an explicit `LazyListState` for the Mine playlist list
- detect only the first Mine-page playlist load while Mine is actually selected
- reset the list to item 0 once that initial async load finishes
- preserve normal scroll position for later refreshes and navigation

## Root cause
At startup, provider catalog content such as `mine-songs` can be rendered before async playlist sections arrive. Because the LazyColumn items use stable keys, Compose keeps the initially visible bottom item anchored while new playlist sections are inserted before it, making the page appear to start at the bottom.

## Validation
- diff is limited to Mine playlist UI state/initial-load handling
- no item keys or incremental loading behavior changed