### PR TITLE
feat: publish master builds as Canary updates

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -71,6 +71,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate update scripts
+        run: bash -n scripts/build-fdroid-pages.sh scripts/write-update-manifest.sh
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -128,6 +131,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    concurrency:
+      group: fuoevolve-github-pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -17,6 +17,9 @@ name: Android APK
       - "gradle/**"
       - "gradlew"
       - "gradlew.bat"
+      - "fdroid/**"
+      - "scripts/build-fdroid-pages.sh"
+      - "scripts/write-update-manifest.sh"
       - ".github/workflows/android-apk.yml"
       - ".github/workflows/android-tests.yml"
   pull_request:
@@ -33,6 +36,9 @@ name: Android APK
       - "gradle/**"
       - "gradlew"
       - "gradlew.bat"
+      - "fdroid/**"
+      - "scripts/build-fdroid-pages.sh"
+      - "scripts/write-update-manifest.sh"
       - ".github/workflows/android-apk.yml"
       - ".github/workflows/android-tests.yml"
 
@@ -49,6 +55,7 @@ jobs:
 
   build-release-apks:
     name: Build signed multi-ABI release APK
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -114,3 +121,76 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           archive: false
           if-no-files-found: error
+
+  publish-canary-pages:
+    name: Publish master Canary update
+    needs: build-release-apks
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      FUO_SIGNING_KEYSTORE_BASE64: ${{ secrets.FUO_SIGNING_KEYSTORE_BASE64 }}
+      FUO_SIGNING_STORE_PASSWORD: ${{ secrets.FUO_SIGNING_STORE_PASSWORD }}
+      FUO_SIGNING_KEY_ALIAS: ${{ secrets.FUO_SIGNING_KEY_ALIAS }}
+      FUO_SIGNING_KEY_PASSWORD: ${{ secrets.FUO_SIGNING_KEY_PASSWORD }}
+      GH_TOKEN: ${{ github.token }}
+      FDROID_DOCKER_IMAGE: registry.gitlab.com/fdroid/docker-executable-fdroidserver:master
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Download current master APK artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: fuo-evolve-release-multi-abi-signed-${{ github.sha }}
+          path: build/canary
+
+      - name: Build F-Droid repository and Pages base
+        run: |
+          docker pull "$FDROID_DOCKER_IMAGE"
+          bash scripts/build-fdroid-pages.sh
+
+      - name: Publish current build as Canary
+        env:
+          CANARY_APK: build/canary/fuo-evolve-release-multi-abi-signed-${{ github.sha }}.apk
+          CANARY_URL: https://feeluown.github.io/FuoEvolve/update/fuo-evolve-canary.apk
+        run: |
+          test -f "$CANARY_APK"
+          mkdir -p build/pages/update
+          cp "$CANARY_APK" build/pages/update/fuo-evolve-canary.apk
+          COMMIT_SHA="$GITHUB_SHA" \
+          WORKFLOW_RUN_ID="$GITHUB_RUN_ID" \
+          RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}" \
+            bash scripts/write-update-manifest.sh \
+              canary \
+              build/pages/update/fuo-evolve-canary.apk \
+              build/pages/update/canary.json \
+              "$CANARY_URL"
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build/pages
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,7 +3,7 @@ name: Android Release
 "on":
   push:
     tags:
-      - "*"
+      - "[0-9]*"
   workflow_dispatch:
 
 jobs:
@@ -185,6 +185,9 @@ jobs:
       needs.publish-release.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: fuoevolve-github-pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -24,7 +24,7 @@ fun gitOutput(vararg args: String): String? = runCatching {
     }.standardOutput.asText.get().trim()
     output.takeIf { it.isNotBlank() }
 }.getOrNull()
-val gitVersionName = gitOutput("describe", "--tags", "--always", "--dirty")
+val gitVersionName = gitOutput("describe", "--tags", "--match", "[0-9]*", "--always", "--dirty")
     ?: "0.1.0"
 // versionCode tracks master commit count at the branch point so feature-branch
 // commits do not bump it (avoids install conflicts across branches).

