### PR TITLE
ci: speed up pull request validation

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -50,9 +50,47 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/android-tests.yml
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+  build-pr:
+    name: Build debug APK for PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Build debug APK
+        env:
+          GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        run: |
+          if [ -n "$GRADLE_ENCRYPTION_KEY" ]; then
+            echo "Using Gradle configuration cache."
+            ./gradlew --configuration-cache :androidApp:assembleDebug
+          else
+            echo "::notice::GRADLE_ENCRYPTION_KEY is unavailable; running without persistent configuration cache."
+            ./gradlew --no-configuration-cache :androidApp:assembleDebug
+          fi
 
   build-release-apks:
     name: Build signed multi-ABI release APK
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -54,7 +54,7 @@ jobs:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   build-pr:
-    name: Build debug APK for PR
+    name: Validate debug app for PR
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -64,6 +64,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -76,16 +82,22 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Build debug APK
+      - name: Compile debug app
         env:
           GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         run: |
           if [ -n "$GRADLE_ENCRYPTION_KEY" ]; then
             echo "Using Gradle configuration cache."
-            ./gradlew --configuration-cache :androidApp:assembleDebug
+            ./gradlew --configuration-cache \
+              :androidApp:compileDebugKotlin \
+              :androidApp:compileDebugJavaWithJavac \
+              :androidApp:processDebugResources
           else
             echo "::notice::GRADLE_ENCRYPTION_KEY is unavailable; running without persistent configuration cache."
-            ./gradlew --no-configuration-cache :androidApp:assembleDebug
+            ./gradlew --no-configuration-cache \
+              :androidApp:compileDebugKotlin \
+              :androidApp:compileDebugJavaWithJavac \
+              :androidApp:processDebugResources
           fi
 
   build-release-apks:

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -50,55 +50,10 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/android-tests.yml
+    with:
+      validate_android_app: ${{ github.event_name == 'pull_request' }}
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-  build-pr:
-    name: Validate debug app for PR
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Prepare Git refs for Gradle versioning
-        run: |
-          if ! git show-ref --verify --quiet refs/heads/master; then
-            git branch master origin/master
-          fi
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-      - name: Compile debug app
-        env:
-          GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        run: |
-          if [ -n "$GRADLE_ENCRYPTION_KEY" ]; then
-            echo "Using Gradle configuration cache."
-            ./gradlew --configuration-cache \
-              :androidApp:compileDebugKotlin \
-              :androidApp:compileDebugJavaWithJavac \
-              :androidApp:processDebugResources
-          else
-            echo "::notice::GRADLE_ENCRYPTION_KEY is unavailable; running without persistent configuration cache."
-            ./gradlew --no-configuration-cache \
-              :androidApp:compileDebugKotlin \
-              :androidApp:compileDebugJavaWithJavac \
-              :androidApp:processDebugResources
-          fi
 
   build-release-apks:
     name: Build signed multi-ABI release APK

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,6 +12,8 @@ jobs:
     uses: ./.github/workflows/android-tests.yml
     permissions:
       contents: read
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   build-release-apks:
     name: Build signed multi-ABI release APK

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -2,6 +2,9 @@ name: Android Tests
 
 "on":
   workflow_call:
+    secrets:
+      GRADLE_ENCRYPTION_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -26,10 +29,13 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run architecture checks, Android unit tests and coverage
         run: >-
           ./gradlew
+          --configuration-cache
           checkArchitectureBoundaries
           :feature:download:checkOfflineFeatureBoundaries
           :feature:providerauth:checkProviderFeatureBoundaries

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -32,10 +38,10 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Run architecture checks, Android unit tests and coverage
+      - name: Run architecture checks
         run: >-
           ./gradlew
-          --configuration-cache
+          --no-configuration-cache
           checkArchitectureBoundaries
           :feature:download:checkOfflineFeatureBoundaries
           :feature:providerauth:checkProviderFeatureBoundaries
@@ -45,6 +51,11 @@ jobs:
           :feature:home:checkHomeFeatureBoundaries
           :feature:playback:checkPlaybackFeatureBoundaries
           :shared:checkP4ContractBoundaries
+
+      - name: Run Android unit tests and coverage
+        run: >-
+          ./gradlew
+          --configuration-cache
           :feature:recognition:testDebugUnitTest
           :feature:search:testDebugUnitTest
           :feature:localplaylist:testDebugUnitTest

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -2,6 +2,11 @@ name: Android Tests
 
 "on":
   workflow_call:
