### PR TITLE
ci: reduce master Android build time

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -48,6 +48,8 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/android-tests.yml
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   build-release-apks:
     name: Build signed multi-ABI release APK
@@ -78,6 +80,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           build-scan-publish: true
           build-scan-terms-of-use-url: https://gradle.com/terms-of-service
           build-scan-terms-of-use-agree: "yes"

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Prepare Git refs for Gradle versioning
+        run: git branch --force master origin/master
+
       - name: Validate update manifest script
         run: bash -n scripts/write-update-manifest.sh
 

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -67,7 +67,10 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare Git refs for Gradle versioning
-        run: git branch --force master origin/master
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
 
       - name: Validate update manifest script
         run: bash -n scripts/write-update-manifest.sh

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -51,7 +51,6 @@ jobs:
 
   build-release-apks:
     name: Build signed multi-ABI release APK
-    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -123,7 +122,9 @@ jobs:
 
   publish-canary:
     name: Publish master Canary update
-    needs: build-release-apks
+    needs:
+      - test
+      - build-release-apks
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -48,8 +48,6 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/android-tests.yml
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   build-release-apks:
     name: Build signed multi-ABI release APK
@@ -100,7 +98,16 @@ jobs:
           printf '%s' "$FUO_SIGNING_KEYSTORE_BASE64" | base64 --decode > "$FUO_SIGNING_STORE_FILE"
 
       - name: Build signed release APK
-        run: ./gradlew :androidApp:assembleRelease
+        env:
+          GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        run: |
+          if [ -n "$GRADLE_ENCRYPTION_KEY" ]; then
+            echo "Using Gradle configuration cache."
+            ./gradlew --configuration-cache :androidApp:assembleRelease
+          else
+            echo "::warning::GRADLE_ENCRYPTION_KEY is not configured; configuration cache persistence is disabled."
+            ./gradlew --no-configuration-cache :androidApp:assembleRelease
+          fi
 
       - name: Prepare signed release APK artifact
         id: artifact

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -2,6 +2,9 @@ name: Android Tests
 
 "on":
   workflow_call:
+    secrets:
+      GRADLE_ENCRYPTION_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -26,12 +29,19 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Run architecture checks, Android unit tests and coverage
+      - name: Run architecture checks
         run: >-
           ./gradlew
+          --no-configuration-cache
           checkArchitectureBoundaries
           :feature:playback:checkPlaybackFeatureBoundaries
+
+      - name: Run Android unit tests and coverage
+        run: >-
+          ./gradlew
           :feature:recognition:testDebugUnitTest
           :feature:search:testDebugUnitTest
           :feature:localplaylist:testDebugUnitTest

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test:
-    name: Run shared tests and coverage
+    name: Run Android tests and coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -27,5 +27,24 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run architecture checks, feature/playback/provider runtime tests, shared tests and coverage
-        run: ./gradlew checkArchitectureBoundaries :feature:recognition:allTests :feature:search:allTests :feature:localplaylist:allTests :feature:localmusic:allTests :feature:download:allTests :feature:providercatalog:allTests :feature:providerauth:allTests :feature:providerdetail:allTests :feature:settings:allTests :feature:onboarding:allTests :feature:home:allTests :feature:playback:allTests :playback:runtime:allTests :provider:runtime:allTests :shared:allTests :shared:koverXmlReportDebug
+      - name: Run architecture checks, Android unit tests and coverage
+        run: >-
+          ./gradlew
+          checkArchitectureBoundaries
+          :feature:playback:checkPlaybackFeatureBoundaries
+          :feature:recognition:testDebugUnitTest
+          :feature:search:testDebugUnitTest
+          :feature:localplaylist:testDebugUnitTest
+          :feature:localmusic:testDebugUnitTest
+          :feature:download:testDebugUnitTest
+          :feature:providercatalog:testDebugUnitTest
+          :feature:providerauth:testDebugUnitTest
+          :feature:providerdetail:testDebugUnitTest
+          :feature:settings:testDebugUnitTest
+          :feature:onboarding:testDebugUnitTest
+          :feature:home:testDebugUnitTest
+          :feature:playback:testDebugUnitTest
+          :playback:runtime:testDebugUnitTest
+          :provider:runtime:testDebugUnitTest
+          :shared:testDebugUnitTest
+          :shared:koverXmlReportDebug

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -2,9 +2,6 @@ name: Android Tests
 
 "on":
   workflow_call:
-    secrets:
-      GRADLE_ENCRYPTION_KEY:
-        required: false
 
 permissions:
   contents: read
@@ -21,9 +18,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Prepare Git refs for Gradle versioning
-        run: git branch --force master origin/master
-
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -32,19 +26,12 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Run architecture checks
+      - name: Run architecture checks, Android unit tests and coverage
         run: >-
           ./gradlew