--- a/scripts/build-fdroid-pages.sh
+++ b/scripts/build-fdroid-pages.sh
@@ -89,8 +89,9 @@ preserve_existing_canary() {
 
     local manifest="$CANARY_BACKUP_DIR/canary.json"
     local apk="$CANARY_BACKUP_DIR/fuo-evolve-canary.apk"
-    if curl --fail --location --silent --show-error "$UPDATE_BASE_URL/canary.json" -o "$manifest" && \
-       curl --fail --location --silent --show-error "$UPDATE_BASE_URL/fuo-evolve-canary.apk" -o "$apk"; then
+    local curl_args=(--fail --location --silent --show-error --connect-timeout 5 --max-time 30)
+    if curl "${curl_args[@]}" "$UPDATE_BASE_URL/canary.json" -o "$manifest" && \
+       curl "${curl_args[@]}" "$UPDATE_BASE_URL/fuo-evolve-canary.apk" -o "$apk"; then
         echo "Preserved existing Canary update files from GitHub Pages"
     else
         rm -f "$manifest" "$apk"
@@ -196,7 +197,7 @@ cp -a "$WORK_DIR/repo" "$PAGES_DIR/fdroid/repo"
 stable_apk_url="https://github.com/$REPOSITORY/releases/download/$latest_release_tag/$latest_release_asset_name"
 PUBLISHED_AT="$latest_release_published_at" \
 RELEASE_NOTES_URL="https://github.com/$REPOSITORY/releases/tag/$latest_release_tag" \
-    "$PROJECT_ROOT/scripts/write-update-manifest.sh" \
+    bash "$PROJECT_ROOT/scripts/write-update-manifest.sh" \
         stable \
         "$latest_release_apk" \
         "$PAGES_DIR/update/stable.json" \

--- a/scripts/build-fdroid-pages.sh
+++ b/scripts/build-fdroid-pages.sh
@@ -9,6 +9,8 @@ readonly RELEASE_LIMIT="${FDROID_RELEASE_LIMIT:-5}"
 readonly REPOSITORY="${GITHUB_REPOSITORY:-feeluown/FuoEvolve}"
 readonly PACKAGE_NAME="org.feeluown.mobile"
 readonly EXPECTED_SIGNER_SHA256="${FUO_APK_SIGNER_SHA256:-8d8be45a04cf3242c13b43361c9ffa1ca8fb2f39d1a43ce35beadfa8dbfefb74}"
+readonly UPDATE_BASE_URL="${FUO_UPDATE_BASE_URL:-https://feeluown.github.io/FuoEvolve/update}"
+readonly CANARY_BACKUP_DIR="$PROJECT_ROOT/build/canary-pages-backup"
 ANDROID_SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
 if [[ -z "$ANDROID_SDK_ROOT" && -f "$PROJECT_ROOT/local.properties" ]]; then
     ANDROID_SDK_ROOT="$(sed -n 's/^sdk\.dir=//p' "$PROJECT_ROOT/local.properties" | tail -n 1)"
@@ -81,6 +83,22 @@ run_fdroid() {
     fi
 }
 
+preserve_existing_canary() {
+    rm -rf "$CANARY_BACKUP_DIR"
+    mkdir -p "$CANARY_BACKUP_DIR"
+
+    local manifest="$CANARY_BACKUP_DIR/canary.json"
+    local apk="$CANARY_BACKUP_DIR/fuo-evolve-canary.apk"
+    if curl --fail --location --silent --show-error "$UPDATE_BASE_URL/canary.json" -o "$manifest" && \
+       curl --fail --location --silent --show-error "$UPDATE_BASE_URL/fuo-evolve-canary.apk" -o "$apk"; then
+        echo "Preserved existing Canary update files from GitHub Pages"
+    else
+        rm -f "$manifest" "$apk"
+        echo "No existing Canary update files to preserve"
+    fi
+}
+
+preserve_existing_canary
 rm -rf "$WORK_DIR" "$PAGES_DIR"
 mkdir -p "$WORK_DIR/repo" "$WORK_DIR/metadata" "$PAGES_DIR"
 
@@ -102,6 +120,10 @@ mapfile -t release_tags < <(
 )
 
 downloaded=0
+latest_release_tag=""
+latest_release_asset_name=""
+latest_release_apk=""
+latest_release_published_at=""
 for tag in "${release_tags[@]}"; do
     asset_name="$(
         gh release view "$tag" \
@@ -118,6 +140,16 @@ for tag in "${release_tags[@]}"; do
         --repo "$REPOSITORY" \
         --pattern "$asset_name" \
         --dir "$WORK_DIR/repo"
+
+    if (( downloaded == 0 )); then
+        latest_release_tag="$tag"
+        latest_release_asset_name="$asset_name"
+        latest_release_apk="$WORK_DIR/repo/$asset_name"
+        latest_release_published_at="$(
+            gh release view "$tag" --repo "$REPOSITORY" --json publishedAt --jq '.publishedAt // ""'
+        )"
+    fi
+
     downloaded=$((downloaded + 1))
     if (( downloaded >= RELEASE_LIMIT )); then
         break
