### PR TITLE
refactor: compose provider capabilities explicitly

### DIFF
--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProtocolSupport.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProtocolSupport.kt
@@ -1,0 +1,144 @@
+package org.feeluown.mobile.provider.bilibili
+
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.AudioQualityPolicy
+import org.feeluown.mobile.provider.core.ProviderCredentials
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.parseCookies
+import org.feeluown.mobile.provider.core.splitResourceId
+import org.feeluown.mobile.provider.core.stringOrNull
+
+internal fun rawIdentifier(value: String): String =
+    splitResourceId(value).second.ifBlank { value.substringAfterLast(':') }
+
+internal fun parsePaged(value: String): Pair<String, Int?> {
+    if (!value.startsWith("paged_")) return value to null
+    val parts = value.removePrefix("paged_").split("__", limit = 2)
+    return parts.first() to parts.getOrNull(1)?.toIntOrNull()
+}
+
+internal fun selectAudio(
+    qualityPolicy: String,
+    audio: List<AudioStream>,
+    flac: AudioStream?,
+): SelectedAudio? {
+    if (qualityPolicy == AudioQualityPolicy.Highest.policy && flac != null) {
+        return SelectedAudio(flac, "SHQ")
+    }
+    val sorted = audio.sortedByDescending { it.bandwidth }
+    val preferred = when (qualityPolicy) {
+        AudioQualityPolicy.Low.policy -> sorted.filter {
+            it.bandwidth <= BilibiliProviderDefinition.AUDIO_LOW_MAX_BANDWIDTH
+        }
+        AudioQualityPolicy.Standard.policy -> sorted.filter {
+            it.bandwidth <= BilibiliProviderDefinition.AUDIO_STANDARD_MAX_BANDWIDTH
+        }
+        else -> sorted
+    }
+    val fallback = if (qualityPolicy == AudioQualityPolicy.Low.policy) sorted.lastOrNull() else sorted.firstOrNull()
+    val selected = preferred.firstOrNull() ?: fallback ?: flac ?: return null
+    return SelectedAudio(selected, selected.qualityLabel())
+}
+
+internal fun JsonObject.toAudioStream(isFlac: Boolean = false): AudioStream? {
+    val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
+    return AudioStream(
+        url = url,
+        bandwidth = long("bandwidth") ?: 0L,
+        durationMs = long("length"),
+        isFlac = isFlac,
+    )
+}
+
+internal fun JsonObject.toVideoStream(): VideoStream? {
+    val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
+    return VideoStream(
+        url = url,
+        bandwidth = long("bandwidth") ?: 0L,
+    )
+}
+
+internal fun stripHtml(value: String): String = value
+    .replace(Regex("<[^>]+>"), "")
+    .replace("&amp;", "&")
+    .replace("&quot;", "\"")
+    .replace("&#39;", "'")
+
+internal fun normalizeCover(value: String?): String? = value?.let {
+    if (it.startsWith("//")) "https:$it" else it
+}
+
+internal fun parseDurationMs(value: String): Long? {
+    val parts = value.split(':').mapNotNull { it.toLongOrNull() }
+    if (parts.isEmpty()) return null
+    return parts.fold(0L) { total, part -> total * 60 + part } * 1_000
+}
+
+internal fun parseSearchTags(value: String?): List<String> = value
+    ?.split(',', '，')
+    ?.map { tag -> tag.trim() }
+    ?.filter { tag -> tag.isNotBlank() }
+    ?.distinct()
+    .orEmpty()
+
+internal fun String.keyFromUrl(): String = substringAfterLast('/').substringBeforeLast('.')
+
+internal fun encodeQueryComponent(value: String): String = buildString {
+    for (byte in value.encodeToByteArray()) {
+        val number = byte.toInt() and 0xff
+        when {
+            number == 0x20 -> append('+')
+            number in 0x30..0x39 ||
+                number in 0x41..0x5a ||
+                number in 0x61..0x7a ||
+                number in setOf(45, 46, 95, 126) -> append(number.toChar())
+            else -> {
+                append('%')
+                append("0123456789ABCDEF"[number ushr 4])
+                append("0123456789ABCDEF"[number and 0x0f])
+            }
+        }
+    }
+}
+
+internal fun mixinKey(value: String): String = BilibiliProviderDefinition.mixinKeyTable.indices
+    .mapNotNull { index -> value.getOrNull(BilibiliProviderDefinition.mixinKeyTable[index]) }
+    .joinToString("")
+    .take(32)
+
+internal fun credentialsArePresent(credentials: ProviderCredentials): Boolean =
+    credentials.cookies.isNotEmpty() ||
+        !credentials.cookieHeader.isNullOrBlank() ||
+        !credentials.authorization.isNullOrBlank()
+
+internal fun csrfCookie(credentials: ProviderCredentials?): String? {
+    credentials ?: return null
+    return credentials.cookies["bili_jct"]?.takeIf { it.isNotBlank() }
+        ?: parseCookies(credentials.cookieHeader.orEmpty())["bili_jct"]?.takeIf { it.isNotBlank() }
+}
+
+internal data class WbiKeys(val mixinKey: String)
+
+internal data class AudioStream(
+    val url: String,
+    val bandwidth: Long,
+    val durationMs: Long?,
+    val isFlac: Boolean = false,
+)
+
+internal data class SelectedAudio(
+    val stream: AudioStream,
+    val quality: String,
+)
+
+internal data class VideoStream(
+    val url: String,
+    val bandwidth: Long,
+)
+
+private fun AudioStream.qualityLabel(): String = when {
+    isFlac -> "SHQ"
+    bandwidth <= BilibiliProviderDefinition.AUDIO_LOW_MAX_BANDWIDTH -> "LQ"
+    bandwidth <= BilibiliProviderDefinition.AUDIO_STANDARD_MAX_BANDWIDTH -> "SQ"
+    else -> "HQ"
+}

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
@@ -1,19 +1,15 @@
 package org.feeluown.mobile.provider.bilibili
 
 import io.ktor.http.Parameters
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.feeluown.mobile.AudioQualityPolicy
 import org.feeluown.mobile.PlaybackPart
 import org.feeluown.mobile.PlaybackPayload
 import org.feeluown.mobile.ProviderAuthState
-import org.feeluown.mobile.ProviderCapabilities
 import org.feeluown.mobile.ProviderComment
 import org.feeluown.mobile.ProviderContentSection
-import org.feeluown.mobile.ProviderContentType
 import org.feeluown.mobile.ProviderFeature
-import org.feeluown.mobile.ProviderFeatureCategory
-import org.feeluown.mobile.ProviderInfo
-import org.feeluown.mobile.ProviderMediaItem
-import org.feeluown.mobile.ProviderMediaItemDetail
 import org.feeluown.mobile.ProviderMutationResult
 import org.feeluown.mobile.ProviderPlaylist
 import org.feeluown.mobile.ProviderPlaylistDetail
@@ -30,7 +26,6 @@ import org.feeluown.mobile.provider.core.int
 import org.feeluown.mobile.provider.core.long
 import org.feeluown.mobile.provider.core.md5Hex
 import org.feeluown.mobile.provider.core.obj
-import org.feeluown.mobile.provider.core.parseCookies
 import org.feeluown.mobile.provider.core.providerJson
 import org.feeluown.mobile.provider.core.splitResourceId
 import org.feeluown.mobile.provider.core.string
