### PR TITLE
feat: extend cover colors across playback surfaces

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -15,6 +15,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import org.feeluown.mobile.playback.api.PlaybackSessionStatus
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -26,6 +29,13 @@ internal fun AppShell(
 ) {
     val videoDetailState by uiGraph.providerDetail.owners.video.uiState.collectAsStateWithLifecycle()
     val playback = uiGraph.playback
+    val isPlaybackLoading by remember(uiGraph.playbackSession) {
+        uiGraph.playbackSession.state
+            .map { it.status == PlaybackSessionStatus.Loading }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(
+        initialValue = uiGraph.playbackSession.state.value.status == PlaybackSessionStatus.Loading,
+    )
     val resourceHeroCoordinator = remember { ResourceHeroCoordinator() }
 
     BoxWithConstraints(Modifier.fillMaxSize()) {
@@ -62,33 +72,48 @@ internal fun AppShell(
             LocalAppLayoutInfo provides layoutInfo,
         ) {
             ProvideNarrowPlaybackUi(playback) {
-                SharedTransitionLayout(Modifier.fillMaxSize()) {
-                    CompositionLocalProvider(
-                        LocalAppSharedTransitionScope provides this,
-                        LocalResourceHeroCoordinator provides resourceHeroCoordinator,
-                    ) {
-                        Box(Modifier.fillMaxSize()) {
-                            AppNavHost(
-                                backStack = appUiState.backStack,
-                                appViewModel = appViewModel,
-                                uiGraph = uiGraph,
-                                platform = platform,
-                                modifier = Modifier.fillMaxSize(),
-                            )
-                            AppGlobalOverlays(uiGraph)
-                            AppFeedbackHost(
-                                appViewModel = appViewModel,
-                                uiGraph = uiGraph,
-                                modifier = Modifier
-                                    .align(Alignment.BottomCenter)
-                                    .navigationBarsPadding()
-                                    .padding(
-                                        start = 16.dp,
-                                        top = 16.dp,
-                                        end = 16.dp,
-                                        bottom = snackbarBottomPadding,
-                                    ),
-                            )
+                ProvidePlaybackColorEnvironment(
+                    themeMode = playback.presentation.themeMode,
+                    dynamicCoverColorEnabled = playback.presentation.dynamicCoverColorEnabled,
+                    coverImageUrl = playback.presentation.currentTrack?.coverUrl,
+                    isLoading = isPlaybackLoading,
+                ) {
+                    SharedTransitionLayout(Modifier.fillMaxSize()) {
+                        CompositionLocalProvider(
+                            LocalAppSharedTransitionScope provides this,
+                            LocalResourceHeroCoordinator provides resourceHeroCoordinator,
+                        ) {
+                            Box(Modifier.fillMaxSize()) {
+                                AppNavHost(
+                                    backStack = appUiState.backStack,
+                                    appViewModel = appViewModel,
+                                    uiGraph = uiGraph,
+                                    platform = platform,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
+                                AppGlobalOverlays(uiGraph)
+                                PlaybackDynamicColorTheme(
+                                    emphasis = if (playback.isFullPlayerOpen) {
+                                        PlaybackColorEmphasis.Immersive
+                                    } else {
+                                        PlaybackColorEmphasis.Ambient
+                                    },
+                                ) {
+                                    AppFeedbackHost(
+                                        appViewModel = appViewModel,
+                                        uiGraph = uiGraph,
+                                        modifier = Modifier
+                                            .align(Alignment.BottomCenter)
+                                            .navigationBarsPadding()
+                                            .padding(
+                                                start = 16.dp,
+                                                top = 16.dp,
+                                                end = 16.dp,
+                                                bottom = snackbarBottomPadding,
+                                            ),
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -92,25 +92,34 @@ internal fun AppShell(
                                     modifier = Modifier.fillMaxSize(),
                                 )
                                 AppGlobalOverlays(uiGraph)
-                                PlaybackDynamicColorTheme(
-                                    emphasis = if (playback.isFullPlayerOpen) {
-                                        PlaybackColorEmphasis.Immersive
-                                    } else {
-                                        PlaybackColorEmphasis.Ambient
-                                    },
-                                ) {
+                                val feedbackModifier = Modifier
+                                    .align(Alignment.BottomCenter)
+                                    .navigationBarsPadding()
+                                    .padding(
+                                        start = 16.dp,
+                                        top = 16.dp,
+                                        end = 16.dp,
+                                        bottom = snackbarBottomPadding,
+                                    )
+                                if (playback.isFullPlayerOpen || miniPlayerVisible) {
+                                    PlaybackDynamicColorTheme(
+                                        emphasis = if (playback.isFullPlayerOpen) {
+                                            PlaybackColorEmphasis.Immersive
+                                        } else {
+                                            PlaybackColorEmphasis.Ambient
+                                        },
+                                    ) {
+                                        AppFeedbackHost(
+                                            appViewModel = appViewModel,
+                                            uiGraph = uiGraph,
+                                            modifier = feedbackModifier,
+                                        )
+                                    }
+                                } else {
                                     AppFeedbackHost(
                                         appViewModel = appViewModel,
                                         uiGraph = uiGraph,
-                                        modifier = Modifier
-                                            .align(Alignment.BottomCenter)
-                                            .navigationBarsPadding()
-                                            .padding(
-                                                start = 16.dp,
-                                                top = 16.dp,
-                                                end = 16.dp,
-                                                bottom = snackbarBottomPadding,
-                                            ),
+                                        modifier = feedbackModifier,
                                     )
                                 }
                             }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoTheme.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
 import com.materialkolor.dynamiccolor.ColorSpec
@@ -27,10 +28,18 @@ import kotlin.math.pow
 
 private const val COVER_THEME_MAX_COLORS = 128
 private const val REQUIRED_CONTRAST_RATIO = 4.5
+private const val PLAYBACK_AMBIENT_SURFACE_BLEND = 0.32f
+private const val PLAYBACK_AMBIENT_ACCENT_BLEND = 0.62f
 
 private val LocalThemePaletteStyle = staticCompositionLocalOf { ThemePaletteStyle.Expressive }
 private val LocalThemeColorSpec = staticCompositionLocalOf { ThemeColorSpec.Expressive_2025 }
 private val LocalBaseTargetColorScheme = staticCompositionLocalOf<ColorScheme?> { null }
+private val LocalPlaybackCoverTargetColorScheme = staticCompositionLocalOf<ColorScheme?> { null }
+
+internal enum class PlaybackColorEmphasis {
+    Ambient,
+    Immersive,
+}
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -64,9 +73,8 @@ fun FuoTheme(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-internal fun PlayerDynamicColorTheme(
+internal fun ProvidePlaybackColorEnvironment(
     themeMode: ThemeMode,
     dynamicCoverColorEnabled: Boolean,
     coverImageUrl: String?,
@@ -74,7 +82,6 @@ internal fun PlayerDynamicColorTheme(
     content: @Composable () -> Unit,
 ) {
     val darkTheme = resolvedDarkTheme(themeMode, isSystemInDarkTheme())
-    val baseTargetColorScheme = LocalBaseTargetColorScheme.current ?: MaterialTheme.colorScheme
     val paletteStyle = LocalThemePaletteStyle.current
     val colorSpec = LocalThemeColorSpec.current
     val coverColorSeed = rememberCoverColorSeed(
@@ -106,13 +113,156 @@ internal fun PlayerDynamicColorTheme(
             null
         }
     }
+    CompositionLocalProvider(
+        LocalPlaybackCoverTargetColorScheme provides coverColorScheme,
+        content = content,
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun PlaybackDynamicColorTheme(
+    emphasis: PlaybackColorEmphasis,
+    content: @Composable () -> Unit,
+) {
+    val baseTargetColorScheme = LocalBaseTargetColorScheme.current ?: MaterialTheme.colorScheme
+    val coverTargetColorScheme = LocalPlaybackCoverTargetColorScheme.current
+    val targetColorScheme = remember(baseTargetColorScheme, coverTargetColorScheme, emphasis) {
+        when {
+            coverTargetColorScheme == null -> baseTargetColorScheme
+            emphasis == PlaybackColorEmphasis.Immersive -> coverTargetColorScheme
+            else -> ambientPlaybackColorScheme(baseTargetColorScheme, coverTargetColorScheme)
+        }
+    }
     val animatedColorScheme = rememberAnimatedColorScheme(
-        target = coverColorScheme ?: baseTargetColorScheme,
-        labelPrefix = "player theme",
+        target = targetColorScheme,
+        labelPrefix = "playback ${emphasis.name.lowercase()} theme",
     )
     FuoExpressiveTheme(
         colorScheme = animatedColorScheme,
         content = content,
+    )
+}
+
+internal fun ambientPlaybackColorScheme(
+    base: ColorScheme,
+    cover: ColorScheme,
+): ColorScheme {
+    val primary = lerp(base.primary, cover.primary, PLAYBACK_AMBIENT_ACCENT_BLEND)
+    val primaryContainer = lerp(
+        base.primaryContainer,
+        cover.primaryContainer,
+        PLAYBACK_AMBIENT_ACCENT_BLEND,
+    )
+    val secondary = lerp(base.secondary, cover.secondary, PLAYBACK_AMBIENT_ACCENT_BLEND)
+    val secondaryContainer = lerp(
+        base.secondaryContainer,
+        cover.secondaryContainer,
+        PLAYBACK_AMBIENT_ACCENT_BLEND,
+    )
+    val surfaceVariant = lerp(
+        base.surfaceVariant,
+        cover.surfaceVariant,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+    val surfaceContainer = lerp(
+        base.surfaceContainer,
+        cover.surfaceContainer,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+    val surfaceContainerHigh = lerp(
+        base.surfaceContainerHigh,
+        cover.surfaceContainerHigh,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+    val surfaceContainerHighest = lerp(
+        base.surfaceContainerHighest,
+        cover.surfaceContainerHighest,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+    val surfaceContainerLow = lerp(
+        base.surfaceContainerLow,
+        cover.surfaceContainerLow,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+    val surfaceContainerLowest = lerp(
+        base.surfaceContainerLowest,
+        cover.surfaceContainerLowest,
+        PLAYBACK_AMBIENT_SURFACE_BLEND,
+    )
+
+    return base.copy(
+        primary = primary,
+        onPrimary = ensureThemeContrast(
+            lerp(base.onPrimary, cover.onPrimary, PLAYBACK_AMBIENT_ACCENT_BLEND),
+            listOf(primary),
+        ),
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = ensureThemeContrast(
+            lerp(
+                base.onPrimaryContainer,
+                cover.onPrimaryContainer,
+                PLAYBACK_AMBIENT_ACCENT_BLEND,
+            ),
+            listOf(primaryContainer),
+        ),
+        inversePrimary = lerp(
+            base.inversePrimary,
+            cover.inversePrimary,
+            PLAYBACK_AMBIENT_ACCENT_BLEND,
+        ),
+        secondary = secondary,
+        onSecondary = ensureThemeContrast(
+            lerp(base.onSecondary, cover.onSecondary, PLAYBACK_AMBIENT_ACCENT_BLEND),
+            listOf(secondary),
+        ),
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = ensureThemeContrast(
+            lerp(
+                base.onSecondaryContainer,
+                cover.onSecondaryContainer,
+                PLAYBACK_AMBIENT_ACCENT_BLEND,
+            ),
+            listOf(secondaryContainer),
+        ),
+        surfaceVariant = surfaceVariant,
+        onSurfaceVariant = ensureThemeContrast(
+            lerp(
+                base.onSurfaceVariant,
+                cover.onSurfaceVariant,
+                PLAYBACK_AMBIENT_SURFACE_BLEND,
+            ),
+            listOf(surfaceVariant),
+        ),
+        surfaceTint = lerp(
+            base.surfaceTint,
+            cover.surfaceTint,
+            PLAYBACK_AMBIENT_ACCENT_BLEND,
+        ),
+        onSurface = ensureThemeContrast(
+            base.onSurface,
+            listOf(
+                base.surface,
+                base.surfaceBright,
+                base.surfaceDim,
+                surfaceContainer,
+                surfaceContainerHigh,
+                surfaceContainerHighest,
+                surfaceContainerLow,
+                surfaceContainerLowest,
+            ),
+        ),
+        outline = lerp(base.outline, cover.outline, PLAYBACK_AMBIENT_SURFACE_BLEND),
+        outlineVariant = lerp(
+            base.outlineVariant,
+            cover.outlineVariant,
+            PLAYBACK_AMBIENT_SURFACE_BLEND,
+        ),
+        surfaceContainer = surfaceContainer,
+        surfaceContainerHigh = surfaceContainerHigh,
+        surfaceContainerHighest = surfaceContainerHighest,
+        surfaceContainerLow = surfaceContainerLow,
+        surfaceContainerLowest = surfaceContainerLowest,
     )
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PlaybackPlayerTheme.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PlaybackPlayerTheme.kt
@@ -1,0 +1,22 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Full-player theme entry point kept at the existing call site while the cover palette is now
+ * produced once by [ProvidePlaybackColorEnvironment] at the app shell.
+ */
+@Suppress("UNUSED_PARAMETER")
+@Composable
+internal fun PlayerDynamicColorTheme(
+    themeMode: ThemeMode,
+    dynamicCoverColorEnabled: Boolean,
+    coverImageUrl: String?,
+    isLoading: Boolean,
+    content: @Composable () -> Unit,
+) {
+    PlaybackDynamicColorTheme(
+        emphasis = PlaybackColorEmphasis.Immersive,
+        content = content,
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -132,10 +132,12 @@ fun ProvideNarrowPlaybackUi(
 @Composable
 fun PlaybackMiniPlayer() {
     val graph = LocalPlaybackUiPort.current
-    RuntimeMiniPlayer(
-        playbackSession = LocalPlaybackSession.current,
-        isFullPlayerOpen = graph.navigation.isFullPlayerOpen,
-        transitionDirection = graph.queue.trackChangeDirection,
-        onOpenFullPlayer = graph.navigation::openFullPlayer,
-    )
+    PlaybackDynamicColorTheme(emphasis = PlaybackColorEmphasis.Ambient) {
+        RuntimeMiniPlayer(
+            playbackSession = LocalPlaybackSession.current,
+            isFullPlayerOpen = graph.navigation.isFullPlayerOpen,
+            transitionDirection = graph.queue.trackChangeDirection,
+            onOpenFullPlayer = graph.navigation::openFullPlayer,
+        )
+    }
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FuoThemeTest.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import androidx.compose.ui.graphics.Color
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class FuoThemeTest {
@@ -32,6 +33,38 @@ class FuoThemeTest {
         ).forEach { seed ->
             assertTrue(hasAccessibleContrast(expressiveColorScheme(seed, darkTheme = false)))
             assertTrue(hasAccessibleContrast(expressiveColorScheme(seed, darkTheme = true)))
+        }
+    }
+
+    @Test
+    fun ambientPlaybackColorsKeepBaseSurfaceAndBlendPlaybackContainers() {
+        val base = expressiveColorScheme(Color(0xFF6750A4), darkTheme = false)
+        val cover = expressiveColorScheme(Color(0xFFCC3A45), darkTheme = false)
+        val ambient = ambientPlaybackColorScheme(base, cover)
+
+        assertEquals(base.surface, ambient.surface)
+        assertNotEquals(base.surfaceContainerHigh, ambient.surfaceContainerHigh)
+        assertNotEquals(cover.surfaceContainerHigh, ambient.surfaceContainerHigh)
+        assertNotEquals(base.primary, ambient.primary)
+        assertTrue(hasAccessibleContrast(ambient))
+    }
+
+    @Test
+    fun ambientPlaybackColorsRemainAccessibleInLightAndDarkModes() {
+        listOf(false, true).forEach { darkTheme ->
+            val base = expressiveColorScheme(Color(0xFF6750A4), darkTheme)
+            listOf(
+                Color(0xFFFF2020),
+                Color(0xFF102040),
+                Color(0xFF22AA77),
+                Color(0xFF8060D0),
+            ).forEach { seed ->
+                val cover = expressiveColorScheme(seed, darkTheme)
+                assertTrue(
+                    hasAccessibleContrast(ambientPlaybackColorScheme(base, cover)),
+                    "ambient scheme for $seed dark=$darkTheme",
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- lift cover-derived palette generation into a shared playback color environment
- keep the full player immersive while applying a weaker ambient blend to the mini player
- apply playback-aware colors to snackbar feedback so overlays match the active player context
- preserve the existing animated theme transition and accessible contrast safeguards
- add tests for ambient playback color blending in light and dark modes

## Scope
This intentionally stays within playback-related surfaces. Normal content screens continue to use the base app theme.

## Validation
- added common tests for ambient color accessibility and blend behavior
- CI will validate multiplatform compilation and existing tests