@@ -158,10 +190,26 @@ done
 )
 
 cp -a "$PROJECT_ROOT/docs/." "$PAGES_DIR/"
-mkdir -p "$PAGES_DIR/fdroid"
+mkdir -p "$PAGES_DIR/fdroid" "$PAGES_DIR/update"
 cp -a "$WORK_DIR/repo" "$PAGES_DIR/fdroid/repo"
+
+stable_apk_url="https://github.com/$REPOSITORY/releases/download/$latest_release_tag/$latest_release_asset_name"
+PUBLISHED_AT="$latest_release_published_at" \
+RELEASE_NOTES_URL="https://github.com/$REPOSITORY/releases/tag/$latest_release_tag" \
+    "$PROJECT_ROOT/scripts/write-update-manifest.sh" \
+        stable \
+        "$latest_release_apk" \
+        "$PAGES_DIR/update/stable.json" \
+        "$stable_apk_url"
+
+if [[ -f "$CANARY_BACKUP_DIR/canary.json" && -f "$CANARY_BACKUP_DIR/fuo-evolve-canary.apk" ]]; then
+    cp "$CANARY_BACKUP_DIR/canary.json" "$PAGES_DIR/update/canary.json"
+    cp "$CANARY_BACKUP_DIR/fuo-evolve-canary.apk" "$PAGES_DIR/update/fuo-evolve-canary.apk"
+fi
+
 touch "$PAGES_DIR/.nojekyll"
 
 test -f "$PAGES_DIR/404.html"
 test -f "$PAGES_DIR/fdroid/repo/index-v2.json"
 test -f "$PAGES_DIR/fdroid/repo/entry.json"
+test -f "$PAGES_DIR/update/stable.json"