+    inputs:
+      validate_android_app:
+        required: false
+        type: boolean
+        default: false
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: false
@@ -52,28 +57,40 @@ jobs:
           :feature:playback:checkPlaybackFeatureBoundaries
           :shared:checkP4ContractBoundaries
 
-      - name: Run Android unit tests and coverage
-        run: >-
-          ./gradlew
-          --configuration-cache
-          :feature:recognition:testDebugUnitTest
-          :feature:search:testDebugUnitTest
-          :feature:localplaylist:testDebugUnitTest
-          :feature:localmusic:testDebugUnitTest
-          :feature:download:testDebugUnitTest
-          :feature:providercatalog:testDebugUnitTest
-          :feature:providerauth:testDebugUnitTest
-          :feature:providerdetail:testDebugUnitTest
-          :feature:settings:testDebugUnitTest
-          :feature:onboarding:testDebugUnitTest
-          :feature:home:testDebugUnitTest
-          :feature:playback:testDebugUnitTest
-          :playback:runtime:testDebugUnitTest
-          :provider:runtime:testDebugUnitTest
-          :persistence:settings:testDebugUnitTest
-          :provider:bilibili:testDebugUnitTest
-          :provider:netease:testDebugUnitTest
-          :provider:qqmusic:testDebugUnitTest
-          :provider:ytmusic:testDebugUnitTest
-          :shared:testDebugUnitTest
-          :shared:koverXmlReportDebug
+      - name: Run Android unit tests, coverage and PR compile validation
+        env:
+          VALIDATE_ANDROID_APP: ${{ inputs.validate_android_app }}
+        run: |
+          tasks=(
+            :feature:recognition:testDebugUnitTest
+            :feature:search:testDebugUnitTest
+            :feature:localplaylist:testDebugUnitTest
+            :feature:localmusic:testDebugUnitTest
+            :feature:download:testDebugUnitTest
+            :feature:providercatalog:testDebugUnitTest
+            :feature:providerauth:testDebugUnitTest
+            :feature:providerdetail:testDebugUnitTest
+            :feature:settings:testDebugUnitTest
+            :feature:onboarding:testDebugUnitTest
+            :feature:home:testDebugUnitTest
+            :feature:playback:testDebugUnitTest
+            :playback:runtime:testDebugUnitTest
+            :provider:runtime:testDebugUnitTest
+            :persistence:settings:testDebugUnitTest
+            :provider:bilibili:testDebugUnitTest
+            :provider:netease:testDebugUnitTest
+            :provider:qqmusic:testDebugUnitTest
+            :provider:ytmusic:testDebugUnitTest
+            :shared:testDebugUnitTest
+            :shared:koverXmlReportDebug
+          )
+
+          if [ "$VALIDATE_ANDROID_APP" = "true" ]; then
+            tasks+=(
+              :androidApp:compileDebugKotlin
+              :androidApp:compileDebugJavaWithJavac
+              :androidApp:processDebugResources
+            )
+          fi
+
+          ./gradlew --configuration-cache "${tasks[@]}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.caching=true
+org.gradle.parallel=true
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
## Summary

- replace full signed/minified release APK construction on pull requests with lightweight Android app compile/resource validation (`compileDebugKotlin`, `compileDebugJavaWithJavac`, `processDebugResources`)
- fold that PR compile validation into the existing test Gradle invocation so the same runner/task graph is reused instead of compiling Debug dependencies twice
- keep the existing signed `:androidApp:assembleRelease` path unchanged for `master` pushes and Canary publishing
- enable Gradle configuration cache for unit tests, coverage, and PR compile validation; keep architecture boundary checks on `--no-configuration-cache` because those custom tasks access Gradle project state at execution time
- enable `org.gradle.parallel=true` for multi-module Gradle execution

## Scope guard

The master/release artifact semantics are unchanged: release minification, resource shrinking, signing, artifact naming/upload, and Canary publishing continue to use the existing release build path.

## Validation

Latest PR CI run is green:
- full signed release job: skipped on PR
- Canary publish: skipped on PR
- architecture checks: passed
- unit tests + coverage + Android app compile/resource validation: passed
- final PR validation job wall time: about 1m38s

For comparison, the previous PR design with a separate Debug compile runner took about 2m44s on its critical path, and the prior full Release-based CI was roughly 6 minutes.