### PR TITLE
fix: align rich lyric secondary tracks correctly

### DIFF
--- a/core/model/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
+++ b/core/model/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
@@ -95,6 +95,24 @@ private fun composeRichLyricsTransport(
 
 private data class TimedRichText(val timeMs: Long, val text: String)
 
+private data class RichAlignmentScore(
+    val matches: Int = 0,
+    val semanticMismatches: Int = 0,
+    val totalDistanceMs: Long = 0L,
+) {
+    fun withMatch(semanticMismatch: Boolean, distanceMs: Long): RichAlignmentScore = copy(
+        matches = matches + 1,
+        semanticMismatches = semanticMismatches + if (semanticMismatch) 1 else 0,
+        totalDistanceMs = totalDistanceMs + distanceMs,
+    )
+
+    fun isBetterThan(other: RichAlignmentScore): Boolean = when {
+        matches != other.matches -> matches > other.matches
+        semanticMismatches != other.semanticMismatches -> semanticMismatches < other.semanticMismatches
+        else -> totalDistanceMs < other.totalDistanceMs
+    }
+}
+
 /**
  * NetEase YRC may prepend JSON metadata lines such as composer/arranger credits.
  * They are not lyric text and the YRC parser intentionally does not render them.
@@ -146,38 +164,70 @@ private fun alignSecondaryRichTrack(
     secondary: List<TimedRichText>,
 ): Map<Int, String> {
     if (primary.isEmpty() || secondary.isEmpty()) return emptyMap()
-    val aligned = mutableMapOf<Int, String>()
-    var minimumPrimaryIndex = 0
 
-    secondary.forEachIndexed { secondaryIndex, secondaryLine ->
-        val secondaryIsCredit = isLikelyLyricCreditText(secondaryLine.text)
-        val nearestIndex = (minimumPrimaryIndex until primary.size)
-            .asSequence()
-            .filter { primaryIndex ->
-                abs(primary[primaryIndex].timeMs - secondaryLine.timeMs) <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS
-            }
-            .minWithOrNull(
-                compareBy<Int> { primaryIndex ->
-                    if (isLikelyLyricCreditText(primary[primaryIndex].text) == secondaryIsCredit) 0 else 1
-                }.thenBy { primaryIndex ->
-                    abs(primary[primaryIndex].timeMs - secondaryLine.timeMs)
-                }.thenBy { it },
-            )
-        val fallbackIndex = if (
-            nearestIndex == null &&
-            primary.size == secondary.size &&
-            secondaryIndex >= minimumPrimaryIndex &&
-            abs(primary[secondaryIndex].timeMs - secondaryLine.timeMs) <= RICH_LYRIC_INDEX_TOLERANCE_MS
-        ) {
-            secondaryIndex
-        } else {
-            null
+    val primarySize = primary.size
+    val secondarySize = secondary.size
+    val hasNormalCandidate = BooleanArray(secondarySize) { secondaryIndex ->
+        primary.any { primaryLine ->
+            abs(primaryLine.timeMs - secondary[secondaryIndex].timeMs) <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS
         }
-        val primaryIndex = nearestIndex ?: fallbackIndex ?: return@forEachIndexed
-        aligned[primaryIndex] = secondaryLine.text
-        minimumPrimaryIndex = primaryIndex + 1
+    }
+    val scores = Array(primarySize + 1) {
+        Array(secondarySize + 1) { RichAlignmentScore() }
+    }
+    val actions = Array(primarySize) { IntArray(secondarySize) }
+
+    for (primaryIndex in primarySize - 1 downTo 0) {
+        for (secondaryIndex in secondarySize - 1 downTo 0) {
+            var bestScore = scores[primaryIndex + 1][secondaryIndex]
+            var bestAction = RICH_ALIGNMENT_SKIP_PRIMARY
+
+            val skipSecondaryScore = scores[primaryIndex][secondaryIndex + 1]
+            if (skipSecondaryScore.isBetterThan(bestScore)) {
+                bestScore = skipSecondaryScore
+                bestAction = RICH_ALIGNMENT_SKIP_SECONDARY
+            }
+
+            val primaryLine = primary[primaryIndex]
+            val secondaryLine = secondary[secondaryIndex]
+            val distanceMs = abs(primaryLine.timeMs - secondaryLine.timeMs)
+            val normalMatch = distanceMs <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS
+            val indexFallbackMatch =
+                !hasNormalCandidate[secondaryIndex] &&
+                    primarySize == secondarySize &&
+                    primaryIndex == secondaryIndex &&
+                    distanceMs <= RICH_LYRIC_INDEX_TOLERANCE_MS
+            if (normalMatch || indexFallbackMatch) {
+                val matchScore = scores[primaryIndex + 1][secondaryIndex + 1].withMatch(
+                    semanticMismatch = isLikelyLyricCreditText(primaryLine.text) !=
+                        isLikelyLyricCreditText(secondaryLine.text),
+                    distanceMs = distanceMs,
+                )
+                if (!bestScore.isBetterThan(matchScore)) {
+                    bestScore = matchScore
+                    bestAction = RICH_ALIGNMENT_MATCH
+                }
+            }
+
+            scores[primaryIndex][secondaryIndex] = bestScore
+            actions[primaryIndex][secondaryIndex] = bestAction
+        }
     }
 
+    val aligned = mutableMapOf<Int, String>()
+    var primaryIndex = 0
+    var secondaryIndex = 0
+    while (primaryIndex < primarySize && secondaryIndex < secondarySize) {
+        when (actions[primaryIndex][secondaryIndex]) {
+            RICH_ALIGNMENT_MATCH -> {
+                aligned[primaryIndex] = secondary[secondaryIndex].text
+                primaryIndex += 1
+                secondaryIndex += 1
+            }
+            RICH_ALIGNMENT_SKIP_SECONDARY -> secondaryIndex += 1
+            else -> primaryIndex += 1
+        }
+    }
     return aligned
 }
 
@@ -211,5 +261,8 @@ private val lyricCreditPrefixRegex = Regex(
     """^\s*(?:(?:作词|作詞|作曲|编曲|編曲|填词|填詞|混音|制作人|製作人|监制|監製|原唱|演唱|歌手|和声|和聲|录音|錄音|母带|母帶|吉他|贝斯|貝斯|鼓|弦乐|弦樂|词|詞|曲)|(?:lyrics?|lyricist|composer|arranger|producer|vocals?|singer|mix(?:ing)?|master(?:ing)?|written\s+by|music\s+by))\s*(?:[:：/]|-\s+)""",
     RegexOption.IGNORE_CASE,
 )
+private const val RICH_ALIGNMENT_SKIP_PRIMARY = 1
+private const val RICH_ALIGNMENT_SKIP_SECONDARY = 2
+private const val RICH_ALIGNMENT_MATCH = 3
 private const val RICH_LYRIC_ALIGNMENT_TOLERANCE_MS = 350L
 private const val RICH_LYRIC_INDEX_TOLERANCE_MS = 1_500L

--- a/core/model/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
+++ b/core/model/src/commonMain/kotlin/org/feeluown/mobile/RichLyrics.kt
@@ -43,22 +43,25 @@ fun composeRichLyrics(
     val secondary = when {
         secondaryTracks.isEmpty() -> null
         primaryLines.isEmpty() || parsedTracks.isEmpty() -> secondaryTracks.first()
-        else -> buildString {
-            primaryLines.forEachIndexed { index, line ->
-                val values = parsedTracks.mapNotNull { track ->
-                    alignedSecondaryText(track, line.timeMs, index, primaryLines.size)
-                }
-                    .map(String::trim)
-                    .filter(String::isNotBlank)
-                    .filter { it != line.text.trim() }
-                    .distinct()
-                values.forEach { value ->
-                    append(formatRichLrcTimestamp(line.timeMs))
-                    append(value)
-                    append('\n')
-                }
+        else -> {
+            val alignedTracks = parsedTracks.map { track ->
+                alignSecondaryRichTrack(primaryLines, track)
             }
-        }.trimEnd().takeIf(String::isNotBlank)
+            buildString {
+                primaryLines.forEachIndexed { index, line ->
+                    val values = alignedTracks.mapNotNull { track -> track[index] }
+                        .map(String::trim)
+                        .filter(String::isNotBlank)
+                        .filter { it != line.text.trim() }
+                        .distinct()
+                    values.forEach { value ->
+                        append(formatRichLrcTimestamp(line.timeMs))
+                        append(value)
+                        append('\n')
+                    }
+                }
+            }.trimEnd().takeIf(String::isNotBlank)
+        }
     }
 
     return composeRichLyricsTransport(
@@ -138,20 +141,48 @@ private fun parseTimedRichTrack(raw: String): List<TimedRichText> = buildList {
     }
 }.sortedBy(TimedRichText::timeMs)
 
-private fun alignedSecondaryText(
-    track: List<TimedRichText>,
-    primaryTimeMs: Long,
-    primaryIndex: Int,
-    primarySize: Int,
-): String? {
-    val nearest = track.minByOrNull { abs(it.timeMs - primaryTimeMs) }
-    if (nearest != null && abs(nearest.timeMs - primaryTimeMs) <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS) {
-        return nearest.text
+private fun alignSecondaryRichTrack(
+    primary: List<TimedRichText>,
+    secondary: List<TimedRichText>,
+): Map<Int, String> {
+    if (primary.isEmpty() || secondary.isEmpty()) return emptyMap()
+    val aligned = mutableMapOf<Int, String>()
+    var minimumPrimaryIndex = 0
+
+    secondary.forEachIndexed { secondaryIndex, secondaryLine ->
+        val secondaryIsCredit = isLikelyLyricCreditText(secondaryLine.text)
+        val nearestIndex = (minimumPrimaryIndex until primary.size)
+            .asSequence()
+            .filter { primaryIndex ->
+                abs(primary[primaryIndex].timeMs - secondaryLine.timeMs) <= RICH_LYRIC_ALIGNMENT_TOLERANCE_MS
+            }
+            .minWithOrNull(
+                compareBy<Int> { primaryIndex ->
+                    if (isLikelyLyricCreditText(primary[primaryIndex].text) == secondaryIsCredit) 0 else 1
+                }.thenBy { primaryIndex ->
+                    abs(primary[primaryIndex].timeMs - secondaryLine.timeMs)
+                }.thenBy { it },
+            )
+        val fallbackIndex = if (
+            nearestIndex == null &&
+            primary.size == secondary.size &&
+            secondaryIndex >= minimumPrimaryIndex &&
+            abs(primary[secondaryIndex].timeMs - secondaryLine.timeMs) <= RICH_LYRIC_INDEX_TOLERANCE_MS
+        ) {
+            secondaryIndex
+        } else {
+            null
+        }
+        val primaryIndex = nearestIndex ?: fallbackIndex ?: return@forEachIndexed
+        aligned[primaryIndex] = secondaryLine.text
+        minimumPrimaryIndex = primaryIndex + 1
     }
-    return track.getOrNull(primaryIndex)
-        ?.takeIf { track.size == primarySize && abs(it.timeMs - primaryTimeMs) <= RICH_LYRIC_INDEX_TOLERANCE_MS }
-        ?.text
+
+    return aligned
 }
+
+private fun isLikelyLyricCreditText(text: String): Boolean =
+    lyricCreditPrefixRegex.containsMatchIn(text.trim())
 
 private fun parseRichLrcTime(match: MatchResult): Long? {
     val minutes = match.groupValues[1].toLongOrNull() ?: return null
@@ -176,5 +207,9 @@ private fun formatRichLrcTimestamp(timeMs: Long): String {
 private val richLrcTimestampRegex = Regex("""\[(\d{1,3}):(\d{1,2})(?:\.(\d{1,3}))?]""")
 private val richWordLineRegex = Regex("""^\[(\d+),(\d+)](.*)$""")
 private val richWordTimestampRegex = Regex("""\(\d+,\d+(?:,\d+)?\)""")
+private val lyricCreditPrefixRegex = Regex(
+    """^\s*(?:(?:作词|作詞|作曲|编曲|編曲|填词|填詞|混音|制作人|製作人|监制|監製|原唱|演唱|歌手|和声|和聲|录音|錄音|母带|母帶|吉他|贝斯|貝斯|鼓|弦乐|弦樂|词|詞|曲)|(?:lyrics?|lyricist|composer|arranger|producer|vocals?|singer|mix(?:ing)?|master(?:ing)?|written\s+by|music\s+by))\s*(?:[:：/]|-\s+)""",
+    RegexOption.IGNORE_CASE,
+)
 private const val RICH_LYRIC_ALIGNMENT_TOLERANCE_MS = 350L
 private const val RICH_LYRIC_INDEX_TOLERANCE_MS = 1_500L

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsParsing.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsParsing.kt
@@ -21,6 +21,24 @@ private data class RawLyricLine(
     val order: Int,
 )
 
+private data class SecondaryAlignmentScore(
+    val matches: Int = 0,
+    val semanticMismatches: Int = 0,
+    val totalDistanceMs: Long = 0L,
+) {
+    fun withMatch(semanticMismatch: Boolean, distanceMs: Long): SecondaryAlignmentScore = copy(
+        matches = matches + 1,
+        semanticMismatches = semanticMismatches + if (semanticMismatch) 1 else 0,
+        totalDistanceMs = totalDistanceMs + distanceMs,
+    )
+
+    fun isBetterThan(other: SecondaryAlignmentScore): Boolean = when {
+        matches != other.matches -> matches > other.matches
+        semanticMismatches != other.semanticMismatches -> semanticMismatches < other.semanticMismatches
+        else -> totalDistanceMs < other.totalDistanceMs
+    }
+}
+
 const val LYRIC_TRANSLATION_MARKER = "\n__FUO_LYRIC_TRANSLATION__\n"
 const val LYRIC_ROMANIZATION_MARKER = "\n__FUO_LYRIC_ROMANIZATION__\n"
 
@@ -149,42 +167,69 @@ private fun alignSecondaryLyricLines(
     }
     if (timedPrimary.isEmpty() || secondary.isEmpty()) return emptyMap()
 
-    val aligned = mutableMapOf<Int, LyricLine>()
-    var minimumPrimaryPosition = 0
-    secondary.forEachIndexed { secondaryIndex, secondaryLine ->
-        val secondaryIsCredit = isLikelyLyricCreditText(secondaryLine.text)
-        val nearestPosition = (minimumPrimaryPosition until timedPrimary.size)
-            .asSequence()
-            .filter { primaryPosition ->
-                kotlin.math.abs(timedPrimary[primaryPosition].second.timeMs - secondaryLine.timeMs) <= toleranceMs
-            }
-            .minWithOrNull(
-                compareBy<Int> { primaryPosition ->
-                    if (
-                        isLikelyLyricCreditText(timedPrimary[primaryPosition].second.text) == secondaryIsCredit
-                    ) {
-                        0
-                    } else {
-                        1
-                    }
-                }.thenBy { primaryPosition ->
-                    kotlin.math.abs(timedPrimary[primaryPosition].second.timeMs - secondaryLine.timeMs)
-                }.thenBy { it },
-            )
-        val fallbackPosition = if (
-            nearestPosition == null &&
-            indexToleranceMs != null &&
-            timedPrimary.size == secondary.size &&
-            secondaryIndex >= minimumPrimaryPosition &&
-            kotlin.math.abs(timedPrimary[secondaryIndex].second.timeMs - secondaryLine.timeMs) <= indexToleranceMs
-        ) {
-            secondaryIndex
-        } else {
-            null
+    val primarySize = timedPrimary.size
+    val secondarySize = secondary.size
+    val hasNormalCandidate = BooleanArray(secondarySize) { secondaryIndex ->
+        timedPrimary.any { (_, primaryLine) ->
+            kotlin.math.abs(primaryLine.timeMs - secondary[secondaryIndex].timeMs) <= toleranceMs
         }
-        val primaryPosition = nearestPosition ?: fallbackPosition ?: return@forEachIndexed
-        aligned[timedPrimary[primaryPosition].first] = secondaryLine
-        minimumPrimaryPosition = primaryPosition + 1
+    }
+    val scores = Array(primarySize + 1) {
+        Array(secondarySize + 1) { SecondaryAlignmentScore() }
+    }
+    val actions = Array(primarySize) { IntArray(secondarySize) }
+
+    for (primaryPosition in primarySize - 1 downTo 0) {
+        for (secondaryIndex in secondarySize - 1 downTo 0) {
+            var bestScore = scores[primaryPosition + 1][secondaryIndex]
+            var bestAction = ALIGNMENT_SKIP_PRIMARY
+
+            val skipSecondaryScore = scores[primaryPosition][secondaryIndex + 1]
+            if (skipSecondaryScore.isBetterThan(bestScore)) {
+                bestScore = skipSecondaryScore
+                bestAction = ALIGNMENT_SKIP_SECONDARY
+            }
+
+            val primaryLine = timedPrimary[primaryPosition].second
+            val secondaryLine = secondary[secondaryIndex]
+            val distanceMs = kotlin.math.abs(primaryLine.timeMs - secondaryLine.timeMs)
+            val normalMatch = distanceMs <= toleranceMs
+            val indexFallbackMatch =
+                !hasNormalCandidate[secondaryIndex] &&
+                    indexToleranceMs != null &&
+                    primarySize == secondarySize &&
+                    primaryPosition == secondaryIndex &&
+                    distanceMs <= indexToleranceMs
+            if (normalMatch || indexFallbackMatch) {
+                val matchScore = scores[primaryPosition + 1][secondaryIndex + 1].withMatch(
+                    semanticMismatch = isLikelyLyricCreditText(primaryLine.text) !=
+                        isLikelyLyricCreditText(secondaryLine.text),
+                    distanceMs = distanceMs,
+                )
+                if (!bestScore.isBetterThan(matchScore)) {
+                    bestScore = matchScore
+                    bestAction = ALIGNMENT_MATCH
+                }
+            }
+
+            scores[primaryPosition][secondaryIndex] = bestScore
+            actions[primaryPosition][secondaryIndex] = bestAction
+        }
+    }
+
+    val aligned = mutableMapOf<Int, LyricLine>()
+    var primaryPosition = 0
+    var secondaryIndex = 0
+    while (primaryPosition < primarySize && secondaryIndex < secondarySize) {
+        when (actions[primaryPosition][secondaryIndex]) {
+            ALIGNMENT_MATCH -> {
+                aligned[timedPrimary[primaryPosition].first] = secondary[secondaryIndex]
+                primaryPosition += 1
+                secondaryIndex += 1
+            }
+            ALIGNMENT_SKIP_SECONDARY -> secondaryIndex += 1
+            else -> primaryPosition += 1
+        }
     }
     return aligned
 }
@@ -192,6 +237,9 @@ private fun alignSecondaryLyricLines(
 private fun isLikelyLyricCreditText(text: String): Boolean =
     lyricCreditPrefixRegex.containsMatchIn(text.trim())
 
+private const val ALIGNMENT_SKIP_PRIMARY = 1
+private const val ALIGNMENT_SKIP_SECONDARY = 2
+private const val ALIGNMENT_MATCH = 3
 private const val LYRIC_TRANSLATION_ALIGNMENT_TOLERANCE_MS = 50L
 private const val LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS = 350L
 private const val LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS = 1_500L

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsParsing.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsParsing.kt
@@ -77,24 +77,32 @@ fun attachLyricTranslations(lines: List<LyricLine>, translationRaw: String?): Li
     if (translationRaw.isNullOrBlank() || lines.isEmpty()) return lines
     val translationLines = parseLrc(translationRaw).filter { it.timeMs != Long.MAX_VALUE }
     if (translationLines.isEmpty()) return lines
-    val byTime = translationLines
+    val groupedTranslationLines = translationLines
         .groupBy { it.timeMs }
-        .mapValues { (_, value) ->
-            value.flatMap { secondary ->
-                listOfNotNull(secondary.text, secondary.translation)
-            }
-                .map(String::trim)
-                .filter(String::isNotBlank)
-                .distinct()
-                .joinToString("\n")
+        .map { (timeMs, sameTimeLines) ->
+            LyricLine(
+                timeMs = timeMs,
+                text = sameTimeLines.flatMap { secondary ->
+                    listOfNotNull(secondary.text, secondary.translation)
+                }
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .distinct()
+                    .joinToString("\n"),
+            )
         }
-    return lines.map { line ->
-        if (line.timeMs == Long.MAX_VALUE || !line.translation.isNullOrBlank()) return@map line
-        val exact = byTime[line.timeMs]
-        val nearestTime = byTime.keys
-            .minByOrNull { kotlin.math.abs(it - line.timeMs) }
-            ?.takeIf { kotlin.math.abs(it - line.timeMs) <= 50 }
-        line.copy(translation = exact ?: nearestTime?.let(byTime::get))
+        .filter { it.text.isNotBlank() }
+        .sortedBy(LyricLine::timeMs)
+    val aligned = alignSecondaryLyricLines(
+        primary = lines,
+        secondary = groupedTranslationLines,
+        toleranceMs = LYRIC_TRANSLATION_ALIGNMENT_TOLERANCE_MS,
+        eligiblePrimary = { it.translation.isNullOrBlank() },
+    )
+    return lines.mapIndexed { index, line ->
+        if (line.timeMs == Long.MAX_VALUE || !line.translation.isNullOrBlank()) return@mapIndexed line
+        val translation = aligned[index]?.text?.takeIf(String::isNotBlank) ?: return@mapIndexed line
+        line.copy(translation = translation)
     }
 }
 
@@ -103,15 +111,16 @@ fun attachLyricRomanization(lines: List<LyricLine>, romanizationRaw: String?): L
     val romanizationLines = parseLyricTrack(romanizationRaw)
         .filter { it.timeMs != Long.MAX_VALUE }
     if (romanizationLines.isEmpty()) return lines
-    val primaryTimedSize = lines.count { it.timeMs != Long.MAX_VALUE }
+    val aligned = alignSecondaryLyricLines(
+        primary = lines,
+        secondary = romanizationLines,
+        toleranceMs = LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS,
+        indexToleranceMs = LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS,
+        eligiblePrimary = { it.romanization.isNullOrBlank() },
+    )
     return lines.mapIndexed { index, line ->
         if (line.timeMs == Long.MAX_VALUE || !line.romanization.isNullOrBlank()) return@mapIndexed line
-        val secondary = alignedRomanizationLine(
-            track = romanizationLines,
-            primaryTimeMs = line.timeMs,
-            primaryIndex = index,
-            primarySize = primaryTimedSize,
-        ) ?: return@mapIndexed line
+        val secondary = aligned[index] ?: return@mapIndexed line
         val romanization = listOfNotNull(secondary.text, secondary.translation)
             .map(String::trim)
             .filter(String::isNotBlank)
@@ -128,26 +137,62 @@ fun attachLyricRomanization(lines: List<LyricLine>, romanizationRaw: String?): L
     }
 }
 
-private fun alignedRomanizationLine(
-    track: List<LyricLine>,
-    primaryTimeMs: Long,
-    primaryIndex: Int,
-    primarySize: Int,
-): LyricLine? {
-    val nearest = track.minByOrNull { kotlin.math.abs(it.timeMs - primaryTimeMs) }
-    if (
-        nearest != null &&
-        kotlin.math.abs(nearest.timeMs - primaryTimeMs) <= LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS
-    ) {
-        return nearest
+private fun alignSecondaryLyricLines(
+    primary: List<LyricLine>,
+    secondary: List<LyricLine>,
+    toleranceMs: Long,
+    indexToleranceMs: Long? = null,
+    eligiblePrimary: (LyricLine) -> Boolean = { true },
+): Map<Int, LyricLine> {
+    val timedPrimary = primary.mapIndexedNotNull { index, line ->
+        if (line.timeMs == Long.MAX_VALUE || !eligiblePrimary(line)) null else index to line
     }
-    return track.getOrNull(primaryIndex)
-        ?.takeIf {
-            track.size == primarySize &&
-                kotlin.math.abs(it.timeMs - primaryTimeMs) <= LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS
+    if (timedPrimary.isEmpty() || secondary.isEmpty()) return emptyMap()
+
+    val aligned = mutableMapOf<Int, LyricLine>()
+    var minimumPrimaryPosition = 0
+    secondary.forEachIndexed { secondaryIndex, secondaryLine ->
+        val secondaryIsCredit = isLikelyLyricCreditText(secondaryLine.text)
+        val nearestPosition = (minimumPrimaryPosition until timedPrimary.size)
+            .asSequence()
+            .filter { primaryPosition ->
+                kotlin.math.abs(timedPrimary[primaryPosition].second.timeMs - secondaryLine.timeMs) <= toleranceMs
+            }
+            .minWithOrNull(
+                compareBy<Int> { primaryPosition ->
+                    if (
+                        isLikelyLyricCreditText(timedPrimary[primaryPosition].second.text) == secondaryIsCredit
+                    ) {
+                        0
+                    } else {
+                        1
+                    }
+                }.thenBy { primaryPosition ->
+                    kotlin.math.abs(timedPrimary[primaryPosition].second.timeMs - secondaryLine.timeMs)
+                }.thenBy { it },
+            )
+        val fallbackPosition = if (
+            nearestPosition == null &&
+            indexToleranceMs != null &&
+            timedPrimary.size == secondary.size &&
+            secondaryIndex >= minimumPrimaryPosition &&
+            kotlin.math.abs(timedPrimary[secondaryIndex].second.timeMs - secondaryLine.timeMs) <= indexToleranceMs
+        ) {
+            secondaryIndex
+        } else {
+            null
         }
+        val primaryPosition = nearestPosition ?: fallbackPosition ?: return@forEachIndexed
+        aligned[timedPrimary[primaryPosition].first] = secondaryLine
+        minimumPrimaryPosition = primaryPosition + 1
+    }
+    return aligned
 }
 
+private fun isLikelyLyricCreditText(text: String): Boolean =
+    lyricCreditPrefixRegex.containsMatchIn(text.trim())
+
+private const val LYRIC_TRANSLATION_ALIGNMENT_TOLERANCE_MS = 50L
 private const val LYRIC_ROMANIZATION_ALIGNMENT_TOLERANCE_MS = 350L
 private const val LYRIC_ROMANIZATION_INDEX_TOLERANCE_MS = 1_500L
 
@@ -204,7 +249,10 @@ fun parseLrc(raw: String?): List<LyricLine> {
         .groupBy { it.timeMs }
         .values
         .flatMap { sameTimeLines ->
-            if (sameTimeLines.size == 2) {
+            if (
+                sameTimeLines.size == 2 &&
+                sameTimeLines.none { isLikelyLyricCreditText(it.text) }
+            ) {
                 val original = sameTimeLines[0]
                 val translation = sameTimeLines[1].text.takeIf { it != original.text }
                 listOf(LyricLine(original.timeMs, original.text, translation))
@@ -272,3 +320,7 @@ val lrcTimeRegex = Regex("""\[(\d{1,3}:\d{1,2}(?:\.\d{1,3})?)]""")
 val lrcMetadataRegex = Regex("""^\[[A-Za-z]+:.*]$""")
 val yrcLineHeaderRegex = Regex("""^\[(\d+),(\d+)]""")
 val yrcWordRegex = Regex("""\((\d+),(\d+),\d+\)([^(]*)""")
+private val lyricCreditPrefixRegex = Regex(
+    """^\s*(?:(?:作词|作詞|作曲|编曲|編曲|填词|填詞|混音|制作人|製作人|监制|監製|原唱|演唱|歌手|和声|和聲|录音|錄音|母带|母帶|吉他|贝斯|貝斯|鼓|弦乐|弦樂|词|詞|曲)|(?:lyrics?|lyricist|composer|arranger|producer|vocals?|singer|mix(?:ing)?|master(?:ing)?|written\s+by|music\s+by))\s*(?:[:：/]|-\s+)""",
+    RegexOption.IGNORE_CASE,
+)

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
@@ -151,6 +151,26 @@ class LyricsParserTest {
     }
 
     @Test
+    fun parseLyricsReservesFollowingExactRomanizationMatch() {
+        val raw = composeLyricsWithRichTracks(
+            main = """
+                [00:01.000]かな
+                [00:01.300]さかな
+            """.trimIndent(),
+            romanization = """
+                [00:01.200]ka na
+                [00:01.300]sa ka na
+            """.trimIndent(),
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals(2, lines.size)
+        assertEquals("ka na", lines[0].romanization)
+        assertEquals("sa ka na", lines[1].romanization)
+    }
+
+    @Test
     fun karaokeFillProgressUsesWordWidthsAndTimeline() {
         val words = listOf(
             LyricWord(1_000, 1_000, "逐"),

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/LyricsParserTest.kt
@@ -26,6 +26,22 @@ class LyricsParserTest {
     }
 
     @Test
+    fun parseLrcKeepsSameTimestampCreditsAsIndependentLines() {
+        val lines = parseLrc(
+            """
+            [00:01.000]作曲：でんの子P
+            [00:01.000]作詞：でんの子P
+            """.trimIndent(),
+        )
+
+        assertEquals(2, lines.size)
+        assertEquals("作曲：でんの子P", lines[0].text)
+        assertNull(lines[0].translation)
+        assertEquals("作詞：でんの子P", lines[1].text)
+        assertNull(lines[1].translation)
+    }
+
+    @Test
     fun parseLrcKeepsLinesWithoutTranslationAndSkipsMetadata() {
         val lines = parseLrc(
             """
@@ -112,6 +128,26 @@ class LyricsParserTest {
         assertEquals("The club isn't the best place", lines.single().text)
         assertEquals("这俱乐部不是个能找到安慰的地方", lines.single().translation)
         assertNull(lines.single().words)
+    }
+
+    @Test
+    fun parseLyricsUsesEachRomanizationLineAtMostOnce() {
+        val raw = composeLyricsWithRichTracks(
+            main = """
+                [00:01.000]作詞：でんの子P
+                [00:01.200]ふわっとしたあなたゆるさせつなさ
+            """.trimIndent(),
+            romanization = "[00:01.200]fu wa tto shi ta a na ta yu ru sa se tsu na sa",
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals(2, lines.size)
+        assertNull(lines[0].romanization)
+        assertEquals(
+            "fu wa tto shi ta a na ta yu ru sa se tsu na sa",
+            lines[1].romanization,
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
@@ -26,6 +26,31 @@ class RichLyricsTest {
     }
 
     @Test
+    fun alignsSecondaryTracksToLyricInsteadOfNearbyCredit() {
+        val raw = composeRichLyrics(
+            main = """
+                [00:01.000]作詞：でんの子P
+                [00:01.200]ふわっとしたあなたゆるさせつなさ
+            """.trimIndent(),
+            translation = "[00:01.100]轻飘飘的你 摇摇晃晃 略显悲伤",
+            romanization = "[00:01.200]fu wa tto shi ta a na ta yu ru sa se tsu na sa",
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals(2, lines.size)
+        assertEquals("作詞：でんの子P", lines[0].text)
+        assertNull(lines[0].translation)
+        assertNull(lines[0].romanization)
+        assertEquals("ふわっとしたあなたゆるさせつなさ", lines[1].text)
+        assertEquals("轻飘飘的你 摇摇晃晃 略显悲伤", lines[1].translation)
+        assertEquals(
+            "fu wa tto shi ta a na ta yu ru sa se tsu na sa",
+            lines[1].romanization,
+        )
+    }
+
+    @Test
     fun preservesWordTimedPrimaryAndRomanizationTracks() {
         val raw = composeRichLyrics(
             main = "[1000,2000](1000,500,0)Hel(1500,1500,0)lo",

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/RichLyricsTest.kt
@@ -51,6 +51,30 @@ class RichLyricsTest {
     }
 
     @Test
+    fun composeRichLyricsReservesFollowingExactSecondaryMatch() {
+        val raw = composeRichLyrics(
+            main = """
+                [00:01.000]First
+                [00:01.300]Second
+            """.trimIndent(),
+            translation = """
+                [00:01.200]第一
+                [00:01.300]第二
+            """.trimIndent(),
+            romanization = """
+                [00:01.000]first
+                [00:01.300]second
+            """.trimIndent(),
+        )
+
+        val lines = parseLyrics(raw)
+
+        assertEquals(2, lines.size)
+        assertEquals("第一", lines[0].translation)
+        assertEquals("第二", lines[1].translation)
+    }
+
+    @Test
     fun preservesWordTimedPrimaryAndRomanizationTracks() {
         val raw = composeRichLyrics(
             main = "[1000,2000](1000,500,0)Hel(1500,1500,0)lo",


### PR DESCRIPTION
## Summary

- keep same-timestamp credit lines as independent primary lyric lines instead of treating them as translation pairs
- align translation and romanization tracks one-to-one so a secondary line cannot be reused by nearby credit and lyric lines
- prefer matching credit metadata to credit metadata and lyric content to lyric content when timestamps are close
- add regression coverage for the reported Japanese lyric/romanization mismatch scenario

## Validation

- added parser and rich-lyrics regression tests
- CI will run the shared/Android verification for the PR