@@ -39,8 +34,6 @@ import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 import org.feeluown.mobile.provider.core.network.ProviderRequestKind
 import org.feeluown.mobile.provider.core.network.currentTimeMillis
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 class BilibiliProvider(
     http: ProviderHttpClient,
@@ -515,11 +508,7 @@ class BilibiliProvider(
 
     private suspend fun currentUserMid(): String? = nav()?.obj("data")?.stringOrNull("mid")
 
-    private suspend fun csrfToken(): String? {
-        val stored = currentCredentials() ?: return null
-        return stored.cookies["bili_jct"]?.takeIf { it.isNotBlank() }
-            ?: parseCookies(stored.cookieHeader.orEmpty())["bili_jct"]?.takeIf { it.isNotBlank() }
-    }
+    private suspend fun csrfToken(): String? = csrfCookie(currentCredentials())
 
     private suspend fun nav(): kotlinx.serialization.json.JsonObject? = runCatching {
         http.getText(
@@ -591,11 +580,6 @@ class BilibiliProvider(
         )
     }
 
-    private fun credentialsArePresent(credentials: org.feeluown.mobile.provider.core.ProviderCredentials): Boolean =
-        credentials.cookies.isNotEmpty() ||
-            !credentials.cookieHeader.isNullOrBlank() ||
-            !credentials.authorization.isNullOrBlank()
-
     private suspend fun headers(extra: Map<String, String> = emptyMap()): Map<String, String> = buildMap {
         putAll(authenticatedHeaders(mapOf("Referer" to "https://www.bilibili.com/", "Accept" to "application/json, text/plain, */*")))
         putAll(extra)
@@ -608,150 +592,15 @@ class BilibiliProvider(
         ),
     )
 
-    private fun rawIdentifier(value: String): String = splitResourceId(value).second.ifBlank { value.substringAfterLast(':') }
-
-    private fun parsePaged(value: String): Pair<String, Int?> {
-        if (!value.startsWith("paged_")) return value to null
-        val parts = value.removePrefix("paged_").split("__", limit = 2)
-        return parts.first() to parts.getOrNull(1)?.toIntOrNull()
-    }
-
-    private fun selectAudio(
-        qualityPolicy: String,
-        audio: List<AudioStream>,
-        flac: AudioStream?,
-    ): SelectedAudio? {
-        if (qualityPolicy == AudioQualityPolicy.Highest.policy && flac != null) {
-            return SelectedAudio(flac, "SHQ")
-        }
-        val sorted = audio.sortedByDescending { it.bandwidth }
-        val preferred = when (qualityPolicy) {
-            AudioQualityPolicy.Low.policy -> sorted.filter { it.bandwidth <= AUDIO_LOW_MAX_BANDWIDTH }
-            AudioQualityPolicy.Standard.policy -> sorted.filter { it.bandwidth <= AUDIO_STANDARD_MAX_BANDWIDTH }
-            else -> sorted
-        }
-        val fallback = if (qualityPolicy == AudioQualityPolicy.Low.policy) sorted.lastOrNull() else sorted.firstOrNull()
-        val selected = preferred.firstOrNull() ?: fallback ?: flac ?: return null
-        return SelectedAudio(selected, selected.qualityLabel())
-    }
-
-    private fun kotlinx.serialization.json.JsonObject.toAudioStream(isFlac: Boolean = false): AudioStream? {
-        val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
-        return AudioStream(
-            url = url,
-            bandwidth = long("bandwidth") ?: 0L,
-            durationMs = long("length"),
-            isFlac = isFlac,
-        )
-    }
-
-    private fun kotlinx.serialization.json.JsonObject.toVideoStream(): VideoStream? {
-        val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
-        return VideoStream(
-            url = url,
-            bandwidth = long("bandwidth") ?: 0L,
-        )
-    }
-
-    private fun AudioStream.qualityLabel(): String = when {
-        isFlac -> "SHQ"
-        bandwidth <= AUDIO_LOW_MAX_BANDWIDTH -> "LQ"
-        bandwidth <= AUDIO_STANDARD_MAX_BANDWIDTH -> "SQ"
-        else -> "HQ"
-    }
-
-    private fun stripHtml(value: String): String = value
-        .replace(Regex("<[^>]+>"), "")
-        .replace("&amp;", "&")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-
-    private fun normalizeCover(value: String?): String? = value?.let { if (it.startsWith("//")) "https:$it" else it }
-
-    private fun parseDurationMs(value: String): Long? {
-        val parts = value.split(':').mapNotNull { it.toLongOrNull() }
-        if (parts.isEmpty()) return null
-        return parts.fold(0L) { total, part -> total * 60 + part } * 1_000
-    }
-
-    private fun parseSearchTags(value: String?): List<String> = value
-        ?.split(',', '，')
-        ?.map { tag -> tag.trim() }
-        ?.filter { tag -> tag.isNotBlank() }
-        ?.distinct()
-        .orEmpty()
-
-    private fun String.keyFromUrl(): String = substringAfterLast('/').substringBeforeLast('.')
-
-    private fun encodeQueryComponent(value: String): String = buildString {
-        for (byte in value.encodeToByteArray()) {
-            val number = byte.toInt() and 0xff
-            when {
-                number == 0x20 -> append('+')
-                number in 0x30..0x39 || number in 0x41..0x5a || number in 0x61..0x7a || number in setOf(45, 46, 95, 126) -> append(number.toChar())
-                else -> {
-                    append('%')
-                    append("0123456789ABCDEF"[number ushr 4])
-                    append("0123456789ABCDEF"[number and 0x0f])
-                }
-            }
-        }
-    }
-
-    private fun mixinKey(value: String): String = MIXIN_KEY_TABLE.indices
-        .mapNotNull { index -> value.getOrNull(MIXIN_KEY_TABLE[index]) }
-        .joinToString("")
-        .take(32)
-
-    private data class WbiKeys(val mixinKey: String)
-
-    private data class AudioStream(
-        val url: String,
-        val bandwidth: Long,
-        val durationMs: Long?,
-        val isFlac: Boolean = false,
-    )
-
-    private data class SelectedAudio(
-        val stream: AudioStream,
-        val quality: String,
-    )
-
-    private data class VideoStream(
-        val url: String,
-        val bandwidth: Long,
-    )
-
     private companion object {
-        const val ID = "bilibili"
-        const val NAME = "哔哩哔哩"
-        const val BASE = "https://api.bilibili.com"
-        const val COLLECTION_PREFIX = "collection_"
-        const val MAX_FAVORITE_PAGE_SIZE = 20
-        const val AUDIO_LOW_MAX_BANDWIDTH = 120_000L
-        const val AUDIO_STANDARD_MAX_BANDWIDTH = 256_000L
-        const val BILIBILI_MEDIA_USER_AGENT =
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
-        val MIXIN_KEY_TABLE = intArrayOf(
-            46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
-            27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
-            37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
-            22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
-        )
-        val INFO = ProviderInfo(
-            providerId = ID,
-            providerName = NAME,
-            loginConfig = org.feeluown.mobile.ProviderLoginConfig(
-                "https://passport.bilibili.com/h5-app/passport/login?gourl=https%3A%2F%2Fm.bilibili.com%2F",
-                listOf(listOf("SESSDATA", "bili_jct")),
-            ),
-            supportedLoginModes = setOf(org.feeluown.mobile.ProviderLoginMode.WebView),
-        )
-        val CAPABILITIES = ProviderCapabilities(providerId = ID, providerName = NAME, canAddSongToPlaylist = true, canRemoveSongFromPlaylist = true)
-        val FEATURES = listOf(
-            ProviderFeature("bilibili_popular_videos", ID, NAME, "热门视频", ProviderFeatureCategory.Music, ProviderContentType.Songs, false),
-            ProviderFeature("bilibili_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
-            ProviderFeature("bilibili_favorite_playlists", ID, NAME, "收藏歌单", ProviderFeatureCategory.MineFavoritePlaylists, ProviderContentType.Playlists, true),
-        )
+        const val ID = BilibiliProviderDefinition.ID
+        const val NAME = BilibiliProviderDefinition.NAME
+        const val BASE = BilibiliProviderDefinition.BASE
+        const val COLLECTION_PREFIX = BilibiliProviderDefinition.COLLECTION_PREFIX
+        const val MAX_FAVORITE_PAGE_SIZE = BilibiliProviderDefinition.MAX_FAVORITE_PAGE_SIZE
+        const val BILIBILI_MEDIA_USER_AGENT = BilibiliProviderDefinition.MEDIA_USER_AGENT
+        val INFO get() = BilibiliProviderDefinition.info
+        val CAPABILITIES get() = BilibiliProviderDefinition.capabilities
+        val FEATURES get() = BilibiliProviderDefinition.features
     }
 }

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderDefinition.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderDefinition.kt
@@ -1,0 +1,49 @@
+package org.feeluown.mobile.provider.bilibili
+
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderContentType
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureCategory
+import org.feeluown.mobile.ProviderInfo
+
+internal object BilibiliProviderDefinition {
+    const val ID = "bilibili"
+    const val NAME = "哔哩哔哩"
+    const val BASE = "https://api.bilibili.com"
+    const val COLLECTION_PREFIX = "collection_"
+    const val MAX_FAVORITE_PAGE_SIZE = 20
+    const val AUDIO_LOW_MAX_BANDWIDTH = 120_000L
+    const val AUDIO_STANDARD_MAX_BANDWIDTH = 256_000L
+    const val MEDIA_USER_AGENT =
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+
+    val mixinKeyTable = intArrayOf(
+        46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+        27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+        37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
+        22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+    )
+
+    val info = ProviderInfo(
+        providerId = ID,
+        providerName = NAME,
+        loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+            "https://passport.bilibili.com/h5-app/passport/login?gourl=https%3A%2F%2Fm.bilibili.com%2F",
+            listOf(listOf("SESSDATA", "bili_jct")),
+        ),
+        supportedLoginModes = setOf(org.feeluown.mobile.ProviderLoginMode.WebView),
+    )
+
+    val capabilities = ProviderCapabilities(
+        providerId = ID,
+        providerName = NAME,
+        canAddSongToPlaylist = true,
+        canRemoveSongFromPlaylist = true,
+    )
+
+    val features = listOf(
+        ProviderFeature("bilibili_popular_videos", ID, NAME, "热门视频", ProviderFeatureCategory.Music, ProviderContentType.Songs, false),
+        ProviderFeature("bilibili_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
+        ProviderFeature("bilibili_favorite_playlists", ID, NAME, "收藏歌单", ProviderFeatureCategory.MineFavoritePlaylists, ProviderContentType.Playlists, true),
+    )
+}

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
@@ -30,7 +30,7 @@ object BilibiliProviderFactory : KotlinProviderFactory {
             account = base,
             discovery = discovery,
             content = content,
-            library = base,
+            library = content,
             playback = base,
         )
     }

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProviderFactory.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile.provider.bilibili
 
+import org.feeluown.mobile.provider.core.CapabilityDelegatingProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.KotlinProviderFactory
 import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
@@ -9,20 +10,40 @@ object BilibiliProviderFactory : KotlinProviderFactory {
     override val providerId: String = "bilibili"
 
     override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
-        val content = BilibiliContentProvider(
+        val base = BilibiliProvider(
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
-        return BilibiliComprehensiveSearchProvider(
+        val content = BilibiliContentProvider(
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+            delegate = base,
+        )
+        val discovery = BilibiliComprehensiveSearchProvider(
             delegate = content,
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
+        return CapabilityDelegatingProvider(
+            base = base,
+            presentation = content,
+            account = base,
+            discovery = discovery,
+            content = content,
+            library = base,
+            playback = base,
+        )
     }
 
-    fun createContentProvider(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider =
-        BilibiliContentProvider(
+    fun createContentProvider(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
+        val base = BilibiliProvider(
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
+        return BilibiliContentProvider(
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+            delegate = base,
+        )
+    }
 }

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseFeatureLoader.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseFeatureLoader.kt
@@ -1,0 +1,510 @@
+package org.feeluown.mobile.provider.netease
+
+import io.ktor.http.Parameters
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.ProviderAuthState
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureFilterCodec
+import org.feeluown.mobile.ProviderMediaItem
+import org.feeluown.mobile.ProviderMediaItemType
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.boolean
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicy
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
+
+internal class NeteaseFeatureLoader(
+    private val context: NeteaseFeatureContext,
+) {
+    private var styleTagCache: List<NeteaseStyleTag>? = null
+    private val styleCursorPages = mutableMapOf<String, MutableMap<Int, String>>()
+
+    suspend fun load(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        if (feature.requiresLogin && !context.authState().isLoggedIn) {
+            return ProviderContentSection(feature, isLoginRequired = true)
+        }
+        val request = parseNeteaseFeatureRequest(feature.id)
+        return when (request.baseId) {
+            "netease_daily_songs" -> {
+                val root = weApi("$BASE/weapi/v3/discovery/recommend/songs", "{}")
+                val songs = root.obj("data")?.array("dailySongs").orEmpty()
+                ProviderContentSection(
+                    feature,
+                    tracks = songs.drop(offset).take(limit).map(context.song),
+                    nextOffset = offset + limit,
+                    hasMore = songs.size > offset + limit,
+                )
+            }
+            "netease_recommended_new_songs" -> {
+                val requestLimit = (offset + limit).coerceAtLeast(limit)
+                val root = weApi(
+                    "$BASE/weapi/personalized/newsong",
+                    """{"type":"recommend","limit":$requestLimit,"areaId":0}""",
+                )
+                val values = root.array("result")
+                val songs = values.map { value -> value.asObject().obj("song") ?: value }
+                val page = songs.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    tracks = context.loadSongs(page),
+                    nextOffset = offset + page.size,
+                    hasMore = songs.size > offset + page.size,
+                )
+            }
+            "netease_radio" -> {
+                val songs = context.getJson(
+                    "$BASE/api/radio/get",
+                    context.neteaseAuthenticatedHeaders(emptyMap()),
+                    null,
+                    ProviderCachePolicies.none,
+                ).array("data")
+                ProviderContentSection(
+                    feature,
+                    tracks = songs.drop(offset).take(limit).map(context.song),
+                    nextOffset = offset + limit,
+                    hasMore = songs.size > offset + limit,
+                )
+            }
+            "netease_toplists" -> {
+                val root = context.getJson(
+                    "$BASE/api/toplist",
+                    context.authenticatedHeaders(emptyMap()),
+                    "netease:toplist",
+                    ProviderCachePolicies.recommendation,
+                )
+                val playlists = root.array("list")
+                ProviderContentSection(
+                    feature,
+                    playlists = playlists.drop(offset).take(limit).map { context.playlist(it.asObject()) },
+                    nextOffset = offset + limit,
+                    hasMore = playlists.size > offset + limit,
+                )
+            }
+            NETEASE_PLAYLIST_SQUARE -> playlistSquare(feature, request, offset, limit)
+            NETEASE_ARTIST_SQUARE -> artistSquare(feature, request, offset, limit)
+            NETEASE_MV_SQUARE -> mvSquare(feature, request, offset, limit)
+            NETEASE_STYLES -> styleFeature(feature, request, offset, limit)
+            "netease_new_songs" -> {
+                val root = weApi(
+                    "$BASE/weapi/v1/discovery/new/songs",
+                    """{"areaId":0,"total":true}""",
+                )
+                val songs = root.array("data")
+                val page = songs.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    tracks = page.map(context.song),
+                    nextOffset = offset + page.size,
+                    hasMore = songs.size > offset + page.size,
+                )
+            }
+            "netease_new_albums" -> {
+                val root = weApi(
+                    "$BASE/weapi/album/new",
+                    """{"limit":$limit,"offset":$offset,"total":true,"area":"ALL"}""",
+                )
+                val values = root.array("albums")
+                ProviderContentSection(
+                    feature = feature,
+                    mediaItems = values.mapNotNull { value ->
+                        runCatching { context.album(value.asObject()) }.getOrNull()
+                    },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("more") ||
+                        root.int("total")?.let { offset + values.size < it } == true ||
+                        values.size == limit,
+                )
+            }
+            "netease_top_artists" -> {
+                val root = weApi(
+                    "$BASE/weapi/artist/top",
+                    """{"limit":$limit,"offset":$offset,"total":true}""",
+                )
+                val values = root.array("artists")
+                ProviderContentSection(
+                    feature = feature,
+                    mediaItems = values.mapNotNull { value ->
+                        runCatching { context.artist(value.asObject()) }.getOrNull()
+                    },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("more") || values.size == limit,
+                )
+            }
+            "netease_highquality_playlists" -> {
+                val requestLimit = (offset + limit).coerceAtLeast(limit)
+                val root = weApi(
+                    "$BASE/weapi/playlist/highquality/list",
+                    """{"cat":"全部","limit":$requestLimit,"lasttime":0,"total":true}""",
+                )
+                val values = root.array("playlists")
+                val page = values.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    playlists = page.mapNotNull { value ->
+                        runCatching { context.playlist(value.asObject()) }.getOrNull()
+                    },
+                    nextOffset = offset + page.size,
+                    hasMore = values.size > offset + page.size || root.boolean("more"),
+                )
+            }
+            "netease_recommended_mvs" -> {
+                val root = weApi("$BASE/weapi/personalized/mv", "{}")
+                val values = root.array("result")
+                val page = values.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature = feature,
+                    videos = page.mapNotNull { value ->
+                        runCatching { context.video(value.asObject()) }.getOrNull()
+                    },
+                    nextOffset = offset + page.size,
+                    hasMore = values.size > offset + page.size,
+                )
+            }
+            "netease_top_mvs" -> {
+                val root = weApi(
+                    "$BASE/weapi/mv/toplist",
+                    """{"area":"","limit":$limit,"offset":$offset,"total":true}""",
+                )
+                val values = root.array("data")
+                ProviderContentSection(
+                    feature = feature,
+                    videos = values.mapNotNull { value ->
+                        runCatching { context.video(value.asObject()) }.getOrNull()
+                    },
+                    nextOffset = offset + values.size,
+                    hasMore = root.boolean("hasMore") || values.size == limit,
+                )
+            }
+            "netease_daily_playlists" -> {
+                val root = weApi("$BASE/api/discovery/recommend/resource", "{}")
+                val playlists = root.array("recommend")
+                val page = playlists.drop(offset).take(limit)
+                ProviderContentSection(
+                    feature,
+                    playlists = page.map { context.playlist(it.asObject()) },
+                    nextOffset = offset + page.size,
+                    hasMore = playlists.size > offset + page.size,
+                )
+            }
+            "netease_user_playlists", "netease_favorite_playlists" -> userPlaylists(feature, request, offset, limit)
+            "netease_favorite_songs" -> favoriteSongs(feature, offset, limit)
+            "netease_cloud_songs" -> context.cloudSongs(feature, offset, limit)
+            "netease_favorite_artists", "netease_favorite_albums" -> {
+                val endpoint = if (request.baseId == "netease_favorite_artists") "artist/sublist" else "album/sublist"
+                val root = weApi(
+                    "$BASE/weapi/$endpoint",
+                    """{"limit":$limit,"offset":$offset,"csrf_token":"${context.csrfToken().jsonString()}"}""",
+                )
+                val type = if (request.baseId == "netease_favorite_artists") {
+                    ProviderMediaItemType.Artist
+                } else {
+                    ProviderMediaItemType.Album
+                }
+                val items = root.array("data").map { value ->
+                    if (type == ProviderMediaItemType.Artist) {
+                        context.artist(value.asObject())
+                    } else {
+                        context.album(value.asObject())
+                    }
+                }
+                ProviderContentSection(
+                    feature,
+                    mediaItems = items.take(limit),
+                    nextOffset = offset + items.size,
+                    hasMore = items.size == limit,
+                )
+            }
+            else -> ProviderContentSection(feature, errorMessage = "网易云音乐暂不支持该内容")
+        }
+    }
+
+    private suspend fun userPlaylists(
+        feature: ProviderFeature,
+        request: NeteaseFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val uid = context.currentUserId()
+            ?: return ProviderContentSection(feature, errorMessage = "无法读取网易云音乐用户信息")
+        val playlists = context.userPlaylists(uid).filter { item ->
+            val subscribed = item.boolean("subscribed")
+            if (request.baseId == "netease_favorite_playlists") subscribed else !subscribed
+        }
+        val page = playlists.drop(offset).take(limit).map { item ->
+            if (item.boolean("subscribed")) context.subscribedPlaylist(item) else context.ownedPlaylist(item)
+        }
+        return ProviderContentSection(
+            feature = feature,
+            playlists = page,
+            nextOffset = offset + page.size,
+            hasMore = playlists.size > offset + page.size,
+        )
+    }
+
+    private suspend fun favoriteSongs(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val uid = context.currentUserId()
+            ?: return ProviderContentSection(feature, errorMessage = "无法读取网易云音乐用户信息")
+        val playlists = context.userPlaylists(uid)
+        val favoritePlaylist = playlists.firstOrNull { it.string("id") == uid }
+            ?: playlists.firstOrNull { !it.boolean("subscribed") }
+            ?: return ProviderContentSection(feature, errorMessage = "未找到我喜欢的音乐歌单")
+        val detail = context.playlistDetail(context.ownedPlaylist(favoritePlaylist), offset, limit)
+        return ProviderContentSection(
+            feature,
+            tracks = detail.tracks,
+            nextOffset = detail.tracksNextOffset,
+            hasMore = detail.tracksHasMore,
+        )
+    }
+
+    private suspend fun playlistSquare(
+        feature: ProviderFeature,
+        request: NeteaseFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val cat = request.params["cat"].orEmpty().ifBlank { "全部" }
+        val order = request.params["order"].orEmpty().ifBlank { "hot" }
+        val root = weApi(
+            "$BASE/weapi/playlist/list",
+            """{"cat":"${cat.jsonString()}","order":"${order.jsonString()}","limit":$limit,"offset":$offset,"total":true}""",
+        )
+        val values = root.array("playlists")
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(feature, playlistSquareFilters(cat, order)),
+            playlists = values.mapNotNull { value ->
+                runCatching { context.playlist(value.asObject()) }.getOrNull()
+            },
+            nextOffset = offset + values.size,
+            hasMore = root.boolean("more") ||
+                root.int("total")?.let { offset + values.size < it } == true ||
+                values.size == limit,
+        )
+    }
+
+    private suspend fun artistSquare(
+        feature: ProviderFeature,
+        request: NeteaseFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val area = request.params["area"].orEmpty().ifBlank { "-1" }
+        val type = request.params["type"].orEmpty().ifBlank { "-1" }
+        val initial = request.params["initial"].orEmpty().ifBlank { "-1" }
+        val root = weApi(
+            "$BASE/weapi/v1/artist/list",
+            """{"initial":$initial,"offset":$offset,"limit":$limit,"total":true,"type":$type,"area":$area}""",
+        )
+        val values = root.array("artists").ifEmpty { root.obj("data")?.array("artists").orEmpty() }
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(feature, artistSquareFilters(area, type, initial)),
+            mediaItems = values.mapNotNull { value ->
+                runCatching { context.artist(value.asObject()) }.getOrNull()
+            },
+            nextOffset = offset + values.size,
+            hasMore = root.boolean("more") || root.obj("data")?.boolean("more") == true || values.size == limit,
+        )
+    }
+
+    private suspend fun mvSquare(
+        feature: ProviderFeature,
+        request: NeteaseFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val area = request.params["area"].orEmpty().ifBlank { "全部" }
+        val type = request.params["type"].orEmpty().ifBlank { "全部" }
+        val order = request.params["order"].orEmpty().ifBlank { "上升最快" }
+        val tags = """{"地区":"${area.jsonString()}","类型":"${type.jsonString()}","排序":"${order.jsonString()}"}"""
+        val root = context.postFormJson(
+            "$BASE/api/mv/all",
+            Parameters.build {
+                append("tags", tags)
+                append("offset", offset.toString())
+                append("total", "true")
+                append("limit", limit.toString())
+            },
+            context.neteaseAuthenticatedHeaders(mapOf("Referer" to "https://music.163.com/")),
+        )
+        val values = root.array("data")
+        return ProviderContentSection(
+            feature = ProviderFeatureFilterCodec.attach(feature, mvSquareFilters(area, type, order)),
+            videos = values.mapNotNull { value -> runCatching { context.video(value.asObject()) }.getOrNull() },
+            nextOffset = offset + values.size,
+            hasMore = root.boolean("hasMore") || root.boolean("more") || values.size == limit,
+        )
+    }
+
+    private suspend fun styleFeature(
+        feature: ProviderFeature,
+        request: NeteaseFeatureRequest,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        val styles = loadStyleTags()
+        if (styles.isEmpty()) return ProviderContentSection(feature, errorMessage = "暂无曲风数据")
+        val requestedTag = request.params["tagId"]
+        val tagId = requestedTag?.takeIf { candidate -> styles.any { it.id == candidate } } ?: styles.first().id
+        val kind = request.params["kind"]?.takeIf { it in STYLE_KINDS } ?: "songs"
+        val cursorKey = "$tagId:$kind"
+        val cursor = if (offset == 0) "0" else styleCursorPages[cursorKey]?.get(offset) ?: "0"
+        val endpoint = when (kind) {
+            "playlists" -> "playlist"
+            "albums" -> "album"
+            "artists" -> "artist"
+            else -> "song"
+        }
+        val root = weApi(
+            "$BASE/weapi/style-tag/home/$endpoint",
+            buildString {
+                append("{\"cursor\":")
+                append(cursor.toLongOrNull()?.toString() ?: "\"${cursor.jsonString()}\"")
+                append(",\"size\":$limit,\"tagId\":")
+                append(tagId.toLongOrNull()?.toString() ?: "\"${tagId.jsonString()}\"")
+                append(",\"sort\":0}")
+            },
+        )
+        val values = styleResourceValues(root, kind)
+        val data = root.obj("data")
+        val nextCursor = data?.stringOrNull("cursor")
+            ?: data?.long("cursor")?.toString()
+            ?: root.stringOrNull("cursor")
+            ?: root.long("cursor")?.toString()
+        val moreFlag = data?.boolean("hasMore") == true || data?.boolean("more") == true ||
+            root.boolean("hasMore") || root.boolean("more")
+        val canContinue = !nextCursor.isNullOrBlank() && nextCursor != cursor && nextCursor != "0" &&
+            (moreFlag || values.size >= limit)
+        val nextOffset = offset + 1
+        if (canContinue) {
+            styleCursorPages.getOrPut(cursorKey) { mutableMapOf() }[nextOffset] = nextCursor.orEmpty()
+        }
+        val presentationFeature = ProviderFeatureFilterCodec.attach(feature, styleFilters(styles, tagId, kind))
+        return when (kind) {
+            "playlists" -> ProviderContentSection(
+                feature = presentationFeature,
+                playlists = values.mapNotNull { value -> runCatching { context.playlist(value.asObject()) }.getOrNull() },
+                nextOffset = nextOffset,
+                hasMore = canContinue,
+            )
+            "albums" -> ProviderContentSection(
+                feature = presentationFeature,
+                mediaItems = values.mapNotNull { value -> runCatching { context.album(value.asObject()) }.getOrNull() },
+                nextOffset = nextOffset,
+                hasMore = canContinue,
+            )
+            "artists" -> ProviderContentSection(
+                feature = presentationFeature,
+                mediaItems = values.mapNotNull { value -> runCatching { context.artist(value.asObject()) }.getOrNull() },
+                nextOffset = nextOffset,
+                hasMore = canContinue,
+            )
+            else -> ProviderContentSection(
+                feature = presentationFeature,
+                tracks = context.loadSongs(values),
+                nextOffset = nextOffset,
+                hasMore = canContinue,
+            )
+        }
+    }
+
+    private suspend fun loadStyleTags(): List<NeteaseStyleTag> {
+        styleTagCache?.takeIf { it.isNotEmpty() }?.let { return it }
+        val root = weApi("$BASE/weapi/tag/list/get", "{}")
+        val candidates = buildList<JsonElement> {
+            addAll(root.array("tagList"))
+            addAll(root.array("tags"))
+            addAll(root.array("list"))
+            addAll(root.array("data"))
+            root.obj("data")?.let { data ->
+                add(data)
+                addAll(data.array("tagList"))
+                addAll(data.array("tags"))
+                addAll(data.array("list"))
+                addAll(data.array("childrenTags"))
+            }
+        }
+        return flattenStyleTags(candidates).distinctBy { it.id }.also { styleTagCache = it }
+    }
+
+    private fun flattenStyleTags(values: Iterable<JsonElement>): List<NeteaseStyleTag> = buildList {
+        values.forEach { element ->
+            val value = runCatching { element.asObject() }.getOrNull() ?: return@forEach
+            val id = value.string("tagId").ifBlank { value.string("id") }
+            val name = value.string("tagName").ifBlank { value.string("name") }
+            if (id.isNotBlank() && name.isNotBlank()) add(NeteaseStyleTag(id, name))
+            listOf("childrenTags", "children", "tags", "tagList", "list").forEach { key ->
+                val children = value.array(key)
+                if (children.isNotEmpty()) addAll(flattenStyleTags(children))
+            }
+        }
+    }
+
+    private fun styleResourceValues(root: JsonObject, kind: String): List<JsonElement> {
+        val keys = when (kind) {
+            "playlists" -> listOf("playlists", "playlistList", "list")
+            "albums" -> listOf("albums", "albumList", "list")
+            "artists" -> listOf("artists", "artistList", "list")
+            else -> listOf("songs", "songList", "list")
+        }
+        val data = root.obj("data")
+        listOfNotNull(data, root).forEach { container ->
+            keys.forEach { key ->
+                val values = container.array(key)
+                if (values.isNotEmpty()) return values
+            }
+        }
+        return root.array("data")
+    }
+
+    private suspend fun weApi(url: String, json: String): JsonObject =
+        context.weApiPost(url, json, ProviderRequestKind.Auth)
+
+    private fun String.jsonString(): String = replace("\\", "\\\\").replace("\"", "\\\"")
+
+    private companion object {
+        const val BASE = "https://music.163.com"
+        val STYLE_KINDS = setOf("songs", "playlists", "albums", "artists")
+    }
+}
+
+internal data class NeteaseFeatureContext(
+    val authState: suspend () -> ProviderAuthState,
+    val weApiPost: suspend (String, String, ProviderRequestKind) -> JsonObject,
+    val getJson: suspend (String, Map<String, String>, String?, ProviderCachePolicy) -> JsonObject,
+    val postFormJson: suspend (String, Parameters, Map<String, String>) -> JsonObject,
+    val authenticatedHeaders: suspend (Map<String, String>) -> Map<String, String>,
+    val neteaseAuthenticatedHeaders: suspend (Map<String, String>) -> Map<String, String>,
+    val song: (JsonElement) -> MusicTrack,
+    val loadSongs: suspend (Iterable<JsonElement>) -> List<MusicTrack>,
+    val playlist: (JsonObject) -> ProviderPlaylist,
+    val artist: (JsonObject) -> ProviderMediaItem,
+    val album: (JsonObject) -> ProviderMediaItem,
+    val video: (JsonObject) -> ProviderVideo,
+    val currentUserId: suspend () -> String?,
+    val userPlaylists: suspend (String) -> List<JsonObject>,
+    val ownedPlaylist: (JsonObject) -> ProviderPlaylist,
+    val subscribedPlaylist: (JsonObject) -> ProviderPlaylist,
+    val playlistDetail: suspend (ProviderPlaylist, Int, Int) -> ProviderPlaylistDetail,
+    val cloudSongs: suspend (ProviderFeature, Int, Int) -> ProviderContentSection,
+    val csrfToken: suspend () -> String,
+)

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProvider.kt
@@ -15,7 +15,6 @@ import org.feeluown.mobile.ProviderContentSection
 import org.feeluown.mobile.ProviderContentType
 import org.feeluown.mobile.ProviderFeature
 import org.feeluown.mobile.ProviderFeatureCategory
-import org.feeluown.mobile.ProviderFeatureFilterCodec
 import org.feeluown.mobile.ProviderInfo
 import org.feeluown.mobile.ProviderMediaItem
 import org.feeluown.mobile.ProviderMediaItemDetail
@@ -62,8 +61,47 @@ class NeteaseProvider(
     capabilities = CAPABILITIES,
     features = FEATURES,
 ), KotlinMusicProvider {
-    private var styleTagCache: List<NeteaseStyleTag>? = null
-    private val styleCursorPages = mutableMapOf<String, MutableMap<Int, String>>()
+    private val featureLoader by lazy {
+        NeteaseFeatureLoader(
+            NeteaseFeatureContext(
+                authState = { authState() },
+                weApiPost = { url, json, kind -> neteaseWeApiPost(url, json, kind) },
+                getJson = { url, headers, cacheKey, cachePolicy ->
+                    http.getText(
+                        providerId = ID,
+                        url = url,
+                        headers = headers,
+                        cacheKey = cacheKey,
+                        cachePolicy = cachePolicy,
+                    ).value.let(::parseNeteaseResponse)
+                },
+                postFormJson = { url, form, headers ->
+                    http.postForm(
+                        providerId = ID,
+                        url = url,
+                        form = form,
+                        headers = headers,
+                        cacheKey = null,
+                    ).value.let(::parseNeteaseResponse)
+                },
+                authenticatedHeaders = { extra -> this@NeteaseProvider.authenticatedHeaders(extra) },
+                neteaseAuthenticatedHeaders = { extra -> this@NeteaseProvider.neteaseAuthenticatedHeaders(extra) },
+                song = ::song,
+                loadSongs = ::loadSongs,
+                playlist = { value -> value.toPlaylist() },
+                artist = ::artist,
+                album = ::album,
+                video = ::mvVideo,
+                currentUserId = ::currentUserId,
+                userPlaylists = ::userPlaylistObjects,
+                ownedPlaylist = ::ownedPlaylist,
+                subscribedPlaylist = ::subscribedPlaylist,
+                playlistDetail = { playlist, offset, limit -> playlistDetail(playlist, offset, limit) },
+                cloudSongs = ::cloudSongs,
+                csrfToken = ::csrfToken,
+            ),
+        )
+    }
 
     override suspend fun search(keyword: String): ProviderSearchResults {
         val tracks = searchType(keyword, 1).array("songs").map(::song)
@@ -484,395 +522,8 @@ class NeteaseProvider(
         return splitResourceId(resourceId, expectedPrefix).second.ifBlank { resourceId.substringAfterLast(':') }
     }
 
-    override suspend fun loadFeature(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection {
-        if (feature.requiresLogin && !authState().isLoggedIn) {
-            return ProviderContentSection(feature, isLoginRequired = true)
-        }
-        val request = parseNeteaseFeatureRequest(feature.id)
-        val payload = when (request.baseId) {
-            "netease_daily_songs" -> {
-                val root = neteaseWeApiPost("$BASE/weapi/v3/discovery/recommend/songs", "{}")
-                val songs = root.obj("data")?.array("dailySongs").orEmpty()
-                ProviderContentSection(feature, tracks = songs.drop(offset).take(limit).map(::song), nextOffset = offset + limit, hasMore = songs.size > offset + limit)
-            }
-            "netease_recommended_new_songs" -> {
-                val requestLimit = (offset + limit).coerceAtLeast(limit)
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/personalized/newsong",
-                    """{"type":"recommend","limit":$requestLimit,"areaId":0}""",
-                )
-                val values = root.array("result")
-                val songs = values.map { value -> value.asObject().obj("song") ?: value }
-                val page = songs.drop(offset).take(limit)
-                ProviderContentSection(
-                    feature = feature,
-                    tracks = loadSongs(page),
-                    nextOffset = offset + page.size,
-                    hasMore = songs.size > offset + page.size,
-                )
-            }
-            "netease_radio" -> {
-                val songs = http.getText(
-                    ID,
-                    "$BASE/api/radio/get",
-                    neteaseAuthenticatedHeaders(),
-                    cacheKey = null,
-                ).value.let { parseNeteaseResponse(it).array("data") }
-                ProviderContentSection(feature, tracks = songs.drop(offset).take(limit).map(::song), nextOffset = offset + limit, hasMore = songs.size > offset + limit)
-            }
-            "netease_toplists" -> {
-                val root = http.getText(ID, "$BASE/api/toplist", authenticatedHeaders(), cacheKey = "netease:toplist", cachePolicy = ProviderCachePolicies.recommendation)
-                    .value.let { parseNeteaseResponse(it) }
-                val playlists = root.array("list")
-                ProviderContentSection(feature, playlists = playlists.drop(offset).take(limit).map { it.asObject().toPlaylist() }, nextOffset = offset + limit, hasMore = playlists.size > offset + limit)
-            }
-            NETEASE_PLAYLIST_SQUARE -> playlistSquare(feature, request, offset, limit)
-            NETEASE_ARTIST_SQUARE -> artistSquare(feature, request, offset, limit)
-            NETEASE_MV_SQUARE -> mvSquare(feature, request, offset, limit)
-            NETEASE_STYLES -> styleFeature(feature, request, offset, limit)
-            "netease_new_songs" -> {
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/v1/discovery/new/songs",
-                    """{"areaId":0,"total":true}""",
-                )
-                val songs = root.array("data")
-                val page = songs.drop(offset).take(limit)
-                ProviderContentSection(
-                    feature = feature,
-                    tracks = page.map(::song),
-                    nextOffset = offset + page.size,
-                    hasMore = songs.size > offset + page.size,
-                )
-            }
-            "netease_new_albums" -> {
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/album/new",
-                    """{"limit":$limit,"offset":$offset,"total":true,"area":"ALL"}""",
-                )
-                val values = root.array("albums")
-                ProviderContentSection(
-                    feature = feature,
-                    mediaItems = values.mapNotNull { value -> runCatching { album(value.asObject()) }.getOrNull() },
-                    nextOffset = offset + values.size,
-                    hasMore = root.boolean("more") || root.int("total")?.let { offset + values.size < it } == true || values.size == limit,
-                )
-            }
-            "netease_top_artists" -> {
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/artist/top",
-                    """{"limit":$limit,"offset":$offset,"total":true}""",
-                )
-                val values = root.array("artists")
-                ProviderContentSection(
-                    feature = feature,
-                    mediaItems = values.mapNotNull { value -> runCatching { artist(value.asObject()) }.getOrNull() },
-                    nextOffset = offset + values.size,
-                    hasMore = root.boolean("more") || values.size == limit,
-                )
-            }
-            "netease_highquality_playlists" -> {
-                val requestLimit = (offset + limit).coerceAtLeast(limit)
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/playlist/highquality/list",
-                    """{"cat":"全部","limit":$requestLimit,"lasttime":0,"total":true}""",
-                )
-                val values = root.array("playlists")
-                val page = values.drop(offset).take(limit)
-                ProviderContentSection(
-                    feature = feature,
-                    playlists = page.mapNotNull { value -> runCatching { value.asObject().toPlaylist() }.getOrNull() },
-                    nextOffset = offset + page.size,
-                    hasMore = values.size > offset + page.size || root.boolean("more"),
-                )
-            }
-            "netease_recommended_mvs" -> {
-                val root = neteaseWeApiPost("$BASE/weapi/personalized/mv", "{}")
-                val values = root.array("result")
-                val page = values.drop(offset).take(limit)
-                ProviderContentSection(
-                    feature = feature,
-                    videos = page.mapNotNull { value -> runCatching { mvVideo(value.asObject()) }.getOrNull() },
-                    nextOffset = offset + page.size,
-                    hasMore = values.size > offset + page.size,
-                )
-            }
-            "netease_top_mvs" -> {
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/mv/toplist",
-                    """{"area":"","limit":$limit,"offset":$offset,"total":true}""",
-                )
-                val values = root.array("data")
-                ProviderContentSection(
-                    feature = feature,
-                    videos = values.mapNotNull { value -> runCatching { mvVideo(value.asObject()) }.getOrNull() },
-                    nextOffset = offset + values.size,
-                    hasMore = root.boolean("hasMore") || values.size == limit,
-                )
-            }
-            "netease_daily_playlists" -> {
-                val root = neteaseWeApiPost("$BASE/api/discovery/recommend/resource", "{}")
-                val playlists = root.array("recommend")
-                val page = playlists.drop(offset).take(limit)
-                ProviderContentSection(feature, playlists = page.map { it.asObject().toPlaylist() }, nextOffset = offset + page.size, hasMore = playlists.size > offset + page.size)
-            }
-            "netease_user_playlists", "netease_favorite_playlists" -> {
-                val uid = currentUserId()
-                if (uid == null) {
-                    ProviderContentSection(feature, errorMessage = "无法读取网易云音乐用户信息")
-                } else {
-                    val playlists = userPlaylistObjects(uid).filter { item ->
-                        val subscribed = item.boolean("subscribed")
-                        if (request.baseId == "netease_favorite_playlists") subscribed else !subscribed
-                    }
-                    val page = playlists.drop(offset).take(limit).map { item ->
-                        if (item.boolean("subscribed")) subscribedPlaylist(item) else ownedPlaylist(item)
-                    }
-                    ProviderContentSection(
-                        feature = feature,
-                        playlists = page,
-                        nextOffset = offset + page.size,
-                        hasMore = playlists.size > offset + page.size,
-                    )
-                }
-            }
-            "netease_favorite_songs" -> {
-                val uid = currentUserId()
-                if (uid == null) {
-                    ProviderContentSection(feature, errorMessage = "无法读取网易云音乐用户信息")
-                } else {
-                    val playlists = userPlaylistObjects(uid)
-                    val favoritePlaylist = playlists.firstOrNull { it.string("id") == uid }
-                        ?: playlists.firstOrNull { !it.boolean("subscribed") }
-                    if (favoritePlaylist == null) {
-                        ProviderContentSection(feature, errorMessage = "未找到我喜欢的音乐歌单")
-                    } else {
-                        val detail = playlistDetail(ownedPlaylist(favoritePlaylist), offset, limit)
-                        ProviderContentSection(
-                            feature,
-                            tracks = detail.tracks,
-                            nextOffset = detail.tracksNextOffset,
-                            hasMore = detail.tracksHasMore,
-                        )
-                    }
-                }
-            }
-            "netease_cloud_songs" -> {
-                cloudSongs(feature, offset, limit)
-            }
-            "netease_favorite_artists", "netease_favorite_albums" -> {
-                val endpoint = if (request.baseId == "netease_favorite_artists") "artist/sublist" else "album/sublist"
-                val root = neteaseWeApiPost(
-                    "$BASE/weapi/$endpoint",
-                    """{"limit":$limit,"offset":$offset,"csrf_token":"${csrfToken().jsonString()}"}""",
-                )
-                val type = if (request.baseId == "netease_favorite_artists") ProviderMediaItemType.Artist else ProviderMediaItemType.Album
-                val items = root.array("data").map { value ->
-                    if (type == ProviderMediaItemType.Artist) artist(value.asObject()) else album(value.asObject())
-                }
-                ProviderContentSection(feature, mediaItems = items.take(limit), nextOffset = offset + items.size, hasMore = items.size == limit)
-            }
-            else -> ProviderContentSection(feature, errorMessage = "网易云音乐暂不支持该内容")
-        }
-        return payload
-    }
-
-    private suspend fun playlistSquare(
-        feature: ProviderFeature,
-        request: NeteaseFeatureRequest,
-        offset: Int,
-        limit: Int,
-    ): ProviderContentSection {
-        val cat = request.params["cat"].orEmpty().ifBlank { "全部" }
-        val order = request.params["order"].orEmpty().ifBlank { "hot" }
-        val root = neteaseWeApiPost(
-            "$BASE/weapi/playlist/list",
-            """{"cat":"${cat.jsonString()}","order":"${order.jsonString()}","limit":$limit,"offset":$offset,"total":true}""",
-        )
-        val values = root.array("playlists")
-        return ProviderContentSection(
-            feature = ProviderFeatureFilterCodec.attach(feature, playlistSquareFilters(cat, order)),
-            playlists = values.mapNotNull { value -> runCatching { value.asObject().toPlaylist() }.getOrNull() },
-            nextOffset = offset + values.size,
-            hasMore = root.boolean("more") || root.int("total")?.let { offset + values.size < it } == true || values.size == limit,
-        )
-    }
-
-    private suspend fun artistSquare(
-        feature: ProviderFeature,
-        request: NeteaseFeatureRequest,
-        offset: Int,
-        limit: Int,
-    ): ProviderContentSection {
-        val area = request.params["area"].orEmpty().ifBlank { "-1" }
-        val type = request.params["type"].orEmpty().ifBlank { "-1" }
-        val initial = request.params["initial"].orEmpty().ifBlank { "-1" }
-        val root = neteaseWeApiPost(
-            "$BASE/weapi/v1/artist/list",
-            """{"initial":$initial,"offset":$offset,"limit":$limit,"total":true,"type":$type,"area":$area}""",
-        )
-        val values = root.array("artists").ifEmpty { root.obj("data")?.array("artists").orEmpty() }
-        return ProviderContentSection(
-            feature = ProviderFeatureFilterCodec.attach(feature, artistSquareFilters(area, type, initial)),
-            mediaItems = values.mapNotNull { value -> runCatching { artist(value.asObject()) }.getOrNull() },
-            nextOffset = offset + values.size,
-            hasMore = root.boolean("more") || root.obj("data")?.boolean("more") == true || values.size == limit,
-        )
-    }
-
-    private suspend fun mvSquare(
-        feature: ProviderFeature,
-        request: NeteaseFeatureRequest,
-        offset: Int,
-        limit: Int,
-    ): ProviderContentSection {
-        val area = request.params["area"].orEmpty().ifBlank { "全部" }
-        val type = request.params["type"].orEmpty().ifBlank { "全部" }
-        val order = request.params["order"].orEmpty().ifBlank { "上升最快" }
-        val tags = """{"地区":"${area.jsonString()}","类型":"${type.jsonString()}","排序":"${order.jsonString()}"}"""
-        val root = http.postForm(
-            ID,
-            "$BASE/api/mv/all",
-            Parameters.build {
-                append("tags", tags)
-                append("offset", offset.toString())
-                append("total", "true")
-                append("limit", limit.toString())
-            },
-            neteaseAuthenticatedHeaders(mapOf("Referer" to "https://music.163.com/")),
-            cacheKey = null,
-        ).value.let { parseNeteaseResponse(it) }
-        val values = root.array("data")
-        return ProviderContentSection(
-            feature = ProviderFeatureFilterCodec.attach(feature, mvSquareFilters(area, type, order)),
-            videos = values.mapNotNull { value -> runCatching { mvVideo(value.asObject()) }.getOrNull() },
-            nextOffset = offset + values.size,
-            hasMore = root.boolean("hasMore") || root.boolean("more") || values.size == limit,
-        )
-    }
-
-    private suspend fun styleFeature(
-        feature: ProviderFeature,
-        request: NeteaseFeatureRequest,
-        offset: Int,
-        limit: Int,
-    ): ProviderContentSection {
-        val styles = loadStyleTags()
-        if (styles.isEmpty()) {
-            return ProviderContentSection(feature, errorMessage = "暂无曲风数据")
-        }
-        val requestedTag = request.params["tagId"]
-        val tagId = requestedTag?.takeIf { candidate -> styles.any { it.id == candidate } } ?: styles.first().id
-        val kind = request.params["kind"]?.takeIf { it in STYLE_KINDS } ?: "songs"
-        val cursorKey = "$tagId:$kind"
-        val cursor = if (offset == 0) "0" else styleCursorPages[cursorKey]?.get(offset) ?: "0"
-        val endpoint = when (kind) {
-            "playlists" -> "playlist"
-            "albums" -> "album"
-            "artists" -> "artist"
-            else -> "song"
-        }
-        val root = neteaseWeApiPost(
-            "$BASE/weapi/style-tag/home/$endpoint",
-            buildString {
-                append("{\"cursor\":")
-                append(cursor.toLongOrNull()?.toString() ?: "\"${cursor.jsonString()}\"")
-                append(",\"size\":$limit,\"tagId\":")
-                append(tagId.toLongOrNull()?.toString() ?: "\"${tagId.jsonString()}\"")
-                append(",\"sort\":0")
-                append('}')
-            },
-        )
-        val values = styleResourceValues(root, kind)
-        val data = root.obj("data")
-        val nextCursor = data?.stringOrNull("cursor")
-            ?: data?.long("cursor")?.toString()
-            ?: root.stringOrNull("cursor")
-            ?: root.long("cursor")?.toString()
-        val moreFlag = data?.boolean("hasMore") == true || data?.boolean("more") == true || root.boolean("hasMore") || root.boolean("more")
-        val canContinue = !nextCursor.isNullOrBlank() && nextCursor != cursor && nextCursor != "0" && (moreFlag || values.size >= limit)
-        val nextOffset = offset + 1
-        if (canContinue) {
-            styleCursorPages.getOrPut(cursorKey) { mutableMapOf() }[nextOffset] = nextCursor.orEmpty()
-        }
-        val presentationFeature = ProviderFeatureFilterCodec.attach(feature, styleFilters(styles, tagId, kind))
-        return when (kind) {
-            "playlists" -> ProviderContentSection(
-                feature = presentationFeature,
-                playlists = values.mapNotNull { value -> runCatching { value.asObject().toPlaylist() }.getOrNull() },
-                nextOffset = nextOffset,
-                hasMore = canContinue,
-            )
-            "albums" -> ProviderContentSection(
-                feature = presentationFeature,
-                mediaItems = values.mapNotNull { value -> runCatching { album(value.asObject()) }.getOrNull() },
-                nextOffset = nextOffset,
-                hasMore = canContinue,
-            )
-            "artists" -> ProviderContentSection(
-                feature = presentationFeature,
-                mediaItems = values.mapNotNull { value -> runCatching { artist(value.asObject()) }.getOrNull() },
-                nextOffset = nextOffset,
-                hasMore = canContinue,
-            )
-            else -> ProviderContentSection(
-                feature = presentationFeature,
-                tracks = loadSongs(values),
-                nextOffset = nextOffset,
-                hasMore = canContinue,
-            )
-        }
-    }
-
-    private suspend fun loadStyleTags(): List<NeteaseStyleTag> {
-        styleTagCache?.takeIf { it.isNotEmpty() }?.let { return it }
-        val root = neteaseWeApiPost("$BASE/weapi/tag/list/get", "{}")
-        val candidates = buildList<JsonElement> {
-            addAll(root.array("tagList"))
-            addAll(root.array("tags"))
-            addAll(root.array("list"))
-            addAll(root.array("data"))
-            root.obj("data")?.let { data ->
-                add(data)
-                addAll(data.array("tagList"))
-                addAll(data.array("tags"))
-                addAll(data.array("list"))
-                addAll(data.array("childrenTags"))
-            }
-        }
-        val styles = flattenStyleTags(candidates).distinctBy { it.id }
-        styleTagCache = styles
-        return styles
-    }
-
-    private fun flattenStyleTags(values: Iterable<JsonElement>): List<NeteaseStyleTag> = buildList {
-        values.forEach { element ->
-            val value = runCatching { element.asObject() }.getOrNull() ?: return@forEach
-            val id = value.string("tagId").ifBlank { value.string("id") }
-            val name = value.string("tagName").ifBlank { value.string("name") }
-            if (id.isNotBlank() && name.isNotBlank()) add(NeteaseStyleTag(id, name))
-            listOf("childrenTags", "children", "tags", "tagList", "list").forEach { key ->
-                val children = value.array(key)
-                if (children.isNotEmpty()) addAll(flattenStyleTags(children))
-            }
-        }
-    }
-
-    private fun styleResourceValues(root: JsonObject, kind: String): List<JsonElement> {
-        val keys = when (kind) {
-            "playlists" -> listOf("playlists", "playlistList", "list")
-            "albums" -> listOf("albums", "albumList", "list")
-            "artists" -> listOf("artists", "artistList", "list")
-            else -> listOf("songs", "songList", "list")
-        }
-        val data = root.obj("data")
-        listOfNotNull(data, root).forEach { container ->
-            keys.forEach { key ->
-                val values = container.array(key)
-                if (values.isNotEmpty()) return values
-            }
-        }
-        return root.array("data")
-    }
+    override suspend fun loadFeature(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection =
+        featureLoader.load(feature, offset, limit)
 
     private suspend fun searchType(keyword: String, type: Int): JsonObject {
         return http.postForm(
@@ -1385,7 +1036,6 @@ class NeteaseProvider(
         const val FAVORITE_RESOURCE_ALBUM = "album"
         const val FAVORITE_STATE_PAGE_SIZE = 200
         const val FAVORITE_STATE_MAX_PAGES = 10
-        val STYLE_KINDS = setOf("songs", "playlists", "albums", "artists")
         val INFO = ProviderInfo(
             providerId = ID,
             providerName = NAME,

--- a/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProviderFactory.kt
+++ b/provider/netease/src/commonMain/kotlin/org/feeluown/mobile/provider/netease/NeteaseProviderFactory.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile.provider.netease
 
+import org.feeluown.mobile.provider.core.CapabilityDelegatingProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.KotlinProviderFactory
 import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
@@ -13,10 +14,19 @@ object NeteaseProviderFactory : KotlinProviderFactory {
             http = dependencies.http,
             credentials = dependencies.credentials,
         )
-        return NeteaseComprehensiveSearchProvider(
+        val discovery = NeteaseComprehensiveSearchProvider(
             delegate = base,
             http = dependencies.http,
             credentials = dependencies.credentials,
+        )
+        return CapabilityDelegatingProvider(
+            base = base,
+            presentation = base,
+            account = base,
+            discovery = discovery,
+            content = base,
+            library = base,
+            playback = base,
         )
     }
 }

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicCompositeProvider.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicCompositeProvider.kt
@@ -16,17 +16,30 @@ import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
 
 /**
- * QQ Music module-local composite. Provider-specific discovery, account library and artist
- * enrichment stay inside the concrete provider module instead of leaking helper types to :shared.
+ * QQ Music module-local content/library composition.
+ *
+ * The delegates are injectable so the factory can share one core provider instance across
+ * playback, content, account and library capabilities instead of constructing nested providers.
  */
 internal class QQMusicCompositeProvider(
     dependencies: ProviderRuntimeDependencies,
+    private val content: QQMusicContentProvider = QQMusicContentProvider(
+        dependencies.http,
+        dependencies.credentials,
+    ),
+    private val userLibrary: QQMusicUserLibrary = QQMusicUserLibrary(
+        dependencies.http,
+        dependencies.credentials,
+    ),
+    private val followedArtists: QQMusicFollowedArtistsLoader = QQMusicFollowedArtistsLoader(
+        dependencies.http,
+        dependencies.credentials,
+    ),
+    private val artistDetails: QQMusicArtistDetailProvider = QQMusicArtistDetailProvider(
+        dependencies.http,
+        dependencies.credentials,
+    ),
 ) : KotlinMusicProvider {
-    private val content = QQMusicContentProvider(dependencies.http, dependencies.credentials)
-    private val userLibrary = QQMusicUserLibrary(dependencies.http, dependencies.credentials)
-    private val followedArtists = QQMusicFollowedArtistsLoader(dependencies.http, dependencies.credentials)
-    private val artistDetails = QQMusicArtistDetailProvider(dependencies.http, dependencies.credentials)
-
     override val id: String get() = content.id
     override val name: String get() = content.name
     override val info get() = content.info
@@ -48,6 +61,7 @@ internal class QQMusicCompositeProvider(
     override suspend fun trackDetail(identifier: String) = content.trackDetail(identifier)
     override suspend fun resolve(track: MusicTrack, qualityPolicy: String) = content.resolve(track, qualityPolicy)
     override suspend fun lyrics(track: MusicTrack) = content.lyrics(track)
+    override suspend fun lyricsSearchKeyword(track: MusicTrack) = content.lyricsSearchKeyword(track)
 
     override suspend fun authState(): ProviderAuthState = enrichAuth(content.authState())
 

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProtocolSupport.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProtocolSupport.kt
@@ -1,0 +1,29 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlinx.serialization.json.JsonObject
+import kotlin.random.Random
+import org.feeluown.mobile.provider.core.md5Hex
+import org.feeluown.mobile.provider.core.string
+
+internal data class QqAudioQuality(
+    val code: String,
+    val prefix: String,
+    val extension: String,
+    val label: String,
+) {
+    fun filename(mediaId: String): String = "$prefix$mediaId.$extension"
+}
+
+internal fun JsonObject.hasPositive(key: String): Boolean =
+    string(key).toLongOrNull()?.let { it > 0 } == true
+
+internal fun qqSign(data: String): String {
+    val randomPart = buildString {
+        repeat(Random.nextInt(10, 17)) {
+            append(QQ_SIGN_ALPHABET[Random.nextInt(QQ_SIGN_ALPHABET.length)])
+        }
+    }
+    return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}"
+}
+
+private const val QQ_SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProvider.kt
@@ -7,12 +7,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import org.feeluown.mobile.AudioQualityPolicy
 import org.feeluown.mobile.PlaybackPayload
-import org.feeluown.mobile.ProviderCapabilities
 import org.feeluown.mobile.ProviderComment
-import org.feeluown.mobile.ProviderContentType
 import org.feeluown.mobile.ProviderFeature
-import org.feeluown.mobile.ProviderFeatureCategory
-import org.feeluown.mobile.ProviderInfo
 import org.feeluown.mobile.ProviderMediaItem
 import org.feeluown.mobile.ProviderMediaItemDetail
 import org.feeluown.mobile.ProviderMediaItemType
@@ -33,7 +29,6 @@ import org.feeluown.mobile.provider.core.base64DecodeToString
 import org.feeluown.mobile.provider.core.boolean
 import org.feeluown.mobile.provider.core.int
 import org.feeluown.mobile.provider.core.long
-import org.feeluown.mobile.provider.core.md5Hex
 import org.feeluown.mobile.provider.core.obj
 import org.feeluown.mobile.provider.core.parseCookies
 import org.feeluown.mobile.provider.core.providerJson
@@ -44,7 +39,6 @@ import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
 import org.feeluown.mobile.provider.core.network.ProviderHttpClient
 import org.feeluown.mobile.provider.core.network.ProviderRequestKind
 import org.feeluown.mobile.provider.core.network.currentTimeMillis
-import kotlin.random.Random
 
 class QQMusicProvider(
     http: ProviderHttpClient,
@@ -972,58 +966,16 @@ class QQMusicProvider(
     }
 
     private companion object {
-        const val ID = "qqmusic"
-        const val NAME = "QQ 音乐"
-        const val SEARCH_BASE = "https://c.y.qq.com"
-        const val VKEY_BASE = "https://u.y.qq.com"
-        const val QQ_AUDIO_BASE = "http://isure.stream.qqmusic.qq.com"
-        const val PLAYLIST_MUTATION_SYNC_ATTEMPTS = 6
-        const val PLAYLIST_MUTATION_SYNC_DELAY_MS = 200L
-        val defaultGuid = Random.nextLong(100_000_000, 1_000_000_000).toString()
-        val INFO = ProviderInfo(
-            providerId = ID,
-            providerName = NAME,
-            loginConfig = org.feeluown.mobile.ProviderLoginConfig(
-                "https://y.qq.com",
-                listOf(listOf("qqmusic_key", "wxuin", "qm_keyst"), listOf("qqmusic_key", "uin", "qm_keyst")),
-            ),
-            supportedLoginModes = setOf(org.feeluown.mobile.ProviderLoginMode.WebView),
-        )
-        val CAPABILITIES = ProviderCapabilities(
-            providerId = ID,
-            providerName = NAME,
-            canAddSongToPlaylist = true,
-            canRemoveSongFromPlaylist = true,
-            canCreatePlaylist = true,
-            canDeletePlaylist = true,
-        )
-        val FEATURES = listOf(
-            ProviderFeature("qqmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
-            ProviderFeature("qqmusic_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
-            ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
-            ProviderFeature("qqmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
-        )
+        const val ID = QQMusicProviderDefinition.ID
+        const val NAME = QQMusicProviderDefinition.NAME
+        const val SEARCH_BASE = QQMusicProviderDefinition.SEARCH_BASE
+        const val VKEY_BASE = QQMusicProviderDefinition.VKEY_BASE
+        const val QQ_AUDIO_BASE = QQMusicProviderDefinition.QQ_AUDIO_BASE
+        const val PLAYLIST_MUTATION_SYNC_ATTEMPTS = QQMusicProviderDefinition.PLAYLIST_MUTATION_SYNC_ATTEMPTS
+        const val PLAYLIST_MUTATION_SYNC_DELAY_MS = QQMusicProviderDefinition.PLAYLIST_MUTATION_SYNC_DELAY_MS
+        val defaultGuid get() = QQMusicProviderDefinition.defaultGuid
+        val INFO get() = QQMusicProviderDefinition.info
+        val CAPABILITIES get() = QQMusicProviderDefinition.capabilities
+        val FEATURES get() = QQMusicProviderDefinition.features
     }
 }
-
-private data class QqAudioQuality(
-    val code: String,
-    val prefix: String,
-    val extension: String,
-    val label: String,
-) {
-    fun filename(mediaId: String): String = "$prefix$mediaId.$extension"
-}
-
-private fun JsonObject.hasPositive(key: String): Boolean = string(key).toLongOrNull()?.let { it > 0 } == true
-
-private fun qqSign(data: String): String {
-    val randomPart = buildString {
-        repeat(Random.nextInt(10, 17)) {
-            append(QQ_SIGN_ALPHABET[Random.nextInt(QQ_SIGN_ALPHABET.length)])
-        }
-    }
-    return "zza$randomPart${md5Hex("CJBPACrRuNy7$data")}"
-}
-
-private const val QQ_SIGN_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderDefinition.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderDefinition.kt
@@ -1,0 +1,46 @@
+package org.feeluown.mobile.provider.qqmusic
+
+import kotlin.random.Random
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderContentType
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureCategory
+import org.feeluown.mobile.ProviderInfo
+
+internal object QQMusicProviderDefinition {
+    const val ID = "qqmusic"
+    const val NAME = "QQ 音乐"
+    const val SEARCH_BASE = "https://c.y.qq.com"
+    const val VKEY_BASE = "https://u.y.qq.com"
+    const val QQ_AUDIO_BASE = "http://isure.stream.qqmusic.qq.com"
+    const val PLAYLIST_MUTATION_SYNC_ATTEMPTS = 6
+    const val PLAYLIST_MUTATION_SYNC_DELAY_MS = 200L
+
+    val defaultGuid = Random.nextLong(100_000_000, 1_000_000_000).toString()
+
+    val info = ProviderInfo(
+        providerId = ID,
+        providerName = NAME,
+        loginConfig = org.feeluown.mobile.ProviderLoginConfig(
+            "https://y.qq.com",
+            listOf(listOf("qqmusic_key", "wxuin", "qm_keyst"), listOf("qqmusic_key", "uin", "qm_keyst")),
+        ),
+        supportedLoginModes = setOf(org.feeluown.mobile.ProviderLoginMode.WebView),
+    )
+
+    val capabilities = ProviderCapabilities(
+        providerId = ID,
+        providerName = NAME,
+        canAddSongToPlaylist = true,
+        canRemoveSongFromPlaylist = true,
+        canCreatePlaylist = true,
+        canDeletePlaylist = true,
+    )
+
+    val features = listOf(
+        ProviderFeature("qqmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
+        ProviderFeature("qqmusic_radio", ID, NAME, "私人 FM", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, true),
+        ProviderFeature("qqmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, true),
+        ProviderFeature("qqmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
+    )
+}

--- a/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderFactory.kt
+++ b/provider/qqmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/qqmusic/QQMusicProviderFactory.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile.provider.qqmusic
 
+import org.feeluown.mobile.provider.core.CapabilityDelegatingProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.KotlinProviderFactory
 import org.feeluown.mobile.provider.core.ProviderRuntimeDependencies
@@ -9,11 +10,32 @@ object QQMusicProviderFactory : KotlinProviderFactory {
     override val providerId: String = "qqmusic"
 
     override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
-        val provider = QQMusicCompositeProvider(dependencies)
-        return QQMusicComprehensiveSearchProvider(
-            delegate = provider,
+        val base = QQMusicProvider(
             http = dependencies.http,
             credentials = dependencies.credentials,
+        )
+        val content = QQMusicContentProvider(
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+            delegate = base,
+        )
+        val composite = QQMusicCompositeProvider(
+            dependencies = dependencies,
+            content = content,
+        )
+        val discovery = QQMusicComprehensiveSearchProvider(
+            delegate = composite,
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+        )
+        return CapabilityDelegatingProvider(
+            base = base,
+            presentation = composite,
+            account = composite,
+            discovery = discovery,
+            content = composite,
+            library = composite,
+            playback = base,
         )
     }
 }

--- a/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/provider/core/CapabilityDelegatingProvider.kt
+++ b/provider/runtime/src/commonMain/kotlin/org/feeluown/mobile/provider/core/CapabilityDelegatingProvider.kt
@@ -1,0 +1,119 @@
+package org.feeluown.mobile.provider.core
+
+import org.feeluown.mobile.MediaRef
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.ProviderAuthState
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderComment
+import org.feeluown.mobile.ProviderContentSection
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderInfo
+import org.feeluown.mobile.ProviderMediaItemDetail
+import org.feeluown.mobile.ProviderMutationResult
+import org.feeluown.mobile.ProviderPlaylist
+import org.feeluown.mobile.ProviderPlaylistDetail
+import org.feeluown.mobile.ProviderResourceState
+import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.VideoPlaybackPayload
+
+/**
+ * Routes the provider SPI by capability instead of forcing every concrete provider to grow into
+ * one implementation class. A provider module can migrate incrementally: capabilities that have
+ * not been extracted yet simply keep using [base].
+ *
+ * [presentation] owns the public metadata/capability/feature surface. This matters for providers
+ * that enrich capabilities or register extra feature shelves in a decorator.
+ */
+class CapabilityDelegatingProvider(
+    private val base: KotlinMusicProvider,
+    private val presentation: KotlinMusicProvider = base,
+    private val account: KotlinMusicProvider = base,
+    private val discovery: KotlinMusicProvider = base,
+    private val content: KotlinMusicProvider = base,
+    private val library: KotlinMusicProvider = base,
+    private val playback: KotlinMusicProvider = base,
+) : KotlinMusicProvider {
+    override val id: String get() = presentation.id
+    override val name: String get() = presentation.name
+    override val info: ProviderInfo get() = presentation.info
+    override val capabilities: ProviderCapabilities get() = presentation.capabilities
+    override val features: List<ProviderFeature> get() = presentation.features
+
+    override suspend fun initialize() = base.initialize()
+
+    override suspend fun search(keyword: String): ProviderSearchResults = discovery.search(keyword)
+
+    override suspend fun trackDetail(identifier: String): MusicTrack? = playback.trackDetail(identifier)
+    override suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload? =
+        playback.resolve(track, qualityPolicy)
+    override suspend fun lyrics(track: MusicTrack): String? = playback.lyrics(track)
+    override suspend fun lyricsSearchKeyword(track: MusicTrack): String? = playback.lyricsSearchKeyword(track)
+    override suspend fun similarTracks(track: MusicTrack): List<MusicTrack> = playback.similarTracks(track)
+    override suspend fun hotComments(track: MusicTrack): List<ProviderComment> = playback.hotComments(track)
+    override suspend fun trackVideo(track: MusicTrack): ProviderVideo? = playback.trackVideo(track)
+    override suspend fun videoPlaybackPayload(video: ProviderVideo): VideoPlaybackPayload =
+        playback.videoPlaybackPayload(video)
+
+    override suspend fun authState(): ProviderAuthState = account.authState()
+    override suspend fun loginWithCookies(cookiesJson: String): ProviderAuthState = account.loginWithCookies(cookiesJson)
+    override suspend fun loginWithHeaders(authorization: String, cookie: String): ProviderAuthState =
+        account.loginWithHeaders(authorization, cookie)
+    override suspend fun loginWithHeaderFile(headerFileJson: String): ProviderAuthState =
+        account.loginWithHeaderFile(headerFileJson)
+    override suspend fun loginWithOAuth(
+        accessToken: String,
+        refreshToken: String,
+        expiresAtMillis: Long?,
+        scope: String?,
+        clientId: String,
+        clientSecret: String,
+    ): ProviderAuthState = account.loginWithOAuth(
+        accessToken = accessToken,
+        refreshToken = refreshToken,
+        expiresAtMillis = expiresAtMillis,
+        scope = scope,
+        clientId = clientId,
+        clientSecret = clientSecret,
+    )
+    override suspend fun logout(): ProviderAuthState = account.logout()
+
+    override suspend fun loadFeature(feature: ProviderFeature, offset: Int, limit: Int): ProviderContentSection =
+        content.loadFeature(feature, offset, limit)
+    override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> = content.playlistTracks(playlist)
+    override suspend fun playlistDetail(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail = content.playlistDetail(playlist, offset, limit)
+    override suspend fun mediaItemTracks(item: MediaRef): List<MusicTrack> = content.mediaItemTracks(item)
+    override suspend fun mediaItemDetail(
+        item: MediaRef,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail = content.mediaItemDetail(item, tracksOffset, albumsOffset, limit)
+
+    override suspend fun playlistOperationTargets(track: MusicTrack): List<ProviderPlaylist> =
+        library.playlistOperationTargets(track)
+    override suspend fun addTrackToPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult = library.addTrackToPlaylist(playlist, track)
+    override suspend fun removeTrackFromPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult = library.removeTrackFromPlaylist(playlist, track)
+    override suspend fun createPlaylist(name: String): ProviderMutationResult = library.createPlaylist(name)
+    override suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderMutationResult = library.deletePlaylist(playlist)
+    override suspend fun setSongDisliked(track: MusicTrack, disliked: Boolean): ProviderMutationResult =
+        library.setSongDisliked(track, disliked)
+    override suspend fun resourceState(resourceType: String, resourceId: String): ProviderResourceState =
+        library.resourceState(resourceType, resourceId)
+    override suspend fun setResourceFavorite(
+        resourceType: String,
+        resourceId: String,
+        favorite: Boolean,
+    ): ProviderMutationResult = library.setResourceFavorite(resourceType, resourceId, favorite)
+}

--- a/provider/runtime/src/commonTest/kotlin/org/feeluown/mobile/CapabilityDelegatingProviderTest.kt
+++ b/provider/runtime/src/commonTest/kotlin/org/feeluown/mobile/CapabilityDelegatingProviderTest.kt
@@ -1,0 +1,239 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import org.feeluown.mobile.provider.core.CapabilityDelegatingProvider
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+
+class CapabilityDelegatingProviderTest {
+    @Test
+    fun routesOperationsToTheirCapabilityDelegates() = kotlinx.coroutines.test.runTest {
+        val base = RecordingProvider("base")
+        val presentation = RecordingProvider("presentation")
+        val account = RecordingProvider("account")
+        val discovery = RecordingProvider("discovery")
+        val content = RecordingProvider("content")
+        val library = RecordingProvider("library")
+        val playback = RecordingProvider("playback")
+        val provider = CapabilityDelegatingProvider(
+            base = base,
+            presentation = presentation,
+            account = account,
+            discovery = discovery,
+            content = content,
+            library = library,
+            playback = playback,
+        )
+        val track = testTrack()
+        val playlist = testPlaylist()
+        val feature = testFeature()
+
+        assertEquals(presentation.id, provider.id)
+        assertSame(presentation.features, provider.features)
+
+        provider.initialize()
+        provider.search("query")
+        provider.authState()
+        provider.resolve(track, "high")
+        provider.loadFeature(feature, 0, 20)
+        provider.createPlaylist("new")
+        provider.playlistDetail(playlist, 0, 20)
+
+        assertEquals(listOf("initialize"), base.calls)
+        assertEquals(listOf("search"), discovery.calls)
+        assertEquals(listOf("authState"), account.calls)
+        assertEquals(listOf("resolve"), playback.calls)
+        assertEquals(listOf("loadFeature", "playlistDetail"), content.calls)
+        assertEquals(listOf("createPlaylist"), library.calls)
+    }
+}
+
+private class RecordingProvider(
+    private val marker: String,
+) : KotlinMusicProvider {
+    val calls = mutableListOf<String>()
+
+    override val id: String = marker
+    override val name: String = marker
+    override val info: ProviderInfo = ProviderInfo(marker, marker)
+    override val capabilities: ProviderCapabilities = ProviderCapabilities(marker, marker)
+    override val features: List<ProviderFeature> = listOf(testFeature(marker))
+
+    override suspend fun initialize() {
+        calls += "initialize"
+    }
+
+    override suspend fun search(keyword: String): ProviderSearchResults {
+        calls += "search"
+        return ProviderSearchResults()
+    }
+
+    override suspend fun trackDetail(identifier: String): MusicTrack? {
+        calls += "trackDetail"
+        return null
+    }
+
+    override suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload? {
+        calls += "resolve"
+        return null
+    }
+
+    override suspend fun authState(): ProviderAuthState {
+        calls += "authState"
+        return ProviderAuthState(marker, marker, false)
+    }
+
+    override suspend fun loginWithCookies(cookiesJson: String): ProviderAuthState {
+        calls += "loginWithCookies"
+        return ProviderAuthState(marker, marker, true)
+    }
+
+    override suspend fun loginWithHeaders(authorization: String, cookie: String): ProviderAuthState {
+        calls += "loginWithHeaders"
+        return ProviderAuthState(marker, marker, true)
+    }
+
+    override suspend fun loginWithHeaderFile(headerFileJson: String): ProviderAuthState {
+        calls += "loginWithHeaderFile"
+        return ProviderAuthState(marker, marker, true)
+    }
+
+    override suspend fun logout(): ProviderAuthState {
+        calls += "logout"
+        return ProviderAuthState(marker, marker, false)
+    }
+
+    override suspend fun loadFeature(
+        feature: ProviderFeature,
+        offset: Int,
+        limit: Int,
+    ): ProviderContentSection {
+        calls += "loadFeature"
+        return ProviderContentSection(feature)
+    }
+
+    override suspend fun playlistTracks(playlist: ProviderPlaylist): List<MusicTrack> {
+        calls += "playlistTracks"
+        return emptyList()
+    }
+
+    override suspend fun playlistDetail(
+        playlist: ProviderPlaylist,
+        offset: Int,
+        limit: Int,
+    ): ProviderPlaylistDetail {
+        calls += "playlistDetail"
+        return ProviderPlaylistDetail(playlist)
+    }
+
+    override suspend fun playlistOperationTargets(track: MusicTrack): List<ProviderPlaylist> {
+        calls += "playlistOperationTargets"
+        return emptyList()
+    }
+
+    override suspend fun addTrackToPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult {
+        calls += "addTrackToPlaylist"
+        return ProviderMutationResult(true)
+    }
+
+    override suspend fun removeTrackFromPlaylist(
+        playlist: ProviderPlaylist,
+        track: MusicTrack,
+    ): ProviderMutationResult {
+        calls += "removeTrackFromPlaylist"
+        return ProviderMutationResult(true)
+    }
+
+    override suspend fun createPlaylist(name: String): ProviderMutationResult {
+        calls += "createPlaylist"
+        return ProviderMutationResult(true)
+    }
+
+    override suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderMutationResult {
+        calls += "deletePlaylist"
+        return ProviderMutationResult(true)
+    }
+
+    override suspend fun setSongDisliked(track: MusicTrack, disliked: Boolean): ProviderMutationResult {
+        calls += "setSongDisliked"
+        return ProviderMutationResult(true)
+    }
+
+    override suspend fun mediaItemTracks(item: MediaRef): List<MusicTrack> {
+        calls += "mediaItemTracks"
+        return emptyList()
+    }
+
+    override suspend fun mediaItemDetail(
+        item: MediaRef,
+        tracksOffset: Int,
+        albumsOffset: Int,
+        limit: Int,
+    ): ProviderMediaItemDetail {
+        calls += "mediaItemDetail"
+        return ProviderMediaItemDetail(item)
+    }
+
+    override suspend fun similarTracks(track: MusicTrack): List<MusicTrack> {
+        calls += "similarTracks"
+        return emptyList()
+    }
+
+    override suspend fun hotComments(track: MusicTrack): List<ProviderComment> {
+        calls += "hotComments"
+        return emptyList()
+    }
+
+    override suspend fun trackVideo(track: MusicTrack): ProviderVideo? {
+        calls += "trackVideo"
+        return null
+    }
+
+    override suspend fun videoPlaybackPayload(video: ProviderVideo): VideoPlaybackPayload {
+        calls += "videoPlaybackPayload"
+        return VideoPlaybackPayload(video)
+    }
+
+    override suspend fun resourceState(resourceType: String, resourceId: String): ProviderResourceState {
+        calls += "resourceState"
+        return ProviderResourceState(marker, resourceId)
+    }
+
+    override suspend fun setResourceFavorite(
+        resourceType: String,
+        resourceId: String,
+        favorite: Boolean,
+    ): ProviderMutationResult {
+        calls += "setResourceFavorite"
+        return ProviderMutationResult(true)
+    }
+}
+
+private fun testTrack() = MusicTrack(
+    id = "test:track",
+    title = "Track",
+    artists = "Artist",
+    album = "Album",
+    source = "test",
+)
+
+private fun testPlaylist() = ProviderPlaylist(
+    id = "playlist:test:1",
+    title = "Playlist",
+    providerId = "test",
+    providerName = "Test",
+)
+
+private fun testFeature(providerId: String = "test") = ProviderFeature(
+    id = "$providerId-feature",
+    providerId = providerId,
+    providerName = providerId,
+    title = "Feature",
+    category = ProviderFeatureCategory.Music,
+    contentType = ProviderContentType.Songs,
+    requiresLogin = false,
+)

--- a/provider/runtime/src/commonTest/kotlin/org/feeluown/mobile/CapabilityDelegatingProviderTest.kt
+++ b/provider/runtime/src/commonTest/kotlin/org/feeluown/mobile/CapabilityDelegatingProviderTest.kt
@@ -137,7 +137,7 @@ private class RecordingProvider(
         track: MusicTrack,
     ): ProviderMutationResult {
         calls += "addTrackToPlaylist"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 
     override suspend fun removeTrackFromPlaylist(
@@ -145,22 +145,22 @@ private class RecordingProvider(
         track: MusicTrack,
     ): ProviderMutationResult {
         calls += "removeTrackFromPlaylist"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 
     override suspend fun createPlaylist(name: String): ProviderMutationResult {
         calls += "createPlaylist"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 
     override suspend fun deletePlaylist(playlist: ProviderPlaylist): ProviderMutationResult {
         calls += "deletePlaylist"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 
     override suspend fun setSongDisliked(track: MusicTrack, disliked: Boolean): ProviderMutationResult {
         calls += "setSongDisliked"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 
     override suspend fun mediaItemTracks(item: MediaRef): List<MusicTrack> {
@@ -209,7 +209,7 @@ private class RecordingProvider(
         favorite: Boolean,
     ): ProviderMutationResult {
         calls += "setResourceFavorite"
-        return ProviderMutationResult(true)
+        return ProviderMutationResult(success = true, message = "ok")
     }
 }
 
@@ -219,6 +219,7 @@ private fun testTrack() = MusicTrack(
     artists = "Artist",
     album = "Album",
     source = "test",
+    sourceType = TrackSourceType.Provider,
 )
 
 private fun testPlaylist() = ProviderPlaylist(

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProvider.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProvider.kt
@@ -52,7 +52,6 @@ class YtMusicProvider(
     private var configLoaded: Boolean = false
 
     override suspend fun search(keyword: String): ProviderSearchResults {
-        // Search is public; avoid OAuth Bearer which can 400 on WEB_REMIX.
         val root = innerTube("search", "{\"query\":${quote(keyword)}}", useOAuth = false)
         val tracks = mutableListOf<org.feeluown.mobile.MusicTrack>()
         collectSearchItems(root, tracks)
@@ -82,7 +81,6 @@ class YtMusicProvider(
         val formats = played.root.obj("streamingData")?.array("adaptiveFormats").orEmpty()
             .map { it.asObject() }
             .filter { it.string("mimeType").startsWith("audio/") }
-        // FeelUOwn ytdl default: m4a/bestaudio/best
         val preferred = formats.filter { it.string("mimeType").startsWith("audio/mp4") }
             .ifEmpty { formats }
             .sortedByDescending { it.int("bitrate") ?: 0 }
@@ -102,11 +100,9 @@ class YtMusicProvider(
             artists = track.artists,
             album = track.album,
             source = ID,
-            // FeelUOwn ytdl: do not set http headers, otherwise ytmusic streams may fail to play.
             headers = played.playbackHeaders,
             coverUrl = track.coverUrl,
             durationMs = selected.long("approxDurationMs") ?: track.durationMs,
-            // InnerTube's audioQuality is codec-aware; bitrate is only a fallback when absent.
             audioQuality = selected.stringOrNull("audioQuality") ?: selected.int("bitrate")?.toString(),
             providerName = NAME,
         )
@@ -123,7 +119,6 @@ class YtMusicProvider(
 
     override suspend fun playlistDetail(playlist: ProviderPlaylist, offset: Int, limit: Int): org.feeluown.mobile.ProviderPlaylistDetail {
         val (_, playlistId) = splitResourceId(playlist.id, "playlist")
-        // TV OAuth + WEB_REMIX InnerTube is unreliable for library content; prefer Data API.
         if (ensureOAuthAccessToken() != null) {
             val page = fetchOAuthPlaylistTracks(playlistId, offset = offset, limit = limit)
             return org.feeluown.mobile.ProviderPlaylistDetail(
@@ -149,8 +144,6 @@ class YtMusicProvider(
         if (feature.id == "ytmusic_user_playlists" && !authState().isLoggedIn) {
             return ProviderContentSection(feature, isLoginRequired = true)
         }
-        // OAuth Bearer + WEB_REMIX InnerTube commonly returns HTTP 400 for library shelves
-        // (ytmusicapi #813). Owned playlists are listed via YouTube Data API v3 instead.
         if (feature.id == "ytmusic_user_playlists" && ensureOAuthAccessToken() != null) {
             val playlists = fetchOAuthPlaylists()
             val page = playlists.drop(offset).take(limit)
@@ -161,13 +154,9 @@ class YtMusicProvider(
                 hasMore = playlists.size > offset + page.size,
             )
         }
-        // Public shelves must not send OAuth Bearer: WEB_REMIX + TV OAuth commonly yields HTTP 400.
-        // Cookie / Headers login keeps InnerTube for library shelves.
         val payload = when (feature.id) {
-            // ytmusicapi get_charts(country=ZZ)
             "ytmusic_toplists" ->
                 "{\"browseId\":\"FEmusic_charts\",\"formData\":{\"selectedValues\":[\"ZZ\"]}}"
-            // ytmusicapi get_library_playlists; FEmusic_liked is rejected with HTTP 400.
             "ytmusic_user_playlists" -> "{\"browseId\":\"FEmusic_liked_playlists\"}"
             else -> "{\"browseId\":\"FEmusic_home\"}"
         }
@@ -201,16 +190,6 @@ class YtMusicProvider(
         val playbackHeaders: Map<String, String>,
     )
 
-    /**
-     * FeelUOwn resolves ytmusic playback via yt-dlp (`ANDROID_VR` player → direct URL,
-     * format `m4a/bestaudio/best`, no playback headers).
-     *
-     * Mobile cannot ship yt-dlp, so we call the same InnerTube player clients yt-dlp uses.
-     * Order:
-     * 1) ANDROID_VR + visitor (yt-dlp default; without visitor → LOGIN_REQUIRED)
-     * 2) ANDROID on www.youtube.com (works without visitor)
-     * 3) WEB_REMIX + signatureTimestamp + cipher (ytmusicapi get_song)
-     */
     private suspend fun playablePlayer(videoId: String): PlayedStream? {
         ensureYoutubeVisitorId()
         if (!visitorId.isNullOrBlank()) {
@@ -257,7 +236,6 @@ class YtMusicProvider(
     private suspend fun player(videoId: String): kotlinx.serialization.json.JsonObject {
         ensureConfig()
         val sts = ensureSignatureTimestamp()
-        // ytmusicapi get_song / fuo_ytmusic song_info
         return innerTube(
             "player",
             "{" +
@@ -270,7 +248,6 @@ class YtMusicProvider(
         )
     }
 
-    /** Same client yt-dlp currently uses for YouTube stream URLs (`android_vr`). */
     private suspend fun androidVrPlayer(videoId: String): kotlinx.serialization.json.JsonObject {
         ensureConfig()
         ensureYoutubeVisitorId()
@@ -315,10 +292,6 @@ class YtMusicProvider(
         ).value.let { providerJson.parseToJsonElement(it).asObject() }
     }
 
-    /**
-     * Robust fallback used when ANDROID_VR lacks visitor data.
-     * `www.youtube.com` + ANDROID returns direct audio URLs without visitor.
-     */
     private suspend fun androidPlayer(videoId: String): kotlinx.serialization.json.JsonObject {
         ensureConfig()
         val body =
@@ -351,8 +324,6 @@ class YtMusicProvider(
         if (!visitorId.isNullOrBlank()) return
         ensureConfig()
         if (!visitorId.isNullOrBlank()) return
-        // Do not cache misses: a consent/stub page without VISITOR_DATA would poison ANDROID_VR
-        // for the whole detail TTL and force resolve() → null → 换源.
         val html = http.getText(
             ID,
             "https://www.youtube.com/watch?v=jNQXAC9IVRw",
@@ -383,12 +354,9 @@ class YtMusicProvider(
     ): kotlinx.serialization.json.JsonObject {
         ensureConfig()
         val oauthToken = if (useOAuth) ensureOAuthAccessToken() else null
-        // Match ytmusicapi / fuo_ytmusic: WEB_REMIX with hl=zh_CN and no unsupported gl=CN.
-        // YouTube Music rejects gl=CN with HTTP 400 INVALID_ARGUMENT on every InnerTube call.
         val body = if (payload.startsWith("{") && payload.endsWith("}")) {
             "{\"context\":{\"client\":{\"clientName\":\"WEB_REMIX\",\"clientVersion\":\"$clientVersion\",\"hl\":\"zh_CN\"},\"user\":{}},${payload.drop(1)}"
         } else payload
-        // Browser / public auth appends the WEB InnerTube key; OAuth omits it.
         val query = buildString {
             append("?alt=json")
             if (oauthToken == null) {
@@ -409,7 +377,6 @@ class YtMusicProvider(
     private suspend fun ytMusicHeaders(oauthToken: YtMusicOAuthToken?): Map<String, String> {
         val origin = YTM_ORIGIN
         if (oauthToken != null) {
-            // Match ytmusicapi OAUTH_CUSTOM_CLIENT headers (desktop UA + Origin, no Referer).
             return buildMap {
                 put("User-Agent", YtMusicOAuth.USER_AGENT)
                 put("Accept", "*/*")
@@ -431,7 +398,6 @@ class YtMusicProvider(
         val cookie = cookieHeader(stored)
         val sapisid = sapisidFromCookie(cookie)
         if (!sapisid.isNullOrBlank()) {
-            // Prefer a fresh SAPISIDHASH (ytmusicapi) over a stale Authorization snapshot.
             base["Authorization"] = sapisidHashAuthorization(sapisid, origin)
         }
         return base
@@ -661,7 +627,6 @@ class YtMusicProvider(
 
     private suspend fun ensureConfig() {
         if (configLoaded) return
-        // ytmusicapi fetches visitor/config without Authorization (OAuth or SAPISIDHASH).
         val html = http.getText(
             ID,
             YTM_ORIGIN,
@@ -685,7 +650,6 @@ class YtMusicProvider(
         configLoaded = true
     }
 
-    /** ytmusicapi get_signatureTimestamp / fuo_ytmusic get_cipher. */
     private suspend fun ensureSignatureTimestamp(): Int {
         signatureTimestamp?.let { return it }
         ensureConfig()
@@ -706,7 +670,6 @@ class YtMusicProvider(
                     return it
                 }
         }
-        // ytmusicapi fallback when base.js is unavailable.
         val fallback = fallbackSignatureTimestamp()
         signatureTimestamp = fallback
         return fallback
@@ -716,7 +679,6 @@ class YtMusicProvider(
         playerJsUrl?.takeIf { it.isNotBlank() }?.let { return it }
         ensureConfig()
         playerJsUrl?.takeIf { it.isNotBlank() }?.let { return it }
-        // music.youtube.com landing is sometimes a consent stub; youtube.com watch pages still expose jsUrl.
         val html = http.getText(
             ID,
             "https://www.youtube.com/watch?v=jNQXAC9IVRw",
@@ -923,162 +885,46 @@ class YtMusicProvider(
     private fun quote(value: String): String = providerJson.encodeToString(kotlinx.serialization.json.JsonPrimitive.serializer(), kotlinx.serialization.json.JsonPrimitive(value))
 
     companion object {
-        const val ID = "ytmusic"
-        const val NAME = "YouTube Music"
-        const val YTM_ORIGIN = "https://music.youtube.com"
-        const val API_BASE = "$YTM_ORIGIN/youtubei/v1"
-        const val DATA_API_BASE = "https://www.googleapis.com/youtube/v3"
-        const val YOUTUBE_API_BASE = "https://www.youtube.com/youtubei/v1"
-        // Same WEB InnerTube key used by ytmusicapi (note casing: Xya6, not xYq6).
-        const val FALLBACK_API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
-        // yt-dlp default jsless client (FeelUOwn library/ytdl.py → YoutubeDL extract_info).
-        const val ANDROID_VR_CLIENT_NAME = "28"
-        const val ANDROID_VR_CLIENT_VERSION = "1.65.10"
-        const val ANDROID_VR_USER_AGENT =
-            "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip"
-        const val ANDROID_CLIENT_NAME = "3"
-        const val ANDROID_CLIENT_VERSION = "20.10.38"
-        const val ANDROID_USER_AGENT =
-            "com.google.android.youtube/20.10.38 (Linux; U; Android 14) gzip"
-        val INFO = ProviderInfo(
-            providerId = ID,
-            providerName = NAME,
-            supportedLoginModes = setOf(
-                org.feeluown.mobile.ProviderLoginMode.Headers,
-                org.feeluown.mobile.ProviderLoginMode.OAuth,
-            ),
+        const val ID = YtMusicProviderDefinition.ID
+        const val NAME = YtMusicProviderDefinition.NAME
+        const val YTM_ORIGIN = YtMusicProviderDefinition.YTM_ORIGIN
+        const val API_BASE = YtMusicProviderDefinition.API_BASE
+        const val DATA_API_BASE = YtMusicProviderDefinition.DATA_API_BASE
+        const val YOUTUBE_API_BASE = YtMusicProviderDefinition.YOUTUBE_API_BASE
+        const val FALLBACK_API_KEY = YtMusicProviderDefinition.FALLBACK_API_KEY
+        const val ANDROID_VR_CLIENT_NAME = YtMusicProviderDefinition.ANDROID_VR_CLIENT_NAME
+        const val ANDROID_VR_CLIENT_VERSION = YtMusicProviderDefinition.ANDROID_VR_CLIENT_VERSION
+        const val ANDROID_VR_USER_AGENT = YtMusicProviderDefinition.ANDROID_VR_USER_AGENT
+        const val ANDROID_CLIENT_NAME = YtMusicProviderDefinition.ANDROID_CLIENT_NAME
+        const val ANDROID_CLIENT_VERSION = YtMusicProviderDefinition.ANDROID_CLIENT_VERSION
+        const val ANDROID_USER_AGENT = YtMusicProviderDefinition.ANDROID_USER_AGENT
+
+        val INFO: ProviderInfo get() = YtMusicProviderDefinition.info
+        val CAPABILITIES: ProviderCapabilities get() = YtMusicProviderDefinition.capabilities
+        val FEATURES: List<ProviderFeature> get() = YtMusicProviderDefinition.features
+
+        fun dynamicClientVersion(nowMillis: Long = currentTimeMillis()): String =
+            YtMusicProviderDefinition.dynamicClientVersion(nowMillis)
+
+        fun sapisidFromCookie(cookie: String): String? = YtMusicProviderDefinition.sapisidFromCookie(cookie)
+
+        fun sapisidHashAuthorization(
+            sapisid: String,
+            origin: String,
+            nowMillis: Long = currentTimeMillis(),
+        ): String = YtMusicProviderDefinition.sapisidHashAuthorization(sapisid, origin, nowMillis)
+
+        fun sha1Hex(value: String): String = YtMusicProviderDefinition.sha1Hex(value)
+        fun sha1(message: ByteArray): ByteArray = YtMusicProviderDefinition.sha1(message)
+    }
+
+    private fun utcYmd(epochMillis: Long): Triple<Int, Int, Int> {
+        val version = YtMusicProviderDefinition.dynamicClientVersion(epochMillis)
+        val date = version.substringAfter("1.").substringBefore(".01.00")
+        return Triple(
+            date.substring(0, 4).toInt(),
+            date.substring(4, 6).toInt(),
+            date.substring(6, 8).toInt(),
         )
-        val CAPABILITIES = ProviderCapabilities(providerId = ID, providerName = NAME, canAddSongToPlaylist = true)
-        val FEATURES = listOf(
-            ProviderFeature("ytmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, false),
-            ProviderFeature("ytmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, false),
-            ProviderFeature("ytmusic_toplists", ID, NAME, "排行榜", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
-            ProviderFeature("ytmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
-        )
-
-        /** ytmusicapi: `1.` + UTC `YYYYMMDD` + `.01.00`. */
-        fun dynamicClientVersion(nowMillis: Long = currentTimeMillis()): String {
-            val (year, month, day) = utcYmd(nowMillis)
-            return "1.${year.toString().padStart(4, '0')}${month.toString().padStart(2, '0')}${day.toString().padStart(2, '0')}.01.00"
-        }
-
-        private fun utcYmd(epochMillis: Long): Triple<Int, Int, Int> {
-            val days = floorDiv(epochMillis, 86_400_000L)
-            // Civil date from days since Unix epoch (Howard Hinnant algorithm).
-            val z = days + 719_468L
-            val era = floorDiv(z, 146_097L)
-            val doe = (z - era * 146_097L).toInt()
-            val yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365
-            val y = (yoe.toLong() + era * 400L).toInt()
-            val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
-            val mp = (5 * doy + 2) / 153
-            val day = doy - (153 * mp + 2) / 5 + 1
-            val month = mp + if (mp < 10) 3 else -9
-            val year = y + if (month <= 2) 1 else 0
-            return Triple(year, month, day)
-        }
-
-        private fun floorDiv(value: Long, divisor: Long): Long {
-            var result = value / divisor
-            if ((value xor divisor) < 0 && result * divisor != value) result -= 1
-            return result
-        }
-
-        fun sapisidFromCookie(cookie: String): String? {
-            if (cookie.isBlank()) return null
-            val parts = cookie.split(';').map { it.trim() }.filter { it.isNotEmpty() }
-            val values = parts.mapNotNull { part ->
-                val index = part.indexOf('=')
-                if (index <= 0) null else part.substring(0, index).trim() to part.substring(index + 1).trim()
-            }.toMap()
-            return values["__Secure-3PAPISID"]
-                ?: values["SAPISID"]
-                ?: values["__Secure-1PAPISID"]
-        }
-
-        fun sapisidHashAuthorization(sapisid: String, origin: String, nowMillis: Long = currentTimeMillis()): String {
-            val timestamp = (nowMillis / 1_000).toString()
-            val digest = sha1Hex("$timestamp $sapisid $origin")
-            return "SAPISIDHASH ${timestamp}_$digest"
-        }
-
-        fun sha1Hex(value: String): String {
-            val bytes = sha1(value.encodeToByteArray())
-            val hex = CharArray(bytes.size * 2)
-            val digits = "0123456789abcdef"
-            bytes.forEachIndexed { index, byte ->
-                val number = byte.toInt() and 0xff
-                hex[index * 2] = digits[number ushr 4]
-                hex[index * 2 + 1] = digits[number and 0x0f]
-            }
-            return hex.concatToString()
-        }
-
-        // Minimal SHA-1 for SAPISIDHASH (no platform crypto dependency in commonMain).
-        fun sha1(message: ByteArray): ByteArray {
-            val h = intArrayOf(0x67452301, 0xEFCDAB89.toInt(), 0x98BADCFE.toInt(), 0x10325476, 0xC3D2E1F0.toInt())
-            val bitLength = message.size.toLong() * 8
-            val withOne = message + byteArrayOf(0x80.toByte())
-            val padding = ((56 - withOne.size % 64) + 64) % 64
-            val padded = withOne + ByteArray(padding) + byteArrayOf(
-                (bitLength ushr 56).toByte(),
-                (bitLength ushr 48).toByte(),
-                (bitLength ushr 40).toByte(),
-                (bitLength ushr 32).toByte(),
-                (bitLength ushr 24).toByte(),
-                (bitLength ushr 16).toByte(),
-                (bitLength ushr 8).toByte(),
-                bitLength.toByte(),
-            )
-            var offset = 0
-            while (offset < padded.size) {
-                val w = IntArray(80)
-                for (i in 0 until 16) {
-                    val j = offset + i * 4
-                    w[i] = ((padded[j].toInt() and 0xff) shl 24) or
-                        ((padded[j + 1].toInt() and 0xff) shl 16) or
-                        ((padded[j + 2].toInt() and 0xff) shl 8) or
-                        (padded[j + 3].toInt() and 0xff)
-                }
-                for (i in 16 until 80) {
-                    w[i] = rotateLeft(w[i - 3] xor w[i - 8] xor w[i - 14] xor w[i - 16], 1)
-                }
-                var a = h[0]
-                var b = h[1]
-                var c = h[2]
-                var d = h[3]
-                var e = h[4]
-                for (i in 0 until 80) {
-                    val (f, k) = when {
-                        i < 20 -> ((b and c) or (b.inv() and d)) to 0x5A827999
-                        i < 40 -> (b xor c xor d) to 0x6ED9EBA1
-                        i < 60 -> ((b and c) or (b and d) or (c and d)) to 0x8F1BBCDC.toInt()
-                        else -> (b xor c xor d) to 0xCA62C1D6.toInt()
-                    }
-                    val temp = rotateLeft(a, 5) + f + e + k + w[i]
-                    e = d
-                    d = c
-                    c = rotateLeft(b, 30)
-                    b = a
-                    a = temp
-                }
-                h[0] += a
-                h[1] += b
-                h[2] += c
-                h[3] += d
-                h[4] += e
-                offset += 64
-            }
-            val out = ByteArray(20)
-            for (i in 0 until 5) {
-                out[i * 4] = (h[i] ushr 24).toByte()
-                out[i * 4 + 1] = (h[i] ushr 16).toByte()
-                out[i * 4 + 2] = (h[i] ushr 8).toByte()
-                out[i * 4 + 3] = h[i].toByte()
-            }
-            return out
-        }
-
-        private fun rotateLeft(value: Int, bits: Int): Int = (value shl bits) or (value ushr (32 - bits))
     }
 }

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderDefinition.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderDefinition.kt
@@ -1,0 +1,174 @@
+package org.feeluown.mobile.provider.ytmusic
+
+import org.feeluown.mobile.ProviderCapabilities
+import org.feeluown.mobile.ProviderContentType
+import org.feeluown.mobile.ProviderFeature
+import org.feeluown.mobile.ProviderFeatureCategory
+import org.feeluown.mobile.ProviderInfo
+import org.feeluown.mobile.provider.core.network.currentTimeMillis
+
+internal object YtMusicProviderDefinition {
+    const val ID = "ytmusic"
+    const val NAME = "YouTube Music"
+    const val YTM_ORIGIN = "https://music.youtube.com"
+    const val API_BASE = "$YTM_ORIGIN/youtubei/v1"
+    const val DATA_API_BASE = "https://www.googleapis.com/youtube/v3"
+    const val YOUTUBE_API_BASE = "https://www.youtube.com/youtubei/v1"
+    const val FALLBACK_API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
+    const val ANDROID_VR_CLIENT_NAME = "28"
+    const val ANDROID_VR_CLIENT_VERSION = "1.65.10"
+    const val ANDROID_VR_USER_AGENT =
+        "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip"
+    const val ANDROID_CLIENT_NAME = "3"
+    const val ANDROID_CLIENT_VERSION = "20.10.38"
+    const val ANDROID_USER_AGENT =
+        "com.google.android.youtube/20.10.38 (Linux; U; Android 14) gzip"
+
+    val info = ProviderInfo(
+        providerId = ID,
+        providerName = NAME,
+        supportedLoginModes = setOf(
+            org.feeluown.mobile.ProviderLoginMode.Headers,
+            org.feeluown.mobile.ProviderLoginMode.OAuth,
+        ),
+    )
+
+    val capabilities = ProviderCapabilities(
+        providerId = ID,
+        providerName = NAME,
+        canAddSongToPlaylist = true,
+    )
+
+    val features = listOf(
+        ProviderFeature("ytmusic_daily_songs", ID, NAME, "每日推荐歌曲", ProviderFeatureCategory.Recommend, ProviderContentType.Songs, false),
+        ProviderFeature("ytmusic_daily_playlists", ID, NAME, "推荐歌单", ProviderFeatureCategory.Recommend, ProviderContentType.Playlists, false),
+        ProviderFeature("ytmusic_toplists", ID, NAME, "排行榜", ProviderFeatureCategory.Music, ProviderContentType.Playlists, false),
+        ProviderFeature("ytmusic_user_playlists", ID, NAME, "我的歌单", ProviderFeatureCategory.MinePlaylists, ProviderContentType.Playlists, true),
+    )
+
+    fun dynamicClientVersion(nowMillis: Long = currentTimeMillis()): String {
+        val (year, month, day) = utcYmd(nowMillis)
+        return "1.${year.toString().padStart(4, '0')}${month.toString().padStart(2, '0')}${day.toString().padStart(2, '0')}.01.00"
+    }
+
+    fun sapisidFromCookie(cookie: String): String? {
+        if (cookie.isBlank()) return null
+        val parts = cookie.split(';').map { it.trim() }.filter { it.isNotEmpty() }
+        val values = parts.mapNotNull { part ->
+            val index = part.indexOf('=')
+            if (index <= 0) null else part.substring(0, index).trim() to part.substring(index + 1).trim()
+        }.toMap()
+        return values["__Secure-3PAPISID"]
+            ?: values["SAPISID"]
+            ?: values["__Secure-1PAPISID"]
+    }
+
+    fun sapisidHashAuthorization(
+        sapisid: String,
+        origin: String,
+        nowMillis: Long = currentTimeMillis(),
+    ): String {
+        val timestamp = (nowMillis / 1_000).toString()
+        val digest = sha1Hex("$timestamp $sapisid $origin")
+        return "SAPISIDHASH ${timestamp}_$digest"
+    }
+
+    fun sha1Hex(value: String): String {
+        val bytes = sha1(value.encodeToByteArray())
+        val hex = CharArray(bytes.size * 2)
+        val digits = "0123456789abcdef"
+        bytes.forEachIndexed { index, byte ->
+            val number = byte.toInt() and 0xff
+            hex[index * 2] = digits[number ushr 4]
+            hex[index * 2 + 1] = digits[number and 0x0f]
+        }
+        return hex.concatToString()
+    }
+
+    fun sha1(message: ByteArray): ByteArray {
+        val h = intArrayOf(0x67452301, 0xEFCDAB89.toInt(), 0x98BADCFE.toInt(), 0x10325476, 0xC3D2E1F0.toInt())
+        val bitLength = message.size.toLong() * 8
+        val withOne = message + byteArrayOf(0x80.toByte())
+        val padding = ((56 - withOne.size % 64) + 64) % 64
+        val padded = withOne + ByteArray(padding) + byteArrayOf(
+            (bitLength ushr 56).toByte(),
+            (bitLength ushr 48).toByte(),
+            (bitLength ushr 40).toByte(),
+            (bitLength ushr 32).toByte(),
+            (bitLength ushr 24).toByte(),
+            (bitLength ushr 16).toByte(),
+            (bitLength ushr 8).toByte(),
+            bitLength.toByte(),
+        )
+        var offset = 0
+        while (offset < padded.size) {
+            val w = IntArray(80)
+            for (i in 0 until 16) {
+                val j = offset + i * 4
+                w[i] = ((padded[j].toInt() and 0xff) shl 24) or
+                    ((padded[j + 1].toInt() and 0xff) shl 16) or
+                    ((padded[j + 2].toInt() and 0xff) shl 8) or
+                    (padded[j + 3].toInt() and 0xff)
+            }
+            for (i in 16 until 80) {
+                w[i] = rotateLeft(w[i - 3] xor w[i - 8] xor w[i - 14] xor w[i - 16], 1)
+            }
+            var a = h[0]
+            var b = h[1]
+            var c = h[2]
+            var d = h[3]
+            var e = h[4]
+            for (i in 0 until 80) {
+                val (f, k) = when {
+                    i < 20 -> ((b and c) or (b.inv() and d)) to 0x5A827999
+                    i < 40 -> (b xor c xor d) to 0x6ED9EBA1
+                    i < 60 -> ((b and c) or (b and d) or (c and d)) to 0x8F1BBCDC.toInt()
+                    else -> (b xor c xor d) to 0xCA62C1D6.toInt()
+                }
+                val temp = rotateLeft(a, 5) + f + e + k + w[i]
+                e = d
+                d = c
+                c = rotateLeft(b, 30)
+                b = a
+                a = temp
+            }
+            h[0] += a
+            h[1] += b
+            h[2] += c
+            h[3] += d
+            h[4] += e
+            offset += 64
+        }
+        val out = ByteArray(20)
+        for (i in 0 until 5) {
+            out[i * 4] = (h[i] ushr 24).toByte()
+            out[i * 4 + 1] = (h[i] ushr 16).toByte()
+            out[i * 4 + 2] = (h[i] ushr 8).toByte()
+            out[i * 4 + 3] = h[i].toByte()
+        }
+        return out
+    }
+
+    private fun utcYmd(epochMillis: Long): Triple<Int, Int, Int> {
+        val days = floorDiv(epochMillis, 86_400_000L)
+        val z = days + 719_468L
+        val era = floorDiv(z, 146_097L)
+        val doe = (z - era * 146_097L).toInt()
+        val yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365
+        val y = (yoe.toLong() + era * 400L).toInt()
+        val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        val mp = (5 * doy + 2) / 153
+        val day = doy - (153 * mp + 2) / 5 + 1
+        val month = mp + if (mp < 10) 3 else -9
+        val year = y + if (month <= 2) 1 else 0
+        return Triple(year, month, day)
+    }
+
+    private fun floorDiv(value: Long, divisor: Long): Long {
+        var result = value / divisor
+        if ((value xor divisor) < 0 && result * divisor != value) result -= 1
+        return result
+    }
+
+    private fun rotateLeft(value: Int, bits: Int): Int = (value shl bits) or (value ushr (32 - bits))
+}

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
@@ -5,6 +5,7 @@ import org.feeluown.mobile.ProviderDeviceAuthorizationPollResult
 import org.feeluown.mobile.ProviderOAuthToken
 import org.feeluown.mobile.ProviderSearchHit
 import org.feeluown.mobile.ProviderSearchResults
+import org.feeluown.mobile.provider.core.CapabilityDelegatingProvider
 import org.feeluown.mobile.provider.core.KotlinMusicProvider
 import org.feeluown.mobile.provider.core.KotlinProviderFactory
 import org.feeluown.mobile.provider.core.ProviderDeviceAuthorizationCapability
@@ -17,15 +18,28 @@ object YtMusicProviderFactory : KotlinProviderFactory {
     override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
         val base = YtMusicProvider(dependencies.http, dependencies.credentials)
         val content = YtMusicContentProvider(base, dependencies.http, dependencies.credentials)
-        return YtMusicApplicationProvider(content)
+        val provider = CapabilityDelegatingProvider(
+            base = base,
+            presentation = content,
+            account = content,
+            discovery = content,
+            content = content,
+            library = content,
+            playback = content,
+        )
+        return YtMusicApplicationProvider(
+            provider = provider,
+            oauth = content,
+        )
     }
 }
 
 private class YtMusicApplicationProvider(
-    private val content: YtMusicContentProvider,
-) : KotlinMusicProvider by content, ProviderDeviceAuthorizationCapability {
+    private val provider: KotlinMusicProvider,
+    private val oauth: YtMusicContentProvider,
+) : KotlinMusicProvider by provider, ProviderDeviceAuthorizationCapability {
     override suspend fun search(keyword: String): ProviderSearchResults {
-        val results = content.search(keyword)
+        val results = provider.search(keyword)
         if (results.bestMatches.isNotEmpty()) return results
         return results.copy(bestMatches = listOfNotNull(bestMatch(keyword, results)))
     }
@@ -33,7 +47,7 @@ private class YtMusicApplicationProvider(
     override suspend fun beginDeviceAuthorization(
         clientId: String,
         clientSecret: String,
-    ): ProviderDeviceAuthorization = content.beginOAuth(clientId, clientSecret).let { code ->
+    ): ProviderDeviceAuthorization = oauth.beginOAuth(clientId, clientSecret).let { code ->
         ProviderDeviceAuthorization(
             providerId = YtMusicProvider.ID,
             deviceCode = code.deviceCode,
@@ -49,7 +63,7 @@ private class YtMusicApplicationProvider(
         clientId: String,
         clientSecret: String,
     ): ProviderDeviceAuthorizationPollResult = when (
-        val result = content.pollOAuth(deviceCode, clientId, clientSecret)
+        val result = oauth.pollOAuth(deviceCode, clientId, clientSecret)
     ) {
         is YtMusicOAuthPollResult.Authorized -> ProviderDeviceAuthorizationPollResult.Authorized(
             ProviderOAuthToken(
@@ -68,7 +82,7 @@ private class YtMusicApplicationProvider(
         oauthJson: String,
         clientId: String,
         clientSecret: String,
-    ) = content.loginWithOAuthJson(oauthJson, clientId, clientSecret)
+    ) = oauth.loginWithOAuthJson(oauthJson, clientId, clientSecret)
 
     private fun bestMatch(keyword: String, results: ProviderSearchResults): ProviderSearchHit? {
         val query = normalize(keyword)


### PR DESCRIPTION
## Summary

- add a shared `CapabilityDelegatingProvider` facade in `provider:runtime`
- route provider SPI operations by account / discovery / content / library / playback capability
- migrate Bilibili, QQ Music, NetEase and YouTube Music factories to the same composition model
- make QQ Music composite dependencies injectable so one core provider instance is shared instead of nested provider construction
- extract YouTube Music provider definition / pure auth hashing helpers out of the large provider implementation
- add runtime tests for capability routing

## Intent

This is the first structural step in reducing the oversized provider implementation files. Existing provider decorators now have explicit capability ownership and unmigrated operations fall back to the core provider, so the remaining large blocks can be moved capability-by-capability without changing the external `KotlinMusicProvider` contract.

## Verification

- `:provider:runtime:allTests` is covered by the repository Android test workflow
- existing provider/shared compilation will validate the four factory compositions
