### PR TITLE
refactor: decompose app shell architecture

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppContainer.kt
@@ -323,8 +323,8 @@ internal class AndroidAppContainer(
 
     private val playbackSession: PlaybackSession by lazy(::wirePlaybackRuntime)
 
-    val appViewModel: FuoAppViewModel by lazy {
-        FuoAppViewModel(
+    val appUiGraph: AppUiGraph by lazy {
+        createAppUiGraph(
             playbackSession = playbackSession,
             playbackNavigationPort = playbackFeatureOwner.navigation,
             playbackPresentationPort = playbackPresentationPort,
@@ -347,12 +347,33 @@ internal class AndroidAppContainer(
             homeFeatureController = homeFeatureController,
             sharedResourceActionPort = sharedResourceActionPort,
             searchController = searchController,
-            recognitionController = recognitionController,
             searchAppPort = searchAppPort,
+            recognitionController = recognitionController,
             recognitionAppPort = recognitionAppPort,
-            settingsRepository = settingsRepository,
-            providerSessionRepository = providerSessionRepository,
+        )
+    }
+
+    private val appBackCoordinator: AppBackCoordinator by lazy {
+        createAppBackCoordinator(
             navigator = navigator,
+            playbackNavigationPort = playbackFeatureOwner.navigation,
+            playlistActionPort = playlistActionPort,
+            providerTrackActionPort = providerTrackActionPort,
+            localMusicFeatureController = localMusicFeatureController,
+            providerDetailOwners = providerDetailOwners,
+            searchAppPort = searchAppPort,
+            recognitionController = recognitionController,
+            settingsFeatureController = settingsFeatureController,
+            localPlaylistFeatureController = localPlaylistFeatureController,
+        )
+    }
+
+    val appViewModel: FuoAppViewModel by lazy {
+        FuoAppViewModel(
+            settingsRepository = settingsRepository,
+            navigator = navigator,
+            recognitionController = recognitionController,
+            backCoordinator = appBackCoordinator,
         )
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -24,6 +24,9 @@ class FuoEvolveApplication : Application() {
     internal val settingsRepository: AppSettingsRepository
         get() = container().settingsRepository
 
+    internal val appUiGraph: AppUiGraph
+        get() = container().appUiGraph
+
     val appViewModel: FuoAppViewModel
         get() = container().appViewModel
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : ComponentActivity() {
             var hasImagePermission by remember { mutableStateOf(hasImagePermission()) }
             var hasMicrophonePermission by remember { mutableStateOf(hasMicrophonePermission()) }
             val appViewModel = fuoApplication.appViewModel
+            val appUiGraph = fuoApplication.appUiGraph
             val providerCredentialBackup = fuoApplication.providerCredentialBackup
             remember { AndroidPredictiveBackPreference.initialize(this@MainActivity); Unit }
             val predictiveBackEnabled by AndroidPredictiveBackPreference.enabled
@@ -67,7 +68,7 @@ class MainActivity : ComponentActivity() {
             ) { result ->
                 hasAudioPermission = hasPermissions(result, audioPermissions())
                 hasImagePermission = hasPermissions(result, imagePermissions())
-                appViewModel.localMusicFeatureController.onPermissionChange(hasAudioPermission)
+                appUiGraph.localMusic.onPermissionChange(hasAudioPermission)
             }
             val microphonePermissionLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestPermission(),
@@ -77,10 +78,11 @@ class MainActivity : ComponentActivity() {
             }
             val notificationPermissionLauncher = rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestPermission(),
-            ) { appViewModel.providerAuthFeatureController.startYtmusicTvOAuthLogin() }
+            ) { appUiGraph.providerAuth.startYtmusicTvOAuthLogin() }
 
             val lifecycleOwner = LocalLifecycleOwner.current
             val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
+            val appShellHandlesBack by appViewModel.handlesTransientBack.collectAsStateWithLifecycle()
             val systemDark = LocalConfiguration.current.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
             SideEffect { configureSystemBars(resolveDarkTheme(appUiState.themeMode, systemDark)) }
             DisposableEffect(lifecycleOwner) {
@@ -89,7 +91,7 @@ class MainActivity : ComponentActivity() {
                         hasAudioPermission = hasAudioPermission()
                         hasImagePermission = hasImagePermission()
                         hasMicrophonePermission = hasMicrophonePermission()
-                        appViewModel.localMusicFeatureController.onPermissionChange(hasAudioPermission)
+                        appUiGraph.localMusic.onPermissionChange(hasAudioPermission)
                         appViewModel.onMicrophonePermissionChange(hasMicrophonePermission)
                     }
                 }
@@ -106,19 +108,19 @@ class MainActivity : ComponentActivity() {
                 if (result.resultCode == RESULT_OK) {
                     val cookies = result.data?.getStringExtra(ProviderWebLoginActivity.EXTRA_COOKIES_JSON).orEmpty()
                     if (providerId.isNotBlank() && cookies.isNotBlank()) {
-                        appViewModel.providerAuthFeatureController.loginWithCookies(providerId, cookies)
+                        appUiGraph.providerAuth.loginWithCookies(providerId, cookies)
                     }
                 }
                 pendingWebLoginProviderId = null
             }
             val ytmusicHeaderFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
                 if (uri != null) {
-                    appViewModel.providerAuthFeatureController.loginYtmusicWithHeaderFile(readText(uri))
+                    appUiGraph.providerAuth.loginYtmusicWithHeaderFile(readText(uri))
                 }
             }
             val ytmusicOAuthFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
                 if (uri != null) {
-                    appViewModel.providerAuthFeatureController.importYtmusicOAuthRelatedJson(readText(uri))
+                    appUiGraph.providerAuth.importYtmusicOAuthRelatedJson(readText(uri))
                 }
             }
 
@@ -176,7 +178,7 @@ class MainActivity : ComponentActivity() {
                 if (uri != null) {
                     val content = readText(uri)
                     if (content.isBlank()) appViewModel.showFeedback("无法读取本地歌单文件")
-                    else appViewModel.localPlaylistFeatureController.prepareImport(displayNameFor(uri), content)
+                    else appUiGraph.localPlaylist.prepareImport(displayNameFor(uri), content)
                 }
             }
             val localPlaylistExportLauncher = rememberLauncherForActivityResult(
@@ -192,64 +194,61 @@ class MainActivity : ComponentActivity() {
                 pendingLocalPlaylistExport = null
             }
 
-            val appShellHandlesBack = appViewModel.playbackUiPort.isFullPlayerOpen ||
-                appViewModel.playbackNavigationPort.isQueueOpen ||
-                appViewModel.providerDetailOwners.video.uiState.value.isFullscreen ||
-                appViewModel.playlistActionPort.targetPickerState.value.track != null ||
-                appViewModel.providerTrackActionPort.artistTargetPickerState.value.track != null ||
-                appViewModel.localMusicFeatureController.uiState.value.metadataEditorTrack != null
             val useLegacyPageBack = AndroidPredictiveBackPreference.isSupported && !predictiveBackEnabled &&
                 appUiState.backStack.size > 1 && appUiState.backStack.lastOrNull() != AppRoute.Settings
             BackHandler(enabled = appShellHandlesBack || useLegacyPageBack) {
-                appViewModel.dispatch(AppIntent.NavigateBack)
+                appViewModel.onBack()
             }
 
             LaunchedEffect(Unit) {
                 launchLocalPlaylistImport?.let(::handleLocalPlaylistImport)
-                launchSharedText?.let(appViewModel.sharedResourceActionPort::open)
+                launchSharedText?.let(appUiGraph.sharedResources::open)
             }
 
             CompositionLocalProvider(LocalProviderCredentialBackupActions provides credentialBackupActions) {
                 AppRoot(
                     appViewModel = appViewModel,
-                    hasAudioPermission = hasAudioPermission,
-                    hasImagePermission = hasImagePermission,
-                    appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                    onRequestAudioPermission = { permissionLauncher.launch(mediaPermissions()) },
-                    onRequestImagePermission = { permissionLauncher.launch(imagePermissions()) },
-                    hasMicrophonePermission = hasMicrophonePermission,
-                    onRequestMicrophonePermission = { microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
-                    onOpenProviderWebLogin = { provider ->
-                        if (provider.loginConfig != null) {
-                            pendingWebLoginProviderId = provider.providerId
-                            webLoginLauncher.launch(ProviderWebLoginActivity.createIntent(this@MainActivity, provider))
-                        }
-                    },
-                    onLogoutProvider = { provider ->
-                        ProviderWebLoginActivity.clearWebLoginState()
-                        appViewModel.providerAuthFeatureController.logout(provider.providerId)
-                    },
-                    onImportYtmusicHeaderFile = { ytmusicHeaderFileLauncher.launch(arrayOf("application/json")) },
-                    onImportYtmusicOAuthFile = { ytmusicOAuthFileLauncher.launch(arrayOf("application/json")) },
-                    onStartYtmusicOAuth = {
-                        val oauthInput = appViewModel.providerAuthFeatureController.oauthInput("ytmusic")
-                        val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                            ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
-                        if (oauthInput.clientId.isNotBlank() && oauthInput.clientSecret.isNotBlank() && needsPermission) {
-                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                        } else {
-                            appViewModel.providerAuthFeatureController.startYtmusicTvOAuthLogin()
-                        }
-                    },
-                    onImportLocalPlaylistFile = {
-                        localPlaylistFileLauncher.launch(arrayOf("text/plain", "application/octet-stream", "application/x-fuo", "*/*"))
-                    },
-                    onExportLocalPlaylistFile = { fileName, content ->
-                        pendingLocalPlaylistExport = PendingLocalPlaylistExport(fileName, content)
-                        localPlaylistExportLauncher.launch(fileName)
-                    },
-                    onShareLocalPlaylistFile = ::shareLocalPlaylistFile,
-                    onShareText = ::shareText,
+                    uiGraph = appUiGraph,
+                    platform = AppPlatformBindings(
+                        hasAudioPermission = hasAudioPermission,
+                        hasImagePermission = hasImagePermission,
+                        appVersionInfo = "版本 ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                        onRequestAudioPermission = { permissionLauncher.launch(mediaPermissions()) },
+                        onRequestImagePermission = { permissionLauncher.launch(imagePermissions()) },
+                        hasMicrophonePermission = hasMicrophonePermission,
+                        onRequestMicrophonePermission = { microphonePermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+                        onOpenProviderWebLogin = { provider ->
+                            if (provider.loginConfig != null) {
+                                pendingWebLoginProviderId = provider.providerId
+                                webLoginLauncher.launch(ProviderWebLoginActivity.createIntent(this@MainActivity, provider))
+                            }
+                        },
+                        onLogoutProvider = { provider ->
+                            ProviderWebLoginActivity.clearWebLoginState()
+                            appUiGraph.providerAuth.logout(provider.providerId)
+                        },
+                        onImportYtmusicHeaderFile = { ytmusicHeaderFileLauncher.launch(arrayOf("application/json")) },
+                        onImportYtmusicOAuthFile = { ytmusicOAuthFileLauncher.launch(arrayOf("application/json")) },
+                        onStartYtmusicOAuth = {
+                            val oauthInput = appUiGraph.providerAuth.oauthInput("ytmusic")
+                            val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                ContextCompat.checkSelfPermission(this@MainActivity, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+                            if (oauthInput.clientId.isNotBlank() && oauthInput.clientSecret.isNotBlank() && needsPermission) {
+                                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                            } else {
+                                appUiGraph.providerAuth.startYtmusicTvOAuthLogin()
+                            }
+                        },
+                        onImportLocalPlaylistFile = {
+                            localPlaylistFileLauncher.launch(arrayOf("text/plain", "application/octet-stream", "application/x-fuo", "*/*"))
+                        },
+                        onExportLocalPlaylistFile = { fileName, content ->
+                            pendingLocalPlaylistExport = PendingLocalPlaylistExport(fileName, content)
+                            localPlaylistExportLauncher.launch(fileName)
+                        },
+                        onShareLocalPlaylistFile = ::shareLocalPlaylistFile,
+                        onShareText = ::shareText,
+                    ),
                 )
 
                 ProviderCredentialBackupDialogs(
@@ -262,9 +261,9 @@ class MainActivity : ComponentActivity() {
                     onExportFile = { fileName -> providerCredentialExportLauncher.launch(fileName) },
                     onRestored = { restoredProviderIds ->
                         val restored = restoredProviderIds.toSet()
-                        val providers = appViewModel.providerCatalogFeatureController.uiState.value.availableProviders
+                        val providers = appUiGraph.providerCatalog.uiState.value.availableProviders
                             .filter { provider -> provider.providerId in restored }
-                        appViewModel.providerAuthFeatureController.refreshAll(providers, refreshUserInfo = true)
+                        appUiGraph.providerAuth.refreshAll(providers, refreshUserInfo = true)
                     },
                     onFeedback = appViewModel::showFeedback,
                 )
@@ -274,7 +273,7 @@ class MainActivity : ComponentActivity() {
                 enabled = !appShellHandlesBack && AndroidPredictiveBackPreference.isSupported && !predictiveBackEnabled &&
                     appUiState.backStack.lastOrNull() != AppRoute.Settings,
             ) {
-                if (appUiState.backStack.size > 1) appViewModel.dispatch(AppIntent.NavigateBack) else finish()
+                if (appUiState.backStack.size > 1) appViewModel.onBack() else finish()
             }
         }
     }
@@ -290,7 +289,7 @@ class MainActivity : ComponentActivity() {
         if (handleOAuthUserCodeCopyIntent(intent)) return
         localPlaylistImportFromIntent(intent)?.let { handleLocalPlaylistImport(it); return }
         sharedTextFromIntent(intent)?.let {
-            (application as FuoEvolveApplication).appViewModel.sharedResourceActionPort.open(it)
+            (application as FuoEvolveApplication).appUiGraph.sharedResources.open(it)
         }
     }
 
@@ -365,9 +364,9 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun handleLocalPlaylistImport(pending: PendingLocalPlaylistImport) {
-        val vm = (application as FuoEvolveApplication).appViewModel
-        if (pending.content.isBlank()) vm.showFeedback("无法读取本地歌单文件")
-        else vm.localPlaylistFeatureController.prepareImport(pending.fileName, pending.content)
+        val application = application as FuoEvolveApplication
+        if (pending.content.isBlank()) application.appViewModel.showFeedback("无法读取本地歌单文件")
+        else application.appUiGraph.localPlaylist.prepareImport(pending.fileName, pending.content)
     }
 
     private fun configureSystemBars(darkTheme: Boolean) {

--- a/docs/app-shell-architecture.md
+++ b/docs/app-shell-architecture.md
@@ -1,0 +1,31 @@
+# App shell architecture
+
+The common app shell separates state ownership, presentation wiring, back coordination and platform capabilities.
+
+## Ownership
+
+- `FuoAppViewModel` owns only app-scoped startup/theme/navigation projection, global app feedback and application lifecycle/navigation events.
+- `AppUiGraph` is composition-only wiring. It groups existing feature owners and narrow UI ports without owning business state or dispatching generic actions.
+- `AppBackCoordinator` owns transient-overlay back precedence and typed-route close coordination so Android/iOS hosts do not know individual overlay implementations.
+- `AppPlatformBindings` is the explicit boundary for permissions, file pickers/export/share and provider web-login callbacks supplied by platform hosts.
+
+## Compose shell
+
+`AppRoot` is the bootstrap entry only. After initialization/onboarding it delegates to `AppShell`.
+
+`AppShell` installs composition-local UI graphs and contains four focused pieces:
+
+- `AppNavHost` — exhaustive typed-route rendering and navigation transitions;
+- `AppGlobalOverlays` — FullPlayer and app-global dialogs/pickers;
+- `AppFeedbackHost` — lifecycle-aware aggregation of feature-local transient feedback;
+- `AppShellComposition` — responsive-layout and mini-player visibility policy.
+
+Feature state remains in the feature owner. The shell only observes state required to compose routes, global overlays and layout policy.
+
+## Composition roots
+
+`AndroidAppContainer` and `IosAppContainer` construct the feature owners, `AppUiGraph`, `AppBackCoordinator` and the narrowed `FuoAppViewModel`. Platform activities/view-controller hosts consume `AppUiGraph` directly for platform integration instead of treating the ViewModel as a feature service locator.
+
+The dependency direction remains:
+
+`platform composition root -> app/shared integration -> feature owner -> stable core/api/persistence contracts`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,13 +159,13 @@ Cross-feature behavior must use the smallest stable contract. Examples:
 
 ## App shell and composition roots
 
-Android uses `AndroidAppContainer`; iOS uses `IosAppContainer`. They construct platform repositories/adapters and compose feature owners, playback runtime and app ports directly. Manual DI remains intentional; a dependency-injection framework is not required to hide this composition graph.
+Android uses `AndroidAppContainer`; iOS uses `IosAppContainer`. They construct platform repositories/adapters, feature owners, playback runtime and app ports directly. Manual DI remains intentional; a dependency-injection framework is not required to hide this composition graph.
 
-`AppRoot` is the canonical common Compose entry and renders typed routes. The P2-era `P2AppRoot` compatibility entry and `LegacyProviderDetailRouteBridge` are retired.
+`AppRoot` is the canonical common Compose bootstrap entry. It owns theme/startup/onboarding gating and delegates the initialized application to `AppShell`. Typed route rendering lives in `AppNavHost`; global player/dialog overlays and transient feedback are composed by dedicated shell components. The P2-era `P2AppRoot` compatibility entry and `LegacyProviderDetailRouteBridge` remain retired.
 
 `AppUiState` is intentionally app-scoped: initialization, onboarding, theme projection and navigation back stack. It must not again become a container for the full settings model, provider sessions or feature-local state.
 
-`FuoAppViewModel` still exposes application wiring required by `AppRoot`; feature business ownership nevertheless remains in feature owners. Future reductions should target demonstrated coupling rather than replacing explicit wiring with another broad facade.
+`FuoAppViewModel` owns only app-scoped state projection and app-level events. Presentation wiring is supplied separately through `AppUiGraph`, which groups existing feature owners and narrow UI ports without owning business state. `AppBackCoordinator` owns transient-overlay/route back precedence so platform hosts do not duplicate feature-specific back rules, while `AppPlatformBindings` carries permissions, file/share and provider-login callbacks into the common shell. This split must not be replaced by another generic controller, service locator or state aggregate. See [`app-shell-architecture.md`](app-shell-architecture.md) for the detailed shell structure.
 
 ## Architecture fitness checks
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppBackCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppBackCoordinator.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 internal data class AppBackTarget(
@@ -21,9 +22,12 @@ class AppBackCoordinator internal constructor(
     private val transientTargets: List<AppBackTarget>,
     private val closeRoute: (AppRoute) -> Boolean,
 ) {
-    val hasTransientBack: Flow<Boolean> = combine(transientTargets.map(AppBackTarget::active)) { active ->
-        active.any { it }
-    }.distinctUntilChanged()
+    val hasTransientBack: Flow<Boolean> = if (transientTargets.isEmpty()) {
+        flowOf(false)
+    } else {
+        combine(transientTargets.map { it.active }) { active -> active.any { it } }
+            .distinctUntilChanged()
+    }
 
     val hasTransientBackNow: Boolean
         get() = transientTargets.any { it.isActiveNow() }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppBackCoordinator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppBackCoordinator.kt
@@ -1,0 +1,144 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+internal data class AppBackTarget(
+    val active: Flow<Boolean>,
+    val isActiveNow: () -> Boolean,
+    val dismiss: () -> Unit,
+)
+
+/**
+ * Owns app-shell back precedence without making platform hosts aware of individual overlays.
+ * Transient UI is dismissed before the current typed route is closed.
+ */
+class AppBackCoordinator internal constructor(
+    private val navigator: AppNavigator,
+    private val transientTargets: List<AppBackTarget>,
+    private val closeRoute: (AppRoute) -> Boolean,
+) {
+    val hasTransientBack: Flow<Boolean> = combine(transientTargets.map(AppBackTarget::active)) { active ->
+        active.any { it }
+    }.distinctUntilChanged()
+
+    val hasTransientBackNow: Boolean
+        get() = transientTargets.any { it.isActiveNow() }
+
+    fun onBack(): Boolean {
+        transientTargets.firstOrNull { it.isActiveNow() }?.let { target ->
+            target.dismiss()
+            return true
+        }
+        return closeRoute(navigator.currentEntry)
+    }
+}
+
+fun createAppBackCoordinator(
+    navigator: AppNavigator,
+    playbackNavigationPort: PlaybackNavigationPort,
+    playlistActionPort: PlaylistActionPort,
+    providerTrackActionPort: ProviderTrackActionPort,
+    localMusicFeatureController: LocalMusicFeatureController,
+    providerDetailOwners: ProviderDetailOwners,
+    searchAppPort: SearchAppPort,
+    recognitionController: RecognitionFeatureController,
+    settingsFeatureController: SettingsFeatureController,
+    localPlaylistFeatureController: LocalPlaylistFeatureController,
+): AppBackCoordinator {
+    val transientTargets = listOf(
+        AppBackTarget(
+            active = playlistActionPort.targetPickerState.map { it.track != null }.distinctUntilChanged(),
+            isActiveNow = { playlistActionPort.targetPickerState.value.track != null },
+            dismiss = playlistActionPort::closePlaylistTargetPicker,
+        ),
+        AppBackTarget(
+            active = providerTrackActionPort.artistTargetPickerState.map { it.track != null }.distinctUntilChanged(),
+            isActiveNow = { providerTrackActionPort.artistTargetPickerState.value.track != null },
+            dismiss = providerTrackActionPort::closeArtistTargetPicker,
+        ),
+        AppBackTarget(
+            active = localMusicFeatureController.uiState.map { it.metadataEditorTrack != null }.distinctUntilChanged(),
+            isActiveNow = { localMusicFeatureController.uiState.value.metadataEditorTrack != null },
+            dismiss = localMusicFeatureController::closeMetadataEditor,
+        ),
+        AppBackTarget(
+            active = snapshotFlow { playbackNavigationPort.isQueueOpen }.distinctUntilChanged(),
+            isActiveNow = { playbackNavigationPort.isQueueOpen },
+            dismiss = playbackNavigationPort::toggleQueue,
+        ),
+        AppBackTarget(
+            active = snapshotFlow { playbackNavigationPort.isFullPlayerOpen }.distinctUntilChanged(),
+            isActiveNow = { playbackNavigationPort.isFullPlayerOpen },
+            dismiss = playbackNavigationPort::closeFullPlayer,
+        ),
+        AppBackTarget(
+            active = providerDetailOwners.video.uiState.map { it.isFullscreen }.distinctUntilChanged(),
+            isActiveNow = { providerDetailOwners.video.uiState.value.isFullscreen },
+            dismiss = providerDetailOwners.video::toggleFullscreen,
+        ),
+    )
+
+    fun closeRecognition(): Boolean {
+        recognitionController.dispatch(RecognitionAction.Close)
+        navigator.pop(AppRoute.AudioRecognition)
+        return true
+    }
+
+    return AppBackCoordinator(
+        navigator = navigator,
+        transientTargets = transientTargets,
+        closeRoute = { route ->
+            when (route) {
+                AppRoute.Home -> false
+                AppRoute.Search -> {
+                    searchAppPort.closeSearch()
+                    true
+                }
+                AppRoute.AudioRecognition -> closeRecognition()
+                AppRoute.Settings -> {
+                    settingsFeatureController.close()
+                    true
+                }
+                AppRoute.DebugLogs -> navigator.pop(AppRoute.DebugLogs)
+                AppRoute.DownloadManager -> navigator.pop(AppRoute.DownloadManager)
+                AppRoute.LocalPlaylist -> {
+                    localPlaylistFeatureController.close()
+                    true
+                }
+                AppRoute.LocalMusicCollection -> {
+                    localMusicFeatureController.closeCollection()
+                    true
+                }
+                is AppRoute.FeatureDetail -> {
+                    providerDetailOwners.feature.close()
+                    true
+                }
+                is AppRoute.PlaylistDetail -> {
+                    providerDetailOwners.playlist.close()
+                    true
+                }
+                is AppRoute.TrackDetail -> {
+                    providerDetailOwners.track.close()
+                    true
+                }
+                is AppRoute.VideoDetail -> {
+                    providerDetailOwners.video.close()
+                    true
+                }
+                is AppRoute.MediaItemDetail -> {
+                    providerDetailOwners.mediaItem.close()
+                    true
+                }
+                AppRoute.Feature,
+                AppRoute.Playlist,
+                AppRoute.Track,
+                AppRoute.Video,
+                AppRoute.MediaItem -> navigator.pop()
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeedbackHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppFeedbackHost.kt
@@ -1,0 +1,103 @@
+package org.feeluown.mobile
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.merge
+
+private data class SnackbarFeedbackEvent(
+    val message: String,
+    val dismiss: () -> Unit,
+)
+
+private fun Flow<String?>.toSnackbarFeedbackEvents(
+    lifecycle: Lifecycle,
+    dismissFeedback: (String) -> Unit,
+): Flow<SnackbarFeedbackEvent> = mapNotNull { message ->
+    if (message == null) {
+        null
+    } else if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+        SnackbarFeedbackEvent(message) { dismissFeedback(message) }
+    } else {
+        dismissFeedback(message)
+        null
+    }
+}
+
+@Composable
+internal fun AppFeedbackHost(
+    appViewModel: FuoAppViewModel,
+    uiGraph: AppUiGraph,
+    modifier: Modifier = Modifier,
+) {
+    val snackbar = remember { SnackbarHostState() }
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val playback = uiGraph.playback
+    val snackbarFeedbackEvents = remember(appViewModel, uiGraph, lifecycle) {
+        merge(
+            playback.playlists.feedback.toSnackbarFeedbackEvents(
+                lifecycle,
+                playback.playlists::dismissFeedback,
+            ),
+            playback.queue.feedback.toSnackbarFeedbackEvents(
+                lifecycle,
+                playback.queue::dismissFeedback,
+            ),
+            playback.providerTrackActions.feedback.toSnackbarFeedbackEvents(
+                lifecycle,
+                playback.providerTrackActions::dismissFeedback,
+            ),
+            playback.downloads.managerState
+                .map { it.queueFeedback }
+                .distinctUntilChanged()
+                .toSnackbarFeedbackEvents(lifecycle, playback.downloads::dismissQueueFeedback),
+            playback.sleepTimer.feedback.toSnackbarFeedbackEvents(
+                lifecycle,
+                playback.sleepTimer::dismissFeedback,
+            ),
+            appViewModel.appFeedback.toSnackbarFeedbackEvents(lifecycle, appViewModel::dismissFeedback),
+            uiGraph.sharedResources.feedback.toSnackbarFeedbackEvents(
+                lifecycle,
+                uiGraph.sharedResources::dismissFeedback,
+            ),
+        )
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        snackbar.currentSnackbarData?.dismiss()
+    }
+    LaunchedEffect(snackbarFeedbackEvents, lifecycle, snackbar) {
+        snackbarFeedbackEvents.collect { event ->
+            try {
+                if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                    snackbar.showSnackbar(event.message)
+                }
+            } finally {
+                event.dismiss()
+            }
+        }
+    }
+
+    SnackbarHost(
+        hostState = snackbar,
+        modifier = modifier,
+    ) { data ->
+        Snackbar(
+            snackbarData = data,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -1,0 +1,32 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
+    val playback = uiGraph.playback
+    AnimatedVisibility(
+        visible = playback.isFullPlayerOpen,
+        modifier = Modifier.fillMaxSize(),
+        enter = slideInVertically(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it / 2 } +
+            fadeIn(tween(FuoMotion.overlayFadeMillis)),
+        exit = slideOutVertically(animationSpec = tween(FuoMotion.overlayExitMillis)) { it / 2 } +
+            fadeOut(tween(FuoMotion.overlayFadeMillis)),
+    ) {
+        RuntimeFullPlayer()
+    }
+    LocalMetadataDialog()
+    PlaylistTargetFeatureDialog(
+        actions = playback.playlists,
+        localPlaylist = uiGraph.localPlaylist,
+    )
+    TrackArtistTargetFeatureDialog(playback.providerTrackActions)
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -1,0 +1,140 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+
+private fun pageTransition(
+    initialOffsetX: (Int) -> Int,
+    targetOffsetX: (Int) -> Int,
+): ContentTransform = (
+    slideInHorizontally(
+        initialOffsetX = initialOffsetX,
+        animationSpec = tween(FuoMotion.pageTransitionMillis),
+    ) + fadeIn(animationSpec = tween(FuoMotion.pageFadeMillis))
+    ) togetherWith (
+    slideOutHorizontally(
+        targetOffsetX = targetOffsetX,
+        animationSpec = tween(FuoMotion.pageTransitionMillis),
+    ) + fadeOut(animationSpec = tween(FuoMotion.pageFadeMillis))
+    )
+
+private fun forwardPageTransition(): ContentTransform =
+    pageTransition(initialOffsetX = { it }, targetOffsetX = { -it })
+
+private fun popPageTransition(): ContentTransform =
+    pageTransition(initialOffsetX = { -it }, targetOffsetX = { it })
+
+private fun settingsForwardPageTransition(): ContentTransform =
+    pageTransition(initialOffsetX = { -it }, targetOffsetX = { it })
+
+private fun settingsPopPageTransition(): ContentTransform =
+    pageTransition(initialOffsetX = { it }, targetOffsetX = { -it })
+
+private fun settingsNavigationMetadata(): Map<String, Any> =
+    NavDisplay.transitionSpec { settingsForwardPageTransition() } +
+        NavDisplay.popTransitionSpec { settingsPopPageTransition() } +
+        NavDisplay.predictivePopTransitionSpec { settingsPopPageTransition() }
+
+@Composable
+internal fun AppNavHost(
+    backStack: List<AppRoute>,
+    appViewModel: FuoAppViewModel,
+    uiGraph: AppUiGraph,
+    platform: AppPlatformBindings,
+    modifier: Modifier = Modifier,
+) {
+    val localPlaylistState by uiGraph.localPlaylist.uiState.collectAsStateWithLifecycle()
+
+    NavDisplay(
+        backStack = backStack,
+        modifier = modifier,
+        onBack = { appViewModel.onBack() },
+        transitionSpec = { forwardPageTransition() },
+        popTransitionSpec = { popPageTransition() },
+        predictivePopTransitionSpec = { popPageTransition() },
+        entryProvider = { route ->
+            NavEntry(
+                key = route,
+                metadata = if (route == AppRoute.Settings) settingsNavigationMetadata() else emptyMap(),
+            ) {
+                when (route) {
+                    AppRoute.Home -> HomeScreen(
+                        home = uiGraph.home.home,
+                        hasAudioPermission = platform.hasAudioPermission,
+                        onRequestAudioPermission = platform.onRequestAudioPermission,
+                        hasImagePermission = platform.hasImagePermission,
+                        onRequestImagePermission = platform.onRequestImagePermission,
+                        onOpenRecognition = appViewModel::openRecognition,
+                    )
+                    AppRoute.Search -> SearchRoute(
+                        graph = uiGraph.search,
+                        onOpenRecognition = appViewModel::openRecognition,
+                    )
+                    AppRoute.AudioRecognition -> RecognitionRoute(
+                        graph = uiGraph.recognition,
+                        onBack = appViewModel::closeRecognition,
+                        onSearchSong = uiGraph.search.controller::searchRecognizedSong,
+                        hasMicrophonePermission = platform.hasMicrophonePermission,
+                        onRequestMicrophonePermission = platform.onRequestMicrophonePermission,
+                    )
+                    AppRoute.Settings -> SettingsFeatureScreen(
+                        settingsController = uiGraph.settings,
+                        providerCatalog = uiGraph.providerCatalog,
+                        providerAuth = uiGraph.providerAuth,
+                        appVersionInfo = platform.appVersionInfo,
+                        onOpenProviderWebLogin = platform.onOpenProviderWebLogin,
+                        onLogoutProvider = platform.onLogoutProvider,
+                        onImportYtmusicHeaderFile = platform.onImportYtmusicHeaderFile,
+                        onImportYtmusicOAuthFile = platform.onImportYtmusicOAuthFile,
+                        onStartYtmusicOAuth = platform.onStartYtmusicOAuth,
+                    )
+                    AppRoute.DebugLogs -> DebugLogFeatureScreen(
+                        uiGraph.debugLogs,
+                        onBack = { appViewModel.onBack() },
+                    )
+                    AppRoute.DownloadManager -> DownloadManagerScreen(
+                        uiGraph.playback.downloads,
+                        onBack = { appViewModel.onBack() },
+                    )
+                    is AppRoute.FeatureDetail -> ProviderFeatureParityDetailRoute(route.feature.toProviderFeature())
+                    is AppRoute.PlaylistDetail -> ProviderPlaylistDetailRoute(
+                        playlist = route.playlist.toProviderPlaylist(),
+                        category = route.category?.let { runCatching { ProviderFeatureCategory.valueOf(it) }.getOrNull() },
+                    )
+                    is AppRoute.TrackDetail -> ProviderTrackDetailRoute(route.track.toMusicTrack())
+                    is AppRoute.VideoDetail -> ProviderVideoDetailRoute(route.video.toProviderVideo())
+                    is AppRoute.MediaItemDetail -> ProviderMediaItemDetailRoute(route.item.toProviderMediaItem())
+                    AppRoute.LocalPlaylist -> LocalPlaylistScreen(
+                        uiState = localPlaylistState,
+                        actions = uiGraph.localPlaylist,
+                        playlist = localPlaylistState.selectedPlaylist,
+                    )
+                    AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen()
+                    AppRoute.Feature,
+                    AppRoute.Playlist,
+                    AppRoute.Track,
+                    AppRoute.Video,
+                    AppRoute.MediaItem -> StaleRouteKindGuard(appViewModel::onBack)
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun StaleRouteKindGuard(onBack: () -> Unit) {
+    LaunchedEffect(Unit) { onBack() }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -127,7 +127,7 @@ internal fun AppNavHost(
                     AppRoute.Playlist,
                     AppRoute.Track,
                     AppRoute.Video,
-                    AppRoute.MediaItem -> StaleRouteKindGuard(appViewModel::onBack)
+                    AppRoute.MediaItem -> StaleRouteKindGuard { appViewModel.onBack() }
                 }
             }
         },

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppPlatformBindings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppPlatformBindings.kt
@@ -1,0 +1,21 @@
+package org.feeluown.mobile
+
+/** Platform capabilities consumed by the common app shell. */
+data class AppPlatformBindings(
+    val hasAudioPermission: Boolean,
+    val onRequestAudioPermission: () -> Unit,
+    val hasMicrophonePermission: Boolean,
+    val onRequestMicrophonePermission: () -> Unit,
+    val onOpenProviderWebLogin: (ProviderInfo) -> Unit,
+    val onLogoutProvider: (ProviderInfo) -> Unit,
+    val onImportYtmusicHeaderFile: (() -> Unit)? = null,
+    val onImportYtmusicOAuthFile: (() -> Unit)? = null,
+    val onStartYtmusicOAuth: (() -> Unit)? = null,
+    val onImportLocalPlaylistFile: (() -> Unit)? = null,
+    val onExportLocalPlaylistFile: ((String, String) -> Unit)? = null,
+    val onShareLocalPlaylistFile: ((String, String) -> Unit)? = null,
+    val onShareText: (String) -> Unit = {},
+    val appVersionInfo: String? = null,
+    val hasImagePermission: Boolean = true,
+    val onRequestImagePermission: () -> Unit = {},
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppRoot.kt
@@ -1,176 +1,16 @@
 package org.feeluown.mobile
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionLayout
-import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation3.runtime.NavEntry
-import androidx.navigation3.ui.NavDisplay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.merge
 
-val LocalShareHandler = staticCompositionLocalOf<(SharePayload) -> Unit> { {} }
-val LocalAppLayoutInfo = staticCompositionLocalOf { AppLayoutInfo() }
-
-@OptIn(ExperimentalSharedTransitionApi::class)
-val LocalPlayerSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope?> { null }
-
-data class AppLayoutInfo(
-    val isLandscape: Boolean = false,
-    val useWideLayout: Boolean = false,
-    val gridColumns: Int = 3,
-)
-
-internal fun appLayoutInfoFor(maxWidth: Dp, maxHeight: Dp): AppLayoutInfo {
-    val isLandscape = maxWidth > maxHeight
-    return AppLayoutInfo(
-        isLandscape = isLandscape,
-        useWideLayout = isLandscape && maxWidth >= 640.dp,
-        gridColumns = when {
-            maxWidth >= 980.dp -> 6
-            maxWidth >= 760.dp -> 5
-            maxWidth >= 640.dp -> 4
-            else -> 3
-        },
-    )
-}
-
-private data class SnackbarFeedbackEvent(
-    val message: String,
-    val dismiss: () -> Unit,
-)
-
-private fun AppRoute.showsMiniPlayer(
-    hasCurrentTrack: Boolean,
-    hasQueueTrack: Boolean,
-    isVideoFullscreen: Boolean,
-): Boolean = when (this) {
-    AppRoute.Home -> hasCurrentTrack
-    AppRoute.LocalPlaylist,
-    AppRoute.LocalMusicCollection,
-    is AppRoute.FeatureDetail,
-    is AppRoute.PlaylistDetail,
-    is AppRoute.TrackDetail,
-    is AppRoute.MediaItemDetail -> hasQueueTrack
-    is AppRoute.VideoDetail -> hasQueueTrack && !isVideoFullscreen
-    AppRoute.Search,
-    AppRoute.AudioRecognition,
-    AppRoute.Settings,
-    AppRoute.DebugLogs,
-    AppRoute.DownloadManager,
-    AppRoute.Feature,
-    AppRoute.Playlist,
-    AppRoute.Track,
-    AppRoute.Video,
-    AppRoute.MediaItem -> false
-}
-
-private fun Flow<String?>.toSnackbarFeedbackEvents(
-    lifecycle: Lifecycle,
-    dismissFeedback: (String) -> Unit,
-): Flow<SnackbarFeedbackEvent> = mapNotNull { message ->
-    if (message == null) {
-        null
-    } else if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-        SnackbarFeedbackEvent(message) { dismissFeedback(message) }
-    } else {
-        dismissFeedback(message)
-        null
-    }
-}
-
-private fun pageTransition(
-    initialOffsetX: (Int) -> Int,
-    targetOffsetX: (Int) -> Int,
-): ContentTransform = (
-    slideInHorizontally(
-        initialOffsetX = initialOffsetX,
-        animationSpec = tween(FuoMotion.pageTransitionMillis),
-    ) + fadeIn(animationSpec = tween(FuoMotion.pageFadeMillis))
-    ) togetherWith (
-    slideOutHorizontally(
-        targetOffsetX = targetOffsetX,
-        animationSpec = tween(FuoMotion.pageTransitionMillis),
-    ) + fadeOut(animationSpec = tween(FuoMotion.pageFadeMillis))
-    )
-
-private fun forwardPageTransition(): ContentTransform =
-    pageTransition(initialOffsetX = { it }, targetOffsetX = { -it })
-
-private fun popPageTransition(): ContentTransform =
-    pageTransition(initialOffsetX = { -it }, targetOffsetX = { it })
-
-private fun settingsForwardPageTransition(): ContentTransform =
-    pageTransition(initialOffsetX = { -it }, targetOffsetX = { it })
-
-private fun settingsPopPageTransition(): ContentTransform =
-    pageTransition(initialOffsetX = { it }, targetOffsetX = { -it })
-
-private fun settingsNavigationMetadata(): Map<String, Any> =
-    NavDisplay.transitionSpec { settingsForwardPageTransition() } +
-        NavDisplay.popTransitionSpec { settingsPopPageTransition() } +
-        NavDisplay.predictivePopTransitionSpec { settingsPopPageTransition() }
-
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun AppRoot(
     appViewModel: FuoAppViewModel,
-    hasAudioPermission: Boolean,
-    onRequestAudioPermission: () -> Unit,
-    hasMicrophonePermission: Boolean,
-    onRequestMicrophonePermission: () -> Unit,
-    onOpenProviderWebLogin: (ProviderInfo) -> Unit,
-    onLogoutProvider: (ProviderInfo) -> Unit,
-    onImportYtmusicHeaderFile: (() -> Unit)? = null,
-    onImportYtmusicOAuthFile: (() -> Unit)? = null,
-    onStartYtmusicOAuth: (() -> Unit)? = null,
-    onImportLocalPlaylistFile: (() -> Unit)? = null,
-    onExportLocalPlaylistFile: ((String, String) -> Unit)? = null,
-    onShareLocalPlaylistFile: ((String, String) -> Unit)? = null,
-    onShareText: (String) -> Unit = {},
-    appVersionInfo: String? = null,
-    hasImagePermission: Boolean = true,
-    onRequestImagePermission: () -> Unit = {},
+    uiGraph: AppUiGraph,
+    platform: AppPlatformBindings,
 ) {
     val appUiState by appViewModel.uiState.collectAsStateWithLifecycle()
-    val localPlaylistState by appViewModel.localPlaylistFeatureController.uiState.collectAsStateWithLifecycle()
-    val videoDetailState by appViewModel.providerDetailOwners.video.uiState.collectAsStateWithLifecycle()
-    val playbackGraph = appViewModel.playbackUiPort
 
     FuoTheme(
         themeMode = appUiState.themeMode,
@@ -178,218 +18,30 @@ fun AppRoot(
         themePaletteStyle = appUiState.themePaletteStyle,
         themeColorSpec = appUiState.themeColorSpec,
     ) {
-        if (!appUiState.isInitialized) {
-            AppInitializationLoadingScreen()
-            return@FuoTheme
-        }
-        if (!appUiState.onboardingCompleted) {
-            val onboarding = requireNotNull(appViewModel.onboardingFeatureController) {
-                "Onboarding feature owner is not installed"
-            }
-            OnboardingFeatureScreen(
-                onboarding = onboarding,
-                settings = appViewModel.settingsFeatureController,
-                providerCatalog = appViewModel.providerCatalogFeatureController,
-                providerAuth = appViewModel.providerAuthFeatureController,
-                onOpenProviderWebLogin = onOpenProviderWebLogin,
-                onLogoutProvider = onLogoutProvider,
-                onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
-                onImportYtmusicOAuthFile = onImportYtmusicOAuthFile,
-                onStartYtmusicOAuth = onStartYtmusicOAuth,
-            )
-            return@FuoTheme
-        }
-
-        val snackbar = remember { SnackbarHostState() }
-        val lifecycle = LocalLifecycleOwner.current.lifecycle
-        val snackbarFeedbackEvents = remember(appViewModel, lifecycle) {
-            merge(
-                appViewModel.playlistActionPort.feedback.toSnackbarFeedbackEvents(
-                    lifecycle,
-                    appViewModel.playlistActionPort::dismissFeedback,
-                ),
-                appViewModel.playbackQueueUiPort.feedback.toSnackbarFeedbackEvents(
-                    lifecycle,
-                    appViewModel.playbackQueueUiPort::dismissFeedback,
-                ),
-                appViewModel.providerTrackActionPort.feedback.toSnackbarFeedbackEvents(
-                    lifecycle,
-                    appViewModel.providerTrackActionPort::dismissFeedback,
-                ),
-                appViewModel.downloadActionPort.managerState
-                    .map { it.queueFeedback }
-                    .distinctUntilChanged()
-                    .toSnackbarFeedbackEvents(lifecycle, appViewModel.downloadActionPort::dismissQueueFeedback),
-                appViewModel.playbackSleepTimerPort.feedback.toSnackbarFeedbackEvents(
-                    lifecycle,
-                    appViewModel.playbackSleepTimerPort::dismissFeedback,
-                ),
-                appViewModel.appFeedback.toSnackbarFeedbackEvents(lifecycle, appViewModel::dismissFeedback),
-                appViewModel.sharedResourceActionPort.feedback.toSnackbarFeedbackEvents(
-                    lifecycle,
-                    appViewModel.sharedResourceActionPort::dismissFeedback,
-                ),
-            )
-        }
-        LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
-            snackbar.currentSnackbarData?.dismiss()
-        }
-        LaunchedEffect(snackbarFeedbackEvents, lifecycle, snackbar) {
-            snackbarFeedbackEvents.collect { event ->
-                try {
-                    if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                        snackbar.showSnackbar(event.message)
-                    }
-                } finally {
-                    event.dismiss()
+        when {
+            !appUiState.isInitialized -> AppInitializationLoadingScreen()
+            !appUiState.onboardingCompleted -> {
+                val onboarding = requireNotNull(uiGraph.onboarding) {
+                    "Onboarding feature owner is not installed"
                 }
+                OnboardingFeatureScreen(
+                    onboarding = onboarding,
+                    settings = uiGraph.settings,
+                    providerCatalog = uiGraph.providerCatalog,
+                    providerAuth = uiGraph.providerAuth,
+                    onOpenProviderWebLogin = platform.onOpenProviderWebLogin,
+                    onLogoutProvider = platform.onLogoutProvider,
+                    onImportYtmusicHeaderFile = platform.onImportYtmusicHeaderFile,
+                    onImportYtmusicOAuthFile = platform.onImportYtmusicOAuthFile,
+                    onStartYtmusicOAuth = platform.onStartYtmusicOAuth,
+                )
             }
-        }
-
-        BoxWithConstraints(Modifier.fillMaxSize()) {
-            val layoutInfo = remember(maxWidth, maxHeight) { appLayoutInfoFor(maxWidth, maxHeight) }
-            val miniPlayerVisible = !playbackGraph.isFullPlayerOpen &&
-                appUiState.backStack.lastOrNull()?.showsMiniPlayer(
-                    hasCurrentTrack = playbackGraph.currentTrack != null,
-                    hasQueueTrack = playbackGraph.queue.currentQueueTrack != null,
-                    isVideoFullscreen = videoDetailState.isFullscreen,
-                ) == true
-            val snackbarBottomPadding = if (miniPlayerVisible) {
-                if (layoutInfo.useWideLayout) 80.dp else 96.dp
-            } else {
-                16.dp
-            }
-            CompositionLocalProvider(
-                LocalPlaybackSession provides appViewModel.playbackSession,
-                LocalPlaybackUiPort provides playbackGraph,
-                LocalLocalMusicUiGraph provides LocalMusicUiGraph(
-                    feature = appViewModel.localMusicFeatureController,
-                    playbackQueue = appViewModel.playbackQueueUiPort,
-                    downloads = appViewModel.downloadActionPort,
-                    providerTrackActions = appViewModel.providerTrackActionPort,
-                ),
-                LocalProviderDetailUiGraph provides appViewModel.providerDetailUiGraph,
-                LocalHomeFeatureUiGraph provides appViewModel.homeFeatureUiGraph,
-                LocalShareHandler provides { onShareText(it.text) },
-                LocalLocalPlaylistFileActions provides LocalPlaylistFileActions(
-                    importFile = onImportLocalPlaylistFile,
-                    exportFile = onExportLocalPlaylistFile,
-                    shareFile = onShareLocalPlaylistFile,
-                ),
-                LocalAppLayoutInfo provides layoutInfo,
-            ) {
-                ProvideNarrowPlaybackUi(playbackGraph) {
-                    SharedTransitionLayout(Modifier.fillMaxSize()) {
-                        CompositionLocalProvider(LocalPlayerSharedTransitionScope provides this) {
-                            Box(Modifier.fillMaxSize()) {
-                                NavDisplay(
-                                    backStack = appUiState.backStack,
-                                    modifier = Modifier.fillMaxSize(),
-                                    onBack = { appViewModel.dispatch(AppIntent.NavigateBack) },
-                                    transitionSpec = { forwardPageTransition() },
-                                    popTransitionSpec = { popPageTransition() },
-                                    predictivePopTransitionSpec = { popPageTransition() },
-                                    entryProvider = { route ->
-                                        NavEntry(
-                                            key = route,
-                                            metadata = if (route == AppRoute.Settings) {
-                                                settingsNavigationMetadata()
-                                            } else {
-                                                emptyMap()
-                                            },
-                                        ) {
-                                            when (route) {
-                                                AppRoute.Home -> HomeScreen(
-                                                    home = appViewModel.homeFeatureController,
-                                                    hasAudioPermission = hasAudioPermission,
-                                                    onRequestAudioPermission = onRequestAudioPermission,
-                                                    hasImagePermission = hasImagePermission,
-                                                    onRequestImagePermission = onRequestImagePermission,
-                                                    onOpenRecognition = appViewModel::openRecognition,
-                                                )
-                                                AppRoute.Search -> SearchRoute(appViewModel, appViewModel.searchAppPort)
-                                                AppRoute.AudioRecognition -> RecognitionRoute(
-                                                    appViewModel = appViewModel,
-                                                    appPort = appViewModel.recognitionAppPort,
-                                                    hasMicrophonePermission = hasMicrophonePermission,
-                                                    onRequestMicrophonePermission = onRequestMicrophonePermission,
-                                                )
-                                                AppRoute.Settings -> SettingsFeatureScreen(
-                                                    settingsController = appViewModel.settingsFeatureController,
-                                                    providerCatalog = appViewModel.providerCatalogFeatureController,
-                                                    providerAuth = appViewModel.providerAuthFeatureController,
-                                                    appVersionInfo = appVersionInfo,
-                                                    onOpenProviderWebLogin = onOpenProviderWebLogin,
-                                                    onLogoutProvider = onLogoutProvider,
-                                                    onImportYtmusicHeaderFile = onImportYtmusicHeaderFile,
-                                                    onImportYtmusicOAuthFile = onImportYtmusicOAuthFile,
-                                                    onStartYtmusicOAuth = onStartYtmusicOAuth,
-                                                )
-                                                AppRoute.DebugLogs -> DebugLogFeatureScreen(appViewModel.debugLogFeatureController, appViewModel::closeDebugLogs)
-                                                AppRoute.DownloadManager -> DownloadManagerScreen(appViewModel.downloadActionPort, appViewModel::closeDownloadManager)
-                                                is AppRoute.FeatureDetail -> ProviderFeatureParityDetailRoute(route.feature.toProviderFeature())
-                                                is AppRoute.PlaylistDetail -> ProviderPlaylistDetailRoute(
-                                                    playlist = route.playlist.toProviderPlaylist(),
-                                                    category = route.category?.let { runCatching { ProviderFeatureCategory.valueOf(it) }.getOrNull() },
-                                                )
-                                                is AppRoute.TrackDetail -> ProviderTrackDetailRoute(route.track.toMusicTrack())
-                                                is AppRoute.VideoDetail -> ProviderVideoDetailRoute(route.video.toProviderVideo())
-                                                is AppRoute.MediaItemDetail -> ProviderMediaItemDetailRoute(route.item.toProviderMediaItem())
-                                                AppRoute.LocalPlaylist -> LocalPlaylistScreen(
-                                                    uiState = localPlaylistState,
-                                                    actions = appViewModel.localPlaylistFeatureController,
-                                                    playlist = localPlaylistState.selectedPlaylist,
-                                                )
-                                                AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen()
-                                                AppRoute.Feature,
-                                                AppRoute.Playlist,
-                                                AppRoute.Track,
-                                                AppRoute.Video,
-                                                AppRoute.MediaItem -> StaleRouteKindGuard(appViewModel)
-                                            }
-                                        }
-                                    },
-                                )
-                                AnimatedVisibility(
-                                    visible = playbackGraph.isFullPlayerOpen,
-                                    modifier = Modifier.fillMaxSize(),
-                                    enter = slideInVertically(animationSpec = tween(FuoMotion.overlayEnterMillis)) { it / 2 } + fadeIn(tween(FuoMotion.overlayFadeMillis)),
-                                    exit = slideOutVertically(animationSpec = tween(FuoMotion.overlayExitMillis)) { it / 2 } + fadeOut(tween(FuoMotion.overlayFadeMillis)),
-                                ) { RuntimeFullPlayer() }
-                                LocalMetadataDialog()
-                                PlaylistTargetFeatureDialog(
-                                    actions = appViewModel.playlistActionPort,
-                                    localPlaylist = appViewModel.localPlaylistFeatureController,
-                                )
-                                TrackArtistTargetFeatureDialog(appViewModel.providerTrackActionPort)
-                                SnackbarHost(
-                                    hostState = snackbar,
-                                    modifier = Modifier
-                                        .align(Alignment.BottomCenter)
-                                        .navigationBarsPadding()
-                                        .padding(
-                                            start = 16.dp,
-                                            top = 16.dp,
-                                            end = 16.dp,
-                                            bottom = snackbarBottomPadding,
-                                        ),
-                                ) { data ->
-                                    Snackbar(
-                                        snackbarData = data,
-                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        contentColor = MaterialTheme.colorScheme.onSurface,
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            else -> AppShell(
+                appViewModel = appViewModel,
+                uiGraph = uiGraph,
+                appUiState = appUiState,
+                platform = platform,
+            )
         }
     }
-}
-
-@Composable
-private fun StaleRouteKindGuard(appViewModel: FuoAppViewModel) {
-    LaunchedEffect(Unit) { appViewModel.dispatch(AppIntent.NavigateBack) }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -1,0 +1,94 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+internal fun AppShell(
+    appViewModel: FuoAppViewModel,
+    uiGraph: AppUiGraph,
+    appUiState: AppUiState,
+    platform: AppPlatformBindings,
+) {
+    val videoDetailState by uiGraph.providerDetail.owners.video.uiState.collectAsStateWithLifecycle()
+    val playback = uiGraph.playback
+
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val layoutInfo = remember(maxWidth, maxHeight) { appLayoutInfoFor(maxWidth, maxHeight) }
+        val miniPlayerVisible = !playback.isFullPlayerOpen &&
+            appUiState.backStack.lastOrNull()?.showsMiniPlayer(
+                hasCurrentTrack = playback.currentTrack != null,
+                hasQueueTrack = playback.queue.currentQueueTrack != null,
+                isVideoFullscreen = videoDetailState.isFullscreen,
+            ) == true
+        val snackbarBottomPadding = if (miniPlayerVisible) {
+            if (layoutInfo.useWideLayout) 80.dp else 96.dp
+        } else {
+            16.dp
+        }
+
+        CompositionLocalProvider(
+            LocalPlaybackSession provides uiGraph.playbackSession,
+            LocalPlaybackUiPort provides playback,
+            LocalLocalMusicUiGraph provides LocalMusicUiGraph(
+                feature = uiGraph.localMusic,
+                playbackQueue = playback.queue,
+                downloads = playback.downloads,
+                providerTrackActions = playback.providerTrackActions,
+            ),
+            LocalProviderDetailUiGraph provides uiGraph.providerDetail,
+            LocalHomeFeatureUiGraph provides uiGraph.home,
+            LocalShareHandler provides { platform.onShareText(it.text) },
+            LocalLocalPlaylistFileActions provides LocalPlaylistFileActions(
+                importFile = platform.onImportLocalPlaylistFile,
+                exportFile = platform.onExportLocalPlaylistFile,
+                shareFile = platform.onShareLocalPlaylistFile,
+            ),
+            LocalAppLayoutInfo provides layoutInfo,
+        ) {
+            ProvideNarrowPlaybackUi(playback) {
+                SharedTransitionLayout(Modifier.fillMaxSize()) {
+                    CompositionLocalProvider(LocalPlayerSharedTransitionScope provides this) {
+                        Box(Modifier.fillMaxSize()) {
+                            AppNavHost(
+                                backStack = appUiState.backStack,
+                                appViewModel = appViewModel,
+                                uiGraph = uiGraph,
+                                platform = platform,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                            AppGlobalOverlays(uiGraph)
+                            AppFeedbackHost(
+                                appViewModel = appViewModel,
+                                uiGraph = uiGraph,
+                                modifier = Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .navigationBarsPadding()
+                                    .padding(
+                                        start = 16.dp,
+                                        top = 16.dp,
+                                        end = 16.dp,
+                                        bottom = snackbarBottomPadding,
+                                    ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShellComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShellComposition.kt
@@ -1,0 +1,58 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+val LocalShareHandler = staticCompositionLocalOf<(SharePayload) -> Unit> { {} }
+val LocalAppLayoutInfo = staticCompositionLocalOf { AppLayoutInfo() }
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalPlayerSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope?> { null }
+
+data class AppLayoutInfo(
+    val isLandscape: Boolean = false,
+    val useWideLayout: Boolean = false,
+    val gridColumns: Int = 3,
+)
+
+internal fun appLayoutInfoFor(maxWidth: Dp, maxHeight: Dp): AppLayoutInfo {
+    val isLandscape = maxWidth > maxHeight
+    return AppLayoutInfo(
+        isLandscape = isLandscape,
+        useWideLayout = isLandscape && maxWidth >= 640.dp,
+        gridColumns = when {
+            maxWidth >= 980.dp -> 6
+            maxWidth >= 760.dp -> 5
+            maxWidth >= 640.dp -> 4
+            else -> 3
+        },
+    )
+}
+
+internal fun AppRoute.showsMiniPlayer(
+    hasCurrentTrack: Boolean,
+    hasQueueTrack: Boolean,
+    isVideoFullscreen: Boolean,
+): Boolean = when (this) {
+    AppRoute.Home -> hasCurrentTrack
+    AppRoute.LocalPlaylist,
+    AppRoute.LocalMusicCollection,
+    is AppRoute.FeatureDetail,
+    is AppRoute.PlaylistDetail,
+    is AppRoute.TrackDetail,
+    is AppRoute.MediaItemDetail -> hasQueueTrack
+    is AppRoute.VideoDetail -> hasQueueTrack && !isVideoFullscreen
+    AppRoute.Search,
+    AppRoute.AudioRecognition,
+    AppRoute.Settings,
+    AppRoute.DebugLogs,
+    AppRoute.DownloadManager,
+    AppRoute.Feature,
+    AppRoute.Playlist,
+    AppRoute.Track,
+    AppRoute.Video,
+    AppRoute.MediaItem -> false
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppState.kt
@@ -8,9 +8,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
-import org.feeluown.mobile.playback.api.PlaybackSession
 
 @Serializable
 sealed interface AppRoute : NavKey {
@@ -119,80 +117,14 @@ private fun appUiState(settingsState: SettingsState, backStack: List<AppRoute>):
     )
 }
 
-sealed interface AppIntent {
-    data object NavigateBack : AppIntent
-    data class UpdateSettings(val transform: (AppSettings) -> AppSettings) : AppIntent
-    data class UpdateThemePaletteStyle(val value: ThemePaletteStyle) : AppIntent
-    data class UpdateThemeColorSpec(val value: ThemeColorSpec) : AppIntent
-}
-
-@Suppress("UNUSED_PARAMETER")
 class FuoAppViewModel(
-    val playbackSession: PlaybackSession,
-    val playbackNavigationPort: PlaybackNavigationPort,
-    val playbackPresentationPort: PlaybackPresentationPort,
-    val playbackQueueUiPort: PlaybackQueueUiPort,
-    val playbackSleepTimerPort: PlaybackSleepTimerPort,
-    val downloadActionPort: DownloadActionPort,
-    val playlistActionPort: PlaylistActionPort,
-    val providerTrackActionPort: ProviderTrackActionPort,
-    val localMusicActionPort: LocalMusicActionPort,
-    val playbackLyricsPort: PlaybackLyricsPort,
-    val replacementActionPort: ReplacementActionPort,
-    val debugLogFeatureController: DebugLogFeatureController,
-    val providerCatalogFeatureController: ProviderCatalogFeatureController,
-    val providerAuthFeatureController: ProviderAuthFeatureController,
-    val settingsFeatureController: SettingsFeatureController,
-    val onboardingFeatureController: OnboardingFeatureController? = null,
-    val providerDetailOwners: ProviderDetailOwners,
-    val localMusicFeatureController: LocalMusicFeatureController,
-    val localPlaylistFeatureController: LocalPlaylistFeatureController,
-    val homeFeatureController: HomeFeatureController,
-    val sharedResourceActionPort: SharedResourceActionPort,
-    private val searchController: SearchFeatureController,
-    private val recognitionController: RecognitionFeatureController,
-    internal val searchAppPort: SearchAppPort,
-    internal val recognitionAppPort: RecognitionAppPort,
     private val settingsRepository: AppSettingsRepository,
-    providerSessionRepository: ProviderSessionRepository,
     private val navigator: AppNavigator,
+    private val recognitionController: RecognitionFeatureController,
+    private val backCoordinator: AppBackCoordinator,
 ) : ViewModel() {
-    val searchUiState: StateFlow<SearchUiState> = searchController.uiState
-    val recognitionUiState: StateFlow<RecognitionUiState> = recognitionController.uiState
     private val mutableAppFeedback = MutableStateFlow<String?>(null)
     val appFeedback: StateFlow<String?> = mutableAppFeedback
-
-    val playbackUiPort = PlaybackUiGraph(
-        navigation = playbackNavigationPort,
-        presentation = playbackPresentationPort,
-        queue = playbackQueueUiPort,
-        sleepTimer = playbackSleepTimerPort,
-        downloads = downloadActionPort,
-        playlists = playlistActionPort,
-        providerTrackActions = providerTrackActionPort,
-        localMusicActions = localMusicActionPort,
-        lyrics = playbackLyricsPort,
-        replacement = replacementActionPort,
-    )
-
-    val providerDetailUiGraph = ProviderDetailUiGraph(
-        owners = providerDetailOwners,
-        playbackQueue = playbackQueueUiPort,
-        downloads = downloadActionPort,
-        playlists = playlistActionPort,
-        providerTrackActions = providerTrackActionPort,
-    )
-
-    val homeFeatureUiGraph = HomeFeatureUiGraph(
-        home = homeFeatureController,
-        providerCatalog = providerCatalogFeatureController,
-        playbackQueue = playbackQueueUiPort,
-        downloads = downloadActionPort,
-        playlists = playlistActionPort,
-        providerTrackActions = providerTrackActionPort,
-        localPlaylist = localPlaylistFeatureController,
-        localMusic = localMusicFeatureController,
-    )
 
     val uiState: StateFlow<AppUiState> = combine(
         settingsRepository.state,
@@ -204,9 +136,11 @@ class FuoAppViewModel(
         initialValue = appUiState(settingsRepository.state.value, navigator.backStack.value),
     )
 
-    fun dispatchSearch(action: SearchAction) = searchController.dispatch(action)
-    fun searchRecognizedSong(song: RecognizedSong) = searchController.searchRecognizedSong(song)
-    fun dispatchRecognition(action: RecognitionAction) = recognitionController.dispatch(action)
+    val handlesTransientBack: StateFlow<Boolean> = backCoordinator.hasTransientBack.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = backCoordinator.hasTransientBackNow,
+    )
 
     fun openRecognition() {
         recognitionController.dispatch(RecognitionAction.Reset)
@@ -217,14 +151,6 @@ class FuoAppViewModel(
         recognitionController.dispatch(RecognitionAction.Close)
         navigator.pop(AppRoute.AudioRecognition)
     }
-
-    fun openDebugLogs() {
-        if (debugLogFeatureController.isAvailable) navigator.navigate(AppRoute.DebugLogs)
-    }
-
-    fun closeDebugLogs() { navigator.pop(AppRoute.DebugLogs) }
-    fun openDownloadManager() { navigator.navigate(AppRoute.DownloadManager) }
-    fun closeDownloadManager() { navigator.pop(AppRoute.DownloadManager) }
 
     fun showFeedback(message: String) {
         if (message.isNotBlank()) mutableAppFeedback.value = message
@@ -240,45 +166,9 @@ class FuoAppViewModel(
         }
     }
 
-    fun onAppBackgrounded() { recognitionController.dispatch(RecognitionAction.CancelIfInProgress) }
-
-    fun dispatch(intent: AppIntent) {
-        when (intent) {
-            AppIntent.NavigateBack -> navigateBack()
-            is AppIntent.UpdateSettings -> viewModelScope.launch { settingsRepository.update(intent.transform) }
-            is AppIntent.UpdateThemePaletteStyle -> viewModelScope.launch { settingsRepository.updateThemePaletteStyle(intent.value) }
-            is AppIntent.UpdateThemeColorSpec -> viewModelScope.launch { settingsRepository.updateThemeColorSpec(intent.value) }
-        }
+    fun onAppBackgrounded() {
+        recognitionController.dispatch(RecognitionAction.CancelIfInProgress)
     }
 
-    private fun navigateBack() {
-        when {
-            playlistActionPort.targetPickerState.value.track != null -> playlistActionPort.closePlaylistTargetPicker()
-            providerTrackActionPort.artistTargetPickerState.value.track != null -> providerTrackActionPort.closeArtistTargetPicker()
-            localMusicFeatureController.uiState.value.metadataEditorTrack != null -> localMusicFeatureController.closeMetadataEditor()
-            playbackNavigationPort.isQueueOpen -> playbackNavigationPort.toggleQueue()
-            playbackNavigationPort.isFullPlayerOpen -> playbackNavigationPort.closeFullPlayer()
-            providerDetailOwners.video.uiState.value.isFullscreen -> providerDetailOwners.video.toggleFullscreen()
-            else -> when (navigator.currentEntry) {
-                AppRoute.Home -> Unit
-                AppRoute.Search -> searchAppPort.closeSearch()
-                AppRoute.AudioRecognition -> closeRecognition()
-                AppRoute.Settings -> settingsFeatureController.close()
-                AppRoute.DebugLogs -> closeDebugLogs()
-                AppRoute.DownloadManager -> closeDownloadManager()
-                AppRoute.LocalPlaylist -> localPlaylistFeatureController.close()
-                AppRoute.LocalMusicCollection -> localMusicFeatureController.closeCollection()
-                is AppRoute.FeatureDetail -> providerDetailOwners.feature.close()
-                is AppRoute.PlaylistDetail -> providerDetailOwners.playlist.close()
-                is AppRoute.TrackDetail -> providerDetailOwners.track.close()
-                is AppRoute.VideoDetail -> providerDetailOwners.video.close()
-                is AppRoute.MediaItemDetail -> providerDetailOwners.mediaItem.close()
-                AppRoute.Feature,
-                AppRoute.Playlist,
-                AppRoute.Track,
-                AppRoute.Video,
-                AppRoute.MediaItem -> navigator.pop()
-            }
-        }
-    }
+    fun onBack(): Boolean = backCoordinator.onBack()
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppUiGraph.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppUiGraph.kt
@@ -1,0 +1,103 @@
+package org.feeluown.mobile
+
+import org.feeluown.mobile.playback.api.PlaybackSession
+
+/** App-shell composition wiring. This graph owns no business state or lifecycle policy. */
+data class AppUiGraph(
+    val playbackSession: PlaybackSession,
+    val playback: PlaybackUiGraph,
+    val providerDetail: ProviderDetailUiGraph,
+    val home: HomeFeatureUiGraph,
+    val search: SearchRouteGraph,
+    val recognition: RecognitionRouteGraph,
+    val debugLogs: DebugLogFeatureController,
+    val providerCatalog: ProviderCatalogFeatureController,
+    val providerAuth: ProviderAuthFeatureController,
+    val settings: SettingsFeatureController,
+    val onboarding: OnboardingFeatureController?,
+    val localMusic: LocalMusicFeatureController,
+    val localPlaylist: LocalPlaylistFeatureController,
+    val sharedResources: SharedResourceActionPort,
+)
+
+data class SearchRouteGraph(
+    val controller: SearchFeatureController,
+    val appPort: SearchAppPort,
+)
+
+data class RecognitionRouteGraph(
+    val controller: RecognitionFeatureController,
+    val appPort: RecognitionAppPort,
+)
+
+fun createAppUiGraph(
+    playbackSession: PlaybackSession,
+    playbackNavigationPort: PlaybackNavigationPort,
+    playbackPresentationPort: PlaybackPresentationPort,
+    playbackQueueUiPort: PlaybackQueueUiPort,
+    playbackSleepTimerPort: PlaybackSleepTimerPort,
+    downloadActionPort: DownloadActionPort,
+    playlistActionPort: PlaylistActionPort,
+    providerTrackActionPort: ProviderTrackActionPort,
+    localMusicActionPort: LocalMusicActionPort,
+    playbackLyricsPort: PlaybackLyricsPort,
+    replacementActionPort: ReplacementActionPort,
+    debugLogFeatureController: DebugLogFeatureController,
+    providerCatalogFeatureController: ProviderCatalogFeatureController,
+    providerAuthFeatureController: ProviderAuthFeatureController,
+    settingsFeatureController: SettingsFeatureController,
+    onboardingFeatureController: OnboardingFeatureController?,
+    providerDetailOwners: ProviderDetailOwners,
+    localMusicFeatureController: LocalMusicFeatureController,
+    localPlaylistFeatureController: LocalPlaylistFeatureController,
+    homeFeatureController: HomeFeatureController,
+    sharedResourceActionPort: SharedResourceActionPort,
+    searchController: SearchFeatureController,
+    searchAppPort: SearchAppPort,
+    recognitionController: RecognitionFeatureController,
+    recognitionAppPort: RecognitionAppPort,
+): AppUiGraph {
+    val playback = PlaybackUiGraph(
+        navigation = playbackNavigationPort,
+        presentation = playbackPresentationPort,
+        queue = playbackQueueUiPort,
+        sleepTimer = playbackSleepTimerPort,
+        downloads = downloadActionPort,
+        playlists = playlistActionPort,
+        providerTrackActions = providerTrackActionPort,
+        localMusicActions = localMusicActionPort,
+        lyrics = playbackLyricsPort,
+        replacement = replacementActionPort,
+    )
+    return AppUiGraph(
+        playbackSession = playbackSession,
+        playback = playback,
+        providerDetail = ProviderDetailUiGraph(
+            owners = providerDetailOwners,
+            playbackQueue = playbackQueueUiPort,
+            downloads = downloadActionPort,
+            playlists = playlistActionPort,
+            providerTrackActions = providerTrackActionPort,
+        ),
+        home = HomeFeatureUiGraph(
+            home = homeFeatureController,
+            providerCatalog = providerCatalogFeatureController,
+            playbackQueue = playbackQueueUiPort,
+            downloads = downloadActionPort,
+            playlists = playlistActionPort,
+            providerTrackActions = providerTrackActionPort,
+            localPlaylist = localPlaylistFeatureController,
+            localMusic = localMusicFeatureController,
+        ),
+        search = SearchRouteGraph(searchController, searchAppPort),
+        recognition = RecognitionRouteGraph(recognitionController, recognitionAppPort),
+        debugLogs = debugLogFeatureController,
+        providerCatalog = providerCatalogFeatureController,
+        providerAuth = providerAuthFeatureController,
+        settings = settingsFeatureController,
+        onboarding = onboardingFeatureController,
+        localMusic = localMusicFeatureController,
+        localPlaylist = localPlaylistFeatureController,
+        sharedResources = sharedResourceActionPort,
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/RecognitionRoute.kt
@@ -17,19 +17,20 @@ import kotlinx.coroutines.launch
 /** App-shell composition for the recognition feature. */
 @Composable
 internal fun RecognitionRoute(
-    appViewModel: FuoAppViewModel,
-    appPort: RecognitionAppPort,
+    graph: RecognitionRouteGraph,
+    onBack: () -> Unit,
+    onSearchSong: (RecognizedSong) -> Unit,
     hasMicrophonePermission: Boolean,
     onRequestMicrophonePermission: () -> Unit,
 ) {
-    val uiState by appViewModel.recognitionUiState.collectAsStateWithLifecycle()
-    val detailLoadState by appPort.detailLoadState.collectAsStateWithLifecycle()
+    val uiState by graph.controller.uiState.collectAsStateWithLifecycle()
+    val detailLoadState by graph.appPort.detailLoadState.collectAsStateWithLifecycle()
     val detailScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(detailLoadState.errorMessage) {
         val message = detailLoadState.errorMessage ?: return@LaunchedEffect
-        appPort.clearDetailLoadError()
+        graph.appPort.clearDetailLoadError()
         snackbarHostState.showSnackbar("资源详情加载失败：$message")
     }
 
@@ -37,12 +38,12 @@ internal fun RecognitionRoute(
         AudioRecognitionFeatureScreen(
             uiState = uiState,
             actions = RecognitionFeatureActions(
-                dispatch = appViewModel::dispatchRecognition,
-                onBack = appViewModel::closeRecognition,
-                onSearchSong = appViewModel::searchRecognizedSong,
-                canOpenNeteaseDetail = appPort::canOpenNeteaseDetail,
+                dispatch = graph.controller::dispatch,
+                onBack = onBack,
+                onSearchSong = onSearchSong,
+                canOpenNeteaseDetail = graph.appPort::canOpenNeteaseDetail,
                 onOpenNeteaseDetail = { song ->
-                    detailScope.launch { appPort.openNeteaseDetail(song) }
+                    detailScope.launch { graph.appPort.openNeteaseDetail(song) }
                 },
             ),
             hasMicrophonePermission = hasMicrophonePermission,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/SearchRoute.kt
@@ -7,17 +7,18 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 /** App-shell composition for the search feature. */
 @Composable
 internal fun SearchRoute(
-    appViewModel: FuoAppViewModel,
-    appPort: SearchAppPort,
+    graph: SearchRouteGraph,
+    onOpenRecognition: () -> Unit,
 ) {
-    val uiState by appViewModel.searchUiState.collectAsStateWithLifecycle()
+    val uiState by graph.controller.uiState.collectAsStateWithLifecycle()
+    val appPort = graph.appPort
 
     SearchFeatureScreen(
         uiState = uiState,
         providers = appPort.providers,
         downloadStates = appPort.downloadStates,
         actions = SearchFeatureActions(
-            dispatch = appViewModel::dispatchSearch,
+            dispatch = graph.controller::dispatch,
             onBack = appPort::closeSearch,
             onPlayResult = appPort::playResult,
             onAddToUpNext = appPort::addToUpNext,
@@ -43,6 +44,6 @@ internal fun SearchRoute(
             onOpenPlaylist = appPort::openPlaylist,
             onOpenVideo = appPort::openVideo,
         ),
-        onOpenRecognition = appViewModel::openRecognition,
+        onOpenRecognition = onOpenRecognition,
     )
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppBackCoordinatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppBackCoordinatorTest.kt
@@ -1,0 +1,67 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppBackCoordinatorTest {
+    @Test
+    fun transientTargetsAreDismissedInPriorityOrder() {
+        val navigator = AppNavigator()
+        val firstActive = MutableStateFlow(true)
+        val secondActive = MutableStateFlow(true)
+        val dismissed = mutableListOf<String>()
+        var routeCloseCount = 0
+        val coordinator = AppBackCoordinator(
+            navigator = navigator,
+            transientTargets = listOf(
+                AppBackTarget(firstActive, { firstActive.value }) { dismissed += "first" },
+                AppBackTarget(secondActive, { secondActive.value }) { dismissed += "second" },
+            ),
+            closeRoute = {
+                routeCloseCount += 1
+                true
+            },
+        )
+
+        assertTrue(coordinator.hasTransientBackNow)
+        assertTrue(coordinator.onBack())
+        assertEquals(listOf("first"), dismissed)
+        assertEquals(0, routeCloseCount)
+    }
+
+    @Test
+    fun routeHandlerRunsOnlyAfterTransientUiIsGone() {
+        val navigator = AppNavigator().also { it.navigate(AppRoute.Search) }
+        val transientActive = MutableStateFlow(false)
+        var closedRoute: AppRoute? = null
+        val coordinator = AppBackCoordinator(
+            navigator = navigator,
+            transientTargets = listOf(
+                AppBackTarget(transientActive, { transientActive.value }) {},
+            ),
+            closeRoute = { route ->
+                closedRoute = route
+                true
+            },
+        )
+
+        assertFalse(coordinator.hasTransientBackNow)
+        assertTrue(coordinator.onBack())
+        assertEquals(AppRoute.Search, closedRoute)
+    }
+
+    @Test
+    fun homeCanLeaveBackUnconsumed() {
+        val coordinator = AppBackCoordinator(
+            navigator = AppNavigator(),
+            transientTargets = emptyList(),
+            closeRoute = { false },
+        )
+
+        assertFalse(coordinator.hasTransientBackNow)
+        assertFalse(coordinator.onBack())
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppShellPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppShellPolicyTest.kt
@@ -34,6 +34,7 @@ class AppShellPolicyTest {
             NavigationVideo(
                 id = "bilibili:BV1",
                 title = "Video",
+                artists = "Uploader",
                 providerId = "bilibili:BV1",
                 providerName = "哔哩哔哩",
             )

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppShellPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppShellPolicyTest.kt
@@ -1,0 +1,58 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppShellPolicyTest {
+    @Test
+    fun homeNeedsCurrentTrackForMiniPlayer() {
+        assertTrue(AppRoute.Home.showsMiniPlayer(hasCurrentTrack = true, hasQueueTrack = false, isVideoFullscreen = false))
+        assertFalse(AppRoute.Home.showsMiniPlayer(hasCurrentTrack = false, hasQueueTrack = true, isVideoFullscreen = false))
+    }
+
+    @Test
+    fun detailRoutesUseQueueTrack() {
+        val route = AppRoute.TrackDetail(
+            NavigationTrack(
+                id = "netease:1",
+                title = "Song",
+                artists = "Artist",
+                album = "Album",
+                source = "netease",
+                sourceType = TrackSourceType.Provider.name,
+            )
+        )
+
+        assertTrue(route.showsMiniPlayer(hasCurrentTrack = false, hasQueueTrack = true, isVideoFullscreen = false))
+        assertFalse(route.showsMiniPlayer(hasCurrentTrack = true, hasQueueTrack = false, isVideoFullscreen = false))
+    }
+
+    @Test
+    fun fullscreenVideoSuppressesMiniPlayer() {
+        val route = AppRoute.VideoDetail(
+            NavigationVideo(
+                id = "bilibili:BV1",
+                title = "Video",
+                providerId = "bilibili:BV1",
+                providerName = "哔哩哔哩",
+            )
+        )
+
+        assertTrue(route.showsMiniPlayer(hasCurrentTrack = false, hasQueueTrack = true, isVideoFullscreen = false))
+        assertFalse(route.showsMiniPlayer(hasCurrentTrack = false, hasQueueTrack = true, isVideoFullscreen = true))
+    }
+
+    @Test
+    fun utilityRoutesNeverShowMiniPlayer() {
+        listOf(
+            AppRoute.Search,
+            AppRoute.AudioRecognition,
+            AppRoute.Settings,
+            AppRoute.DebugLogs,
+            AppRoute.DownloadManager,
+        ).forEach { route ->
+            assertFalse(route.showsMiniPlayer(hasCurrentTrack = true, hasQueueTrack = true, isVideoFullscreen = false))
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppHost.kt
@@ -73,44 +73,47 @@ private fun IosApp(
     }
     AppRoot(
         appViewModel = container.appViewModel,
-        hasAudioPermission = container.hasAudioPermission,
-        onRequestAudioPermission = container::requestAudioPermission,
-        hasMicrophonePermission = container.hasMicrophonePermission,
-        onRequestMicrophonePermission = container::requestMicrophonePermission,
-        onOpenProviderWebLogin = container::openProviderWebLogin,
-        onLogoutProvider = container::logoutProvider,
-        onImportYtmusicHeaderFile = {
-            localPlaylistFileOutput.importFile { _, content ->
-                handleIosJsonImportResult(
-                    content = content,
-                    onImport = container.appViewModel.providerAuthFeatureController::loginYtmusicWithHeaderFile,
-                    onReadFailure = { container.appViewModel.showFeedback("无法读取 ytmusic_header.json") },
-                )
-            }
-        },
-        onImportYtmusicOAuthFile = {
-            localPlaylistFileOutput.importFile { _, content ->
-                handleIosJsonImportResult(
-                    content = content,
-                    onImport = container.appViewModel.providerAuthFeatureController::importYtmusicOAuthRelatedJson,
-                    onReadFailure = { container.appViewModel.showFeedback("无法读取 OAuth JSON") },
-                )
-            }
-        },
-        onStartYtmusicOAuth = container.appViewModel.providerAuthFeatureController::startYtmusicTvOAuthLogin,
-        onImportLocalPlaylistFile = {
-            localPlaylistFileOutput.importFile { fileName, content ->
-                handleIosLocalPlaylistImportResult(
-                    fileName = fileName,
-                    content = content,
-                    onImport = container.appViewModel.localPlaylistFeatureController::prepareImport,
-                    onReadFailure = { container.appViewModel.showFeedback("无法读取本地歌单文件") },
-                )
-            }
-        },
-        onExportLocalPlaylistFile = localPlaylistFileOutput::exportFile,
-        onShareLocalPlaylistFile = localPlaylistFileOutput::shareFile,
-        onShareText = shareOutput::share,
+        uiGraph = container.appUiGraph,
+        platform = AppPlatformBindings(
+            hasAudioPermission = container.hasAudioPermission,
+            onRequestAudioPermission = container::requestAudioPermission,
+            hasMicrophonePermission = container.hasMicrophonePermission,
+            onRequestMicrophonePermission = container::requestMicrophonePermission,
+            onOpenProviderWebLogin = container::openProviderWebLogin,
+            onLogoutProvider = container::logoutProvider,
+            onImportYtmusicHeaderFile = {
+                localPlaylistFileOutput.importFile { _, content ->
+                    handleIosJsonImportResult(
+                        content = content,
+                        onImport = container.appUiGraph.providerAuth::loginYtmusicWithHeaderFile,
+                        onReadFailure = { container.appViewModel.showFeedback("无法读取 ytmusic_header.json") },
+                    )
+                }
+            },
+            onImportYtmusicOAuthFile = {
+                localPlaylistFileOutput.importFile { _, content ->
+                    handleIosJsonImportResult(
+                        content = content,
+                        onImport = container.appUiGraph.providerAuth::importYtmusicOAuthRelatedJson,
+                        onReadFailure = { container.appViewModel.showFeedback("无法读取 OAuth JSON") },
+                    )
+                }
+            },
+            onStartYtmusicOAuth = container.appUiGraph.providerAuth::startYtmusicTvOAuthLogin,
+            onImportLocalPlaylistFile = {
+                localPlaylistFileOutput.importFile { fileName, content ->
+                    handleIosLocalPlaylistImportResult(
+                        fileName = fileName,
+                        content = content,
+                        onImport = container.appUiGraph.localPlaylist::prepareImport,
+                        onReadFailure = { container.appViewModel.showFeedback("无法读取本地歌单文件") },
+                    )
+                }
+            },
+            onExportLocalPlaylistFile = localPlaylistFileOutput::exportFile,
+            onShareLocalPlaylistFile = localPlaylistFileOutput::shareFile,
+            onShareText = shareOutput::share,
+        ),
     )
 }
 
@@ -378,35 +381,56 @@ private class IosAppContainer(
         DefaultPlaybackPresentationPort(playbackEngine, playbackFeatureOwner.transport, settingsRepository, scope)
     }
 
+    val appUiGraph: AppUiGraph by lazy {
+        createAppUiGraph(
+            playbackSession = playbackSession,
+            playbackNavigationPort = playbackFeatureOwner.navigation,
+            playbackPresentationPort = playbackPresentationPort,
+            playbackQueueUiPort = playbackFeatureOwner.transport,
+            playbackSleepTimerPort = playbackFeatureOwner.sleepTimer,
+            downloadActionPort = downloadActionPort,
+            playlistActionPort = playlistActionPort,
+            providerTrackActionPort = providerTrackActionPort,
+            localMusicActionPort = localMusicFeatureController,
+            playbackLyricsPort = playbackFeatureOwner.lyrics,
+            replacementActionPort = playbackFeatureOwner.replacement,
+            debugLogFeatureController = debugLogFeatureController,
+            providerCatalogFeatureController = providerCatalogFeatureController,
+            providerAuthFeatureController = providerAuthFeatureController,
+            settingsFeatureController = settingsFeatureController,
+            onboardingFeatureController = onboardingFeatureController,
+            providerDetailOwners = providerDetailOwners,
+            localMusicFeatureController = localMusicFeatureController,
+            localPlaylistFeatureController = localPlaylistFeatureController,
+            homeFeatureController = homeFeatureController,
+            sharedResourceActionPort = sharedResourceActionPort,
+            searchController = searchController,
+            searchAppPort = searchAppPort,
+            recognitionController = recognitionController,
+            recognitionAppPort = recognitionAppPort,
+        )
+    }
+
+    private val appBackCoordinator: AppBackCoordinator by lazy {
+        createAppBackCoordinator(
+            navigator = navigator,
+            playbackNavigationPort = playbackFeatureOwner.navigation,
+            playlistActionPort = playlistActionPort,
+            providerTrackActionPort = providerTrackActionPort,
+            localMusicFeatureController = localMusicFeatureController,
+            providerDetailOwners = providerDetailOwners,
+            searchAppPort = searchAppPort,
+            recognitionController = recognitionController,
+            settingsFeatureController = settingsFeatureController,
+            localPlaylistFeatureController = localPlaylistFeatureController,
+        )
+    }
+
     val appViewModel = FuoAppViewModel(
-        playbackSession = playbackSession,
-        playbackNavigationPort = playbackFeatureOwner.navigation,
-        playbackPresentationPort = playbackPresentationPort,
-        playbackQueueUiPort = playbackFeatureOwner.transport,
-        playbackSleepTimerPort = playbackFeatureOwner.sleepTimer,
-        downloadActionPort = downloadActionPort,
-        playlistActionPort = playlistActionPort,
-        providerTrackActionPort = providerTrackActionPort,
-        localMusicActionPort = localMusicFeatureController,
-        playbackLyricsPort = playbackFeatureOwner.lyrics,
-        replacementActionPort = playbackFeatureOwner.replacement,
-        debugLogFeatureController = debugLogFeatureController,
-        providerCatalogFeatureController = providerCatalogFeatureController,
-        providerAuthFeatureController = providerAuthFeatureController,
-        settingsFeatureController = settingsFeatureController,
-        onboardingFeatureController = onboardingFeatureController,
-        providerDetailOwners = providerDetailOwners,
-        localMusicFeatureController = localMusicFeatureController,
-        localPlaylistFeatureController = localPlaylistFeatureController,
-        homeFeatureController = homeFeatureController,
-        sharedResourceActionPort = sharedResourceActionPort,
-        searchController = searchController,
-        recognitionController = recognitionController,
-        searchAppPort = searchAppPort,
-        recognitionAppPort = recognitionAppPort,
         settingsRepository = settingsRepository,
-        providerSessionRepository = providerSessionRepository,
         navigator = navigator,
+        recognitionController = recognitionController,
+        backCoordinator = appBackCoordinator,
     )
 
     var hasMicrophonePermission by mutableStateOf(audioRecognitionOutput.hasPermission())


### PR DESCRIPTION
## Summary

- move presentation-only wiring out of `FuoAppViewModel` into an explicit `AppUiGraph` and platform callbacks into `AppPlatformBindings`
- centralize transient-overlay and route back precedence in `AppBackCoordinator`, so platform hosts no longer duplicate FullPlayer/queue/video/picker/editor state checks
- narrow `FuoAppViewModel` to app-scoped startup/theme/navigation projection, app feedback, recognition lifecycle and back events
- split the former monolithic `AppRoot` into bootstrap, `AppShell`, typed `AppNavHost`, global overlays, feedback host and shell/layout policy
- migrate both Android and iOS composition roots to construct/use the new shell graph
- narrow Search/Recognition route dependencies and add back-precedence / mini-player-policy coverage
- document the resulting app-shell ownership boundaries

## Architecture impact

This keeps the existing dependency direction intact:

`platform composition root -> app/shared integration -> feature owner -> stable core/api/persistence contracts`

Feature business state remains feature-owned. `AppUiGraph` is composition-only wiring and does not introduce a new broad controller, service locator or generic dispatch surface. `AppUiState` remains limited to initialization, onboarding, theme projection and navigation back stack. No new Gradle modules or DI framework are introduced.

## Compatibility

The change is intended to be behavior-preserving: typed routes, feature owners, playback/runtime contracts, persistence and provider boundaries remain unchanged. Existing back precedence and mini-player visibility policy are preserved, but are now owned/tested in one app-shell location.

## Validation

- added focused common tests for `AppBackCoordinator`
- added table-style coverage for mini-player route policy
- CI/build validation pending on this PR