### PR TITLE
feat: add comprehensive multi-provider search

### DIFF
--- a/feature/search/src/commonMain/kotlin/org/feeluown/mobile/SearchFeature.kt
+++ b/feature/search/src/commonMain/kotlin/org/feeluown/mobile/SearchFeature.kt
@@ -1,6 +1,9 @@
 package org.feeluown.mobile
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,6 +20,7 @@ enum class SearchScope {
 
 @Serializable
 enum class ProviderSearchTab {
+    Comprehensive,
     Songs,
     Artists,
     Albums,
@@ -38,7 +42,7 @@ data class SearchFeatureState<Track, ProviderResults>(
     val searchScope: SearchScope = SearchScope.All,
     val selectedSearchProviderId: String? = null,
     val searchResults: List<Track> = emptyList(),
-    val providerSearchTab: ProviderSearchTab = ProviderSearchTab.Songs,
+    val providerSearchTab: ProviderSearchTab = ProviderSearchTab.Comprehensive,
     val isLoading: Boolean = false,
     val message: String? = null,
 )
@@ -218,7 +222,7 @@ private class SearchController<Track, ProviderResults>(
                 }.joinToString(" "),
                 searchScope = SearchScope.All,
                 selectedSearchProviderId = null,
-                providerSearchTab = ProviderSearchTab.Songs,
+                providerSearchTab = ProviderSearchTab.Comprehensive,
             )
         }
         notifyPreferencesChanged()
@@ -280,13 +284,13 @@ private class SearchController<Track, ProviderResults>(
                             resultOperations.tracks(provider)
                         }
 
