### PR TITLE
ui: move resource grid more action to section corner

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderCollectionComponents.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderCollectionComponents.kt
@@ -2,25 +2,19 @@ package org.feeluown.mobile
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LibraryMusic
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.currentCompositeKeyHashCode
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
@@ -40,44 +34,31 @@ fun ProviderPlaylistGrid(
     val capacity = columns * (maxRows ?: 2)
     val isLimited = maxRows != null || onMore != null
     val hasMore = isLimited && playlists.size > capacity
-    val visiblePlaylists = when {
-        hasMore && onMore != null -> playlists.take(capacity - 1)
-        hasMore -> playlists.take(capacity)
-        else -> playlists
-    }
+    val visiblePlaylists = if (hasMore) playlists.take(capacity) else playlists
     val resolvedHeroScopeKey = heroScopeKey ?: "composition:${currentCompositeKeyHashCode}"
     val heroOccurrences = mutableMapOf<ResourceCoverHeroKey, Int>()
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        val cells = visiblePlaylists.map<ProviderPlaylist, PlaylistGridCell> { PlaylistGridCell.Playlist(it) } +
-            if (hasMore && onMore != null) listOf(PlaylistGridCell.More) else emptyList()
-        cells.chunked(columns).forEach { row ->
+        if (hasMore && onMore != null) {
+            ProviderCollectionMoreAction(onClick = onMore)
+        }
+        visiblePlaylists.chunked(columns).forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
-                row.forEach { cell ->
-                    when (cell) {
-                        PlaylistGridCell.More -> {
-                            ProviderPlaylistMoreCard(
-                                onClick = { onMore?.invoke() },
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        is PlaylistGridCell.Playlist -> {
-                            val identity = cell.value.coverHeroKey()
-                            val occurrence = heroOccurrences[identity] ?: 0
-                            heroOccurrences[identity] = occurrence + 1
-                            ProviderPlaylistCard(
-                                playlist = cell.value,
-                                onClick = { onClick(cell.value) },
-                                modifier = Modifier.weight(1f),
-                                heroSourceId = identity.forSource(resolvedHeroScopeKey, occurrence).sourceInstanceId,
-                            )
-                        }
-                    }
+                row.forEach { playlist ->
+                    val identity = playlist.coverHeroKey()
+                    val occurrence = heroOccurrences[identity] ?: 0
+                    heroOccurrences[identity] = occurrence + 1
+                    ProviderPlaylistCard(
+                        playlist = playlist,
+                        onClick = { onClick(playlist) },
+                        modifier = Modifier.weight(1f),
+                        heroSourceId = identity.forSource(resolvedHeroScopeKey, occurrence).sourceInstanceId,
+                    )
                 }
                 repeat(columns - row.size) {
                     Spacer(Modifier.weight(1f))
@@ -87,66 +68,15 @@ fun ProviderPlaylistGrid(
     }
 }
 
-private sealed interface PlaylistGridCell {
-    data class Playlist(val value: ProviderPlaylist) : PlaylistGridCell
-    data object More : PlaylistGridCell
-}
-
 @Composable
-fun ProviderPlaylistMoreCard(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    ProviderCollectionMoreCard(
-        subtitle = "全部歌单",
-        onClick = onClick,
-        modifier = modifier,
-    )
-}
-
-@Composable
-private fun ProviderCollectionMoreCard(
-    subtitle: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val isWideLayout = LocalAppLayoutInfo.current.useWideLayout
-    Column(
-        modifier = modifier
-            .fuoInteractive()
-            .clickable(role = Role.Button, onClick = onClick)
-            .padding(vertical = if (isWideLayout) 2.dp else 6.dp),
+private fun ProviderCollectionMoreAction(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
     ) {
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f),
-            shape = MaterialTheme.shapes.medium,
-            color = MaterialTheme.colorScheme.tertiaryContainer,
-            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector = Icons.Filled.LibraryMusic,
-                    contentDescription = null,
-                    modifier = Modifier.size(if (isWideLayout) 40.dp else 44.dp),
-                )
-            }
+        TextButton(onClick = onClick) {
+            Text("查看更多")
         }
-        Spacer(Modifier.height(if (isWideLayout) 4.dp else 8.dp))
-        Text(
-            text = "查看更多",
-            style = MaterialTheme.typography.titleSmall,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }
 
@@ -215,56 +145,37 @@ fun ProviderMediaItemGrid(
     val capacity = columns * (maxRows ?: 2)
     val isLimited = maxRows != null || onMore != null
     val hasMore = isLimited && items.size > capacity
-    val visibleItems = when {
-        hasMore && onMore != null -> items.take(capacity - 1)
-        hasMore -> items.take(capacity)
-        else -> items
-    }
-    val itemType = items.firstOrNull()?.type
+    val visibleItems = if (hasMore) items.take(capacity) else items
     val resolvedHeroScopeKey = heroScopeKey ?: "composition:${currentCompositeKeyHashCode}"
     val heroOccurrences = mutableMapOf<ResourceCoverHeroKey, Int>()
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(spacing),
     ) {
-        val cells = visibleItems.map<ProviderMediaItem, MediaItemGridCell> { MediaItemGridCell.Item(it) } +
-            if (hasMore && onMore != null) listOf(MediaItemGridCell.More) else emptyList()
-        cells.chunked(columns).forEachIndexed { rowIndex, row ->
+        if (hasMore && onMore != null) {
+            ProviderCollectionMoreAction(onClick = onMore)
+        }
+        visibleItems.chunked(columns).forEachIndexed { rowIndex, row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
             ) {
-                row.forEachIndexed { columnIndex, cell ->
-                    when (cell) {
-                        MediaItemGridCell.More -> {
-                            ProviderCollectionMoreCard(
-                                subtitle = when (itemType) {
-                                    ProviderMediaItemType.Artist -> "全部歌手"
-                                    ProviderMediaItemType.Album -> "全部专辑"
-                                    null -> "全部内容"
-                                },
-                                onClick = { onMore?.invoke() },
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        is MediaItemGridCell.Item -> {
-                            val index = rowIndex * columns + columnIndex
-                            if (onItemVisible != null) {
-                                LaunchedEffect(index, items.size) {
-                                    onItemVisible(index)
-                                }
-                            }
-                            val identity = cell.value.coverHeroKey()
-                            val occurrence = heroOccurrences[identity] ?: 0
-                            heroOccurrences[identity] = occurrence + 1
-                            ProviderMediaItemCard(
-                                item = cell.value,
-                                onClick = { onClick(cell.value) },
-                                modifier = Modifier.weight(1f),
-                                heroSourceId = identity.forSource(resolvedHeroScopeKey, occurrence).sourceInstanceId,
-                            )
+                row.forEachIndexed { columnIndex, item ->
+                    val index = rowIndex * columns + columnIndex
+                    if (onItemVisible != null) {
+                        LaunchedEffect(index, items.size) {
+                            onItemVisible(index)
                         }
                     }
+                    val identity = item.coverHeroKey()
+                    val occurrence = heroOccurrences[identity] ?: 0
+                    heroOccurrences[identity] = occurrence + 1
+                    ProviderMediaItemCard(
+                        item = item,
+                        onClick = { onClick(item) },
+                        modifier = Modifier.weight(1f),
+                        heroSourceId = identity.forSource(resolvedHeroScopeKey, occurrence).sourceInstanceId,
+                    )
                 }
                 repeat(columns - row.size) {
                     Spacer(Modifier.weight(1f))
@@ -272,11 +183,6 @@ fun ProviderMediaItemGrid(
             }
         }
     }
-}
-
-private sealed interface MediaItemGridCell {
-    data class Item(val value: ProviderMediaItem) : MediaItemGridCell
-    data object More : MediaItemGridCell
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- remove the dedicated “查看更多” resource card from playlist/media grids
- keep the full preview capacity available for actual resources
- render “查看更多” as a shared top-right action when the grid has additional content
- preserve existing `onMore` behavior for home and comprehensive search callers

## Notes
- no caller-specific layout duplication; the behavior is centralized in the shared resource grid component
- sections without additional content do not show the action