-          --no-configuration-cache
           checkArchitectureBoundaries
           :feature:playback:checkPlaybackFeatureBoundaries
-
-      - name: Run Android unit tests and coverage
-        run: >-
-          ./gradlew
           :feature:recognition:testDebugUnitTest
           :feature:search:testDebugUnitTest
           :feature:localplaylist:testDebugUnitTest

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -31,7 +31,14 @@ jobs:
         run: >-
           ./gradlew
           checkArchitectureBoundaries
+          :feature:download:checkOfflineFeatureBoundaries
+          :feature:providerauth:checkProviderFeatureBoundaries
+          :feature:providerdetail:checkProviderDetailFeatureBoundaries
+          :feature:settings:checkSettingsFeatureBoundaries
+          :feature:onboarding:checkOnboardingFeatureBoundaries
+          :feature:home:checkHomeFeatureBoundaries
           :feature:playback:checkPlaybackFeatureBoundaries
+          :shared:checkP4ContractBoundaries
           :feature:recognition:testDebugUnitTest
           :feature:search:testDebugUnitTest
           :feature:localplaylist:testDebugUnitTest
@@ -46,5 +53,10 @@ jobs:
           :feature:playback:testDebugUnitTest
           :playback:runtime:testDebugUnitTest
           :provider:runtime:testDebugUnitTest
+          :persistence:settings:testDebugUnitTest
+          :provider:bilibili:testDebugUnitTest
+          :provider:netease:testDebugUnitTest
+          :provider:qqmusic:testDebugUnitTest
+          :provider:ytmusic:testDebugUnitTest
           :shared:testDebugUnitTest
           :shared:koverXmlReportDebug

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Prepare Git refs for Gradle versioning
+        run: git branch --force master origin/master
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.caching=true
-org.gradle.configuration-cache=true
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.caching=true
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
## Summary

- run Android tests and signed Release APK build in parallel
- keep Canary publishing gated on both jobs succeeding
- replace broad KMP `allTests` aggregation with Android Debug unit-test tasks while preserving equivalent Android CI coverage
- explicitly retain all custom architecture/boundary checks
- explicitly retain settings persistence and Bilibili / NetEase / QQ Music / YouTube Music provider Android tests
- keep Kover coverage reporting
- enable Gradle build cache globally
- add Gradle configuration-cache support for the signed Release build
- safely fall back to a normal Release build when `GRADLE_ENCRYPTION_KEY` is not configured

## Why

The previous master workflow serialized a ~5 minute test job and ~6 minute Release build, while the Android test workflow invoked `allTests` for every KMP module. The optimization reduces wall-clock time by parallelizing the jobs and restricting CI tests to the Android target without dropping the custom verification tasks or provider/persistence tests previously pulled in indirectly by `allTests`.

Configuration-cache validation found custom architecture-boundary tasks that access Gradle Project/script state during execution. Enabling configuration cache for the test job would require splitting those checks into another Gradle invocation, adding startup/configuration overhead and largely cancelling the benefit. The test pipeline therefore remains a single Gradle invocation and relies on the build cache.

The Release task has no equivalent incompatibility and has been validated in strict configuration-cache mode. Cross-run configuration-cache persistence is enabled when the repository provides `GRADLE_ENCRYPTION_KEY`, as required by `gradle/actions/setup-gradle`; otherwise CI emits a warning and runs with `--no-configuration-cache`.

## Validation

Latest CI run on head `4bc6652098b58838c8ff6f10c8ae0cb2191ce51e` succeeded.

- Android tests + architecture checks: Gradle `BUILD SUCCESSFUL in 2m 4s`
- test task count: 390 actionable tasks, 261 executed, 129 from cache
- test job wall clock: ~2m22s
- original Android test job: ~5m15s / 858 actionable tasks
- signed Release APK: Gradle `BUILD SUCCESSFUL in 3m 33s`
- Release task count: 945 actionable tasks, 783 executed, 162 from cache
- Release job wall clock: ~3m56s
- Release fallback path without `GRADLE_ENCRYPTION_KEY` validated successfully
- strict configuration-cache `:androidApp:assembleRelease` validation succeeded in an earlier run and stored a configuration-cache entry
- Release keeps R8/resource shrinking unchanged
- PR and master Git-ref handling is supported for git-derived Android versioning

## Review feedback addressed

- restored `:persistence:settings:testDebugUnitTest`
- restored Android unit tests for Bilibili, NetEase, QQ Music, and YouTube Music providers
- restored offline, provider auth/catalog, provider detail, settings, onboarding, home, playback, shared P4, and root architecture boundary checks

## Repository setup

To enable cross-run Release configuration-cache reuse, add an Actions repository secret named `GRADLE_ENCRYPTION_KEY`. A suitable value can be generated with `openssl rand -base64 16`.