### PR TITLE
feat: smooth theme color transitions

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
@@ -1,0 +1,85 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.tween
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+
+@Composable
+internal fun rememberAnimatedColorScheme(
+    target: ColorScheme,
+    labelPrefix: String,
+): ColorScheme {
+    val animationSpec = remember(FuoMotion.themeColorTransitionMillis) {
+        tween<Color>(durationMillis = FuoMotion.themeColorTransitionMillis)
+    }
+
+    return target.copy(
+        primary = animatedThemeColor(target.primary, animationSpec, "$labelPrefix primary"),
+        onPrimary = animatedThemeColor(target.onPrimary, animationSpec, "$labelPrefix onPrimary"),
+        primaryContainer = animatedThemeColor(target.primaryContainer, animationSpec, "$labelPrefix primaryContainer"),
+        onPrimaryContainer = animatedThemeColor(target.onPrimaryContainer, animationSpec, "$labelPrefix onPrimaryContainer"),
+        inversePrimary = animatedThemeColor(target.inversePrimary, animationSpec, "$labelPrefix inversePrimary"),
+        secondary = animatedThemeColor(target.secondary, animationSpec, "$labelPrefix secondary"),
+        onSecondary = animatedThemeColor(target.onSecondary, animationSpec, "$labelPrefix onSecondary"),
+        secondaryContainer = animatedThemeColor(target.secondaryContainer, animationSpec, "$labelPrefix secondaryContainer"),
+        onSecondaryContainer = animatedThemeColor(target.onSecondaryContainer, animationSpec, "$labelPrefix onSecondaryContainer"),
+        tertiary = animatedThemeColor(target.tertiary, animationSpec, "$labelPrefix tertiary"),
+        onTertiary = animatedThemeColor(target.onTertiary, animationSpec, "$labelPrefix onTertiary"),
+        tertiaryContainer = animatedThemeColor(target.tertiaryContainer, animationSpec, "$labelPrefix tertiaryContainer"),
+        onTertiaryContainer = animatedThemeColor(target.onTertiaryContainer, animationSpec, "$labelPrefix onTertiaryContainer"),
+        background = animatedThemeColor(target.background, animationSpec, "$labelPrefix background"),
+        onBackground = animatedThemeColor(target.onBackground, animationSpec, "$labelPrefix onBackground"),
+        surface = animatedThemeColor(target.surface, animationSpec, "$labelPrefix surface"),
+        onSurface = animatedThemeColor(target.onSurface, animationSpec, "$labelPrefix onSurface"),
+        surfaceVariant = animatedThemeColor(target.surfaceVariant, animationSpec, "$labelPrefix surfaceVariant"),
+        onSurfaceVariant = animatedThemeColor(target.onSurfaceVariant, animationSpec, "$labelPrefix onSurfaceVariant"),
+        surfaceTint = animatedThemeColor(target.surfaceTint, animationSpec, "$labelPrefix surfaceTint"),
+        inverseSurface = animatedThemeColor(target.inverseSurface, animationSpec, "$labelPrefix inverseSurface"),
+        inverseOnSurface = animatedThemeColor(target.inverseOnSurface, animationSpec, "$labelPrefix inverseOnSurface"),
+        error = animatedThemeColor(target.error, animationSpec, "$labelPrefix error"),
+        onError = animatedThemeColor(target.onError, animationSpec, "$labelPrefix onError"),
+        errorContainer = animatedThemeColor(target.errorContainer, animationSpec, "$labelPrefix errorContainer"),
+        onErrorContainer = animatedThemeColor(target.onErrorContainer, animationSpec, "$labelPrefix onErrorContainer"),
+        outline = animatedThemeColor(target.outline, animationSpec, "$labelPrefix outline"),
+        outlineVariant = animatedThemeColor(target.outlineVariant, animationSpec, "$labelPrefix outlineVariant"),
+        scrim = animatedThemeColor(target.scrim, animationSpec, "$labelPrefix scrim"),
+        surfaceBright = animatedThemeColor(target.surfaceBright, animationSpec, "$labelPrefix surfaceBright"),
+        surfaceDim = animatedThemeColor(target.surfaceDim, animationSpec, "$labelPrefix surfaceDim"),
+        surfaceContainer = animatedThemeColor(target.surfaceContainer, animationSpec, "$labelPrefix surfaceContainer"),
+        surfaceContainerHigh = animatedThemeColor(target.surfaceContainerHigh, animationSpec, "$labelPrefix surfaceContainerHigh"),
+        surfaceContainerHighest = animatedThemeColor(target.surfaceContainerHighest, animationSpec, "$labelPrefix surfaceContainerHighest"),
+        surfaceContainerLow = animatedThemeColor(target.surfaceContainerLow, animationSpec, "$labelPrefix surfaceContainerLow"),
+        surfaceContainerLowest = animatedThemeColor(target.surfaceContainerLowest, animationSpec, "$labelPrefix surfaceContainerLowest"),
+        primaryFixed = animatedThemeColor(target.primaryFixed, animationSpec, "$labelPrefix primaryFixed"),
+        primaryFixedDim = animatedThemeColor(target.primaryFixedDim, animationSpec, "$labelPrefix primaryFixedDim"),
+        onPrimaryFixed = animatedThemeColor(target.onPrimaryFixed, animationSpec, "$labelPrefix onPrimaryFixed"),
+        onPrimaryFixedVariant = animatedThemeColor(target.onPrimaryFixedVariant, animationSpec, "$labelPrefix onPrimaryFixedVariant"),
+        secondaryFixed = animatedThemeColor(target.secondaryFixed, animationSpec, "$labelPrefix secondaryFixed"),
+        secondaryFixedDim = animatedThemeColor(target.secondaryFixedDim, animationSpec, "$labelPrefix secondaryFixedDim"),
+        onSecondaryFixed = animatedThemeColor(target.onSecondaryFixed, animationSpec, "$labelPrefix onSecondaryFixed"),
+        onSecondaryFixedVariant = animatedThemeColor(target.onSecondaryFixedVariant, animationSpec, "$labelPrefix onSecondaryFixedVariant"),
+        tertiaryFixed = animatedThemeColor(target.tertiaryFixed, animationSpec, "$labelPrefix tertiaryFixed"),
+        tertiaryFixedDim = animatedThemeColor(target.tertiaryFixedDim, animationSpec, "$labelPrefix tertiaryFixedDim"),
+        onTertiaryFixed = animatedThemeColor(target.onTertiaryFixed, animationSpec, "$labelPrefix onTertiaryFixed"),
+        onTertiaryFixedVariant = animatedThemeColor(target.onTertiaryFixedVariant, animationSpec, "$labelPrefix onTertiaryFixedVariant"),
+    )
+}
+
+@Composable
+private fun animatedThemeColor(
+    target: Color,
+    animationSpec: FiniteAnimationSpec<Color>,
+    label: String,
+): Color {
+    val animated by animateColorAsState(
+        targetValue = target,
+        animationSpec = animationSpec,
+        label = label,
+    )
+    return animated
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
@@ -8,6 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+
+private const val MIN_THEME_TRANSITION_CONTRAST_RATIO = 4.5
+private const val CONTRAST_SEARCH_ITERATIONS = 14
 
 @Composable
 internal fun rememberAnimatedColorScheme(
@@ -18,56 +22,262 @@ internal fun rememberAnimatedColorScheme(
         tween<Color>(durationMillis = FuoMotion.themeColorTransitionMillis)
     }
 
+    val primary = animatedThemeColor(target.primary, animationSpec, "$labelPrefix primary")
+    val primaryContainer = animatedThemeColor(
+        target.primaryContainer,
+        animationSpec,
+        "$labelPrefix primaryContainer",
+    )
+    val secondary = animatedThemeColor(target.secondary, animationSpec, "$labelPrefix secondary")
+    val secondaryContainer = animatedThemeColor(
+        target.secondaryContainer,
+        animationSpec,
+        "$labelPrefix secondaryContainer",
+    )
+    val tertiary = animatedThemeColor(target.tertiary, animationSpec, "$labelPrefix tertiary")
+    val tertiaryContainer = animatedThemeColor(
+        target.tertiaryContainer,
+        animationSpec,
+        "$labelPrefix tertiaryContainer",
+    )
+    val background = animatedThemeColor(target.background, animationSpec, "$labelPrefix background")
+    val surface = animatedThemeColor(target.surface, animationSpec, "$labelPrefix surface")
+    val surfaceVariant = animatedThemeColor(
+        target.surfaceVariant,
+        animationSpec,
+        "$labelPrefix surfaceVariant",
+    )
+    val inverseSurface = animatedThemeColor(
+        target.inverseSurface,
+        animationSpec,
+        "$labelPrefix inverseSurface",
+    )
+    val error = animatedThemeColor(target.error, animationSpec, "$labelPrefix error")
+    val errorContainer = animatedThemeColor(
+        target.errorContainer,
+        animationSpec,
+        "$labelPrefix errorContainer",
+    )
+    val surfaceBright = animatedThemeColor(
+        target.surfaceBright,
+        animationSpec,
+        "$labelPrefix surfaceBright",
+    )
+    val surfaceDim = animatedThemeColor(target.surfaceDim, animationSpec, "$labelPrefix surfaceDim")
+    val surfaceContainer = animatedThemeColor(
+        target.surfaceContainer,
+        animationSpec,
+        "$labelPrefix surfaceContainer",
+    )
+    val surfaceContainerHigh = animatedThemeColor(
+        target.surfaceContainerHigh,
+        animationSpec,
+        "$labelPrefix surfaceContainerHigh",
+    )
+    val surfaceContainerHighest = animatedThemeColor(
+        target.surfaceContainerHighest,
+        animationSpec,
+        "$labelPrefix surfaceContainerHighest",
+    )
+    val surfaceContainerLow = animatedThemeColor(
+        target.surfaceContainerLow,
+        animationSpec,
+        "$labelPrefix surfaceContainerLow",
+    )
+    val surfaceContainerLowest = animatedThemeColor(
+        target.surfaceContainerLowest,
+        animationSpec,
+        "$labelPrefix surfaceContainerLowest",
+    )
+    val primaryFixed = animatedThemeColor(
+        target.primaryFixed,
+        animationSpec,
+        "$labelPrefix primaryFixed",
+    )
+    val primaryFixedDim = animatedThemeColor(
+        target.primaryFixedDim,
+        animationSpec,
+        "$labelPrefix primaryFixedDim",
+    )
+    val secondaryFixed = animatedThemeColor(
+        target.secondaryFixed,
+        animationSpec,
+        "$labelPrefix secondaryFixed",
+    )
+    val secondaryFixedDim = animatedThemeColor(
+        target.secondaryFixedDim,
+        animationSpec,
+        "$labelPrefix secondaryFixedDim",
+    )
+    val tertiaryFixed = animatedThemeColor(
+        target.tertiaryFixed,
+        animationSpec,
+        "$labelPrefix tertiaryFixed",
+    )
+    val tertiaryFixedDim = animatedThemeColor(
+        target.tertiaryFixedDim,
+        animationSpec,
+        "$labelPrefix tertiaryFixedDim",
+    )
+
     return target.copy(
-        primary = animatedThemeColor(target.primary, animationSpec, "$labelPrefix primary"),
-        onPrimary = animatedThemeColor(target.onPrimary, animationSpec, "$labelPrefix onPrimary"),
-        primaryContainer = animatedThemeColor(target.primaryContainer, animationSpec, "$labelPrefix primaryContainer"),
-        onPrimaryContainer = animatedThemeColor(target.onPrimaryContainer, animationSpec, "$labelPrefix onPrimaryContainer"),
+        primary = primary,
+        onPrimary = animatedContrastThemeColor(
+            target.onPrimary,
+            animationSpec,
+            "$labelPrefix onPrimary",
+            primary,
+        ),
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = animatedContrastThemeColor(
+            target.onPrimaryContainer,
+            animationSpec,
+            "$labelPrefix onPrimaryContainer",
+            primaryContainer,
+        ),
         inversePrimary = animatedThemeColor(target.inversePrimary, animationSpec, "$labelPrefix inversePrimary"),
-        secondary = animatedThemeColor(target.secondary, animationSpec, "$labelPrefix secondary"),
-        onSecondary = animatedThemeColor(target.onSecondary, animationSpec, "$labelPrefix onSecondary"),
-        secondaryContainer = animatedThemeColor(target.secondaryContainer, animationSpec, "$labelPrefix secondaryContainer"),
-        onSecondaryContainer = animatedThemeColor(target.onSecondaryContainer, animationSpec, "$labelPrefix onSecondaryContainer"),
-        tertiary = animatedThemeColor(target.tertiary, animationSpec, "$labelPrefix tertiary"),
-        onTertiary = animatedThemeColor(target.onTertiary, animationSpec, "$labelPrefix onTertiary"),
-        tertiaryContainer = animatedThemeColor(target.tertiaryContainer, animationSpec, "$labelPrefix tertiaryContainer"),
-        onTertiaryContainer = animatedThemeColor(target.onTertiaryContainer, animationSpec, "$labelPrefix onTertiaryContainer"),
-        background = animatedThemeColor(target.background, animationSpec, "$labelPrefix background"),
-        onBackground = animatedThemeColor(target.onBackground, animationSpec, "$labelPrefix onBackground"),
-        surface = animatedThemeColor(target.surface, animationSpec, "$labelPrefix surface"),
-        onSurface = animatedThemeColor(target.onSurface, animationSpec, "$labelPrefix onSurface"),
-        surfaceVariant = animatedThemeColor(target.surfaceVariant, animationSpec, "$labelPrefix surfaceVariant"),
-        onSurfaceVariant = animatedThemeColor(target.onSurfaceVariant, animationSpec, "$labelPrefix onSurfaceVariant"),
+        secondary = secondary,
+        onSecondary = animatedContrastThemeColor(
+            target.onSecondary,
+            animationSpec,
+            "$labelPrefix onSecondary",
+            secondary,
+        ),
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = animatedContrastThemeColor(
+            target.onSecondaryContainer,
+            animationSpec,
+            "$labelPrefix onSecondaryContainer",
+            secondaryContainer,
+        ),
+        tertiary = tertiary,
+        onTertiary = animatedContrastThemeColor(
+            target.onTertiary,
+            animationSpec,
+            "$labelPrefix onTertiary",
+            tertiary,
+        ),
+        tertiaryContainer = tertiaryContainer,
+        onTertiaryContainer = animatedContrastThemeColor(
+            target.onTertiaryContainer,
+            animationSpec,
+            "$labelPrefix onTertiaryContainer",
+            tertiaryContainer,
+        ),
+        background = background,
+        onBackground = animatedContrastThemeColor(
+            target.onBackground,
+            animationSpec,
+            "$labelPrefix onBackground",
+            background,
+        ),
+        surface = surface,
+        onSurface = animatedContrastThemeColor(
+            target.onSurface,
+            animationSpec,
+            "$labelPrefix onSurface",
+            surface,
+            surfaceBright,
+            surfaceDim,
+            surfaceContainer,
+            surfaceContainerHigh,
+            surfaceContainerHighest,
+            surfaceContainerLow,
+            surfaceContainerLowest,
+        ),
+        surfaceVariant = surfaceVariant,
+        onSurfaceVariant = animatedContrastThemeColor(
+            target.onSurfaceVariant,
+            animationSpec,
+            "$labelPrefix onSurfaceVariant",
+            surfaceVariant,
+        ),
         surfaceTint = animatedThemeColor(target.surfaceTint, animationSpec, "$labelPrefix surfaceTint"),
-        inverseSurface = animatedThemeColor(target.inverseSurface, animationSpec, "$labelPrefix inverseSurface"),
-        inverseOnSurface = animatedThemeColor(target.inverseOnSurface, animationSpec, "$labelPrefix inverseOnSurface"),
-        error = animatedThemeColor(target.error, animationSpec, "$labelPrefix error"),
-        onError = animatedThemeColor(target.onError, animationSpec, "$labelPrefix onError"),
-        errorContainer = animatedThemeColor(target.errorContainer, animationSpec, "$labelPrefix errorContainer"),
-        onErrorContainer = animatedThemeColor(target.onErrorContainer, animationSpec, "$labelPrefix onErrorContainer"),
+        inverseSurface = inverseSurface,
+        inverseOnSurface = animatedContrastThemeColor(
+            target.inverseOnSurface,
+            animationSpec,
+            "$labelPrefix inverseOnSurface",
+            inverseSurface,
+        ),
+        error = error,
+        onError = animatedContrastThemeColor(
+            target.onError,
+            animationSpec,
+            "$labelPrefix onError",
+            error,
+        ),
+        errorContainer = errorContainer,
+        onErrorContainer = animatedContrastThemeColor(
+            target.onErrorContainer,
+            animationSpec,
+            "$labelPrefix onErrorContainer",
+            errorContainer,
+        ),
         outline = animatedThemeColor(target.outline, animationSpec, "$labelPrefix outline"),
         outlineVariant = animatedThemeColor(target.outlineVariant, animationSpec, "$labelPrefix outlineVariant"),
         scrim = animatedThemeColor(target.scrim, animationSpec, "$labelPrefix scrim"),
-        surfaceBright = animatedThemeColor(target.surfaceBright, animationSpec, "$labelPrefix surfaceBright"),
-        surfaceDim = animatedThemeColor(target.surfaceDim, animationSpec, "$labelPrefix surfaceDim"),
-        surfaceContainer = animatedThemeColor(target.surfaceContainer, animationSpec, "$labelPrefix surfaceContainer"),
-        surfaceContainerHigh = animatedThemeColor(target.surfaceContainerHigh, animationSpec, "$labelPrefix surfaceContainerHigh"),
-        surfaceContainerHighest = animatedThemeColor(target.surfaceContainerHighest, animationSpec, "$labelPrefix surfaceContainerHighest"),
-        surfaceContainerLow = animatedThemeColor(target.surfaceContainerLow, animationSpec, "$labelPrefix surfaceContainerLow"),
-        surfaceContainerLowest = animatedThemeColor(target.surfaceContainerLowest, animationSpec, "$labelPrefix surfaceContainerLowest"),
-        primaryFixed = animatedThemeColor(target.primaryFixed, animationSpec, "$labelPrefix primaryFixed"),
-        primaryFixedDim = animatedThemeColor(target.primaryFixedDim, animationSpec, "$labelPrefix primaryFixedDim"),
-        onPrimaryFixed = animatedThemeColor(target.onPrimaryFixed, animationSpec, "$labelPrefix onPrimaryFixed"),
-        onPrimaryFixedVariant = animatedThemeColor(target.onPrimaryFixedVariant, animationSpec, "$labelPrefix onPrimaryFixedVariant"),
-        secondaryFixed = animatedThemeColor(target.secondaryFixed, animationSpec, "$labelPrefix secondaryFixed"),
-        secondaryFixedDim = animatedThemeColor(target.secondaryFixedDim, animationSpec, "$labelPrefix secondaryFixedDim"),
-        onSecondaryFixed = animatedThemeColor(target.onSecondaryFixed, animationSpec, "$labelPrefix onSecondaryFixed"),
-        onSecondaryFixedVariant = animatedThemeColor(target.onSecondaryFixedVariant, animationSpec, "$labelPrefix onSecondaryFixedVariant"),
-        tertiaryFixed = animatedThemeColor(target.tertiaryFixed, animationSpec, "$labelPrefix tertiaryFixed"),
-        tertiaryFixedDim = animatedThemeColor(target.tertiaryFixedDim, animationSpec, "$labelPrefix tertiaryFixedDim"),
-        onTertiaryFixed = animatedThemeColor(target.onTertiaryFixed, animationSpec, "$labelPrefix onTertiaryFixed"),
-        onTertiaryFixedVariant = animatedThemeColor(target.onTertiaryFixedVariant, animationSpec, "$labelPrefix onTertiaryFixedVariant"),
+        surfaceBright = surfaceBright,
+        surfaceDim = surfaceDim,
+        surfaceContainer = surfaceContainer,
+        surfaceContainerHigh = surfaceContainerHigh,
+        surfaceContainerHighest = surfaceContainerHighest,
+        surfaceContainerLow = surfaceContainerLow,
+        surfaceContainerLowest = surfaceContainerLowest,
+        primaryFixed = primaryFixed,
+        primaryFixedDim = primaryFixedDim,
+        onPrimaryFixed = animatedContrastThemeColor(
+            target.onPrimaryFixed,
+            animationSpec,
+            "$labelPrefix onPrimaryFixed",
+            primaryFixed,
+            primaryFixedDim,
+        ),
+        onPrimaryFixedVariant = animatedThemeColor(
+            target.onPrimaryFixedVariant,
+            animationSpec,
+            "$labelPrefix onPrimaryFixedVariant",
+        ),
+        secondaryFixed = secondaryFixed,
+        secondaryFixedDim = secondaryFixedDim,
+        onSecondaryFixed = animatedContrastThemeColor(
+            target.onSecondaryFixed,
+            animationSpec,
+            "$labelPrefix onSecondaryFixed",
+            secondaryFixed,
+            secondaryFixedDim,
+        ),
+        onSecondaryFixedVariant = animatedThemeColor(
+            target.onSecondaryFixedVariant,
+            animationSpec,
+            "$labelPrefix onSecondaryFixedVariant",
+        ),
+        tertiaryFixed = tertiaryFixed,
+        tertiaryFixedDim = tertiaryFixedDim,
+        onTertiaryFixed = animatedContrastThemeColor(
+            target.onTertiaryFixed,
+            animationSpec,
+            "$labelPrefix onTertiaryFixed",
+            tertiaryFixed,
+            tertiaryFixedDim,
+        ),
+        onTertiaryFixedVariant = animatedThemeColor(
+            target.onTertiaryFixedVariant,
+            animationSpec,
+            "$labelPrefix onTertiaryFixedVariant",
+        ),
     )
+}
+
+@Composable
+private fun animatedContrastThemeColor(
+    target: Color,
+    animationSpec: FiniteAnimationSpec<Color>,
+    label: String,
+    vararg backgrounds: Color,
+): Color {
+    val animated = animatedThemeColor(target, animationSpec, label)
+    return ensureThemeContrast(animated, backgrounds.asList())
 }
 
 @Composable
@@ -82,4 +292,38 @@ private fun animatedThemeColor(
         label = label,
     )
     return animated
+}
+
+internal fun ensureThemeContrast(
+    foreground: Color,
+    backgrounds: List<Color>,
+    minimumRatio: Double = MIN_THEME_TRANSITION_CONTRAST_RATIO,
+): Color {
+    if (backgrounds.isEmpty() || backgrounds.all { colorContrastRatio(foreground, it) >= minimumRatio }) {
+        return foreground
+    }
+
+    fun minimumContrast(candidate: Color): Double = backgrounds.minOf {
+        colorContrastRatio(candidate, it)
+    }
+
+    val blackContrast = minimumContrast(Color.Black)
+    val whiteContrast = minimumContrast(Color.White)
+    val anchor = if (blackContrast >= whiteContrast) Color.Black else Color.White
+    val anchorContrast = maxOf(blackContrast, whiteContrast)
+    if (anchorContrast < minimumRatio) {
+        return anchor
+    }
+
+    var low = 0f
+    var high = 1f
+    repeat(CONTRAST_SEARCH_ITERATIONS) {
+        val fraction = (low + high) / 2f
+        if (minimumContrast(lerp(foreground, anchor, fraction)) >= minimumRatio) {
+            high = fraction
+        } else {
+            low = fraction
+        }
+    }
+    return lerp(foreground, anchor, high)
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoColorSchemeMotion.kt
@@ -176,14 +176,16 @@ internal fun rememberAnimatedColorScheme(
             target.onSurface,
             animationSpec,
             "$labelPrefix onSurface",
-            surface,
-            surfaceBright,
-            surfaceDim,
-            surfaceContainer,
-            surfaceContainerHigh,
-            surfaceContainerHighest,
-            surfaceContainerLow,
-            surfaceContainerLowest,
+            listOf(
+                surface,
+                surfaceBright,
+                surfaceDim,
+                surfaceContainer,
+                surfaceContainerHigh,
+                surfaceContainerHighest,
+                surfaceContainerLow,
+                surfaceContainerLowest,
+            ),
         ),
         surfaceVariant = surfaceVariant,
         onSurfaceVariant = animatedContrastThemeColor(
@@ -230,8 +232,7 @@ internal fun rememberAnimatedColorScheme(
             target.onPrimaryFixed,
             animationSpec,
             "$labelPrefix onPrimaryFixed",
-            primaryFixed,
-            primaryFixedDim,
+            listOf(primaryFixed, primaryFixedDim),
         ),
         onPrimaryFixedVariant = animatedThemeColor(
             target.onPrimaryFixedVariant,
@@ -244,8 +245,7 @@ internal fun rememberAnimatedColorScheme(
             target.onSecondaryFixed,
             animationSpec,
             "$labelPrefix onSecondaryFixed",
-            secondaryFixed,
-            secondaryFixedDim,
+            listOf(secondaryFixed, secondaryFixedDim),
         ),
         onSecondaryFixedVariant = animatedThemeColor(
             target.onSecondaryFixedVariant,
@@ -258,8 +258,7 @@ internal fun rememberAnimatedColorScheme(
             target.onTertiaryFixed,
             animationSpec,
             "$labelPrefix onTertiaryFixed",
-            tertiaryFixed,
-            tertiaryFixedDim,
+            listOf(tertiaryFixed, tertiaryFixedDim),
         ),
         onTertiaryFixedVariant = animatedThemeColor(
             target.onTertiaryFixedVariant,
@@ -274,10 +273,23 @@ private fun animatedContrastThemeColor(
     target: Color,
     animationSpec: FiniteAnimationSpec<Color>,
     label: String,
-    vararg backgrounds: Color,
+    background: Color,
+): Color = animatedContrastThemeColor(
+    target = target,
+    animationSpec = animationSpec,
+    label = label,
+    backgrounds = listOf(background),
+)
+
+@Composable
+private fun animatedContrastThemeColor(
+    target: Color,
+    animationSpec: FiniteAnimationSpec<Color>,
+    label: String,
+    backgrounds: List<Color>,
 ): Color {
     val animated = animatedThemeColor(target, animationSpec, label)
-    return ensureThemeContrast(animated, backgrounds.asList())
+    return ensureThemeContrast(animated, backgrounds)
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoDesignSystem.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoDesignSystem.kt
@@ -52,7 +52,7 @@ internal object FuoMotion {
     const val pageFadeMillis = 180
     const val coverTransitionMillis = 360
     const val coverFadeMillis = 220
-    const val coverColorTransitionMillis = 420
+    const val themeColorTransitionMillis = 420
     const val progressAnimationMillis = 180
     const val overlayEnterMillis = 240
     const val overlayExitMillis = 200

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
@@ -8,11 +8,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -32,6 +29,7 @@ private const val REQUIRED_CONTRAST_RATIO = 4.5
 
 private val LocalThemePaletteStyle = staticCompositionLocalOf { ThemePaletteStyle.Expressive }
 private val LocalThemeColorSpec = staticCompositionLocalOf { ThemeColorSpec.Expressive_2025 }
+private val LocalBaseTargetColorScheme = staticCompositionLocalOf<ColorScheme?> { null }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -43,18 +41,23 @@ fun FuoTheme(
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
-    val colorScheme = fuoColorScheme(
+    val targetColorScheme = fuoColorScheme(
         themeColorScheme = themeColorScheme,
         darkTheme = darkTheme,
         paletteStyle = themePaletteStyle,
         colorSpec = themeColorSpec,
     )
+    val animatedColorScheme = rememberAnimatedColorScheme(
+        target = targetColorScheme,
+        labelPrefix = "app theme",
+    )
     CompositionLocalProvider(
         LocalThemePaletteStyle provides themePaletteStyle,
         LocalThemeColorSpec provides themeColorSpec,
+        LocalBaseTargetColorScheme provides targetColorScheme,
     ) {
-        FuoExpressiveTheme(colorScheme = colorScheme) {
-            platformWindowSurfaceEffect(colorScheme.surface)
+        FuoExpressiveTheme(colorScheme = animatedColorScheme) {
+            platformWindowSurfaceEffect(animatedColorScheme.surface)
             content()
         }
     }
@@ -70,7 +73,7 @@ internal fun PlayerDynamicColorTheme(
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
-    val baseColorScheme = MaterialTheme.colorScheme
+    val baseTargetColorScheme = LocalBaseTargetColorScheme.current ?: MaterialTheme.colorScheme
     val paletteStyle = LocalThemePaletteStyle.current
     val colorSpec = LocalThemeColorSpec.current
     val coverColorSeed = rememberCoverColorSeed(
@@ -84,21 +87,16 @@ internal fun PlayerDynamicColorTheme(
     val hasCoverColor = dynamicCoverColorEnabled &&
         (isLoading || !coverImageUrl.isNullOrBlank()) &&
         coverColorSeed != null
-    val animatedCoverColorSeed by animateColorAsState(
-        targetValue = coverColorSeed ?: baseColorScheme.primary,
-        animationSpec = tween(FuoMotion.coverColorTransitionMillis),
-        label = "player cover color",
-    )
     val coverColorScheme = remember(
-        animatedCoverColorSeed,
+        coverColorSeed,
         darkTheme,
         hasCoverColor,
         paletteStyle,
         colorSpec,
     ) {
-        if (hasCoverColor) {
+        if (hasCoverColor && coverColorSeed != null) {
             generatedColorScheme(
-                seedColor = animatedCoverColorSeed,
+                seedColor = coverColorSeed,
                 darkTheme = darkTheme,
                 paletteStyle = paletteStyle,
                 colorSpec = colorSpec,
@@ -107,8 +105,12 @@ internal fun PlayerDynamicColorTheme(
             null
         }
     }
+    val animatedColorScheme = rememberAnimatedColorScheme(
+        target = coverColorScheme ?: baseTargetColorScheme,
+        labelPrefix = "player theme",
+    )
     FuoExpressiveTheme(
-        colorScheme = coverColorScheme ?: baseColorScheme,
+        colorScheme = animatedColorScheme,
         content = content,
     )
 }
@@ -209,29 +211,40 @@ private fun fuoColorScheme(
     paletteStyle: ThemePaletteStyle,
     colorSpec: ThemeColorSpec,
 ): ColorScheme {
-    if (themeColorScheme == ThemeColorScheme.Dynamic) {
-        platformDynamicColorScheme(darkTheme)?.let { platformScheme ->
+    val platformPrimary = if (themeColorScheme == ThemeColorScheme.Dynamic) {
+        platformDynamicColorScheme(darkTheme)?.primary
+    } else {
+        null
+    }
+    return remember(
+        themeColorScheme,
+        darkTheme,
+        paletteStyle,
+        colorSpec,
+        platformPrimary,
+    ) {
+        if (platformPrimary != null) {
             val generated = generatedColorScheme(
-                seedColor = platformScheme.primary,
+                seedColor = platformPrimary,
                 darkTheme = darkTheme,
                 paletteStyle = paletteStyle,
                 colorSpec = colorSpec,
             )
             if (hasAccessibleContrast(generated)) {
-                return generated
+                return@remember generated
             }
         }
+        presetColorScheme(
+            preset = if (themeColorScheme == ThemeColorScheme.Dynamic) {
+                ThemeColorScheme.ExpressiveDefault
+            } else {
+                themeColorScheme
+            },
+            darkTheme = darkTheme,
+            paletteStyle = paletteStyle,
+            colorSpec = colorSpec,
+        )
     }
-    return presetColorScheme(
-        preset = if (themeColorScheme == ThemeColorScheme.Dynamic) {
-            ThemeColorScheme.ExpressiveDefault
-        } else {
-            themeColorScheme
-        },
-        darkTheme = darkTheme,
-        paletteStyle = paletteStyle,
-        colorSpec = colorSpec,
-    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.staticCompositionLocalOf

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
@@ -50,4 +50,26 @@ class FuoThemeTest {
         assertEquals(21.0, colorContrastRatio(Color.White, Color.Black), absoluteTolerance = 0.01)
         assertTrue(colorContrastRatio(Color.Black, Color.White) >= 21.0 - 0.01)
     }
+
+    @Test
+    fun transitionContrastCorrectionProtectsLowContrastMidpoint() {
+        val midpoint = Color(0xFF777777)
+        val corrected = ensureThemeContrast(
+            foreground = midpoint,
+            backgrounds = listOf(midpoint),
+        )
+
+        assertTrue(colorContrastRatio(corrected, midpoint) >= 4.5)
+    }
+
+    @Test
+    fun transitionContrastCorrectionKeepsAccessibleColorUnchanged() {
+        val foreground = Color.Black
+        val background = Color.White
+
+        assertEquals(
+            foreground,
+            ensureThemeContrast(foreground, listOf(background)),
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- animate the final Material 3 `ColorScheme` at the theme boundary so light/dark mode and palette changes transition smoothly
- reuse the same color-scheme transition for player cover-driven dynamic colors
- keep the raw app target scheme available to nested player theming so global theme changes do not incur a second trailing animation
- stop regenerating a dynamic palette on every cover-color animation frame; generate the target scheme once and animate semantic color roles instead
- centralize the duration as `FuoMotion.themeColorTransitionMillis`

## Behavior
- manual light/dark changes now transition smoothly
- preset/dynamic palette changes now transition smoothly
- cover-to-cover player color changes transition smoothly
- player cover loading continues preserving the previous valid cover palette until the next one is ready
- window surface color follows the same transition

## Validation
- existing theme contrast tests remain applicable to generated target schemes
- CI should validate common/Android compilation and tests