-                        SearchScope.All -> {
-                            val local = localRepository.search(keyword)
-                            val provider = resultOperations.merge(
-                                providerIdsForSearch().map { providerId ->
-                                    providerRepository.searchAll(keyword, providerId)
-                                }
-                            )
+                        SearchScope.All -> coroutineScope {
+                            val localDeferred = async { localRepository.search(keyword) }
+                            val providerDeferreds = providerIdsForSearch().map { providerId ->
+                                async { providerRepository.searchAll(keyword, providerId) }
+                            }
+                            val local = localDeferred.await()
+                            val provider = resultOperations.merge(providerDeferreds.awaitAll())
                             state.update { it.copy(providerSearchResults = provider) }
                             mergeResults(local, resultOperations.tracks(provider))
                         }

--- a/feature/search/src/commonTest/kotlin/org/feeluown/mobile/SearchFeatureTest.kt
+++ b/feature/search/src/commonTest/kotlin/org/feeluown/mobile/SearchFeatureTest.kt
@@ -16,6 +16,8 @@ class SearchFeatureTest {
             onPreferencesChanged = { searchScope, providerId -> persistedPreferences += searchScope to providerId },
         )
 
+        assertEquals(ProviderSearchTab.Comprehensive, owner.uiState.value.providerSearchTab)
+
         owner.dispatch(SearchAction.ScopeChanged(SearchScope.Local))
         owner.dispatch(SearchAction.ProviderChanged("netease"))
         owner.dispatch(SearchAction.QueryChanged("hello"))
@@ -88,7 +90,7 @@ class SearchFeatureTest {
         assertEquals("Song Artist A / Artist B", owner.uiState.value.query)
         assertEquals(SearchScope.All, owner.uiState.value.searchScope)
         assertEquals(null, owner.uiState.value.selectedSearchProviderId)
-        assertEquals(ProviderSearchTab.Songs, owner.uiState.value.providerSearchTab)
+        assertEquals(ProviderSearchTab.Comprehensive, owner.uiState.value.providerSearchTab)
         assertEquals(1, opened)
     }
 

--- a/provider/api/src/commonMain/kotlin/org/feeluown/mobile/ProviderRepositoryContracts.kt
+++ b/provider/api/src/commonMain/kotlin/org/feeluown/mobile/ProviderRepositoryContracts.kt
@@ -1,5 +1,36 @@
 package org.feeluown.mobile
 
+/** Provider-native best match preserved across the provider-neutral search boundary. */
+sealed interface ProviderSearchHit {
+    val providerId: String
+    val providerName: String
+
+    data class Track(val value: MusicTrack) : ProviderSearchHit {
+        override val providerId: String get() = value.source
+        override val providerName: String get() = value.providerName.orEmpty()
+    }
+
+    data class Artist(val value: MediaRef) : ProviderSearchHit {
+        override val providerId: String get() = value.providerId
+        override val providerName: String get() = value.providerName
+    }
+
+    data class Album(val value: MediaRef) : ProviderSearchHit {
+        override val providerId: String get() = value.providerId
+        override val providerName: String get() = value.providerName
+    }
+
+    data class Playlist(val value: ProviderPlaylist) : ProviderSearchHit {
+        override val providerId: String get() = value.providerId
+        override val providerName: String get() = value.providerName
+    }
+
+    data class Video(val value: ProviderVideo) : ProviderSearchHit {
+        override val providerId: String get() = value.providerId
+        override val providerName: String get() = value.providerName
+    }
+}
+
 /** Provider-neutral aggregate search result shared by catalog consumers. */
 data class ProviderSearchResults(
     val tracks: List<MusicTrack> = emptyList(),
@@ -7,6 +38,7 @@ data class ProviderSearchResults(
     val artists: List<MediaRef> = emptyList(),
     val albums: List<MediaRef> = emptyList(),
     val videos: List<ProviderVideo> = emptyList(),
+    val bestMatches: List<ProviderSearchHit> = emptyList(),
     val failure: ProviderFailure? = null,
 )
 

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliComprehensiveSearchProvider.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliComprehensiveSearchProvider.kt
@@ -1,0 +1,233 @@
+package org.feeluown.mobile.provider.bilibili
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.MediaRef
+import org.feeluown.mobile.MediaRefType
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderSearchHit
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.mediaItemKey
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.trackKey
+import org.feeluown.mobile.provider.core.videoKey
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+
+/** Maps Bilibili's native all-search response onto the common provider search contract. */
+internal class BilibiliComprehensiveSearchProvider(
+    private val delegate: KotlinMusicProvider,
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) : KotlinMusicProvider by delegate {
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        if (keyword.isBlank()) return ProviderSearchResults()
+        val comprehensive = runCatching { comprehensiveSearch(keyword) }.getOrNull()
+        if (comprehensive != null && comprehensive.hasCatalogResults()) return comprehensive
+        val fallback = delegate.search(keyword)
+        return fallback.copy(
+            bestMatches = fallback.bestMatches.ifEmpty { listOfNotNull(fallback.fallbackBestMatch(keyword)) },
+        )
+    }
+
+    private suspend fun comprehensiveSearch(keyword: String): ProviderSearchResults {
+        val root = http.getText(
+            providerId = ID,
+            url = "$BASE/x/web-interface/search/all/v2?keyword=${encodeUrlComponent(keyword)}&page=1",
+            headers = headers(),
+            cacheKey = "bilibili:search:comprehensive:$keyword",
+            cachePolicy = ProviderCachePolicies.search,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        val groups = root.obj("data")?.array("result").orEmpty()
+        val tracks = mutableListOf<MusicTrack>()
+        val artists = mutableListOf<MediaRef>()
+        val albums = mutableListOf<MediaRef>()
+        val videos = mutableListOf<ProviderVideo>()
+        var nativeBest: ProviderSearchHit? = null
+
+        groups.forEach { groupValue ->
+            val group = runCatching { groupValue.asObject() }.getOrNull() ?: return@forEach
+            val type = group.string("result_type")
+            group.array("data").forEach { itemValue ->
+                val item = runCatching { itemValue.asObject() }.getOrNull() ?: return@forEach
+                when (type) {
+                    "video" -> {
+                        val track = toTrack(item)
+                        val video = toVideo(item)
+                        if (track != null) tracks += track
+                        if (video != null) videos += video
+                        if (nativeBest == null) nativeBest = track?.let(ProviderSearchHit::Track)
+                            ?: video?.let(ProviderSearchHit::Video)
+                    }
+                    "bili_user" -> {
+                        val artist = toArtist(item)
+                        if (artist != null) artists += artist
+                        if (nativeBest == null) nativeBest = artist?.let(ProviderSearchHit::Artist)
+                    }
+                    "media_bangumi", "media_ft" -> {
+                        val album = toSeason(item)
+                        if (album != null) albums += album
+                        if (nativeBest == null) nativeBest = album?.let(ProviderSearchHit::Album)
+                    }
+                }
+            }
+        }
+
+        val results = ProviderSearchResults(
+            tracks = tracks.distinctBy { it.id },
+            artists = artists.distinctBy { it.id },
+            albums = albums.distinctBy { it.id },
+            videos = videos.distinctBy { it.id },
+        )
+        return results.copy(
+            bestMatches = listOfNotNull(nativeBest ?: results.fallbackBestMatch(keyword)),
+        )
+    }
+
+    private suspend fun headers(): Map<String, String> {
+        val cookie = cookieHeader(credentials.read(ID))
+        return buildMap {
+            put("User-Agent", USER_AGENT)
+            put("Referer", "https://www.bilibili.com/")
+            if (cookie.isNotBlank()) put("Cookie", cookie)
+        }
+    }
+
+    private fun toTrack(item: JsonObject): MusicTrack? {
+        val bvid = item.stringOrNull("bvid") ?: return null
+        return MusicTrack(
+            id = trackKey(ID, bvid),
+            title = item.string("title").stripHtml(),
+            artists = item.string("author").stripHtml(),
+            album = item.string("typename"),
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = normalizeCover(item.stringOrNull("pic")),
+            durationMs = parseDurationMs(item.string("duration")),
+            providerId = trackKey(ID, bvid),
+            providerName = NAME,
+            artistItemId = item.stringOrNull("mid")?.let { mediaItemKey(MediaRefType.Artist, ID, it) },
+            providerUrl = "https://www.bilibili.com/video/$bvid",
+        )
+    }
+
+    private fun toVideo(item: JsonObject): ProviderVideo? {
+        val bvid = item.stringOrNull("bvid") ?: return null
+        return ProviderVideo(
+            id = videoKey(ID, bvid),
+            title = item.string("title").stripHtml(),
+            artists = item.string("author").stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = normalizeCover(item.stringOrNull("pic")),
+            durationMs = parseDurationMs(item.string("duration")),
+            providerUrl = "https://www.bilibili.com/video/$bvid",
+        )
+    }
+
+    private fun toArtist(item: JsonObject): MediaRef? {
+        val identifier = item.string("mid")
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Artist, ID, identifier),
+            title = item.string("uname").ifBlank { item.string("name") }.stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Artist,
+            coverUrl = normalizeCover(item.stringOrNull("upic") ?: item.stringOrNull("face")),
+            description = item.string("usign").stripHtml(),
+            providerUrl = "https://space.bilibili.com/$identifier",
+        )
+    }
+
+    private fun toSeason(item: JsonObject): MediaRef? {
+        val seasonId = item.string("season_id")
+            .ifBlank { item.long("season_id")?.toString().orEmpty() }
+            .ifBlank { item.string("seasonId") }
+        if (seasonId.isBlank()) return null
+        val title = item.string("title").ifBlank { item.string("org_title") }.stripHtml()
+        val description = item.string("evaluate").ifBlank {
+            item.obj("new_ep")?.string("index_show").orEmpty()
+        }
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Album, ID, "$SEASON_PREFIX$seasonId"),
+            title = title,
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Album,
+            coverUrl = normalizeCover(item.stringOrNull("cover")),
+            description = description.stripHtml(),
+            providerUrl = "https://www.bilibili.com/bangumi/play/ss$seasonId",
+        )
+    }
+
+    private fun ProviderSearchResults.hasCatalogResults(): Boolean =
+        tracks.isNotEmpty() || artists.isNotEmpty() || albums.isNotEmpty() || videos.isNotEmpty()
+
+    private fun ProviderSearchResults.fallbackBestMatch(keyword: String): ProviderSearchHit? {
+        val normalized = normalize(keyword)
+        return artists.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Artist)
+            ?: albums.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Album)
+            ?: tracks.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Track)
+            ?: videos.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Video)
+            ?: tracks.firstOrNull()?.let(ProviderSearchHit::Track)
+            ?: artists.firstOrNull()?.let(ProviderSearchHit::Artist)
+            ?: albums.firstOrNull()?.let(ProviderSearchHit::Album)
+            ?: videos.firstOrNull()?.let(ProviderSearchHit::Video)
+    }
+
+    private fun parseDurationMs(value: String): Long? {
+        val parts = value.trim().split(':').mapNotNull(String::toLongOrNull)
+        if (parts.isEmpty()) return null
+        var seconds = 0L
+        parts.forEach { part -> seconds = seconds * 60 + part }
+        return seconds * 1_000
+    }
+
+    private fun normalizeCover(value: String?): String? = value
+        ?.trim()
+        ?.takeIf(String::isNotBlank)
+        ?.let { if (it.startsWith("//")) "https:$it" else it }
+
+    private fun String.stripHtml(): String = replace(Regex("<[^>]+>"), "")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+
+    private fun normalize(value: String): String = value.stripHtml().trim().lowercase().replace(" ", "")
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val number = byte.toInt() and 0xff
+            if (number in 0x30..0x39 || number in 0x41..0x5a || number in 0x61..0x7a || number in setOf(45, 46, 95, 126)) {
+                append(number.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[number ushr 4])
+                append("0123456789ABCDEF"[number and 15])
+            }
+        }
+    }
+
+    private companion object {
+        const val ID = "bilibili"
+        const val NAME = "哔哩哔哩"
+        const val BASE = "https://api.bilibili.com"
+        const val SEASON_PREFIX = "season_"
+        const val USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36"
+    }
+}

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
@@ -8,11 +8,17 @@ import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
 object BilibiliProviderFactory : KotlinProviderFactory {
     override val providerId: String = "bilibili"
 
-    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider =
-        BilibiliProvider(
+    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
+        val content = BilibiliContentProvider(
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
+        return BilibiliComprehensiveSearchProvider(
+            delegate = content,
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+        )
+    }
 
     fun createContentProvider(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider =
         BilibiliContentProvider(

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
@@ -1,0 +1,280 @@
+package org.feeluown.mobile.provider.netease
+
+import io.ktor.http.Parameters
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.MediaRef
+import org.feeluown.mobile.MediaRefType
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderSearchHit
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.asString
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.mediaItemKey
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.playlistKey
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.trackKey
+import org.feeluown.mobile.provider.core.videoKey
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+
+/**
+ * NetEase default search is a native comprehensive-search request (`type=1018`).
+ * The old typed-search implementation remains the compatibility fallback for response variants
+ * that do not expose any of the expected comprehensive buckets.
+ */
+internal class NeteaseComprehensiveSearchProvider(
+    private val delegate: NeteaseProvider,
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) : KotlinMusicProvider by delegate {
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        if (keyword.isBlank()) return ProviderSearchResults()
+        val comprehensive = runCatching { comprehensiveSearch(keyword) }.getOrNull()
+        if (comprehensive != null && comprehensive.hasCatalogResults()) return comprehensive
+        return delegate.search(keyword).withFallbackBestMatch(keyword)
+    }
+
+    private suspend fun comprehensiveSearch(keyword: String): ProviderSearchResults {
+        val raw = http.postForm(
+            providerId = ID,
+            url = "$BASE/api/search/get",
+            form = Parameters.build {
+                append("s", keyword)
+                append("type", COMPREHENSIVE_SEARCH_TYPE.toString())
+                append("offset", "0")
+                append("total", "true")
+                append("limit", "30")
+            },
+            headers = authenticatedHeaders(),
+            cacheKey = "netease:search:comprehensive:$keyword",
+            cachePolicy = ProviderCachePolicies.search,
+        ).value
+        val root = providerJson.parseToJsonElement(raw).asObject()
+        val result = root.obj("result") ?: root
+
+        val tracks = songValues(result).mapNotNull(::toTrack).distinctBy { it.id }
+        val artists = artistValues(result).mapNotNull(::toArtist).distinctBy { it.id }
+        val albums = albumValues(result).mapNotNull(::toAlbum).distinctBy { it.id }
+        val playlists = playlistValues(result).mapNotNull(::toPlaylist).distinctBy { it.id }
+        val videos = mvValues(result).mapNotNull(::toVideo).distinctBy { it.id }
+        val resultValue = ProviderSearchResults(
+            tracks = tracks,
+            playlists = playlists,
+            artists = artists,
+            albums = albums,
+            videos = videos,
+        )
+        return resultValue.copy(
+            bestMatches = nativeBestMatches(result, resultValue).ifEmpty {
+                resultValue.fallbackBestMatches(keyword)
+            },
+        )
+    }
+
+    private suspend fun authenticatedHeaders(): Map<String, String> {
+        val cookie = cookieHeader(credentials.read(ID))
+        return buildMap {
+            put("User-Agent", USER_AGENT)
+            put("Referer", "$BASE/")
+            if (cookie.isNotBlank()) put("Cookie", cookie)
+        }
+    }
+
+    private fun songValues(result: JsonObject): JsonArray = firstNonEmpty(
+        result.array("songs"),
+        result.obj("song")?.array("songs").orEmpty(),
+        result.obj("song")?.array("items").orEmpty(),
+        result.obj("song")?.array("list").orEmpty(),
+    )
+
+    private fun artistValues(result: JsonObject): JsonArray = firstNonEmpty(
+        result.array("artists"),
+        result.obj("artist")?.array("artists").orEmpty(),
+        result.obj("artist")?.array("items").orEmpty(),
+        result.obj("artist")?.array("list").orEmpty(),
+    )
+
+    private fun albumValues(result: JsonObject): JsonArray = firstNonEmpty(
+        result.array("albums"),
+        result.obj("album")?.array("albums").orEmpty(),
+        result.obj("album")?.array("items").orEmpty(),
+        result.obj("album")?.array("list").orEmpty(),
+    )
+
+    private fun playlistValues(result: JsonObject): JsonArray = firstNonEmpty(
+        result.array("playlists"),
+        result.array("playLists"),
+        result.obj("playlist")?.array("playlists").orEmpty(),
+        result.obj("playlist")?.array("playLists").orEmpty(),
+        result.obj("playList")?.array("playlists").orEmpty(),
+        result.obj("playList")?.array("playLists").orEmpty(),
+        result.obj("playList")?.array("items").orEmpty(),
+    )
+
+    private fun mvValues(result: JsonObject): JsonArray = firstNonEmpty(
+        result.array("mvs"),
+        result.obj("mv")?.array("mvs").orEmpty(),
+        result.obj("mv")?.array("items").orEmpty(),
+        result.obj("mv")?.array("list").orEmpty(),
+    )
+
+    private fun nativeBestMatches(result: JsonObject, values: ProviderSearchResults): List<ProviderSearchHit> {
+        val order = result.array("order").map(JsonElement::asString).filter(String::isNotBlank)
+        if (order.isEmpty()) return emptyList()
+        return order.asSequence().mapNotNull { key ->
+            when (key.lowercase()) {
+                "song", "songs" -> values.tracks.firstOrNull()?.let(ProviderSearchHit::Track)
+                "artist", "artists" -> values.artists.firstOrNull()?.let(ProviderSearchHit::Artist)
+                "album", "albums" -> values.albums.firstOrNull()?.let(ProviderSearchHit::Album)
+                "playlist", "playlists", "playlistresult" -> values.playlists.firstOrNull()?.let(ProviderSearchHit::Playlist)
+                "mv", "mvs", "video", "videos" -> values.videos.firstOrNull()?.let(ProviderSearchHit::Video)
+                else -> null
+            }
+        }.take(1).toList()
+    }
+
+    private fun ProviderSearchResults.withFallbackBestMatch(keyword: String): ProviderSearchResults =
+        copy(bestMatches = bestMatches.ifEmpty { fallbackBestMatches(keyword) })
+
+    private fun ProviderSearchResults.fallbackBestMatches(keyword: String): List<ProviderSearchHit> {
+        val normalized = normalize(keyword)
+        val exact = sequenceOf(
+            artists.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Artist),
+            albums.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Album),
+            tracks.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Track),
+            playlists.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Playlist),
+            videos.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Video),
+        ).filterNotNull().firstOrNull()
+        val fallback = tracks.firstOrNull()?.let(ProviderSearchHit::Track)
+            ?: artists.firstOrNull()?.let(ProviderSearchHit::Artist)
+            ?: albums.firstOrNull()?.let(ProviderSearchHit::Album)
+            ?: playlists.firstOrNull()?.let(ProviderSearchHit::Playlist)
+            ?: videos.firstOrNull()?.let(ProviderSearchHit::Video)
+        return listOfNotNull(exact ?: fallback)
+    }
+
+    private fun ProviderSearchResults.hasCatalogResults(): Boolean =
+        tracks.isNotEmpty() || playlists.isNotEmpty() || artists.isNotEmpty() || albums.isNotEmpty() || videos.isNotEmpty()
+
+    private fun toTrack(value: JsonElement): MusicTrack? {
+        val item = runCatching { value.asObject() }.getOrNull() ?: return null
+        val identifier = item.string("id").ifBlank { item.string("songId") }
+        if (identifier.isBlank()) return null
+        val artistValues = item.array("ar").takeIf { it.isNotEmpty() } ?: item.array("artists")
+        val artist = artistValues.firstOrNull()?.let { runCatching { it.asObject() }.getOrNull() }
+        val album = item.obj("al") ?: item.obj("album")
+        return MusicTrack(
+            id = trackKey(ID, identifier),
+            title = item.string("name").ifBlank { item.string("title") },
+            artists = artistValues.mapNotNull { runCatching { it.asObject().string("name") }.getOrNull() }
+                .filter(String::isNotBlank)
+                .joinToString(" / ")
+                .ifBlank { item.string("artistName") },
+            album = album?.string("name").orEmpty().ifBlank { item.string("albumName") },
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = album?.stringOrNull("picUrl") ?: item.stringOrNull("picUrl"),
+            durationMs = item.long("dt") ?: item.long("duration") ?: item.long("interval")?.times(1_000),
+            providerId = trackKey(ID, identifier),
+            providerName = NAME,
+            artistItemId = artist?.stringOrNull("id")?.let { mediaItemKey(MediaRefType.Artist, ID, it) },
+            albumItemId = album?.stringOrNull("id")?.let { mediaItemKey(MediaRefType.Album, ID, it) },
+            providerUrl = "$BASE/#/song?id=$identifier",
+        )
+    }
+
+    private fun toArtist(value: JsonElement): MediaRef? {
+        val item = runCatching { value.asObject() }.getOrNull() ?: return null
+        val identifier = item.string("id")
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Artist, ID, identifier),
+            title = item.string("name"),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Artist,
+            coverUrl = item.stringOrNull("picUrl") ?: item.stringOrNull("avatar") ?: item.stringOrNull("cover"),
+            providerUrl = "$BASE/#/artist?id=$identifier",
+        )
+    }
+
+    private fun toAlbum(value: JsonElement): MediaRef? {
+        val item = runCatching { value.asObject() }.getOrNull() ?: return null
+        val identifier = item.string("id")
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Album, ID, identifier),
+            title = item.string("name"),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Album,
+            coverUrl = item.stringOrNull("picUrl") ?: item.stringOrNull("coverUrl") ?: item.stringOrNull("cover"),
+            providerUrl = "$BASE/#/album?id=$identifier",
+        )
+    }
+
+    private fun toPlaylist(value: JsonElement): ProviderPlaylist? {
+        val item = runCatching { value.asObject() }.getOrNull() ?: return null
+        val identifier = item.string("id")
+        if (identifier.isBlank()) return null
+        return ProviderPlaylist(
+            id = playlistKey(ID, identifier),
+            title = item.string("name"),
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("coverImgUrl") ?: item.stringOrNull("picUrl"),
+            description = item.string("description").ifBlank {
+                item.obj("creator")?.stringOrNull("nickname") ?: item.string("creatorName")
+            },
+            playCount = item.long("playCount"),
+            providerUrl = "$BASE/#/playlist?id=$identifier",
+            trackCount = item.int("trackCount"),
+        )
+    }
+
+    private fun toVideo(value: JsonElement): ProviderVideo? {
+        val item = runCatching { value.asObject() }.getOrNull() ?: return null
+        val identifier = item.string("id").ifBlank { item.string("mvId") }
+        if (identifier.isBlank()) return null
+        val artists = item.array("artists").mapNotNull { element ->
+            runCatching { element.asObject().string("name") }.getOrNull()
+        }.filter(String::isNotBlank).joinToString(" / ")
+        return ProviderVideo(
+            id = videoKey(ID, identifier),
+            title = item.string("name").ifBlank { item.string("title") },
+            artists = artists.ifBlank { item.string("artistName") },
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("cover") ?: item.stringOrNull("imgurl") ?: item.stringOrNull("coverUrl"),
+            durationMs = item.long("duration") ?: item.long("durationMs"),
+            providerUrl = "$BASE/#/mv?id=$identifier",
+        )
+    }
+
+    private fun firstNonEmpty(vararg values: JsonArray): JsonArray = values.firstOrNull { it.isNotEmpty() } ?: JsonArray(emptyList())
+
+    private fun normalize(value: String): String = value.trim().lowercase().replace(" ", "")
+
+    private companion object {
+        const val ID = "netease"
+        const val NAME = "网易云音乐"
+        const val BASE = "https://music.163.com"
+        const val COMPREHENSIVE_SEARCH_TYPE = 1018
+        const val USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36"
+    }
+}

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
@@ -96,44 +96,44 @@ internal class NeteaseComprehensiveSearchProvider(
 
     private fun songValues(result: JsonObject): JsonArray = firstNonEmpty(
         result.array("songs"),
-        result.obj("song")?.array("songs").orEmpty(),
-        result.obj("song")?.array("items").orEmpty(),
-        result.obj("song")?.array("list").orEmpty(),
+        result.obj("song").arrayOrEmpty("songs"),
+        result.obj("song").arrayOrEmpty("items"),
+        result.obj("song").arrayOrEmpty("list"),
     )
 
     private fun artistValues(result: JsonObject): JsonArray = firstNonEmpty(
         result.array("artists"),
-        result.obj("artist")?.array("artists").orEmpty(),
-        result.obj("artist")?.array("items").orEmpty(),
-        result.obj("artist")?.array("list").orEmpty(),
+        result.obj("artist").arrayOrEmpty("artists"),
+        result.obj("artist").arrayOrEmpty("items"),
+        result.obj("artist").arrayOrEmpty("list"),
     )
 
     private fun albumValues(result: JsonObject): JsonArray = firstNonEmpty(
         result.array("albums"),
-        result.obj("album")?.array("albums").orEmpty(),
-        result.obj("album")?.array("items").orEmpty(),
-        result.obj("album")?.array("list").orEmpty(),
+        result.obj("album").arrayOrEmpty("albums"),
+        result.obj("album").arrayOrEmpty("items"),
+        result.obj("album").arrayOrEmpty("list"),
     )
 
     private fun playlistValues(result: JsonObject): JsonArray = firstNonEmpty(
         result.array("playlists"),
         result.array("playLists"),
-        result.obj("playlist")?.array("playlists").orEmpty(),
-        result.obj("playlist")?.array("playLists").orEmpty(),
-        result.obj("playList")?.array("playlists").orEmpty(),
-        result.obj("playList")?.array("playLists").orEmpty(),
-        result.obj("playList")?.array("items").orEmpty(),
+        result.obj("playlist").arrayOrEmpty("playlists"),
+        result.obj("playlist").arrayOrEmpty("playLists"),
+        result.obj("playList").arrayOrEmpty("playlists"),
+        result.obj("playList").arrayOrEmpty("playLists"),
+        result.obj("playList").arrayOrEmpty("items"),
     )
 
     private fun mvValues(result: JsonObject): JsonArray = firstNonEmpty(
         result.array("mvs"),
-        result.obj("mv")?.array("mvs").orEmpty(),
-        result.obj("mv")?.array("items").orEmpty(),
-        result.obj("mv")?.array("list").orEmpty(),
+        result.obj("mv").arrayOrEmpty("mvs"),
+        result.obj("mv").arrayOrEmpty("items"),
+        result.obj("mv").arrayOrEmpty("list"),
     )
 
     private fun nativeBestMatches(result: JsonObject, values: ProviderSearchResults): List<ProviderSearchHit> {
-        val order = result.array("order").map(JsonElement::asString).filter(String::isNotBlank)
+        val order = result.array("order").map { it.asString() }.filter(String::isNotBlank)
         if (order.isEmpty()) return emptyList()
         return order.asSequence().mapNotNull { key ->
             when (key.lowercase()) {
@@ -265,7 +265,10 @@ internal class NeteaseComprehensiveSearchProvider(
         )
     }
 
-    private fun firstNonEmpty(vararg values: JsonArray): JsonArray = values.firstOrNull { it.isNotEmpty() } ?: JsonArray(emptyList())
+    private fun JsonObject?.arrayOrEmpty(key: String): JsonArray = this?.array(key) ?: JsonArray(emptyList())
+
+    private fun firstNonEmpty(vararg values: JsonArray): JsonArray =
+        values.firstOrNull { it.isNotEmpty() } ?: JsonArray(emptyList())
 
     private fun normalize(value: String): String = value.trim().lowercase().replace(" ", "")
 

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
@@ -32,6 +32,7 @@ import org.feeluown.mobile.provider.core.trackKey
 import org.feeluown.mobile.provider.core.videoKey
 import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
 
 /**
  * NetEase default search uses cloud-search (`type=1018`) for the full result set and the native
@@ -97,14 +98,18 @@ internal class NeteaseComprehensiveSearchProvider(
     }
 
     private suspend fun multimatchBestMatches(keyword: String): List<ProviderSearchHit> {
+        val payload = NeteaseWeApi.encrypt(
+            """{"s":${jsonString(keyword)},"type":1}""",
+        )
         val raw = http.postForm(
             providerId = ID,
-            url = "$BASE/api/search/suggest/multimatch",
+            url = "$BASE/weapi/search/suggest/multimatch",
             form = Parameters.build {
-                append("s", keyword)
-                append("type", "1")
+                append("params", payload.params)
+                append("encSecKey", payload.encSecKey)
             },
             headers = authenticatedHeaders(),
+            kind = ProviderRequestKind.SafeRead,
             cacheKey = "netease:search:multimatch:$keyword",
             cachePolicy = ProviderCachePolicies.search,
         ).value
@@ -308,6 +313,9 @@ internal class NeteaseComprehensiveSearchProvider(
 
     private fun firstNonEmpty(vararg values: JsonArray): JsonArray =
         values.firstOrNull { it.isNotEmpty() } ?: JsonArray(emptyList())
+
+    private fun jsonString(value: String): String =
+        "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
     private fun normalize(value: String): String = value.trim().lowercase().replace(" ", "")
 

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseComprehensiveSearchProvider.kt
@@ -1,6 +1,8 @@
 package org.feeluown.mobile.provider.netease
 
 import io.ktor.http.Parameters
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -32,26 +34,47 @@ import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 
 /**
- * NetEase default search is a native comprehensive-search request (`type=1018`).
- * The old typed-search implementation remains the compatibility fallback for response variants
- * that do not expose any of the expected comprehensive buckets.
+ * NetEase default search uses cloud-search (`type=1018`) for the full result set and the native
+ * multimatch endpoint for the provider-ranked best match. The old typed-search implementation
+ * remains the compatibility fallback when the native comprehensive response cannot be consumed.
  */
 internal class NeteaseComprehensiveSearchProvider(
     private val delegate: NeteaseProvider,
     private val http: ProviderHttpClient,
     private val credentials: ProviderCredentialStore,
 ) : KotlinMusicProvider by delegate {
-    override suspend fun search(keyword: String): ProviderSearchResults {
-        if (keyword.isBlank()) return ProviderSearchResults()
-        val comprehensive = runCatching { comprehensiveSearch(keyword) }.getOrNull()
-        if (comprehensive != null && comprehensive.hasCatalogResults()) return comprehensive
-        return delegate.search(keyword).withFallbackBestMatch(keyword)
+    override suspend fun search(keyword: String): ProviderSearchResults = coroutineScope {
+        if (keyword.isBlank()) return@coroutineScope ProviderSearchResults()
+
+        val comprehensiveDeferred = async {
+            runCatching { comprehensiveSearch(keyword) }.getOrNull()
+        }
+        val multimatchDeferred = async {
+            runCatching { multimatchBestMatches(keyword) }.getOrElse { emptyList() }
+        }
+
+        val comprehensive = comprehensiveDeferred.await()
+        val multimatch = multimatchDeferred.await()
+        if (comprehensive != null && comprehensive.hasCatalogResults()) {
+            return@coroutineScope comprehensive.copy(
+                bestMatches = multimatch.ifEmpty {
+                    comprehensive.bestMatches.ifEmpty { comprehensive.fallbackBestMatches(keyword) }
+                },
+            )
+        }
+
+        val fallback = delegate.search(keyword)
+        fallback.copy(
+            bestMatches = multimatch.ifEmpty {
+                fallback.bestMatches.ifEmpty { fallback.fallbackBestMatches(keyword) }
+            },
+        )
     }
 
     private suspend fun comprehensiveSearch(keyword: String): ProviderSearchResults {
         val raw = http.postForm(
             providerId = ID,
-            url = "$BASE/api/search/get",
+            url = "$BASE/api/cloudsearch/pc",
             form = Parameters.build {
                 append("s", keyword)
                 append("type", COMPREHENSIVE_SEARCH_TYPE.toString())
@@ -65,25 +88,41 @@ internal class NeteaseComprehensiveSearchProvider(
         ).value
         val root = providerJson.parseToJsonElement(raw).asObject()
         val result = root.obj("result") ?: root
-
-        val tracks = songValues(result).mapNotNull(::toTrack).distinctBy { it.id }
-        val artists = artistValues(result).mapNotNull(::toArtist).distinctBy { it.id }
-        val albums = albumValues(result).mapNotNull(::toAlbum).distinctBy { it.id }
-        val playlists = playlistValues(result).mapNotNull(::toPlaylist).distinctBy { it.id }
-        val videos = mvValues(result).mapNotNull(::toVideo).distinctBy { it.id }
-        val resultValue = ProviderSearchResults(
-            tracks = tracks,
-            playlists = playlists,
-            artists = artists,
-            albums = albums,
-            videos = videos,
-        )
-        return resultValue.copy(
-            bestMatches = nativeBestMatches(result, resultValue).ifEmpty {
-                resultValue.fallbackBestMatches(keyword)
+        val values = searchResultsFrom(result)
+        return values.copy(
+            bestMatches = orderedBestMatches(result, values).ifEmpty {
+                values.fallbackBestMatches(keyword)
             },
         )
     }
+
+    private suspend fun multimatchBestMatches(keyword: String): List<ProviderSearchHit> {
+        val raw = http.postForm(
+            providerId = ID,
+            url = "$BASE/api/search/suggest/multimatch",
+            form = Parameters.build {
+                append("s", keyword)
+                append("type", "1")
+            },
+            headers = authenticatedHeaders(),
+            cacheKey = "netease:search:multimatch:$keyword",
+            cachePolicy = ProviderCachePolicies.search,
+        ).value
+        val root = providerJson.parseToJsonElement(raw).asObject()
+        val result = root.obj("result") ?: root
+        val values = searchResultsFrom(result)
+        return orderedBestMatches(result, values).ifEmpty {
+            values.fallbackBestMatches(keyword)
+        }
+    }
+
+    private fun searchResultsFrom(result: JsonObject): ProviderSearchResults = ProviderSearchResults(
+        tracks = songValues(result).mapNotNull(::toTrack).distinctBy { it.id },
+        playlists = playlistValues(result).mapNotNull(::toPlaylist).distinctBy { it.id },
+        artists = artistValues(result).mapNotNull(::toArtist).distinctBy { it.id },
+        albums = albumValues(result).mapNotNull(::toAlbum).distinctBy { it.id },
+        videos = mvValues(result).mapNotNull(::toVideo).distinctBy { it.id },
+    )
 
     private suspend fun authenticatedHeaders(): Map<String, String> {
         val cookie = cookieHeader(credentials.read(ID))
@@ -132,23 +171,23 @@ internal class NeteaseComprehensiveSearchProvider(
         result.obj("mv").arrayOrEmpty("list"),
     )
 
-    private fun nativeBestMatches(result: JsonObject, values: ProviderSearchResults): List<ProviderSearchHit> {
-        val order = result.array("order").map { it.asString() }.filter(String::isNotBlank)
+    private fun orderedBestMatches(result: JsonObject, values: ProviderSearchResults): List<ProviderSearchHit> {
+        val order = firstNonEmpty(result.array("orders"), result.array("order"))
+            .map { it.asString() }
+            .filter(String::isNotBlank)
         if (order.isEmpty()) return emptyList()
-        return order.asSequence().mapNotNull { key ->
-            when (key.lowercase()) {
-                "song", "songs" -> values.tracks.firstOrNull()?.let(ProviderSearchHit::Track)
-                "artist", "artists" -> values.artists.firstOrNull()?.let(ProviderSearchHit::Artist)
-                "album", "albums" -> values.albums.firstOrNull()?.let(ProviderSearchHit::Album)
-                "playlist", "playlists", "playlistresult" -> values.playlists.firstOrNull()?.let(ProviderSearchHit::Playlist)
-                "mv", "mvs", "video", "videos" -> values.videos.firstOrNull()?.let(ProviderSearchHit::Video)
-                else -> null
-            }
-        }.take(1).toList()
+        return order.asSequence().mapNotNull { key -> bestMatchForKey(key, values) }.take(1).toList()
     }
 
-    private fun ProviderSearchResults.withFallbackBestMatch(keyword: String): ProviderSearchResults =
-        copy(bestMatches = bestMatches.ifEmpty { fallbackBestMatches(keyword) })
+    private fun bestMatchForKey(key: String, values: ProviderSearchResults): ProviderSearchHit? =
+        when (key.lowercase()) {
+            "song", "songs" -> values.tracks.firstOrNull()?.let(ProviderSearchHit::Track)
+            "artist", "artists" -> values.artists.firstOrNull()?.let(ProviderSearchHit::Artist)
+            "album", "albums" -> values.albums.firstOrNull()?.let(ProviderSearchHit::Album)
+            "playlist", "playlists", "playlistresult" -> values.playlists.firstOrNull()?.let(ProviderSearchHit::Playlist)
+            "mv", "mvs", "video", "videos" -> values.videos.firstOrNull()?.let(ProviderSearchHit::Video)
+            else -> null
+        }
 
     private fun ProviderSearchResults.fallbackBestMatches(keyword: String): List<ProviderSearchHit> {
         val normalized = normalize(keyword)

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProviderFactory.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProviderFactory.kt
@@ -8,9 +8,15 @@ import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
 object NeteaseProviderFactory : KotlinProviderFactory {
     override val providerId: String = "netease"
 
-    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider =
-        NeteaseProvider(
+    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
+        val base = NeteaseProvider(
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
+        return NeteaseComprehensiveSearchProvider(
+            delegate = base,
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+        )
+    }
 }

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicComprehensiveSearchProvider.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicComprehensiveSearchProvider.kt
@@ -1,0 +1,407 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.feeluown.mobile.MediaRef
+import org.feeluown.mobile.MediaRefType
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderSearchHit
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.TrackSourceType
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.md5Hex
+import org.feeluown.mobile.provider.core.mediaItemKey
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.playlistKey
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.trackKey
+import org.feeluown.mobile.provider.core.videoKey
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+import kotlin.random.Random
+
+/** Uses QQ Music's SearchAdaptor/do_search_v2 as the default multi-type search surface. */
+internal class QQMusicComprehensiveSearchProvider(
+    private val delegate: KotlinMusicProvider,
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+) : KotlinMusicProvider by delegate {
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        if (keyword.isBlank()) return ProviderSearchResults()
+        val quickBest = runCatching { quickSearchBestMatch(keyword) }.getOrNull()
+        val comprehensive = runCatching { generalSearch(keyword) }.getOrNull()
+        if (comprehensive != null && comprehensive.hasCatalogResults()) {
+            return comprehensive.copy(
+                bestMatches = listOfNotNull(quickBest ?: comprehensive.fallbackBestMatch(keyword)),
+            )
+        }
+        val fallback = delegate.search(keyword)
+        return fallback.copy(
+            bestMatches = fallback.bestMatches.ifEmpty {
+                listOfNotNull(quickBest ?: fallback.fallbackBestMatch(keyword))
+            },
+        )
+    }
+
+    private suspend fun generalSearch(keyword: String): ProviderSearchResults {
+        val request = """
+            {
+              "search":{
+                "module":"music.adaptor.SearchAdaptor",
+                "method":"do_search_v2",
+                "param":{
+                  "searchid":${currentTimeMillis()},
+                  "search_type":100,
+                  "page_num":20,
+                  "query":${jsonString(keyword)},
+                  "page_id":1,
+                  "highlight":false,
+                  "grp":true
+                }
+              },
+              "comm":{"ct":24,"cv":0,"uin":"0","format":"json"}
+            }
+        """.trimIndent()
+        val root = rpc(request, "qqmusic:search:comprehensive:$keyword")
+        val data = root.obj("search")?.obj("data") ?: root.obj("search") ?: root
+        val body = data.obj("body") ?: data
+        return ProviderSearchResults(
+            tracks = bucket(body, "item_song").mapNotNull(::toTrack).distinctBy { it.id },
+            artists = bucket(body, "singer").mapNotNull(::toArtist).distinctBy { it.id },
+            albums = bucket(body, "item_album").mapNotNull(::toAlbum).distinctBy { it.id },
+            playlists = bucket(body, "item_songlist").mapNotNull(::toPlaylist).distinctBy { it.id },
+            videos = bucket(body, "item_mv").mapNotNull(::toVideo).distinctBy { it.id },
+        )
+    }
+
+    private suspend fun quickSearchBestMatch(keyword: String): ProviderSearchHit? {
+        val root = http.getText(
+            providerId = ID,
+            url = "$QUICK_SEARCH_BASE?key=${encodeUrlComponent(keyword)}",
+            headers = publicHeaders(),
+            cacheKey = "qqmusic:search:quick:$keyword",
+            cachePolicy = ProviderCachePolicies.search,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        val data = root.obj("data") ?: return null
+        val categories = listOf(
+            QuickCategory("song", data.obj("song")),
+            QuickCategory("singer", data.obj("singer")),
+            QuickCategory("album", data.obj("album")),
+            QuickCategory("mv", data.obj("mv")),
+        ).filter { it.value?.array("itemlist")?.isNotEmpty() == true }
+        if (categories.isEmpty()) return null
+
+        val normalized = normalize(keyword)
+        val exact = categories.asSequence().flatMap { category ->
+            category.value!!.array("itemlist").asSequence().mapNotNull { value ->
+                val item = runCatching { value.asObject() }.getOrNull() ?: return@mapNotNull null
+                if (normalize(item.string("name")) != normalized) return@mapNotNull null
+                quickHit(category.key, item)
+            }
+        }.firstOrNull()
+        if (exact != null) return exact
+
+        val selected = categories.minByOrNull { category ->
+            category.value?.int("order")?.takeIf { it > 0 } ?: Int.MAX_VALUE
+        } ?: return null
+        val item = selected.value?.array("itemlist")?.firstOrNull()?.let {
+            runCatching { it.asObject() }.getOrNull()
+        } ?: return null
+        return quickHit(selected.key, item)
+    }
+
+    private fun quickHit(type: String, item: JsonObject): ProviderSearchHit? = when (type) {
+        "song" -> toQuickTrack(item)?.let(ProviderSearchHit::Track)
+        "singer" -> toQuickArtist(item)?.let(ProviderSearchHit::Artist)
+        "album" -> toQuickAlbum(item)?.let(ProviderSearchHit::Album)
+        "mv" -> toQuickVideo(item)?.let(ProviderSearchHit::Video)
+        else -> null
+    }
+
+    private suspend fun rpc(payload: String, cacheKey: String): JsonObject {
+        val signedPayload = payload
+        val sign = contentSign(signedPayload)
+        return http.getText(
+            providerId = ID,
+            url = "$RPC_BASE/cgi-bin/musicu.fcg?_=${currentTimeMillis()}&sign=${encodeUrlComponent(sign)}&data=${encodeUrlComponent(signedPayload)}",
+            headers = publicHeaders(),
+            cacheKey = cacheKey,
+            cachePolicy = ProviderCachePolicies.search,
+        ).value.let { providerJson.parseToJsonElement(it).asObject() }
+    }
+
+    private suspend fun publicHeaders(): Map<String, String> {
+        val cookie = cookieHeader(credentials.read(ID))
+        return buildMap {
+            put("User-Agent", USER_AGENT)
+            put("Referer", "https://y.qq.com/")
+            if (cookie.isNotBlank()) put("Cookie", cookie)
+        }
+    }
+
+    private fun bucket(body: JsonObject, key: String): List<JsonElement> {
+        val value = body.obj(key)
+        return firstNonEmpty(
+            value?.array("items").orEmpty(),
+            value?.array("list").orEmpty(),
+            body.array(key),
+        )
+    }
+
+    private fun toTrack(value: JsonElement): MusicTrack? {
+        val source = runCatching { value.asObject() }.getOrNull() ?: return null
+        val item = source.obj("songInfo") ?: source.obj("data") ?: source
+        val identifier = item.string("mid")
+            .ifBlank { item.string("songmid") }
+            .ifBlank { item.string("song_id") }
+            .ifBlank { item.string("songid") }
+            .ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        val singerValues = item.array("singer")
+        val firstSinger = singerValues.firstOrNull()?.let { runCatching { it.asObject() }.getOrNull() }
+        val album = item.obj("album")
+        val albumMid = album?.string("mid").orEmpty().ifBlank { item.string("albummid") }
+        val albumId = album?.string("id").orEmpty().ifBlank { item.string("albumid") }
+        return MusicTrack(
+            id = trackKey(ID, identifier),
+            title = item.string("name").ifBlank { item.string("title") }.stripHtml(),
+            artists = singerValues.mapNotNull { element ->
+                runCatching { element.asObject().string("name") }.getOrNull()
+            }.filter(String::isNotBlank).joinToString(" / ").ifBlank { item.string("singername") },
+            album = album?.string("name").orEmpty().ifBlank { item.string("albumname") },
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = item.stringOrNull("pic") ?: albumMid.takeIf(String::isNotBlank)?.let(::albumCover),
+            durationMs = item.long("interval")?.times(1_000) ?: item.long("duration")?.let(::durationToMillis),
+            providerId = trackKey(ID, identifier),
+            providerName = NAME,
+            artistItemId = firstSinger?.stringOrNull("mid")?.let { mediaItemKey(MediaRefType.Artist, ID, it) },
+            albumItemId = (albumMid.takeIf(String::isNotBlank) ?: albumId.takeIf(String::isNotBlank))
+                ?.let { mediaItemKey(MediaRefType.Album, ID, it) },
+            providerUrl = "https://y.qq.com/n/ryqq/songDetail/$identifier",
+        )
+    }
+
+    private fun toArtist(value: JsonElement): MediaRef? {
+        val source = runCatching { value.asObject() }.getOrNull() ?: return null
+        val item = source.obj("singerInfo") ?: source.obj("data") ?: source
+        val identifier = item.string("mid")
+            .ifBlank { item.string("singerMID") }
+            .ifBlank { item.string("singerMid") }
+            .ifBlank { item.string("singer_mid") }
+            .ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Artist, ID, identifier),
+            title = item.string("name").ifBlank { item.string("singerName") }.stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Artist,
+            coverUrl = item.stringOrNull("singerPic") ?: item.stringOrNull("pic"),
+            description = item.string("subtitle"),
+            providerUrl = "https://y.qq.com/n/ryqq/singer/$identifier",
+        )
+    }
+
+    private fun toAlbum(value: JsonElement): MediaRef? {
+        val source = runCatching { value.asObject() }.getOrNull() ?: return null
+        val item = source.obj("albumInfo") ?: source.obj("data") ?: source
+        val identifier = item.string("mid")
+            .ifBlank { item.string("albumMID") }
+            .ifBlank { item.string("albumMid") }
+            .ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Album, ID, identifier),
+            title = item.string("name").ifBlank { item.string("albumName") }.ifBlank { item.string("title") }.stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Album,
+            coverUrl = item.stringOrNull("pic") ?: albumCover(identifier),
+            description = item.string("description"),
+            providerUrl = "https://y.qq.com/n/ryqq/albumDetail/$identifier",
+        )
+    }
+
+    private fun toPlaylist(value: JsonElement): ProviderPlaylist? {
+        val source = runCatching { value.asObject() }.getOrNull() ?: return null
+        val item = source.obj("dissInfo") ?: source.obj("data") ?: source
+        val identifier = item.string("dissid")
+            .ifBlank { item.string("tid") }
+            .ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return ProviderPlaylist(
+            id = playlistKey(ID, identifier),
+            title = item.string("dissname").ifBlank { item.string("title") }.ifBlank { item.string("name") }.stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("imgurl") ?: item.stringOrNull("logo") ?: item.stringOrNull("pic"),
+            description = item.string("introduction").ifBlank { item.string("desc") },
+            playCount = item.long("listennum") ?: item.long("visitnum"),
+            providerUrl = "https://y.qq.com/n/ryqq/playlist/$identifier",
+            trackCount = item.int("song_count") ?: item.int("songnum"),
+        )
+    }
+
+    private fun toVideo(value: JsonElement): ProviderVideo? {
+        val source = runCatching { value.asObject() }.getOrNull() ?: return null
+        val item = source.obj("mvInfo") ?: source.obj("data") ?: source
+        val identifier = item.string("vid")
+            .ifBlank { item.string("mv_id") }
+            .ifBlank { item.string("mid") }
+        if (identifier.isBlank()) return null
+        val singers = item.array("singer").mapNotNull { element ->
+            runCatching { element.asObject().string("name") }.getOrNull()
+        }.filter(String::isNotBlank).joinToString(" / ")
+        return ProviderVideo(
+            id = videoKey(ID, identifier),
+            title = item.string("mv_name").ifBlank { item.string("name") }.ifBlank { item.string("title") }.stripHtml(),
+            artists = singers.ifBlank { item.string("singer_name") }.ifBlank { item.string("singername") },
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("picurl") ?: item.stringOrNull("pic"),
+            durationMs = item.long("duration")?.let(::durationToMillis),
+            providerUrl = "https://y.qq.com/n/ryqq/mvdetail/$identifier",
+        )
+    }
+
+    private fun toQuickTrack(item: JsonObject): MusicTrack? {
+        val identifier = item.string("mid").ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return MusicTrack(
+            id = trackKey(ID, identifier),
+            title = item.string("name").stripHtml(),
+            artists = item.string("singer").stripHtml(),
+            album = "",
+            source = ID,
+            sourceType = TrackSourceType.Provider,
+            coverUrl = item.stringOrNull("pic"),
+            providerId = trackKey(ID, identifier),
+            providerName = NAME,
+            providerUrl = "https://y.qq.com/n/ryqq/songDetail/$identifier",
+        )
+    }
+
+    private fun toQuickArtist(item: JsonObject): MediaRef? {
+        val identifier = item.string("mid").ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Artist, ID, identifier),
+            title = item.string("name").stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Artist,
+            coverUrl = item.stringOrNull("pic"),
+            providerUrl = "https://y.qq.com/n/ryqq/singer/$identifier",
+        )
+    }
+
+    private fun toQuickAlbum(item: JsonObject): MediaRef? {
+        val identifier = item.string("mid").ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return MediaRef(
+            id = mediaItemKey(MediaRefType.Album, ID, identifier),
+            title = item.string("name").stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            type = MediaRefType.Album,
+            coverUrl = item.stringOrNull("pic") ?: albumCover(identifier),
+            providerUrl = "https://y.qq.com/n/ryqq/albumDetail/$identifier",
+        )
+    }
+
+    private fun toQuickVideo(item: JsonObject): ProviderVideo? {
+        val identifier = item.string("vid").ifBlank { item.string("mid") }.ifBlank { item.string("id") }
+        if (identifier.isBlank()) return null
+        return ProviderVideo(
+            id = videoKey(ID, identifier),
+            title = item.string("name").stripHtml(),
+            artists = item.string("singer").stripHtml(),
+            providerId = ID,
+            providerName = NAME,
+            coverUrl = item.stringOrNull("pic"),
+            providerUrl = "https://y.qq.com/n/ryqq/mvdetail/$identifier",
+        )
+    }
+
+    private fun ProviderSearchResults.hasCatalogResults(): Boolean =
+        tracks.isNotEmpty() || playlists.isNotEmpty() || artists.isNotEmpty() || albums.isNotEmpty() || videos.isNotEmpty()
+
+    private fun ProviderSearchResults.fallbackBestMatch(keyword: String): ProviderSearchHit? {
+        val normalized = normalize(keyword)
+        return artists.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Artist)
+            ?: albums.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Album)
+            ?: tracks.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Track)
+            ?: playlists.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Playlist)
+            ?: videos.firstOrNull { normalize(it.title) == normalized }?.let(ProviderSearchHit::Video)
+            ?: tracks.firstOrNull()?.let(ProviderSearchHit::Track)
+            ?: artists.firstOrNull()?.let(ProviderSearchHit::Artist)
+            ?: albums.firstOrNull()?.let(ProviderSearchHit::Album)
+            ?: playlists.firstOrNull()?.let(ProviderSearchHit::Playlist)
+            ?: videos.firstOrNull()?.let(ProviderSearchHit::Video)
+    }
+
+    private fun durationToMillis(value: Long): Long = if (value < 100_000) value * 1_000 else value
+
+    private fun albumCover(mid: String): String = "https://y.qq.com/music/photo_new/T002R300x300M000$mid.jpg"
+
+    private fun String.stripHtml(): String = replace(Regex("<[^>]+>"), "")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+
+    private fun normalize(value: String): String = value.stripHtml().trim().lowercase().replace(" ", "")
+
+    private fun jsonString(value: String): String = JsonPrimitive(value).toString()
+
+    private fun contentSign(data: String): String {
+        val randomPart = buildString {
+            repeat(Random.nextInt(10, 17)) {
+                append(SIGN_ALPHABET[Random.nextInt(SIGN_ALPHABET.length)])
+            }
+        }
+        return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}"
+    }
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val number = byte.toInt() and 0xff
+            if (number in 0x30..0x39 || number in 0x41..0x5a || number in 0x61..0x7a || number in setOf(45, 46, 95, 126)) {
+                append(number.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[number ushr 4])
+                append("0123456789ABCDEF"[number and 15])
+            }
+        }
+    }
+
+    private data class QuickCategory(val key: String, val value: JsonObject?)
+
+    private companion object {
+        const val ID = "qqmusic"
+        const val NAME = "QQ 音乐"
+        const val RPC_BASE = "https://u.y.qq.com"
+        const val QUICK_SEARCH_BASE = "https://c.y.qq.com/splcloud/fcgi-bin/smartbox_new.fcg"
+        const val SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+        const val USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36"
+    }
+}
+
+private fun <T> firstNonEmpty(vararg values: List<T>): List<T> =
+    values.firstOrNull { it.isNotEmpty() }.orEmpty()

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderFactory.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderFactory.kt
@@ -8,6 +8,12 @@ import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
 object QQMusicProviderFactory : KotlinProviderFactory {
     override val providerId: String = "qqmusic"
 
-    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider =
-        QQMusicCompositeProvider(dependencies)
+    override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
+        val provider = QQMusicCompositeProvider(dependencies)
+        return QQMusicComprehensiveSearchProvider(
+            delegate = provider,
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+        )
+    }
 }

