### PR TITLE
ci: parallelize Android release validation

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -19,6 +19,7 @@ name: Android APK
       - "gradlew.bat"
       - "scripts/write-update-manifest.sh"
       - ".github/workflows/android-apk.yml"
+      - ".github/workflows/android-release.yml"
       - ".github/workflows/android-tests.yml"
   pull_request:
     paths:
@@ -36,6 +37,7 @@ name: Android APK
       - "gradlew.bat"
       - "scripts/write-update-manifest.sh"
       - ".github/workflows/android-apk.yml"
+      - ".github/workflows/android-release.yml"
       - ".github/workflows/android-tests.yml"
 
 concurrency:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -16,7 +16,6 @@ jobs:
   build-release-apks:
     name: Build signed multi-ABI release APK
     if: github.event_name == 'push'
-    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -34,6 +33,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -43,6 +48,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           build-scan-publish: true
           build-scan-terms-of-use-url: https://gradle.com/terms-of-service
           build-scan-terms-of-use-agree: "yes"
@@ -59,7 +65,16 @@ jobs:
           printf '%s' "$FUO_SIGNING_KEYSTORE_BASE64" | base64 --decode > "$FUO_SIGNING_STORE_FILE"
 
       - name: Build signed release APK
-        run: ./gradlew :androidApp:assembleRelease
+        env:
+          GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        run: |
+          if [ -n "$GRADLE_ENCRYPTION_KEY" ]; then
+            echo "Using Gradle configuration cache."
+            ./gradlew --configuration-cache :androidApp:assembleRelease
+          else
+            echo "::warning::GRADLE_ENCRYPTION_KEY is not configured; configuration cache persistence is disabled."
+            ./gradlew --no-configuration-cache :androidApp:assembleRelease
+          fi
 
       - name: Prepare release APK asset
         id: asset
@@ -87,7 +102,9 @@ jobs:
 
   publish-release:
     name: Publish signed release APKs
-    needs: build-release-apks
+    needs:
+      - test
+      - build-release-apks
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

- run release tests and signed APK build in parallel
- keep GitHub Release publishing gated on both jobs succeeding
- align the release APK build with master CI Gradle build/configuration-cache handling
- prepare the local `master` ref for git-derived Gradle versioning on tag builds
- make changes to `android-release.yml` trigger the Android APK validation workflow in PRs and on master

## Flow

Before:

`test -> build-release-apks -> publish-release -> publish-fdroid-pages`

After:

`test + build-release-apks (parallel) -> publish-release -> publish-fdroid-pages`

`publish-release` explicitly depends on both validation jobs, so the release gate is unchanged: publishing only starts after tests and the signed APK build both succeed. F-Droid Pages remains downstream of `publish-release`.

## Gradle alignment

The signed release build now matches the master APK workflow:

- uses the global Gradle build cache
- supplies `GRADLE_ENCRYPTION_KEY` to `setup-gradle`
- uses `--configuration-cache` when the key exists
- safely falls back to `--no-configuration-cache` when it does not

## Validation

Android APK validation run `33287815286` succeeded on head `3c0064e4e84ba34f624822002c03446b96b9877a`.

- test and signed Release APK jobs started together and ran concurrently
- Android tests + architecture checks: `BUILD SUCCESSFUL in 27s`
- test tasks: 390 actionable, 125 executed, 265 from cache
- test job wall clock: ~37s
- signed Release APK: `BUILD SUCCESSFUL in 4m 15s`
- Release tasks: 945 actionable, 597 executed, 348 from cache
- Release job wall clock: ~4m37s
- `GRADLE_ENCRYPTION_KEY` was detected and the strict `--configuration-cache` path was exercised
- Gradle reported `Configuration cache entry stored.` for the Release build
- signed APK artifact upload succeeded

The actual tag-triggered release/publish path was not invoked during PR validation because doing so would publish a release. Its dependency graph and existing publish/F-Droid behavior are preserved except for the intended test/build parallelization.

No release packaging, signing, generated notes, latest-release behavior, or F-Droid Pages ordering is changed.