### PR TITLE
fix: avoid implicit Gradle dependency in playback boundary check

### DIFF
--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -72,15 +72,21 @@ val retiredSharedPlaybackBusinessFiles = listOf(
     "ReplacementTieBreak.kt",
 ).map { name -> rootProject.file("shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/$name") }
 
+val providerKotlinSources = rootProject.fileTree("provider") {
+    include("**/src/**/*.kt")
+}
+
 val checkPlaybackFeatureBoundaries = tasks.register("checkPlaybackFeatureBoundaries") {
     group = "verification"
     description = "Reject shared/app dependencies, provider aggregation, or restoration of playback business ownership in :shared."
 
+    inputs.file(project.buildFile)
     inputs.files(playbackRequiredFiles.map(rootProject::file))
     inputs.dir(rootProject.file("feature/playback/src/commonMain/kotlin"))
     inputs.files(retiredSharedPlaybackBusinessFiles)
     inputs.dir(rootProject.file("shared/src/commonMain/kotlin"))
-    inputs.dir(rootProject.file("provider"))
+    inputs.dir(rootProject.file("shared/src/iosMain/kotlin"))
+    inputs.files(providerKotlinSources)
     inputs.dir(rootProject.file("androidApp/src/main/kotlin"))
 
     doLast {
@@ -154,10 +160,11 @@ val checkPlaybackFeatureBoundaries = tasks.register("checkPlaybackFeatureBoundar
             }
         }
 
-        val replacementPolicyLeaks = listOf(
-            rootProject.file("shared/src/commonMain/kotlin"),
-            rootProject.file("provider"),
-        ).flatMap { root -> root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList() }
+        val replacementPolicyFiles = rootProject.file("shared/src/commonMain/kotlin")
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList() + providerKotlinSources.files
+        val replacementPolicyLeaks = replacementPolicyFiles
             .flatMap { file ->
                 file.readLines().mapIndexedNotNull { index, line ->
                     if (Regex("\\b(?:bilibiliReplacementScore|rankReplacementCandidates|selectRankedReplacementCandidate|replacementTieBreakConfidence|sortReplacementScoreTies)\\b")


### PR DESCRIPTION
## Summary
- scope the playback boundary check's provider input to Kotlin source files under `provider/**/src`
- scan the same provider source set at execution time instead of the whole `provider/` tree
- declare the build script and iOS shared source root that the task already reads as explicit inputs

## Why
The 1.5.0 Android Release run fails in `:shared:allTests` because `:feature:playback:checkPlaybackFeatureBoundaries` declares the entire `provider/` directory as an input. During `allTests`, that directory also contains outputs from provider compilation/resource tasks, so Gradle 8.13 reports undeclared implicit task dependencies and aborts the build.

This keeps the architectural boundary check focused on source code and removes the accidental dependency on generated/build outputs.