--- a/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/ProviderResultFailureCompatibility.kt
+++ b/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/ProviderResultFailureCompatibility.kt
@@ -13,6 +13,7 @@ fun ProviderSearchResults(
     artists: List<MediaRef> = emptyList(),
     albums: List<MediaRef> = emptyList(),
     videos: List<ProviderVideo> = emptyList(),
+    bestMatches: List<ProviderSearchHit> = emptyList(),
     errorMessage: String?,
     compatibility: Unit = Unit,
 ): ProviderSearchResults = ProviderSearchResults(
@@ -21,6 +22,7 @@ fun ProviderSearchResults(
     artists = artists,
     albums = albums,
     videos = videos,
+    bestMatches = bestMatches,
     failure = errorMessage.toProviderResultFailure(),
 )
 

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
@@ -3,6 +3,8 @@ package org.feeluown.mobile.provider.ytmusic
 import org.feeluown.mobile.ProviderDeviceAuthorization
 import org.feeluown.mobile.ProviderDeviceAuthorizationPollResult
 import org.feeluown.mobile.ProviderOAuthToken
+import org.feeluown.mobile.ProviderSearchHit
+import org.feeluown.mobile.ProviderSearchResults
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.KotlinProviderFactory
 import org.feeluown.mobile.provider.core.ProviderDeviceAuthorizationCapability
@@ -22,6 +24,12 @@ object YtMusicProviderFactory : KotlinProviderFactory {
 private class YtMusicApplicationProvider(
     private val content: YtMusicContentProvider,
 ) : KotlinMusicProvider by content, ProviderDeviceAuthorizationCapability {
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        val results = content.search(keyword)
+        if (results.bestMatches.isNotEmpty()) return results
+        return results.copy(bestMatches = listOfNotNull(bestMatch(keyword, results)))
+    }
+
     override suspend fun beginDeviceAuthorization(
         clientId: String,
         clientSecret: String,
@@ -61,4 +69,46 @@ private class YtMusicApplicationProvider(
         clientId: String,
         clientSecret: String,
     ) = content.loginWithOAuthJson(oauthJson, clientId, clientSecret)
+
+    private fun bestMatch(keyword: String, results: ProviderSearchResults): ProviderSearchHit? {
+        val query = normalize(keyword)
+        if (query.isBlank()) return null
+        return buildList {
+            results.artists.take(5).forEachIndexed { index, item ->
+                add(Candidate(ProviderSearchHit.Artist(item), item.title, index, 5))
+            }
+            results.albums.take(5).forEachIndexed { index, item ->
+                add(Candidate(ProviderSearchHit.Album(item), item.title, index, 4))
+            }
+            results.tracks.take(5).forEachIndexed { index, item ->
+                val extra = if (normalize(item.artists) == query) 250 else 0
+                add(Candidate(ProviderSearchHit.Track(item), item.title, index, 3, extra))
+            }
+            results.playlists.take(5).forEachIndexed { index, item ->
+                add(Candidate(ProviderSearchHit.Playlist(item), item.title, index, 2))
+            }
+            results.videos.take(5).forEachIndexed { index, item ->
+                add(Candidate(ProviderSearchHit.Video(item), item.title, index, 1))
+            }
+        }.maxByOrNull { candidate ->
+            val title = normalize(candidate.title)
+            val relevance = when {
+                title == query -> 1_000
+                title.startsWith(query) -> 600
+                title.contains(query) -> 350
+                else -> 0
+            }
+            relevance + candidate.extraScore + candidate.typePriority * 10 - candidate.index
+        }?.hit
+    }
+
+    private fun normalize(value: String): String = value.trim().lowercase().replace(" ", "")
+
+    private data class Candidate(
+        val hit: ProviderSearchHit,
+        val title: String,
+        val index: Int,
+        val typePriority: Int,
+        val extraScore: Int = 0,
+    )
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/KotlinProviderRepository.kt
@@ -95,6 +95,7 @@ class KotlinProviderRepository :
             artists = results.flatMap { it.artists }.distinctBy { it.id },
             albums = results.flatMap { it.albums }.distinctBy { it.id },
             videos = results.flatMap { it.videos }.distinctBy { it.id },
+            bestMatches = results.flatMap { it.bestMatches }.distinctBy(::searchHitKey),
             errorMessage = results.mapNotNull { it.errorMessage }.firstOrNull(),
         )
     }
@@ -309,6 +310,14 @@ class KotlinProviderRepository :
         }
         return splitResourceId(resourceId, expectedPrefix).first
     }
