### PR TITLE
fix: refine mini player background and mine scroll state

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -26,6 +26,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -130,14 +131,14 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
     val local by graph.localPlaylist.uiState.collectAsStateWithLifecycle()
     val catalog by graph.providerCatalog.uiState.collectAsStateWithLifecycle()
     val fileActions = LocalLocalPlaylistFileActions.current
-    val listState = rememberLazyListState()
-    var initialPlaylistLoadPending by remember {
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
+    var initialPlaylistLoadPending by rememberSaveable {
         mutableStateOf(
             state.isLoading ||
                 (state.minePlaylistSections.isEmpty() && state.mineFavoritePlaylistSections.isEmpty()),
         )
     }
-    var initialPlaylistLoadStarted by remember { mutableStateOf(false) }
+    var initialPlaylistLoadStarted by rememberSaveable { mutableStateOf(false) }
     var createLocal by remember { mutableStateOf(false) }
     var createProvider by remember { mutableStateOf<String?>(null) }
     var name by remember { mutableStateOf("") }
@@ -196,10 +197,16 @@ private fun MineOwnerPlaylists(home: HomeFeatureController, showFilter: Boolean,
             modifier = Modifier.weight(1f).fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            if (state.playlistFilter == PlaylistFilter.UserPlaylists && frequent.isNotEmpty()) {
+            if (state.playlistFilter == PlaylistFilter.UserPlaylists) {
                 item("mine-frequent") {
-                    Text("我的常听", style = MaterialTheme.typography.titleMedium)
-                    ProviderPlaylistGrid(frequent, { home.openPlaylist(it, home.categoryForMinePlaylist(it)) }, maxRows = 2)
+                    if (frequent.isNotEmpty()) {
+                        Text("我的常听", style = MaterialTheme.typography.titleMedium)
+                        ProviderPlaylistGrid(
+                            frequent,
+                            { home.openPlaylist(it, home.categoryForMinePlaylist(it)) },
+                            maxRows = 2,
+                        )
+                    }
                 }
             }
             if (state.playlistFilter == PlaylistFilter.Local) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/RuntimeMiniPlayer.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -99,13 +100,9 @@ internal fun RuntimeMiniPlayer(
                 onClick = onOpenFullPlayer,
             ),
         shape = if (isWideLayout) MaterialTheme.shapes.medium else MaterialTheme.shapes.extraLarge,
-        color = if (isWideLayout) {
-            MaterialTheme.colorScheme.surfaceContainer
-        } else {
-            MaterialTheme.colorScheme.surfaceContainerHigh
-        },
+        color = Color.Transparent,
         contentColor = MaterialTheme.colorScheme.onSurface,
-        tonalElevation = if (isWideLayout) 3.dp else 5.dp,
+        tonalElevation = 0.dp,
     ) {
         Column {
             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
## Summary
- remove the mini player's elevated surface background so the player sits on a transparent base
- persist the Mine playlist `LazyListState` across pager disposal/restoration
- persist the one-shot initial-load scroll flags so refresh/navigation cannot accidentally reset a restored position
- keep a stable `mine-frequent` lazy item key while listening-history stats load, preventing async insertion from anchoring the viewport at “我的歌单” instead of the top

## Expected behavior
- first entry to Mine opens at the top
- switching to Recommend/Explore and back to Mine restores the previous playlist scroll position
- later refreshes do not force a restored list back to the top
- mini player no longer renders the extra light/elevated container background

## Validation
- reviewed the focused diffs against current `master`
- CI should run the repository's shared/Android checks on this PR