### PR TITLE
feat: refresh expressive home navigation and mini player

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
@@ -111,6 +110,11 @@ fun HomeScreen(
             }
         }
     }
+    val selectSection: (Int, HomeSection) -> Unit = { index, section ->
+        if (section != state.homeSection || index != pagerState.currentPage) {
+            scope.launch { pagerState.animateScrollToPage(index) }
+        }
+    }
 
     LaunchedEffect(state.homeSection) {
         val page = HomePrimarySections.indexOfFirst { it.first == state.homeSection }
@@ -119,7 +123,7 @@ fun HomeScreen(
         isNavigationCompact = false
     }
 
-    LaunchedEffect(pagerState) {
+    LaunchedEffect(pagerState, state.homeSection) {
         snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page ->
@@ -127,12 +131,6 @@ fun HomeScreen(
                     if (section != state.homeSection) home.setHomeSection(section)
                 }
             }
-    }
-
-    fun selectSection(index: Int, section: HomeSection) {
-        if (section != state.homeSection || index != pagerState.currentPage) {
-            scope.launch { pagerState.animateScrollToPage(index) }
-        }
     }
 
     Scaffold(
@@ -145,7 +143,7 @@ fun HomeScreen(
                     onSettings = home::openSettings,
                     onRecognition = onOpenRecognition,
                     onSearch = home::openSearch,
-                    onSectionClick = ::selectSection,
+                    onSectionClick = selectSection,
                 )
             }
         },
