### PR TITLE
ci: share Android test workflow

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -18,6 +18,7 @@ name: Android APK
       - "gradlew"
       - "gradlew.bat"
       - ".github/workflows/android-apk.yml"
+      - ".github/workflows/android-tests.yml"
   pull_request:
     paths:
       - "androidApp/**"
@@ -33,6 +34,7 @@ name: Android APK
       - "gradlew"
       - "gradlew.bat"
       - ".github/workflows/android-apk.yml"
+      - ".github/workflows/android-tests.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,30 +45,7 @@ permissions:
 
 jobs:
   test:
-    name: Run shared tests and coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Run architecture checks, feature/playback/provider runtime tests, shared tests and coverage
-        run: ./gradlew checkArchitectureBoundaries :feature:recognition:allTests :feature:search:allTests :feature:localplaylist:allTests :feature:localmusic:allTests :feature:download:allTests :feature:providercatalog:allTests :feature:providerauth:allTests :feature:providerdetail:allTests :feature:settings:allTests :feature:onboarding:allTests :feature:home:allTests :feature:playback:allTests :playback:runtime:allTests :provider:runtime:allTests :shared:allTests :shared:koverXmlReportDebug
+    uses: ./.github/workflows/android-tests.yml
 
   build-release-apks:
     name: Build signed multi-ABI release APK

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,28 +8,10 @@ name: Android Release
 
 jobs:
   test:
-    name: Run shared tests
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    uses: ./.github/workflows/android-tests.yml
     permissions:
       contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Run shared tests
-        run: ./gradlew :shared:allTests
 
   build-release-apks:
     name: Build signed multi-ABI release APK

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -1,0 +1,31 @@
+name: Android Tests
+
+"on":
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run shared tests and coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run architecture checks, feature/playback/provider runtime tests, shared tests and coverage
+        run: ./gradlew checkArchitectureBoundaries :feature:recognition:allTests :feature:search:allTests :feature:localplaylist:allTests :feature:localmusic:allTests :feature:download:allTests :feature:providercatalog:allTests :feature:providerauth:allTests :feature:providerdetail:allTests :feature:settings:allTests :feature:onboarding:allTests :feature:home:allTests :feature:playback:allTests :playback:runtime:allTests :provider:runtime:allTests :shared:allTests :shared:koverXmlReportDebug


### PR DESCRIPTION
## Summary

- add reusable `.github/workflows/android-tests.yml` as the single Android verification entry
- make both `android-apk.yml` and `android-release.yml` call the same reusable workflow
- keep the complete master CI task set: architecture checks, all feature tests, playback/provider runtime tests, shared tests, and Kover coverage
- align checkout depth through the shared workflow so tag releases and master PR/push CI use the same test setup
- make `android-apk.yml` react to changes in the shared test workflow

## Motivation

The 1.5.0 tag release exposed a Gradle task-graph difference because Android APK CI and Android Release CI maintained different test commands. Centralizing the test job prevents future drift and missed updates when adding new feature test tasks.