+}
+
+private fun searchHitKey(hit: ProviderSearchHit): String = when (hit) {
+    is ProviderSearchHit.Track -> "track:${hit.value.id}"
+    is ProviderSearchHit.Artist -> "artist:${hit.value.id}"
+    is ProviderSearchHit.Album -> "album:${hit.value.id}"
+    is ProviderSearchHit.Playlist -> "playlist:${hit.value.id}"
+    is ProviderSearchHit.Video -> "video:${hit.value.id}"
 }
 
 private const val NETEASE_PROVIDER_ID = "netease"

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchFeatureBindings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchFeatureBindings.kt
@@ -64,7 +64,13 @@ fun SearchFeatureController.searchRecognizedSong(song: RecognizedSong) {
 private object AppSearchResultOperations : SearchResultOperations<MusicTrack, ProviderSearchResults> {
     override fun empty(errorMessage: String?): ProviderSearchResults = ProviderSearchResults(errorMessage = errorMessage)
 
-    override fun tracks(results: ProviderSearchResults): List<MusicTrack> = results.tracks
+    override fun tracks(results: ProviderSearchResults): List<MusicTrack> =
+        buildList {
+            results.bestMatches.forEach { hit ->
+                if (hit is ProviderSearchHit.Track) add(hit.value)
+            }
+            addAll(results.tracks)
+        }.distinctBy { it.id }
 
     override fun merge(results: List<ProviderSearchResults>): ProviderSearchResults = ProviderSearchResults(
         tracks = roundRobin(results.map { it.tracks }).distinctBy { it.id },
@@ -77,7 +83,7 @@ private object AppSearchResultOperations : SearchResultOperations<MusicTrack, Pr
     )
 
     override fun totalCount(results: ProviderSearchResults): Int =
-        results.tracks.size +
+        tracks(results).size +
             results.playlists.size +
             results.artists.size +
             results.albums.size +

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchFeatureBindings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchFeatureBindings.kt
@@ -13,7 +13,7 @@ fun SearchUiState(
     selectedSearchProviderId: String? = null,
     searchResults: List<MusicTrack> = emptyList(),
     providerSearchResults: ProviderSearchResults = ProviderSearchResults(),
-    providerSearchTab: ProviderSearchTab = ProviderSearchTab.Songs,
+    providerSearchTab: ProviderSearchTab = ProviderSearchTab.Comprehensive,
     isLoading: Boolean = false,
     message: String? = null,
 ): SearchUiState = SearchFeatureState(
@@ -67,11 +67,12 @@ private object AppSearchResultOperations : SearchResultOperations<MusicTrack, Pr
     override fun tracks(results: ProviderSearchResults): List<MusicTrack> = results.tracks
 
     override fun merge(results: List<ProviderSearchResults>): ProviderSearchResults = ProviderSearchResults(
-        tracks = results.flatMap { it.tracks }.distinctBy { it.id },
-        playlists = results.flatMap { it.playlists }.distinctBy { it.id },
-        artists = results.flatMap { it.artists }.distinctBy { it.id },
-        albums = results.flatMap { it.albums }.distinctBy { it.id },
-        videos = results.flatMap { it.videos }.distinctBy { it.id },
+        tracks = roundRobin(results.map { it.tracks }).distinctBy { it.id },
+        playlists = roundRobin(results.map { it.playlists }).distinctBy { it.id },
+        artists = roundRobin(results.map { it.artists }).distinctBy { it.id },
+        albums = roundRobin(results.map { it.albums }).distinctBy { it.id },
+        videos = roundRobin(results.map { it.videos }).distinctBy { it.id },
+        bestMatches = results.flatMap { it.bestMatches }.distinctBy(::searchHitKey),
         errorMessage = results.firstNotNullOfOrNull { it.errorMessage },
     )
 
@@ -85,4 +86,22 @@ private object AppSearchResultOperations : SearchResultOperations<MusicTrack, Pr
     override fun errorMessage(results: ProviderSearchResults): String? = results.errorMessage
 
     override fun trackId(track: MusicTrack): String = track.id
+}
+
+private fun <T> roundRobin(groups: List<List<T>>): List<T> {
+    if (groups.isEmpty()) return emptyList()
+    val maxSize = groups.maxOfOrNull { it.size } ?: 0
+    return buildList {
+        repeat(maxSize) { index ->
+            groups.forEach { group -> group.getOrNull(index)?.let(::add) }
+        }
+    }
+}
+
+private fun searchHitKey(hit: ProviderSearchHit): String = when (hit) {
+    is ProviderSearchHit.Track -> "track:${hit.value.id}"
+    is ProviderSearchHit.Artist -> "artist:${hit.value.id}"
+    is ProviderSearchHit.Album -> "album:${hit.value.id}"
+    is ProviderSearchHit.Playlist -> "playlist:${hit.value.id}"
+    is ProviderSearchHit.Video -> "video:${hit.value.id}"
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchScreen.kt
@@ -256,7 +256,7 @@ internal fun SearchFeatureScreen(
                         }
                         Row(
                             modifier = Modifier
-                                .padding(start = 56.dp)
+                                .padding(start = FuoSpacing.sm)
                                 .horizontalScroll(rememberScrollState()),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
@@ -462,13 +462,26 @@ private fun androidx.compose.foundation.lazy.LazyListScope.comprehensiveItems(
         return
     }
 
-    if (providerResults.bestMatches.isNotEmpty()) {
+    val bestCardHits = providerResults.bestMatches.filter { hit ->
+        hit is ProviderSearchHit.Artist ||
+            hit is ProviderSearchHit.Album ||
+            hit is ProviderSearchHit.Playlist
+    }
+    val bestListHits = providerResults.bestMatches.filter { hit ->
+        hit is ProviderSearchHit.Track || hit is ProviderSearchHit.Video
+    }
+    if (bestCardHits.isNotEmpty() || bestListHits.isNotEmpty()) {
         sectionTitle("最佳结果")
+        if (bestCardHits.isNotEmpty()) {
+            item(key = "best:cards") {
+                BestMatchCardGrid(bestCardHits, actions)
+            }
+        }
         itemsIndexed(
-            providerResults.bestMatches,
-            key = { _, hit -> "best:${bestMatchKey(hit)}" },
+            bestListHits,
+            key = { _, hit -> "best:list:${bestMatchKey(hit)}" },
         ) { _, hit ->
-            bestMatchRow(hit, uiState, actions, downloadStates)
+            bestMatchListRow(hit, uiState, actions, downloadStates)
             HorizontalDivider()
         }
     }
@@ -494,70 +507,94 @@ private fun androidx.compose.foundation.lazy.LazyListScope.comprehensiveItems(
         }
     }
 
-    comprehensiveMediaSection(
-        title = "歌手",
-        items = providerResults.artists,
-        type = ProviderMediaItemType.Artist,
-        actions = actions,
-    )
-    comprehensiveMediaSection(
-        title = "专辑",
-        items = providerResults.albums,
-        type = ProviderMediaItemType.Album,
-        actions = actions,
-    )
-
-    val playlistItems = providerResults.playlists.take(COMPREHENSIVE_SECTION_LIMIT)
-    if (playlistItems.isNotEmpty()) {
-        sectionTitle("歌单")
-        itemsIndexed(playlistItems, key = { _, item -> "comprehensive-playlist:${item.id}" }) { _, playlist ->
-            ProviderSearchRow(
-                title = playlist.title,
-                subtitle = playlist.providerName,
-                coverUrl = playlist.coverUrl,
-                placeholder = CoverPlaceholder.Playlist,
-                onClick = { actions.onOpenPlaylist(playlist) },
+    if (providerResults.artists.isNotEmpty()) {
+        sectionTitle("歌手")
+        item(key = "comprehensive:artists") {
+            ProviderMediaItemGrid(
+                items = providerResults.artists,
+                onClick = actions.onOpenMediaItem,
+                onMore = { actions.dispatch(SearchAction.ProviderTabChanged(ProviderSearchTab.Artists)) },
+                maxRows = 2,
             )
-            HorizontalDivider()
+        }
+    }
+
+    if (providerResults.albums.isNotEmpty()) {
+        sectionTitle("专辑")
+        item(key = "comprehensive:albums") {
+            ProviderMediaItemGrid(
+                items = providerResults.albums,
+                onClick = actions.onOpenMediaItem,
+                onMore = { actions.dispatch(SearchAction.ProviderTabChanged(ProviderSearchTab.Albums)) },
+                maxRows = 2,
+            )
+        }
+    }
+
+    if (providerResults.playlists.isNotEmpty()) {
+        sectionTitle("歌单")
+        item(key = "comprehensive:playlists") {
+            ProviderPlaylistGrid(
+                playlists = providerResults.playlists,
+                onClick = actions.onOpenPlaylist,
+                onMore = { actions.dispatch(SearchAction.ProviderTabChanged(ProviderSearchTab.Playlists)) },
+                maxRows = 2,
+            )
         }
     }
 
     val videoItems = providerResults.videos.take(COMPREHENSIVE_SECTION_LIMIT)
     if (videoItems.isNotEmpty()) {
         sectionTitle("视频")
-        itemsIndexed(videoItems, key = { _, item -> "comprehensive-video:${item.id}" }) { _, video ->
-            ProviderSearchRow(
-                title = video.title,
-                subtitle = listOf(video.artists, video.providerName).filter { it.isNotBlank() }.joinToString(" · "),
-                coverUrl = video.coverUrl,
-                onClick = { actions.onOpenVideo(video) },
-            )
-            HorizontalDivider()
+        item(key = "comprehensive:videos") {
+            ProviderVideoList(videoItems, actions.onOpenVideo)
         }
     }
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.comprehensiveMediaSection(
-    title: String,
-    items: List<ProviderMediaItem>,
-    type: ProviderMediaItemType,
+@Composable
+private fun BestMatchCardGrid(
+    hits: List<ProviderSearchHit>,
     actions: SearchFeatureActions,
 ) {
-    val preview = items.take(COMPREHENSIVE_SECTION_LIMIT)
-    if (preview.isEmpty()) return
-    sectionTitle(title)
-    itemsIndexed(preview, key = { _, item -> "comprehensive-${type.name.lowercase()}:${item.id}" }) { _, item ->
-        ProviderSearchRow(
-            title = item.title,
-            subtitle = item.providerName,
-            coverUrl = item.coverUrl,
-            placeholder = when (type) {
-                ProviderMediaItemType.Artist -> CoverPlaceholder.Artist
-                ProviderMediaItemType.Album -> CoverPlaceholder.Album
-            },
-            onClick = { actions.onOpenMediaItem(item) },
-        )
-        HorizontalDivider()
+    val layoutInfo = LocalAppLayoutInfo.current
+    val columns = layoutInfo.gridColumns.coerceAtLeast(1)
+    val spacing = if (layoutInfo.useWideLayout) FuoSpacing.sm else FuoSpacing.md
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing),
+    ) {
+        hits.chunked(columns).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing),
+            ) {
+                row.forEach { hit ->
+                    when (hit) {
+                        is ProviderSearchHit.Artist -> ProviderMediaItemCard(
+                            item = hit.value,
+                            onClick = { actions.onOpenMediaItem(hit.value) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        is ProviderSearchHit.Album -> ProviderMediaItemCard(
+                            item = hit.value,
+                            onClick = { actions.onOpenMediaItem(hit.value) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        is ProviderSearchHit.Playlist -> ProviderPlaylistCard(
+                            playlist = hit.value,
+                            onClick = { actions.onOpenPlaylist(hit.value) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        is ProviderSearchHit.Track,
+                        is ProviderSearchHit.Video -> Unit
+                    }
+                }
+                repeat(columns - row.size) {
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+        }
     }
 }
 
@@ -572,7 +609,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.sectionTitle(title: S
 }
 
 @Composable
-private fun bestMatchRow(
+private fun bestMatchListRow(
     hit: ProviderSearchHit,
     uiState: SearchUiState,
     actions: SearchFeatureActions,
@@ -595,35 +632,10 @@ private fun bestMatchRow(
                 onAddToPlaylist = actions.onAddToPlaylist(track),
             )
         }
-        is ProviderSearchHit.Artist -> ProviderSearchRow(
-            title = hit.value.title,
-            subtitle = "歌手 · ${hit.value.providerName}",
-            coverUrl = hit.value.coverUrl,
-            placeholder = CoverPlaceholder.Artist,
-            onClick = { actions.onOpenMediaItem(hit.value) },
-        )
-        is ProviderSearchHit.Album -> ProviderSearchRow(
-            title = hit.value.title,
-            subtitle = "专辑 · ${hit.value.providerName}",
-            coverUrl = hit.value.coverUrl,
-            placeholder = CoverPlaceholder.Album,
-            onClick = { actions.onOpenMediaItem(hit.value) },
-        )
-        is ProviderSearchHit.Playlist -> ProviderSearchRow(
-            title = hit.value.title,
-            subtitle = "歌单 · ${hit.value.providerName}",
-            coverUrl = hit.value.coverUrl,
-            placeholder = CoverPlaceholder.Playlist,
-            onClick = { actions.onOpenPlaylist(hit.value) },
-        )
-        is ProviderSearchHit.Video -> ProviderSearchRow(
-            title = hit.value.title,
-            subtitle = listOf("视频", hit.value.artists, hit.value.providerName)
-                .filter { it.isNotBlank() }
-                .joinToString(" · "),
-            coverUrl = hit.value.coverUrl,
-            onClick = { actions.onOpenVideo(hit.value) },
-        )
+        is ProviderSearchHit.Video -> ProviderVideoList(listOf(hit.value), actions.onOpenVideo)
+        is ProviderSearchHit.Artist,
+        is ProviderSearchHit.Album,
+        is ProviderSearchHit.Playlist -> Unit
     }
 }
 
@@ -671,18 +683,8 @@ private fun androidx.compose.foundation.lazy.LazyListScope.mediaItems(
     if (items.isEmpty()) {
         item { ProviderContentMessage(emptyMessage) }
     } else {
-        itemsIndexed(items, key = { _, item -> item.id }) { _, item ->
-            ProviderSearchRow(
-                title = item.title,
-                subtitle = listOf(item.type.name, item.providerName).joinToString(" · "),
-                coverUrl = item.coverUrl,
-                placeholder = when (item.type) {
-                    ProviderMediaItemType.Artist -> CoverPlaceholder.Artist
-                    ProviderMediaItemType.Album -> CoverPlaceholder.Album
-                },
-                onClick = { actions.onOpenMediaItem(item) },
-            )
-            HorizontalDivider()
+        item(key = "search-media-grid:${items.first().type}") {
+            ProviderMediaItemGrid(items = items, onClick = actions.onOpenMediaItem)
         }
     }
 }
@@ -694,15 +696,8 @@ private fun androidx.compose.foundation.lazy.LazyListScope.playlists(
     if (playlists.isEmpty()) {
         item { ProviderContentMessage("没有歌单结果") }
     } else {
-        itemsIndexed(playlists, key = { _, item -> item.id }) { _, playlist ->
-            ProviderSearchRow(
-                title = playlist.title,
-                subtitle = playlist.providerName,
-                coverUrl = playlist.coverUrl,
-                placeholder = CoverPlaceholder.Playlist,
-                onClick = { actions.onOpenPlaylist(playlist) },
-            )
-            HorizontalDivider()
+        item(key = "search-playlist-grid") {
+            ProviderPlaylistGrid(playlists = playlists, onClick = actions.onOpenPlaylist)
         }
     }
 }
@@ -714,58 +709,10 @@ private fun androidx.compose.foundation.lazy.LazyListScope.videos(
     if (videos.isEmpty()) {
         item { ProviderContentMessage("没有视频结果") }
     } else {
-        itemsIndexed(videos, key = { _, item -> item.id }) { _, video ->
-            ProviderSearchRow(
-                title = video.title,
-                subtitle = listOf(video.artists, video.providerName).filter { it.isNotBlank() }.joinToString(" · "),
-                coverUrl = video.coverUrl,
-                onClick = { actions.onOpenVideo(video) },
-            )
-            HorizontalDivider()
+        item(key = "search-video-list") {
+            ProviderVideoList(videos, actions.onOpenVideo)
         }
     }
-}
-
-@Composable
-private fun ProviderSearchRow(
-    title: String,
-    subtitle: String,
-    coverUrl: String?,
-    placeholder: CoverPlaceholder = CoverPlaceholder.Song,
-    onClick: () -> Unit,
-) {
-    FuoListItem(
-        modifier = Modifier.fillMaxWidth(),
-        onClick = onClick,
-        leadingContent = {
-            CoverBox(
-                track = MusicTrack(
-                    id = title,
-                    title = title,
-                    artists = "",
-                    album = "",
-                    source = "",
-                    sourceType = TrackSourceType.Provider,
-                    coverUrl = coverUrl,
-                ),
-                modifier = Modifier.size(48.dp),
-                placeholder = placeholder,
-            )
-        },
-        headlineContent = {
-            Text(
-                text = title.ifBlank { "未命名" },
-                maxLines = 1,
-            )
-        },
-        supportingContent = {
-            Text(
-                text = subtitle,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-            )
-        },
-    )
 }
 
 private fun ProviderSearchTab.label(uiState: SearchUiState): String = when (this) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/search/SearchScreen.kt
@@ -36,9 +36,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 private const val MAX_SEARCH_HISTORY_ITEMS = 20
+private const val COMPREHENSIVE_SECTION_LIMIT = 6
 
 /**
  * Search feature UI contract.
@@ -427,27 +428,8 @@ private fun androidx.compose.foundation.lazy.LazyListScope.searchResultItems(
     compactTop: Boolean = false,
 ) {
     when (uiState.providerSearchTab.takeIf { uiState.searchScope != SearchScope.Local } ?: ProviderSearchTab.Songs) {
-        ProviderSearchTab.Songs -> {
-            if (uiState.searchResults.isEmpty()) {
-                item { EmptySearchHint(uiState.query, compactTop = compactTop) }
-            } else {
-                itemsIndexed(uiState.searchResults, key = { _, item -> item.id }) { index, track ->
-                    TrackRow(
-                        track = track,
-                        downloadState = downloadStates[track.id],
-                        onClick = { actions.onPlayResult(index) },
-                        onAddToUpNext = { actions.onAddToUpNext(track) },
-                        onDownload = { actions.onDownload(track) },
-                        onDeleteDownload = { actions.onDeleteDownload(track) },
-                        onOpenArtist = { actions.onOpenArtist(track) },
-                        onOpenAlbum = { actions.onOpenAlbum(track) },
-                        onOpenDetail = actions.onOpenTrackDetail(track),
-                        onAddToPlaylist = actions.onAddToPlaylist(track),
-                    )
-                    HorizontalDivider()
-                }
-            }
-        }
+        ProviderSearchTab.Comprehensive -> comprehensiveItems(actions, downloadStates, uiState, compactTop)
+        ProviderSearchTab.Songs -> songs(uiState.searchResults, actions, downloadStates, uiState.query, compactTop)
         ProviderSearchTab.Artists -> mediaItems(
             uiState.providerSearchResults.artists,
             "没有歌手结果",
@@ -460,6 +442,224 @@ private fun androidx.compose.foundation.lazy.LazyListScope.searchResultItems(
         )
         ProviderSearchTab.Playlists -> playlists(uiState.providerSearchResults.playlists, actions)
         ProviderSearchTab.Videos -> videos(uiState.providerSearchResults.videos, actions)
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.comprehensiveItems(
+    actions: SearchFeatureActions,
+    downloadStates: Map<String, DownloadState>,
+    uiState: SearchUiState,
+    compactTop: Boolean,
+) {
+    val providerResults = uiState.providerSearchResults
+    val isEmpty = uiState.searchResults.isEmpty() &&
+        providerResults.artists.isEmpty() &&
+        providerResults.albums.isEmpty() &&
+        providerResults.playlists.isEmpty() &&
+        providerResults.videos.isEmpty()
+    if (isEmpty) {
+        item { EmptySearchHint(uiState.query, compactTop = compactTop) }
+        return
+    }
+
+    if (providerResults.bestMatches.isNotEmpty()) {
+        sectionTitle("最佳结果")
+        itemsIndexed(
+            providerResults.bestMatches,
+            key = { _, hit -> "best:${bestMatchKey(hit)}" },
+        ) { _, hit ->
+            bestMatchRow(hit, uiState, actions, downloadStates)
+            HorizontalDivider()
+        }
+    }
+
+    val tracks = uiState.searchResults.take(COMPREHENSIVE_SECTION_LIMIT)
+    if (tracks.isNotEmpty()) {
+        sectionTitle("歌曲")
+        itemsIndexed(tracks, key = { _, track -> "comprehensive-track:${track.id}" }) { _, track ->
+            val index = uiState.searchResults.indexOfFirst { it.id == track.id }
+            TrackRow(
+                track = track,
+                downloadState = downloadStates[track.id],
+                onClick = { if (index >= 0) actions.onPlayResult(index) },
+                onAddToUpNext = { actions.onAddToUpNext(track) },
+                onDownload = { actions.onDownload(track) },
+                onDeleteDownload = { actions.onDeleteDownload(track) },
+                onOpenArtist = { actions.onOpenArtist(track) },
+                onOpenAlbum = { actions.onOpenAlbum(track) },
+                onOpenDetail = actions.onOpenTrackDetail(track),
+                onAddToPlaylist = actions.onAddToPlaylist(track),
+            )
+            HorizontalDivider()
+        }
+    }
+
+    comprehensiveMediaSection(
+        title = "歌手",
+        items = providerResults.artists,
+        type = ProviderMediaItemType.Artist,
+        actions = actions,
+    )
+    comprehensiveMediaSection(
+        title = "专辑",
+        items = providerResults.albums,
+        type = ProviderMediaItemType.Album,
+        actions = actions,
+    )
+
+    val playlistItems = providerResults.playlists.take(COMPREHENSIVE_SECTION_LIMIT)
+    if (playlistItems.isNotEmpty()) {
+        sectionTitle("歌单")
+        itemsIndexed(playlistItems, key = { _, item -> "comprehensive-playlist:${item.id}" }) { _, playlist ->
+            ProviderSearchRow(
+                title = playlist.title,
+                subtitle = playlist.providerName,
+                coverUrl = playlist.coverUrl,
+                placeholder = CoverPlaceholder.Playlist,
+                onClick = { actions.onOpenPlaylist(playlist) },
+            )
+            HorizontalDivider()
+        }
+    }
+
+    val videoItems = providerResults.videos.take(COMPREHENSIVE_SECTION_LIMIT)
+    if (videoItems.isNotEmpty()) {
+        sectionTitle("视频")
+        itemsIndexed(videoItems, key = { _, item -> "comprehensive-video:${item.id}" }) { _, video ->
+            ProviderSearchRow(
+                title = video.title,
+                subtitle = listOf(video.artists, video.providerName).filter { it.isNotBlank() }.joinToString(" · "),
+                coverUrl = video.coverUrl,
+                onClick = { actions.onOpenVideo(video) },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.comprehensiveMediaSection(
+    title: String,
+    items: List<ProviderMediaItem>,
+    type: ProviderMediaItemType,
+    actions: SearchFeatureActions,
+) {
+    val preview = items.take(COMPREHENSIVE_SECTION_LIMIT)
+    if (preview.isEmpty()) return
+    sectionTitle(title)
+    itemsIndexed(preview, key = { _, item -> "comprehensive-${type.name.lowercase()}:${item.id}" }) { _, item ->
+        ProviderSearchRow(
+            title = item.title,
+            subtitle = item.providerName,
+            coverUrl = item.coverUrl,
+            placeholder = when (type) {
+                ProviderMediaItemType.Artist -> CoverPlaceholder.Artist
+                ProviderMediaItemType.Album -> CoverPlaceholder.Album
+            },
+            onClick = { actions.onOpenMediaItem(item) },
+        )
+        HorizontalDivider()
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.sectionTitle(title: String) {
+    item(key = "section:$title") {
+        Text(
+            text = title,
+            modifier = Modifier.padding(top = FuoSpacing.md, bottom = FuoSpacing.xs),
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}
+
+@Composable
+private fun bestMatchRow(
+    hit: ProviderSearchHit,
+    uiState: SearchUiState,
+    actions: SearchFeatureActions,
+    downloadStates: Map<String, DownloadState>,
+) {
+    when (hit) {
+        is ProviderSearchHit.Track -> {
+            val track = hit.value
+            val index = uiState.searchResults.indexOfFirst { it.id == track.id }
+            TrackRow(
+                track = track,
+                downloadState = downloadStates[track.id],
+                onClick = { if (index >= 0) actions.onPlayResult(index) },
+                onAddToUpNext = { actions.onAddToUpNext(track) },
+                onDownload = { actions.onDownload(track) },
+                onDeleteDownload = { actions.onDeleteDownload(track) },
+                onOpenArtist = { actions.onOpenArtist(track) },
+                onOpenAlbum = { actions.onOpenAlbum(track) },
+                onOpenDetail = actions.onOpenTrackDetail(track),
+                onAddToPlaylist = actions.onAddToPlaylist(track),
+            )
+        }
+        is ProviderSearchHit.Artist -> ProviderSearchRow(
+            title = hit.value.title,
+            subtitle = "歌手 · ${hit.value.providerName}",
+            coverUrl = hit.value.coverUrl,
+            placeholder = CoverPlaceholder.Artist,
+            onClick = { actions.onOpenMediaItem(hit.value) },
+        )
+        is ProviderSearchHit.Album -> ProviderSearchRow(
+            title = hit.value.title,
+            subtitle = "专辑 · ${hit.value.providerName}",
+            coverUrl = hit.value.coverUrl,
+            placeholder = CoverPlaceholder.Album,
+            onClick = { actions.onOpenMediaItem(hit.value) },
+        )
+        is ProviderSearchHit.Playlist -> ProviderSearchRow(
+            title = hit.value.title,
+            subtitle = "歌单 · ${hit.value.providerName}",
+            coverUrl = hit.value.coverUrl,
+            placeholder = CoverPlaceholder.Playlist,
+            onClick = { actions.onOpenPlaylist(hit.value) },
+        )
+        is ProviderSearchHit.Video -> ProviderSearchRow(
+            title = hit.value.title,
+            subtitle = listOf("视频", hit.value.artists, hit.value.providerName)
+                .filter { it.isNotBlank() }
+                .joinToString(" · "),
+            coverUrl = hit.value.coverUrl,
+            onClick = { actions.onOpenVideo(hit.value) },
+        )
+    }
+}
+
+private fun bestMatchKey(hit: ProviderSearchHit): String = when (hit) {
+    is ProviderSearchHit.Track -> "track:${hit.value.id}"
+    is ProviderSearchHit.Artist -> "artist:${hit.value.id}"
+    is ProviderSearchHit.Album -> "album:${hit.value.id}"
+    is ProviderSearchHit.Playlist -> "playlist:${hit.value.id}"
+    is ProviderSearchHit.Video -> "video:${hit.value.id}"
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.songs(
+    tracks: List<MusicTrack>,
+    actions: SearchFeatureActions,
+    downloadStates: Map<String, DownloadState>,
+    query: String,
+    compactTop: Boolean,
+) {
+    if (tracks.isEmpty()) {
+        item { EmptySearchHint(query, compactTop = compactTop) }
+    } else {
+        itemsIndexed(tracks, key = { _, item -> item.id }) { index, track ->
+            TrackRow(
+                track = track,
+                downloadState = downloadStates[track.id],
+                onClick = { actions.onPlayResult(index) },
+                onAddToUpNext = { actions.onAddToUpNext(track) },
+                onDownload = { actions.onDownload(track) },
+                onDeleteDownload = { actions.onDeleteDownload(track) },
+                onOpenArtist = { actions.onOpenArtist(track) },
+                onOpenAlbum = { actions.onOpenAlbum(track) },
+                onOpenDetail = actions.onOpenTrackDetail(track),
+                onAddToPlaylist = actions.onAddToPlaylist(track),
+            )
+            HorizontalDivider()
+        }
     }
 }
 
@@ -569,6 +769,7 @@ private fun ProviderSearchRow(
 }
 
 private fun ProviderSearchTab.label(uiState: SearchUiState): String = when (this) {
+    ProviderSearchTab.Comprehensive -> "综合"
     ProviderSearchTab.Songs -> "歌曲 ${uiState.searchResults.size}"
     ProviderSearchTab.Artists -> "歌手 ${uiState.providerSearchResults.artists.size}"
     ProviderSearchTab.Albums -> "专辑 ${uiState.providerSearchResults.albums.size}"


### PR DESCRIPTION
## Summary

- make `综合` the default search view and keep category tabs for focused browsing
- preserve provider-native best matches in the common search result model and render them first
- query enabled providers concurrently and round-robin normal results across providers
- use native comprehensive search surfaces where available:
  - NetEase `type=1018` with typed-search fallback
  - QQ Music `SearchAdaptor/do_search_v2`, with `smartbox_new.fcg` quick search for the best match
  - Bilibili `/x/web-interface/search/all/v2`, mapping videos, creators and seasons
  - YouTube Music unfiltered search with a ranked best-match projection
- compose Bilibili's richer content provider so creator/season comprehensive results open through existing detail flows
- update search feature tests for the comprehensive default

## Validation

CI will validate the latest merge result against current `master`. Provider wrappers retain the previous search implementation as a fallback when native comprehensive response parsing yields no supported results.