--- a/scripts/write-update-manifest.sh
+++ b/scripts/write-update-manifest.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 <stable|canary> <apk> <output-json> <apk-url>" >&2
+    exit 2
+fi
+
+readonly CHANNEL="$1"
+readonly APK_PATH="$2"
+readonly OUTPUT_PATH="$3"
+readonly APK_URL="$4"
+readonly PACKAGE_NAME="org.feeluown.mobile"
+
+case "$CHANNEL" in
+    stable|canary) ;;
+    *) echo "Unsupported update channel: $CHANNEL" >&2; exit 2 ;;
+esac
+
+if [[ ! -f "$APK_PATH" ]]; then
+    echo "APK does not exist: $APK_PATH" >&2
+    exit 1
+fi
+
+ANDROID_SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [[ -z "$ANDROID_SDK_ROOT" ]]; then
+    echo "ANDROID_HOME or ANDROID_SDK_ROOT is required" >&2
+    exit 1
+fi
+
+find_android_tool() {
+    local tool_name="$1"
+    local resolved
+
+    if resolved="$(command -v "$tool_name" 2>/dev/null)"; then
+        printf '%s\n' "$resolved"
+        return
+    fi
+
+    resolved="$(find "$ANDROID_SDK_ROOT/build-tools" -type f -name "$tool_name" -print | sort -V | tail -n 1)"
+    if [[ -z "$resolved" ]]; then
+        echo "Unable to find Android tool: $tool_name" >&2
+        return 1
+    fi
+    printf '%s\n' "$resolved"
+}
+
+AAPT="$(find_android_tool aapt)" || exit 1
+readonly AAPT
+
+badging="$($AAPT dump badging "$APK_PATH")"
+actual_package="$(sed -n "s/^package: name='\([^']*\)'.*/\1/p" <<< "$badging")"
+version_code="$(sed -n "s/^package:.* versionCode='\([^']*\)'.*/\1/p" <<< "$badging")"
+version_name="$(sed -n "s/^package:.* versionName='\([^']*\)'.*/\1/p" <<< "$badging")"
+
+if [[ "$actual_package" != "$PACKAGE_NAME" ]]; then
+    echo "Unexpected package in $APK_PATH: $actual_package" >&2
+    exit 1
+fi
+if [[ ! "$version_code" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid APK versionCode: $version_code" >&2
+    exit 1
+fi
+if [[ -z "$version_name" ]]; then
+    echo "Missing APK versionName" >&2
+    exit 1
+fi
+
+sha256="$(sha256sum "$APK_PATH" | awk '{print $1}')"
+size="$(stat -c '%s' "$APK_PATH")"
+published_at="${PUBLISHED_AT:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+CHANNEL="$CHANNEL" \
+VERSION_CODE="$version_code" \
+VERSION_NAME="$version_name" \
+APK_URL="$APK_URL" \
+APK_SHA256="$sha256" \
+APK_SIZE="$size" \
+PUBLISHED_AT="$published_at" \
+COMMIT_SHA="${COMMIT_SHA:-}" \
+WORKFLOW_RUN_ID="${WORKFLOW_RUN_ID:-}" \
+RELEASE_NOTES_URL="${RELEASE_NOTES_URL:-}" \
+python3 - "$OUTPUT_PATH" <<'PY'
+import json
+import os
+import sys
+
+output = sys.argv[1]
+payload = {
+    "schemaVersion": 1,
+    "channel": os.environ["CHANNEL"],
+    "versionCode": int(os.environ["VERSION_CODE"]),
+    "versionName": os.environ["VERSION_NAME"],
+    "publishedAt": os.environ["PUBLISHED_AT"],
+    "apk": {
+        "url": os.environ["APK_URL"],
+        "sha256": os.environ["APK_SHA256"],
+        "size": int(os.environ["APK_SIZE"]),
+    },
+}
+commit_sha = os.environ.get("COMMIT_SHA")
+if commit_sha:
+    payload["commitSha"] = commit_sha
+workflow_run_id = os.environ.get("WORKFLOW_RUN_ID")
+if workflow_run_id:
+    payload["workflowRunId"] = int(workflow_run_id)
+release_notes_url = os.environ.get("RELEASE_NOTES_URL")
+if release_notes_url:
+    payload["releaseNotesUrl"] = release_notes_url
+
+with open(output, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, ensure_ascii=False, indent=2)
+    handle.write("\n")
+PY
+
+printf 'Generated %s update manifest: %s (versionCode=%s, versionName=%s)\n' \
+    "$CHANNEL" "$OUTPUT_PATH" "$version_code" "$version_name"


### PR DESCRIPTION
## Summary

- define Canary as the signed APK produced by the latest successful `master` Android APK workflow
- publish that exact APK to a stable GitHub Pages URL together with a machine-readable `canary.json`
- generate `stable.json` from the latest stable GitHub Release while rebuilding the existing F-Droid Pages site
- preserve the previously published Canary files when the stable release workflow rebuilds Pages
- make release APK builds depend on the shared Android test job so failed master CI cannot become the latest Canary
- keep `versionName` based only on numeric stable tags so update-channel infrastructure cannot pollute app version names
- restrict the release workflow to numeric stable tags and serialize Stable/Canary Pages deployments to prevent concurrent overwrites

## Update endpoints

After the first successful `master` run following merge:

- `https://feeluown.github.io/FuoEvolve/update/stable.json`
- `https://feeluown.github.io/FuoEvolve/update/canary.json`
- `https://feeluown.github.io/FuoEvolve/update/fuo-evolve-canary.apk`

`canary.json` records the master commit SHA and workflow run ID. Both manifests include APK versionCode/versionName, SHA-256, size, publication time and download URL.

## Architecture / compatibility

No Canary tag or GitHub Release is introduced. GitHub Actions Artifact remains the authoritative Canary build output; Pages only exposes the same APK through a stable public URL suitable for the future in-app updater.

The existing F-Droid Pages deployment remains intact and now also emits stable update metadata. Existing Canary files are best-effort preserved during stable Pages rebuilds.

## Validation

- PR CI runs the shared Android test workflow before building the signed APK.
- The APK build validates the new update shell scripts with `bash -n`.
- The Pages deployment job is gated to `push` on `master`, so the public Canary endpoint can only be created/updated from a successful master build.
- Stable and Canary Pages jobs share a concurrency group so they cannot deploy the site at the same time.