@@ -170,7 +168,7 @@ fun HomeScreen(
                 hasImagePermission = hasImagePermission,
                 onRequestImagePermission = onRequestImagePermission,
                 onOpenRecognition = onOpenRecognition,
-                onSectionClick = ::selectSection,
+                onSectionClick = selectSection,
                 modifier = Modifier
                     .weight(1f)
                     .then(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,7 +23,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.filled.Mic
@@ -52,6 +50,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -76,6 +75,10 @@ private val HomePrimarySections = listOf(
 
 private val HomeNavigationScrollThreshold = 28.dp
 private val HomeNavigationItemSpacing = 4.dp
+private val HomeRailCompactHeightThreshold = 400.dp
+private val HomeRailRecognitionHeightThreshold = 320.dp
+private val HomeRailExpandedItemHeight = 64.dp
+private val HomeRailCompactItemHeight = 48.dp
 
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
@@ -323,7 +326,7 @@ private fun HomeNavigationItem(
     label: String,
     selected: Boolean,
     compact: Boolean,
-    contentColor: androidx.compose.ui.graphics.Color,
+    contentColor: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -399,6 +402,16 @@ internal class HomeNavigationScrollAccumulator(
         accumulatedY = 0f
     }
 }
+
+internal data class HomeRailLayoutPolicy(
+    val showLabels: Boolean,
+    val showRecognition: Boolean,
+)
+
+internal fun homeRailLayoutPolicyFor(maxHeight: Dp): HomeRailLayoutPolicy = HomeRailLayoutPolicy(
+    showLabels = maxHeight >= HomeRailCompactHeightThreshold,
+    showRecognition = maxHeight >= HomeRailRecognitionHeightThreshold,
+)
 
 @Composable
 fun HomeSectionPager(
@@ -496,44 +509,91 @@ fun HomeSectionRail(
     Surface(
         modifier = Modifier.width(64.dp).fillMaxHeight(),
         color = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
-        Column(
-            modifier = Modifier.fillMaxHeight().padding(vertical = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            IconButton(onClick = onSettings) { Icon(Icons.Filled.Settings, contentDescription = "设置") }
-            Spacer(Modifier.weight(1f))
-            sections.forEachIndexed { index, (section, label) ->
-                val selected = index == selectedIndex
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .fuoInteractive()
-                        .clickable(role = Role.Tab) { onClick(index, section) }
-                        .padding(vertical = 4.dp),
-                    color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
-                    contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
-                    shape = RoundedCornerShape(8.dp),
-                ) {
-                    Column(
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 8.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Icon(homeSectionIcon(section), contentDescription = label)
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val policy = homeRailLayoutPolicyFor(maxHeight)
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(vertical = if (policy.showLabels) 8.dp else 4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                IconButton(onClick = onSettings) {
+                    Icon(Icons.Filled.Settings, contentDescription = "设置")
+                }
+                Spacer(Modifier.weight(1f))
+                sections.forEachIndexed { index, (section, label) ->
+                    HomeSectionRailItem(
+                        section = section,
+                        label = label,
+                        selected = index == selectedIndex,
+                        showLabel = policy.showLabels,
+                        onClick = { onClick(index, section) },
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                if (policy.showRecognition) {
+                    IconButton(onClick = onRecognition) {
+                        Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
                     }
                 }
+                IconButton(onClick = onSearch) {
+                    Icon(Icons.Filled.Search, contentDescription = "搜索")
+                }
             }
-            Spacer(Modifier.weight(1f))
-            IconButton(onClick = onRecognition) { Icon(Icons.Filled.Mic, contentDescription = "听歌识曲") }
-            IconButton(onClick = onSearch) { Icon(Icons.Filled.Search, contentDescription = "搜索") }
+        }
+    }
+}
+
+@Composable
+private fun HomeSectionRailItem(
+    section: HomeSection,
+    label: String,
+    selected: Boolean,
+    showLabel: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(if (showLabel) HomeRailExpandedItemHeight else HomeRailCompactItemHeight)
+            .fuoInteractive()
+            .selectable(
+                selected = selected,
+                interactionSource = interactionSource,
+                indication = null,
+                role = Role.Tab,
+                onClick = onClick,
+            ),
+        color = if (selected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        contentColor = if (selected) {
+            MaterialTheme.colorScheme.onSecondaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        shape = MaterialTheme.shapes.extraLarge,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(homeSectionIcon(section), contentDescription = if (showLabel) null else label)
+            if (showLabel) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -1,6 +1,9 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,13 +12,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
@@ -24,37 +29,47 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlin.math.absoluteValue
+
+private val HomePrimarySections = listOf(
+    HomeSection.Recommend to "推荐",
+    HomeSection.Music to "探索",
+    HomeSection.Mine to "我的",
+)
+
+private val HomeNavigationScrollThreshold = 28.dp
 
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
@@ -63,7 +78,6 @@ fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     home: HomeFeatureController,
@@ -76,27 +90,62 @@ fun HomeScreen(
     val layoutInfo = LocalAppLayoutInfo.current
     val playbackUiPort = LocalPlaybackUiPort.current
     val state = home.uiState.collectAsStateWithLifecycle().value
+    val selectedIndex = HomePrimarySections.indexOfFirst { it.first == state.homeSection }.coerceAtLeast(0)
+    val pagerState = rememberPagerState(
+        initialPage = selectedIndex,
+        pageCount = { HomePrimarySections.size },
+    )
+    val scope = rememberCoroutineScope()
+    var isNavigationCompact by remember { mutableStateOf(false) }
+    val scrollThresholdPx = with(LocalDensity.current) { HomeNavigationScrollThreshold.toPx() }
+    val navigationScrollAccumulator = remember(scrollThresholdPx) {
+        HomeNavigationScrollAccumulator(scrollThresholdPx)
+    }
+    val navigationScrollConnection = remember(navigationScrollAccumulator) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                navigationScrollAccumulator.onScroll(available.y)?.let { compact ->
+                    isNavigationCompact = compact
+                }
+                return Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(state.homeSection) {
+        val page = HomePrimarySections.indexOfFirst { it.first == state.homeSection }
+        if (page >= 0 && page != pagerState.currentPage) pagerState.animateScrollToPage(page)
+        navigationScrollAccumulator.reset()
+        isNavigationCompact = false
+    }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.settledPage }
+            .distinctUntilChanged()
+            .collect { page ->
+                HomePrimarySections.getOrNull(page)?.first?.let { section ->
+                    if (section != state.homeSection) home.setHomeSection(section)
+                }
+            }
+    }
+
+    fun selectSection(index: Int, section: HomeSection) {
+        if (section != state.homeSection || index != pagerState.currentPage) {
+            scope.launch { pagerState.animateScrollToPage(index) }
+        }
+    }
+
     Scaffold(
         topBar = {
             if (!layoutInfo.useWideLayout) {
-                CenterAlignedTopAppBar(
-                    title = {},
-                    navigationIcon = {
-                        IconButton(onClick = { home.openSettings() }) {
-                            Icon(Icons.Filled.Settings, contentDescription = "设置")
-                        }
-                    },
-                    actions = {
-                        IconButton(onClick = onOpenRecognition) {
-                            Icon(Icons.Filled.Mic, contentDescription = "听歌识曲")
-                        }
-                        IconButton(onClick = home::openSearch) {
-                            Icon(Icons.Filled.Search, contentDescription = "搜索")
-                        }
-                    },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                    ),
+                ExpressiveHomeTopBar(
+                    sections = HomePrimarySections,
+                    selectedIndex = pagerState.currentPage.coerceIn(0, HomePrimarySections.lastIndex),
+                    compact = isNavigationCompact,
+                    onSettings = home::openSettings,
+                    onRecognition = onOpenRecognition,
+                    onSearch = home::openSearch,
+                    onSectionClick = ::selectSection,
                 )
             }
         },
@@ -106,7 +155,7 @@ fun HomeScreen(
     ) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize().padding(paddingValues),
-            verticalArrangement = Arrangement.spacedBy(if (layoutInfo.useWideLayout) 6.dp else 12.dp),
+            verticalArrangement = Arrangement.spacedBy(if (layoutInfo.useWideLayout) 6.dp else 8.dp),
         ) {
             LoadingIndicator(
                 visible = state.isLoading,
@@ -114,12 +163,20 @@ fun HomeScreen(
             )
             HomeSectionPager(
                 home = home,
+                sections = HomePrimarySections,
+                pagerState = pagerState,
                 hasAudioPermission = hasAudioPermission,
                 onRequestAudioPermission = onRequestAudioPermission,
                 hasImagePermission = hasImagePermission,
                 onRequestImagePermission = onRequestImagePermission,
                 onOpenRecognition = onOpenRecognition,
-                modifier = Modifier.weight(1f),
+                onSectionClick = ::selectSection,
+                modifier = Modifier
+                    .weight(1f)
+                    .then(
+                        if (layoutInfo.useWideLayout) Modifier
+                        else Modifier.nestedScroll(navigationScrollConnection),
+                    ),
                 contentHorizontalPadding = if (layoutInfo.useWideLayout) 8.dp else 16.dp,
             )
         }
@@ -127,41 +184,208 @@ fun HomeScreen(
 }
 
 @Composable
+private fun ExpressiveHomeTopBar(
+    sections: List<Pair<HomeSection, String>>,
+    selectedIndex: Int,
+    compact: Boolean,
+    onSettings: () -> Unit,
+    onRecognition: () -> Unit,
+    onSearch: () -> Unit,
+    onSectionClick: (Int, HomeSection) -> Unit,
+) {
+    val verticalPadding by animateDpAsState(
+        targetValue = if (compact) 4.dp else 10.dp,
+        animationSpec = tween(FuoMotion.overlayEnterMillis),
+        label = "home navigation vertical padding",
+    )
+    val itemHeight by animateDpAsState(
+        targetValue = if (compact) 40.dp else 52.dp,
+        animationSpec = tween(FuoMotion.overlayEnterMillis),
+        label = "home navigation item height",
+    )
+    val elevation by animateDpAsState(
+        targetValue = if (compact) 2.dp else 0.dp,
+        animationSpec = tween(FuoMotion.overlayFadeMillis),
+        label = "home navigation elevation",
+    )
+    val containerColor by animateColorAsState(
+        targetValue = if (compact) {
+            MaterialTheme.colorScheme.surfaceContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        animationSpec = tween(FuoMotion.overlayFadeMillis),
+        label = "home navigation container color",
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = containerColor,
+        tonalElevation = elevation,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 8.dp, vertical = verticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HomeNavigationAction(
+                compact = compact,
+                onClick = onSettings,
+                contentDescription = "设置",
+                icon = Icons.Filled.Settings,
+            )
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                sections.forEachIndexed { index, (section, label) ->
+                    HomeNavigationItem(
+                        modifier = Modifier.weight(1f),
+                        label = label,
+                        selected = index == selectedIndex,
+                        compact = compact,
+                        height = itemHeight,
+                        onClick = { onSectionClick(index, section) },
+                    )
+                }
+            }
+            HomeNavigationAction(
+                compact = compact,
+                onClick = onRecognition,
+                contentDescription = "听歌识曲",
+                icon = Icons.Filled.Mic,
+            )
+            HomeNavigationAction(
+                compact = compact,
+                onClick = onSearch,
+                contentDescription = "搜索",
+                icon = Icons.Filled.Search,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeNavigationItem(
+    label: String,
+    selected: Boolean,
+    compact: Boolean,
+    height: Dp,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
+        animationSpec = tween(FuoMotion.overlayFadeMillis),
+        label = "home navigation item color",
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (selected) {
+            MaterialTheme.colorScheme.onSecondaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = tween(FuoMotion.overlayFadeMillis),
+        label = "home navigation item content color",
+    )
+
+    Surface(
+        modifier = modifier
+            .height(height)
+            .selectable(
+                selected = selected,
+                role = Role.Tab,
+                onClick = onClick,
+            ),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = containerColor,
+        contentColor = contentColor,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = if (compact) MaterialTheme.typography.labelLarge else MaterialTheme.typography.titleMedium,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeNavigationAction(
+    compact: Boolean,
+    onClick: () -> Unit,
+    contentDescription: String,
+    icon: ImageVector,
+) {
+    if (compact) {
+        IconButton(onClick = onClick) {
+            Icon(icon, contentDescription = contentDescription)
+        }
+    } else {
+        FilledTonalIconButton(onClick = onClick) {
+            Icon(icon, contentDescription = contentDescription)
+        }
+    }
+}
+
+internal class HomeNavigationScrollAccumulator(
+    private val thresholdPx: Float,
+) {
+    private var accumulatedY = 0f
+
+    init {
+        require(thresholdPx > 0f)
+    }
+
+    fun onScroll(deltaY: Float): Boolean? {
+        if (deltaY == 0f) return null
+        if ((deltaY > 0f && accumulatedY < 0f) || (deltaY < 0f && accumulatedY > 0f)) {
+            accumulatedY = 0f
+        }
+        accumulatedY += deltaY
+        return when {
+            accumulatedY <= -thresholdPx -> {
+                accumulatedY = 0f
+                true
+            }
+            accumulatedY >= thresholdPx -> {
+                accumulatedY = 0f
+                false
+            }
+            else -> null
+        }
+    }
+
+    fun reset() {
+        accumulatedY = 0f
+    }
+}
+
+@Composable
 fun HomeSectionPager(
     home: HomeFeatureController,
+    sections: List<Pair<HomeSection, String>>,
+    pagerState: PagerState,
     hasAudioPermission: Boolean,
     onRequestAudioPermission: () -> Unit,
     hasImagePermission: Boolean,
     onRequestImagePermission: () -> Unit,
     onOpenRecognition: () -> Unit,
+    onSectionClick: (Int, HomeSection) -> Unit,
     modifier: Modifier,
     contentHorizontalPadding: Dp,
 ) {
-    val state = home.uiState.collectAsStateWithLifecycle().value
-    val sections = listOf(
-        HomeSection.Recommend to "推荐",
-        HomeSection.Music to "探索",
-        HomeSection.Mine to "我的",
-    )
-    val selectedIndex = sections.indexOfFirst { it.first == state.homeSection }.coerceAtLeast(0)
-    val pagerState = rememberPagerState(initialPage = selectedIndex, pageCount = { sections.size })
-    val scope = rememberCoroutineScope()
-
-    LaunchedEffect(state.homeSection) {
-        val page = sections.indexOfFirst { it.first == state.homeSection }
-        if (page >= 0 && page != pagerState.currentPage) pagerState.animateScrollToPage(page)
-    }
-
-    LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.settledPage }
-            .distinctUntilChanged()
-            .collect { page ->
-                sections.getOrNull(page)?.first?.let { section ->
-                    if (section != state.homeSection) home.setHomeSection(section)
-                }
-            }
-    }
-
     if (LocalAppLayoutInfo.current.useWideLayout) {
         Row(
             modifier = modifier.fillMaxWidth().padding(horizontal = contentHorizontalPadding),
@@ -170,69 +394,64 @@ fun HomeSectionPager(
             HomeSectionRail(
                 sections = sections,
                 selectedIndex = pagerState.currentPage.coerceIn(0, sections.lastIndex),
-                onSettings = { home.openSettings() },
+                onSettings = home::openSettings,
                 onSearch = home::openSearch,
                 onRecognition = onOpenRecognition,
-                onClick = { index, section ->
-                    if (section != state.homeSection || index != pagerState.currentPage) {
-                        scope.launch { pagerState.animateScrollToPage(index) }
-                    }
-                },
+                onClick = onSectionClick,
             )
-            HorizontalPager(
-                state = pagerState,
+            HomeSectionPages(
+                home = home,
+                sections = sections,
+                pagerState = pagerState,
+                hasAudioPermission = hasAudioPermission,
+                onRequestAudioPermission = onRequestAudioPermission,
+                hasImagePermission = hasImagePermission,
+                onRequestImagePermission = onRequestImagePermission,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
-                pageSpacing = 16.dp,
-            ) { page ->
-                when (sections[page].first) {
-                    HomeSection.Recommend -> ProviderContentHomeSection(home, HomeSection.Recommend, Modifier.fillMaxSize())
-                    HomeSection.Music -> ProviderContentHomeSection(home, HomeSection.Music, Modifier.fillMaxSize())
-                    HomeSection.Mine -> MineHomeSection(
-                        home = home,
-                        hasAudioPermission = hasAudioPermission,
-                        onRequestAudioPermission = onRequestAudioPermission,
-                        hasImagePermission = hasImagePermission,
-                        onRequestImagePermission = onRequestImagePermission,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-            }
+            )
         }
         return
     }
 
-    Column(
-        modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
-    ) {
-        HomeSectionTabs(
-            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
-            sections = sections,
-            selectedIndex = pagerState.currentPage.coerceIn(0, sections.lastIndex),
-            indicatorOffsetFraction = pagerState.currentPageOffsetFraction,
-            onClick = { index, section ->
-                if (section != state.homeSection || index != pagerState.currentPage) {
-                    scope.launch { pagerState.animateScrollToPage(index) }
-                }
-            },
-        )
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = contentHorizontalPadding),
-            pageSpacing = 16.dp,
-        ) { page ->
-            when (sections[page].first) {
-                HomeSection.Recommend -> ProviderContentHomeSection(home, HomeSection.Recommend, Modifier.fillMaxSize())
-                HomeSection.Music -> ProviderContentHomeSection(home, HomeSection.Music, Modifier.fillMaxSize())
-                HomeSection.Mine -> MineHomeSection(
-                    home = home,
-                    hasAudioPermission = hasAudioPermission,
-                    onRequestAudioPermission = onRequestAudioPermission,
-                    hasImagePermission = hasImagePermission,
-                    onRequestImagePermission = onRequestImagePermission,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
+    HomeSectionPages(
+        home = home,
+        sections = sections,
+        pagerState = pagerState,
+        hasAudioPermission = hasAudioPermission,
+        onRequestAudioPermission = onRequestAudioPermission,
+        hasImagePermission = hasImagePermission,
+        onRequestImagePermission = onRequestImagePermission,
+        modifier = modifier.fillMaxWidth().padding(horizontal = contentHorizontalPadding),
+    )
+}
+
+@Composable
+private fun HomeSectionPages(
+    home: HomeFeatureController,
+    sections: List<Pair<HomeSection, String>>,
+    pagerState: PagerState,
+    hasAudioPermission: Boolean,
+    onRequestAudioPermission: () -> Unit,
+    hasImagePermission: Boolean,
+    onRequestImagePermission: () -> Unit,
+    modifier: Modifier,
+) {
+    HorizontalPager(
+        state = pagerState,
+        modifier = modifier,
+        pageSpacing = 16.dp,
+    ) { page ->
+        when (sections[page].first) {
+            HomeSection.Recommend -> ProviderContentHomeSection(home, HomeSection.Recommend, Modifier.fillMaxSize())
+            HomeSection.Music -> ProviderContentHomeSection(home, HomeSection.Music, Modifier.fillMaxSize())
+            HomeSection.Mine -> MineHomeSection(
+                home = home,
+                hasAudioPermission = hasAudioPermission,
+                onRequestAudioPermission = onRequestAudioPermission,
+                hasImagePermission = hasImagePermission,
+                onRequestImagePermission = onRequestImagePermission,
+                modifier = Modifier.fillMaxSize(),
+            )
         }
     }
 }
@@ -259,9 +478,11 @@ fun HomeSectionRail(
             sections.forEachIndexed { index, (section, label) ->
                 val selected = index == selectedIndex
                 Surface(
-                    modifier = Modifier.fillMaxWidth().fuoInteractive().clickable(role = Role.Tab) {
-                        onClick(index, section)
-                    }.padding(vertical = 4.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fuoInteractive()
+                        .clickable(role = Role.Tab) { onClick(index, section) }
+                        .padding(vertical = 4.dp),
                     color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
                     contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
                     shape = RoundedCornerShape(8.dp),
@@ -285,61 +506,6 @@ fun HomeSectionRail(
             Spacer(Modifier.weight(1f))
             IconButton(onClick = onRecognition) { Icon(Icons.Filled.Mic, contentDescription = "听歌识曲") }
             IconButton(onClick = onSearch) { Icon(Icons.Filled.Search, contentDescription = "搜索") }
-        }
-    }
-}
-
-@Composable
-@Suppress("DEPRECATION")
-fun HomeSectionTabs(
-    sections: List<Pair<HomeSection, String>>,
-    selectedIndex: Int,
-    indicatorOffsetFraction: Float,
-    onClick: (Int, HomeSection) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    TabRow(
-        selectedTabIndex = selectedIndex,
-        modifier = modifier.fillMaxWidth(),
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.primary,
-        indicator = { tabPositions ->
-            val current = tabPositions.getOrNull(selectedIndex) ?: return@TabRow
-            val targetIndex = when {
-                indicatorOffsetFraction > 0f -> (selectedIndex + 1).coerceAtMost(tabPositions.lastIndex)
-                indicatorOffsetFraction < 0f -> (selectedIndex - 1).coerceAtLeast(0)
-                else -> selectedIndex
-            }
-            val target = tabPositions[targetIndex]
-            val progress = indicatorOffsetFraction.absoluteValue.coerceIn(0f, 1f)
-            val indicatorLeft = lerp(current.left, target.left, progress)
-            val indicatorWidth = lerp(current.width, target.width, progress)
-            TabRowDefaults.SecondaryIndicator(
-                modifier = Modifier.fillMaxWidth().wrapContentSize(Alignment.BottomStart)
-                    .offset { IntOffset(indicatorLeft.roundToPx(), 0) }.width(indicatorWidth),
-            )
-        },
-    ) {
-        sections.forEachIndexed { index, (section, label) ->
-            Tab(
-                selected = index == selectedIndex,
-                onClick = { onClick(index, section) },
-                text = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(homeSectionIcon(section), contentDescription = null, modifier = Modifier.size(18.dp))
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = if (index == selectedIndex) FontWeight.SemiBold else FontWeight.Normal,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                },
-            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -5,7 +5,10 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
@@ -48,7 +52,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -62,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlin.math.absoluteValue
 
 private val HomePrimarySections = listOf(
     HomeSection.Recommend to "推荐",
@@ -70,6 +75,7 @@ private val HomePrimarySections = listOf(
 )
 
 private val HomeNavigationScrollThreshold = 28.dp
+private val HomeNavigationItemSpacing = 4.dp
 
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
@@ -140,7 +146,7 @@ fun HomeScreen(
             if (!layoutInfo.useWideLayout) {
                 ExpressiveHomeTopBar(
                     sections = HomePrimarySections,
-                    selectedIndex = pagerState.currentPage.coerceIn(0, HomePrimarySections.lastIndex),
+                    pagerState = pagerState,
                     compact = isNavigationCompact,
                     onSettings = home::openSettings,
                     onRecognition = onOpenRecognition,
@@ -186,7 +192,7 @@ fun HomeScreen(
 @Composable
 private fun ExpressiveHomeTopBar(
     sections: List<Pair<HomeSection, String>>,
-    selectedIndex: Int,
+    pagerState: PagerState,
     compact: Boolean,
     onSettings: () -> Unit,
     onRecognition: () -> Unit,
@@ -221,6 +227,7 @@ private fun ExpressiveHomeTopBar(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = containerColor,
+        contentColor = MaterialTheme.colorScheme.onSurface,
         tonalElevation = elevation,
     ) {
         Row(
@@ -237,22 +244,14 @@ private fun ExpressiveHomeTopBar(
                 contentDescription = "设置",
                 icon = Icons.Filled.Settings,
             )
-            Row(
+            HomeNavigationTabs(
                 modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                sections.forEachIndexed { index, (section, label) ->
-                    HomeNavigationItem(
-                        modifier = Modifier.weight(1f),
-                        label = label,
-                        selected = index == selectedIndex,
-                        compact = compact,
-                        height = itemHeight,
-                        onClick = { onSectionClick(index, section) },
-                    )
-                }
-            }
+                sections = sections,
+                pagerState = pagerState,
+                compact = compact,
+                height = itemHeight,
+                onSectionClick = onSectionClick,
+            )
             HomeNavigationAction(
                 compact = compact,
                 onClick = onRecognition,
@@ -270,54 +269,83 @@ private fun ExpressiveHomeTopBar(
 }
 
 @Composable
+private fun HomeNavigationTabs(
+    sections: List<Pair<HomeSection, String>>,
+    pagerState: PagerState,
+    compact: Boolean,
+    height: Dp,
+    onSectionClick: (Int, HomeSection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val pagerPosition = (
+        pagerState.currentPage.toFloat() + pagerState.currentPageOffsetFraction
+        ).coerceIn(0f, sections.lastIndex.toFloat())
+    val selectedIndex = pagerState.currentPage.coerceIn(0, sections.lastIndex)
+    val selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer
+    val selectedContentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    val unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    BoxWithConstraints(modifier = modifier.height(height)) {
+        val itemWidth = (
+            maxWidth - HomeNavigationItemSpacing * sections.lastIndex.toFloat()
+            ) / sections.size.toFloat()
+        val indicatorOffset = (itemWidth + HomeNavigationItemSpacing) * pagerPosition
+        Surface(
+            modifier = Modifier
+                .offset(x = indicatorOffset)
+                .width(itemWidth)
+                .fillMaxHeight(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = selectedContainerColor,
+        ) {}
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(HomeNavigationItemSpacing),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            sections.forEachIndexed { index, (section, label) ->
+                val emphasis = (1f - (pagerPosition - index).absoluteValue).coerceIn(0f, 1f)
+                HomeNavigationItem(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    label = label,
+                    selected = index == selectedIndex,
+                    compact = compact,
+                    contentColor = lerp(unselectedContentColor, selectedContentColor, emphasis),
+                    onClick = { onSectionClick(index, section) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun HomeNavigationItem(
     label: String,
     selected: Boolean,
     compact: Boolean,
-    height: Dp,
+    contentColor: androidx.compose.ui.graphics.Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val containerColor by animateColorAsState(
-        targetValue = if (selected) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
-        animationSpec = tween(FuoMotion.overlayFadeMillis),
-        label = "home navigation item color",
-    )
-    val contentColor by animateColorAsState(
-        targetValue = if (selected) {
-            MaterialTheme.colorScheme.onSecondaryContainer
-        } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        },
-        animationSpec = tween(FuoMotion.overlayFadeMillis),
-        label = "home navigation item content color",
-    )
-
-    Surface(
-        modifier = modifier
-            .height(height)
-            .selectable(
-                selected = selected,
-                role = Role.Tab,
-                onClick = onClick,
-            ),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = containerColor,
-        contentColor = contentColor,
+    val interactionSource = remember { MutableInteractionSource() }
+    Box(
+        modifier = modifier.selectable(
+            selected = selected,
+            interactionSource = interactionSource,
+            indication = null,
+            role = Role.Tab,
+            onClick = onClick,
+        ),
+        contentAlignment = Alignment.Center,
     ) {
-        Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = label,
-                style = if (compact) MaterialTheme.typography.labelLarge else MaterialTheme.typography.titleMedium,
-                fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+        Text(
+            text = label,
+            style = if (compact) MaterialTheme.typography.labelLarge else MaterialTheme.typography.titleMedium,
+            color = contentColor,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -89,6 +90,7 @@ fun HomeScreen(
     val layoutInfo = LocalAppLayoutInfo.current
     val playbackUiPort = LocalPlaybackUiPort.current
     val state = home.uiState.collectAsStateWithLifecycle().value
+    val currentHomeSection by rememberUpdatedState(state.homeSection)
     val selectedIndex = HomePrimarySections.indexOfFirst { it.first == state.homeSection }.coerceAtLeast(0)
     val pagerState = rememberPagerState(
         initialPage = selectedIndex,
@@ -123,12 +125,12 @@ fun HomeScreen(
         isNavigationCompact = false
     }
 
-    LaunchedEffect(pagerState, state.homeSection) {
+    LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page ->
                 HomePrimarySections.getOrNull(page)?.first?.let { section ->
-                    if (section != state.homeSection) home.setHomeSection(section)
+                    if (section != currentHomeSection) home.setHomeSection(section)
                 }
             }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -74,6 +75,7 @@ internal fun RuntimeMiniPlayer(
     val state by playbackSession.state.collectAsStateWithLifecycle()
     val isLoadingAudio = state.status == PlaybackSessionStatus.Loading
     val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
+    val openPlayerInteractionSource = remember { MutableInteractionSource() }
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -83,13 +85,19 @@ internal fun RuntimeMiniPlayer(
             )
             .animateContentSize(animationSpec = tween(220))
             .fuoInteractive()
-            .clickable(role = Role.Button, onClick = onOpenFullPlayer),
+            .clickable(
+                interactionSource = openPlayerInteractionSource,
+                indication = null,
+                role = Role.Button,
+                onClick = onOpenFullPlayer,
+            ),
         shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.extraLarge,
         color = if (isWideLayout) {
             MaterialTheme.colorScheme.surfaceContainer
         } else {
             MaterialTheme.colorScheme.surfaceContainerHigh
         },
+        contentColor = MaterialTheme.colorScheme.onSurface,
         tonalElevation = if (isWideLayout) 3.dp else 5.dp,
     ) {
         Column {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,10 +28,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -49,6 +54,8 @@ import org.feeluown.mobile.core.model.TrackRef
 import org.feeluown.mobile.playback.api.PlaybackSession
 import org.feeluown.mobile.playback.api.PlaybackSessionState
 import org.feeluown.mobile.playback.api.PlaybackSessionStatus
+
+private val MiniPlayerPreviousControlBreakpoint = 420.dp
 
 /**
  * Controller-free MiniPlayer implementation backed by the app-scoped playback session.
@@ -70,107 +77,151 @@ internal fun RuntimeMiniPlayer(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(
+                horizontal = if (isWideLayout) 0.dp else 8.dp,
+                vertical = if (isWideLayout) 0.dp else 4.dp,
+            )
             .animateContentSize(animationSpec = tween(220))
             .fuoInteractive()
             .clickable(role = Role.Button, onClick = onOpenFullPlayer),
-        shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        tonalElevation = 3.dp,
+        shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.extraLarge,
+        color = if (isWideLayout) {
+            MaterialTheme.colorScheme.surfaceContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        tonalElevation = if (isWideLayout) 3.dp else 5.dp,
     ) {
         Column {
-            Row(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = if (isWideLayout) 8.dp else 10.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                state.currentTrack?.let { track ->
-                    RuntimeMiniPlayerCover(
-                        track = track,
-                        heroEnabled = !isFullPlayerOpen,
-                        transitionDirection = transitionDirection,
-                        isLoading = isLoadingAudio,
-                        cornerRadius = if (isWideLayout) 10.dp else 12.dp,
-                        modifier = Modifier.size(if (isWideLayout) 44.dp else 56.dp),
-                    )
-                }
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = state.currentTrack?.title ?: "未播放",
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = if (isLoadingAudio) {
-                            "正在加载音频"
-                        } else {
-                            state.currentTrack?.let(::runtimeArtistAlbumLabel) ?: "选择一首音乐开始播放"
-                        },
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isLoadingAudio) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    RuntimeMiniPlayerLyricLine(state)
-                }
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                val showPrevious = shouldShowMiniPlayerPreviousControl(maxWidth, isWideLayout)
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(
+                        horizontal = if (isWideLayout) 12.dp else 14.dp,
+                        vertical = if (isWideLayout) 8.dp else 8.dp,
+                    ),
+                    horizontalArrangement = Arrangement.spacedBy(if (isWideLayout) 12.dp else 14.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    RoundControlButton(
-                        imageVector = Icons.Filled.SkipPrevious,
-                        contentDescription = "上一首",
-                        onClick = playbackSession::previous,
-                        size = 48.dp,
-                        iconSize = 24.dp,
-                    )
-                    PlayPauseButton(
-                        isPlaying = state.status == PlaybackSessionStatus.Playing,
-                        isLoading = state.status == PlaybackSessionStatus.Loading,
-                        onClick = playbackSession::toggle,
-                        size = 48.dp,
-                        iconSize = 26.dp,
-                    )
-                    RoundControlButton(
-                        imageVector = Icons.Filled.SkipNext,
-                        contentDescription = "下一首",
-                        onClick = playbackSession::next,
-                        size = 48.dp,
-                        iconSize = 24.dp,
-                    )
+                    state.currentTrack?.let { track ->
+                        RuntimeMiniPlayerCover(
+                            track = track,
+                            heroEnabled = !isFullPlayerOpen,
+                            transitionDirection = transitionDirection,
+                            isLoading = isLoadingAudio,
+                            cornerRadius = if (isWideLayout) 10.dp else 18.dp,
+                            modifier = Modifier.size(if (isWideLayout) 48.dp else 64.dp),
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = state.currentTrack?.title ?: "未播放",
+                            style = if (isWideLayout) {
+                                MaterialTheme.typography.titleSmall
+                            } else {
+                                MaterialTheme.typography.titleMedium
+                            },
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = if (isLoadingAudio) {
+                                "正在加载音频"
+                            } else {
+                                state.currentTrack?.let(::runtimeArtistAlbumLabel) ?: "选择一首音乐开始播放"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (isLoadingAudio) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        RuntimeMiniPlayerLyricLine(state)
+                    }
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (showPrevious) {
+                            RoundControlButton(
+                                imageVector = Icons.Filled.SkipPrevious,
+                                contentDescription = "上一首",
+                                onClick = playbackSession::previous,
+                                size = 48.dp,
+                                iconSize = 24.dp,
+                            )
+                        }
+                        PlayPauseButton(
+                            isPlaying = state.status == PlaybackSessionStatus.Playing,
+                            isLoading = state.status == PlaybackSessionStatus.Loading,
+                            onClick = playbackSession::toggle,
+                            size = if (isWideLayout) 48.dp else 56.dp,
+                            iconSize = if (isWideLayout) 26.dp else 30.dp,
+                            prominent = !isWideLayout,
+                        )
+                        RoundControlButton(
+                            imageVector = Icons.Filled.SkipNext,
+                            contentDescription = "下一首",
+                            onClick = playbackSession::next,
+                            size = 48.dp,
+                            iconSize = 24.dp,
+                        )
+                    }
                 }
             }
-            RuntimeMiniPlayerProgress(state, isLoadingAudio)
+            RuntimeMiniPlayerProgress(
+                state = state,
+                isLoadingAudio = isLoadingAudio,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = if (isWideLayout) 12.dp else 16.dp)
+                    .padding(bottom = if (isWideLayout) 6.dp else 8.dp),
+            )
         }
     }
 }
 
+internal fun shouldShowMiniPlayerPreviousControl(maxWidth: Dp, isWideLayout: Boolean): Boolean =
+    isWideLayout || maxWidth >= MiniPlayerPreviousControlBreakpoint
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun RuntimeMiniPlayerProgress(
     state: PlaybackSessionState,
     isLoadingAudio: Boolean,
+    modifier: Modifier = Modifier,
 ) {
-    val duration = state.durationMs.takeIf { it > 0 }
-    if (isLoadingAudio || duration != null) {
-        val targetProgress = duration?.let {
-            state.positionMs.coerceIn(0, it).toFloat() / it
-        } ?: 0f
-        val progress by animateFloatAsState(
-            targetValue = targetProgress,
-            animationSpec = tween(FuoMotion.progressAnimationMillis),
-            label = "mini player progress",
-        )
+    if (isLoadingAudio) {
         LinearProgressIndicator(
-            progress = { progress },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp),
+            modifier = modifier.height(4.dp),
         )
+        return
     }
+    val duration = state.durationMs.takeIf { it > 0 } ?: return
+    val targetProgress = state.positionMs.coerceIn(0, duration).toFloat() / duration
+    val progress by animateFloatAsState(
+        targetValue = targetProgress,
+        animationSpec = tween(FuoMotion.progressAnimationMillis),
+        label = "mini player progress",
+    )
+    LinearWavyProgressIndicator(
+        progress = { progress },
+        modifier = modifier.height(5.dp),
+        amplitude = { value ->
+            if (state.status == PlaybackSessionStatus.Playing) {
+                WavyProgressIndicatorDefaults.indicatorAmplitude(value)
+            } else {
+                0f
+            }
+        },
+    )
 }
 
 @Composable

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/HomeNavigationUiPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/HomeNavigationUiPolicyTest.kt
@@ -1,0 +1,40 @@
+package org.feeluown.mobile
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HomeNavigationUiPolicyTest {
+    @Test
+    fun navigationCompactsAfterSustainedUpwardScrollAndExpandsOnReverseScroll() {
+        val accumulator = HomeNavigationScrollAccumulator(thresholdPx = 28f)
+
+        assertNull(accumulator.onScroll(-12f))
+        assertNull(accumulator.onScroll(-12f))
+        assertEquals(true, accumulator.onScroll(-4f))
+
+        assertNull(accumulator.onScroll(10f))
+        assertEquals(false, accumulator.onScroll(18f))
+    }
+
+    @Test
+    fun navigationDirectionChangeResetsPartialScrollDistance() {
+        val accumulator = HomeNavigationScrollAccumulator(thresholdPx = 28f)
+
+        assertNull(accumulator.onScroll(-20f))
+        assertNull(accumulator.onScroll(12f))
+        assertNull(accumulator.onScroll(15f))
+        assertEquals(false, accumulator.onScroll(13f))
+    }
+
+    @Test
+    fun compactMiniPlayerKeepsPreviousControlForRoomierLayoutsOnly() {
+        assertFalse(shouldShowMiniPlayerPreviousControl(360.dp, isWideLayout = false))
+        assertFalse(shouldShowMiniPlayerPreviousControl(419.dp, isWideLayout = false))
+        assertTrue(shouldShowMiniPlayerPreviousControl(420.dp, isWideLayout = false))
+        assertTrue(shouldShowMiniPlayerPreviousControl(360.dp, isWideLayout = true))
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/HomeNavigationUiPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/HomeNavigationUiPolicyTest.kt
@@ -37,4 +37,19 @@ class HomeNavigationUiPolicyTest {
         assertTrue(shouldShowMiniPlayerPreviousControl(420.dp, isWideLayout = false))
         assertTrue(shouldShowMiniPlayerPreviousControl(360.dp, isWideLayout = true))
     }
+
+    @Test
+    fun shortHomeRailDropsLabelsBeforeRecognitionAndKeepsSearchOutsidePolicy() {
+        val veryShort = homeRailLayoutPolicyFor(280.dp)
+        assertFalse(veryShort.showLabels)
+        assertFalse(veryShort.showRecognition)
+
+        val compactWithRecognition = homeRailLayoutPolicyFor(320.dp)
+        assertFalse(compactWithRecognition.showLabels)
+        assertTrue(compactWithRecognition.showRecognition)
+
+        val expanded = homeRailLayoutPolicyFor(400.dp)
+        assertTrue(expanded.showLabels)
+        assertTrue(expanded.showRecognition)
+    }
 }


### PR DESCRIPTION
## Summary
- keep the compact-phone primary navigation at the top, but replace the standard tab row with an expressive tonal navigation surface
- animate the selected navigation pill continuously with pager position for both taps and swipe gestures, without square/unbounded ripple feedback
- collapse the top navigation after sustained upward content scroll and restore the expanded treatment on reverse scroll or section changes
- keep the wide-layout navigation rail, but adapt it to short available heights: hide section labels first, then hide the outer audio-recognition action while always preserving Search
- refresh the mini player with a larger cover, stronger title hierarchy, prominent play/pause action, wavy playback progress, and an expressive elevated container
- hide the previous-track action below 420dp to preserve text space on narrow phones while keeping it on roomier and wide layouts

## Validation
- added focused common tests for navigation scroll hysteresis, mini-player control breakpoint behavior, and short-height rail policy
- CI runs the repository's shared Android/iOS test workflows on this PR

## Deferred
- no drag/swipe gestures on the mini player in this PR
- no bottom navigation migration
- no adaptive width-class refactor; the rail adapts only to its actual available height in this PR