### PR TITLE
feat: expand lyrics alignment for replacement playback

### DIFF
--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
@@ -111,8 +111,9 @@ internal class PlaybackLyricsController(
     private var searchJob: Job? = null
     private var selectionJob: Job? = null
     private var loadedForTrackId: String? = null
+    private var loadedForPlaybackSourceTrackId: String? = null
     private var loadedAssociationTrackId: String? = null
-    private var currentSourceTrackId: String? = null
+    private var currentAlignmentPersistenceKey: String? = null
     private var associationSearchTrack: MusicTrack? = null
     private var associationQueryEdited = false
 
@@ -124,8 +125,9 @@ internal class PlaybackLyricsController(
         searchJob = null
         selectionJob = null
         loadedForTrackId = null
+        loadedForPlaybackSourceTrackId = null
         loadedAssociationTrackId = null
-        currentSourceTrackId = null
+        currentAlignmentPersistenceKey = null
         associationSearchTrack = null
         associationQueryEdited = false
         mutableAssociationState.value = LyricsAssociationUiState()
@@ -165,19 +167,38 @@ internal class PlaybackLyricsController(
     fun maybeLoad(track: MusicTrack?) {
         if (track == null) return
         val lyricTrack = lyricSourceTrackForPlayback(track)
+        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(track)
         val associatedTrackId = associationForTrackId(lyricTrack.id)
             ?.trim()
             ?.takeIf { it.isNotBlank() }
-        val alignmentOffsetMs = associatedTrackId?.let { lyricsTrackId ->
-            alignmentOffsetForTrackId(
-                lyricsAlignmentPersistenceKey(lyricTrack.id, lyricsTrackId),
-            ).coerceIn(-3_000L, 3_000L)
+        val defaultAlignmentKey = if (track.isSmartReplacement) {
+            lyricsAlignmentPersistenceKey(playbackSourceTrackId, lyricTrack.id)
+        } else {
+            null
+        }
+        val associationAlignmentKey = associatedTrackId?.let { lyricsTrackId ->
+            lyricsAlignmentPersistenceKey(playbackSourceTrackId, lyricsTrackId)
+        }
+        val alignmentOffsetMs = (associationAlignmentKey ?: defaultAlignmentKey)?.let { alignmentKey ->
+            alignmentOffsetForTrackId(alignmentKey).coerceIn(-3_000L, 3_000L)
         } ?: 0L
-        currentSourceTrackId = lyricTrack.id
+        currentAlignmentPersistenceKey = associationAlignmentKey ?: defaultAlignmentKey
 
-        if (loadedForTrackId == track.id && loadedAssociationTrackId == associatedTrackId) {
+        if (
+            loadedForTrackId == track.id &&
+            loadedForPlaybackSourceTrackId == playbackSourceTrackId &&
+            loadedAssociationTrackId == associatedTrackId
+        ) {
             val current = mutableAssociationState.value
-            val effectiveAlignmentOffsetMs = if (current.isManualAssociation) alignmentOffsetMs else 0L
+            val effectiveAlignmentKey = if (current.isManualAssociation) {
+                associationAlignmentKey
+            } else {
+                defaultAlignmentKey
+            }
+            val effectiveAlignmentOffsetMs = effectiveAlignmentKey?.let { alignmentKey ->
+                alignmentOffsetForTrackId(alignmentKey).coerceIn(-3_000L, 3_000L)
+            } ?: 0L
+            currentAlignmentPersistenceKey = effectiveAlignmentKey
             if (
                 current.trackId == track.id &&
                 current.alignmentOffsetMs != effectiveAlignmentOffsetMs
@@ -190,6 +211,7 @@ internal class PlaybackLyricsController(
         }
 
         loadedForTrackId = track.id
+        loadedForPlaybackSourceTrackId = playbackSourceTrackId
         loadedAssociationTrackId = associatedTrackId
         val requestSerial = currentRequestSerial()
         loadJob?.cancel()
@@ -206,6 +228,7 @@ internal class PlaybackLyricsController(
                 if (!isCurrent(track, requestSerial)) return@launch
                 if (associatedTrack != null && associatedLyrics != null) {
                     updateLyrics(associatedLyrics)
+                    currentAlignmentPersistenceKey = associationAlignmentKey
                     mutableAssociationState.value = LyricsAssociationUiState(
                         trackId = track.id,
                         isManualAssociation = true,
@@ -223,10 +246,14 @@ internal class PlaybackLyricsController(
                         ?.takeIf { it.isNotBlank() }
                 if (!isCurrent(track, requestSerial)) return@launch
                 if (fallbackLyrics != null) updateLyrics(fallbackLyrics)
+                val fallbackAlignmentOffsetMs = defaultAlignmentKey?.let { alignmentKey ->
+                    alignmentOffsetForTrackId(alignmentKey).coerceIn(-3_000L, 3_000L)
+                } ?: 0L
+                currentAlignmentPersistenceKey = defaultAlignmentKey
                 mutableAssociationState.value = LyricsAssociationUiState(
                     trackId = track.id,
                     isLyricsUnavailable = fallbackLyrics == null,
-                    alignmentOffsetMs = 0L,
+                    alignmentOffsetMs = fallbackAlignmentOffsetMs,
                 )
             }
             return
@@ -235,7 +262,7 @@ internal class PlaybackLyricsController(
         currentLyrics()?.takeIf { it.isNotBlank() }?.let {
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
-                alignmentOffsetMs = 0L,
+                alignmentOffsetMs = alignmentOffsetMs,
             )
             return
         }
@@ -243,7 +270,7 @@ internal class PlaybackLyricsController(
             updateLyrics(it)
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
-                alignmentOffsetMs = 0L,
+                alignmentOffsetMs = alignmentOffsetMs,
             )
             return
         }
@@ -257,7 +284,7 @@ internal class PlaybackLyricsController(
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = track.id,
                 isLyricsUnavailable = lyrics == null,
-                alignmentOffsetMs = 0L,
+                alignmentOffsetMs = alignmentOffsetMs,
             )
         }
     }
@@ -266,16 +293,24 @@ internal class PlaybackLyricsController(
         associationSearchTrack = track
         associationQueryEdited = false
         val sourceTrack = lyricSourceTrackForPlayback(track)
-        currentSourceTrackId = sourceTrack.id
+        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(track)
         val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
         val persistedAssociationTrackId = associationForTrackId(sourceTrack.id)
             ?.trim()
             ?.takeIf { it.isNotBlank() }
+        val alignmentKey = when {
+            previous?.isManualAssociation == true && previous.associatedTrackId != null ->
+                lyricsAlignmentPersistenceKey(playbackSourceTrackId, previous.associatedTrackId)
+            persistedAssociationTrackId != null ->
+                lyricsAlignmentPersistenceKey(playbackSourceTrackId, persistedAssociationTrackId)
+            track.isSmartReplacement ->
+                lyricsAlignmentPersistenceKey(playbackSourceTrackId, sourceTrack.id)
+            else -> null
+        }
+        currentAlignmentPersistenceKey = alignmentKey
         val alignmentOffsetMs = previous?.alignmentOffsetMs
-            ?: persistedAssociationTrackId?.let { lyricsTrackId ->
-                alignmentOffsetForTrackId(
-                    lyricsAlignmentPersistenceKey(sourceTrack.id, lyricsTrackId),
-                ).coerceIn(-3_000L, 3_000L)
+            ?: alignmentKey?.let { persistedKey ->
+                alignmentOffsetForTrackId(persistedKey).coerceIn(-3_000L, 3_000L)
             }
             ?: 0L
         mutableAssociationState.value = LyricsAssociationUiState(
@@ -336,7 +371,9 @@ internal class PlaybackLyricsController(
     override fun selectAssociation(track: MusicTrack) {
         val playbackTrack = associationSearchTrack ?: return
         val sourceTrack = lyricSourceTrackForPlayback(playbackTrack)
-        currentSourceTrackId = sourceTrack.id
+        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(playbackTrack)
+        val alignmentKey = lyricsAlignmentPersistenceKey(playbackSourceTrackId, track.id)
+        currentAlignmentPersistenceKey = alignmentKey
         val requestSerial = currentRequestSerial()
         selectionJob?.cancel()
         mutableAssociationState.value = mutableAssociationState.value.copy(
@@ -358,11 +395,11 @@ internal class PlaybackLyricsController(
                 return@launch
             }
 
-            val alignmentOffsetMs = alignmentOffsetForTrackId(
-                lyricsAlignmentPersistenceKey(sourceTrack.id, track.id),
-            ).coerceIn(-3_000L, 3_000L)
+            val alignmentOffsetMs = alignmentOffsetForTrackId(alignmentKey)
+                .coerceIn(-3_000L, 3_000L)
             rememberAssociation(sourceTrack.id, track.id)
             loadedForTrackId = playbackTrack.id
+            loadedForPlaybackSourceTrackId = playbackSourceTrackId
             loadedAssociationTrackId = track.id
             updateLyrics(lyrics)
             mutableAssociationState.value = LyricsAssociationUiState(
@@ -396,15 +433,8 @@ internal class PlaybackLyricsController(
         val current = mutableAssociationState.value
         if (current.alignmentOffsetMs == clamped) return
         mutableAssociationState.value = current.copy(alignmentOffsetMs = clamped)
-        if (current.isManualAssociation) {
-            val sourceTrackId = currentSourceTrackId
-            val lyricsTrackId = current.associatedTrackId
-            if (sourceTrackId != null && lyricsTrackId != null) {
-                rememberAlignmentOffset(
-                    lyricsAlignmentPersistenceKey(sourceTrackId, lyricsTrackId),
-                    clamped,
-                )
-            }
+        currentAlignmentPersistenceKey?.let { alignmentKey ->
+            rememberAlignmentOffset(alignmentKey, clamped)
         }
     }
 
@@ -456,6 +486,11 @@ internal class PlaybackLyricsController(
         } else {
             wrapped
         }
+    }
+
+    private fun alignmentSourceTrackIdForPlayback(track: MusicTrack): String {
+        if (!track.isSmartReplacement) return track.id
+        return track.replacementId?.takeIf { it.isNotBlank() } ?: track.id
     }
 
     private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack {

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
@@ -182,7 +182,7 @@ internal class PlaybackLyricsController(
         val alignmentOffsetMs = (associationAlignmentKey ?: defaultAlignmentKey)?.let { alignmentKey ->
             alignmentOffsetForTrackId(alignmentKey).coerceIn(-3_000L, 3_000L)
         } ?: 0L
-        currentAlignmentPersistenceKey = associationAlignmentKey ?: defaultAlignmentKey
+        currentAlignmentPersistenceKey = defaultAlignmentKey
 
         if (
             loadedForTrackId == track.id &&
@@ -301,6 +301,9 @@ internal class PlaybackLyricsController(
         val alignmentKey = when {
             previous?.isManualAssociation == true && previous.associatedTrackId != null ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, previous.associatedTrackId)
+            previous != null && track.isSmartReplacement ->
+                lyricsAlignmentPersistenceKey(playbackSourceTrackId, sourceTrack.id)
+            previous != null -> null
             persistedAssociationTrackId != null ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, persistedAssociationTrackId)
             track.isSmartReplacement ->
@@ -373,7 +376,6 @@ internal class PlaybackLyricsController(
         val sourceTrack = lyricSourceTrackForPlayback(playbackTrack)
         val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(playbackTrack)
         val alignmentKey = lyricsAlignmentPersistenceKey(playbackSourceTrackId, track.id)
-        currentAlignmentPersistenceKey = alignmentKey
         val requestSerial = currentRequestSerial()
         selectionJob?.cancel()
         mutableAssociationState.value = mutableAssociationState.value.copy(
@@ -401,6 +403,7 @@ internal class PlaybackLyricsController(
             loadedForTrackId = playbackTrack.id
             loadedForPlaybackSourceTrackId = playbackSourceTrackId
             loadedAssociationTrackId = track.id
+            currentAlignmentPersistenceKey = alignmentKey
             updateLyrics(lyrics)
             mutableAssociationState.value = LyricsAssociationUiState(
                 trackId = playbackTrack.id,

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsReplacementAlignmentTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsReplacementAlignmentTest.kt
@@ -1,0 +1,150 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaybackLyricsReplacementAlignmentTest {
+    @Test
+    fun nativeLyricsOffsetUsesActualReplacementSource() = runTest {
+        val original = providerTrack("netease:original", "原曲", "netease")
+        val replacement = replacementTrack(original, "ytmusic:replacement-a")
+        val rememberedOffsets = mutableListOf<Pair<String, Long>>()
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = FakePlaybackLyricsRepository(
+                lyrics = mapOf(original.id to "[00:00.00]原曲歌词"),
+            ),
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { replacement.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+            rememberAlignmentOffset = { key, offsetMs -> rememberedOffsets += key to offsetMs },
+        )
+
+        controller.maybeLoad(replacement)
+        advanceUntilIdle()
+        controller.updateAlignmentOffset(750L)
+
+        assertEquals("[00:00.00]原曲歌词", currentLyrics)
+        assertEquals(
+            listOf(lyricsAlignmentPersistenceKey("ytmusic:replacement-a", original.id) to 750L),
+            rememberedOffsets,
+        )
+        assertEquals(750L, controller.associationState.value.alignmentOffsetMs)
+    }
+
+    @Test
+    fun switchingReplacementSourceRestoresEachSourcesOffset() = runTest {
+        val original = providerTrack("netease:original", "原曲", "netease")
+        val replacementA = replacementTrack(original, "ytmusic:replacement-a")
+        val replacementB = replacementTrack(original, "qqmusic:replacement-b")
+        var currentTrack = replacementA
+        var currentLyrics: String? = null
+        val savedOffsets = mapOf(
+            lyricsAlignmentPersistenceKey("ytmusic:replacement-a", original.id) to 750L,
+            lyricsAlignmentPersistenceKey("qqmusic:replacement-b", original.id) to -500L,
+        )
+        val controller = PlaybackLyricsController(
+            repository = FakePlaybackLyricsRepository(
+                lyrics = mapOf(original.id to "[00:00.00]原曲歌词"),
+            ),
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { currentTrack.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { null },
+            rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { savedOffsets[it] ?: 0L },
+        )
+
+        controller.maybeLoad(currentTrack)
+        advanceUntilIdle()
+        assertEquals(750L, controller.associationState.value.alignmentOffsetMs)
+
+        currentTrack = replacementB
+        controller.maybeLoad(currentTrack)
+        advanceUntilIdle()
+
+        assertEquals(-500L, controller.associationState.value.alignmentOffsetMs)
+    }
+
+    @Test
+    fun manualAssociationOnReplacementAlsoUsesActualPlaybackSource() = runTest {
+        val original = providerTrack("netease:original", "原曲", "netease")
+        val replacement = replacementTrack(original, "ytmusic:replacement-a")
+        val associated = providerTrack("qqmusic:lyrics", "歌词歌曲", "qqmusic")
+        val rememberedOffsets = mutableListOf<Pair<String, Long>>()
+        val alignmentKey = lyricsAlignmentPersistenceKey("ytmusic:replacement-a", associated.id)
+        var currentLyrics: String? = null
+        val controller = PlaybackLyricsController(
+            repository = FakePlaybackLyricsRepository(
+                details = mapOf(associated.id to associated),
+                lyrics = mapOf(associated.id to "[00:00.00]关联歌词"),
+            ),
+            scope = this,
+            currentRequestSerial = { 1L },
+            currentTrackId = { replacement.id },
+            currentLyrics = { currentLyrics },
+            updateLyrics = { currentLyrics = it },
+            associationForTrackId = { if (it == original.id) associated.id else null },
+            rememberAssociation = { _, _ -> },
+            alignmentOffsetForTrackId = { if (it == alignmentKey) 1_000L else 0L },
+            rememberAlignmentOffset = { key, offsetMs -> rememberedOffsets += key to offsetMs },
+        )
+
+        controller.maybeLoad(replacement)
+        advanceUntilIdle()
+
+        assertTrue(controller.associationState.value.isManualAssociation)
+        assertEquals(1_000L, controller.associationState.value.alignmentOffsetMs)
+
+        controller.updateAlignmentOffset(-250L)
+
+        assertEquals(listOf(alignmentKey to -250L), rememberedOffsets)
+    }
+
+    private fun providerTrack(id: String, title: String, source: String) = MusicTrack(
+        id = id,
+        title = title,
+        artists = "artist",
+        album = "",
+        source = source,
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+        providerName = source,
+    )
+
+    private fun replacementTrack(original: MusicTrack, replacementId: String) = original.copy(
+        isSmartReplacement = true,
+        originalId = original.id,
+        originalTitle = original.title,
+        originalArtists = original.artists,
+        originalAlbum = original.album,
+        originalSource = original.source,
+        originalProviderName = original.providerName,
+        originalCoverUrl = original.coverUrl,
+        replacementId = replacementId,
+        replacementTitle = "替代音源",
+        replacementArtists = "artist",
+        replacementAlbum = "",
+        replacementSource = replacementId.substringBefore(':'),
+        replacementProviderName = replacementId.substringBefore(':'),
+    )
+
+    private class FakePlaybackLyricsRepository(
+        private val details: Map<String, MusicTrack> = emptyMap(),
+        private val lyrics: Map<String, String> = emptyMap(),
+    ) : PlaybackLyricsRepository {
+        override suspend fun lyrics(track: MusicTrack): String? = lyrics[track.id]
+        override suspend fun search(keyword: String): List<MusicTrack> = emptyList()
+        override suspend fun trackDetail(trackId: String): MusicTrack? = details[trackId]
+        override suspend fun searchKeyword(track: MusicTrack): String? = null
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -20,9 +19,11 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -51,6 +52,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlin.math.roundToInt
 
+private const val LYRIC_ALIGNMENT_STEP_MS = 250L
+private const val LYRIC_ALIGNMENT_LIMIT_MS = 3_000L
+private const val LYRIC_ALIGNMENT_SLIDER_STEPS = 23
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifier) {
     val lyricsPort = LocalPlaybackLyricsPort.current
@@ -60,7 +66,12 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
     val currentTrack = state.currentTrack
     val associationMatchesTrack = associationState.trackId == currentTrack?.id
     val lyricOffsetMs = if (associationMatchesTrack) associationState.alignmentOffsetMs else 0L
-    var alignmentPanelOpen by remember(currentTrack?.id) { mutableStateOf(false) }
+    val canAdjustLyricsAlignment = currentTrack != null &&
+        associationMatchesTrack &&
+        (associationState.isManualAssociation || currentTrack.isSmartReplacement)
+    var alignmentSheetOpen by remember(currentTrack?.id, currentTrack?.replacementId) {
+        mutableStateOf(false)
+    }
     val renderPositionMs = rememberKaraokePositionMs(
         positionMs = state.positionMs,
         isPlaying = state.status == PlayerStatus.Playing,
@@ -230,11 +241,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         Spacer(modifier = Modifier.height(edgeSpacerHeight))
                     }
                 }
-                if (
-                    currentTrack != null &&
-                    associationMatchesTrack &&
-                    associationState.isManualAssociation
-                ) {
+                if (canAdjustLyricsAlignment) {
                     Row(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -242,70 +249,35 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         horizontalArrangement = Arrangement.spacedBy(2.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        IconButton(onClick = { lyricsPort.openAssociationSearch(currentTrack) }) {
-                            Icon(
-                                imageVector = Icons.Default.Edit,
-                                contentDescription = "更换歌词",
-                            )
+                        if (associationState.isManualAssociation) {
+                            IconButton(onClick = { lyricsPort.openAssociationSearch(currentTrack) }) {
+                                Icon(
+                                    imageVector = Icons.Default.Edit,
+                                    contentDescription = "更换歌词",
+                                )
+                            }
                         }
-                        IconButton(onClick = { alignmentPanelOpen = !alignmentPanelOpen }) {
+                        IconButton(onClick = { alignmentSheetOpen = true }) {
                             Icon(
                                 imageVector = Icons.Default.Tune,
                                 contentDescription = "微调歌词对齐",
                             )
                         }
                     }
-                    if (alignmentPanelOpen) {
-                        Surface(
-                            modifier = Modifier
-                                .align(Alignment.TopEnd)
-                                .padding(top = 60.dp, end = FuoSpacing.sm)
-                                .width(280.dp),
-                            shape = MaterialTheme.shapes.medium,
-                            tonalElevation = 3.dp,
-                        ) {
-                            Column(
-                                modifier = Modifier.padding(FuoSpacing.md),
-                                verticalArrangement = Arrangement.spacedBy(FuoSpacing.xs),
-                            ) {
-                                Text(
-                                    text = "歌词对齐：${lyricOffsetLabel(lyricOffsetMs)}",
-                                    style = MaterialTheme.typography.labelLarge,
-                                )
-                                Slider(
-                                    value = lyricOffsetMs.toFloat(),
-                                    onValueChange = { value ->
-                                        lyricsPort.updateAlignmentOffset(
-                                            ((value / 250f).roundToInt() * 250L).coerceIn(-3_000L, 3_000L),
-                                        )
-                                    },
-                                    valueRange = -3_000f..3_000f,
-                                    steps = 23,
-                                )
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(
-                                        text = "提前 3 秒",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                    TextButton(onClick = { lyricsPort.updateAlignmentOffset(0L) }) {
-                                        Text("归零")
-                                    }
-                                    Text(
-                                        text = "延后 3 秒",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                            }
-                        }
-                    }
                 }
             }
+        }
+    }
+
+    if (alignmentSheetOpen && canAdjustLyricsAlignment) {
+        ModalBottomSheet(
+            onDismissRequest = { alignmentSheetOpen = false },
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ) {
+            LyricsAlignmentSheetContent(
+                offsetMs = lyricOffsetMs,
+                onOffsetChange = lyricsPort::updateAlignmentOffset,
+            )
         }
     }
 
@@ -317,6 +289,100 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
             onSelect = lyricsPort::selectAssociation,
             onDismiss = lyricsPort::closeAssociationSearch,
         )
+    }
+}
+
+@Composable
+private fun LyricsAlignmentSheetContent(
+    offsetMs: Long,
+    onOffsetChange: (Long) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = FuoSpacing.lg)
+            .padding(bottom = FuoSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+    ) {
+        Text(
+            text = "歌词微调",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "同步偏移",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = lyricOffsetLabel(offsetMs),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Slider(
+            value = offsetMs.toFloat(),
+            onValueChange = { value ->
+                onOffsetChange(
+                    ((value / LYRIC_ALIGNMENT_STEP_MS).roundToInt() * LYRIC_ALIGNMENT_STEP_MS)
+                        .coerceIn(-LYRIC_ALIGNMENT_LIMIT_MS, LYRIC_ALIGNMENT_LIMIT_MS),
+                )
+            },
+            valueRange = -LYRIC_ALIGNMENT_LIMIT_MS.toFloat()..LYRIC_ALIGNMENT_LIMIT_MS.toFloat(),
+            steps = LYRIC_ALIGNMENT_SLIDER_STEPS,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "提前 3 秒",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "延后 3 秒",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(
+                onClick = {
+                    onOffsetChange(
+                        (offsetMs - LYRIC_ALIGNMENT_STEP_MS).coerceAtLeast(-LYRIC_ALIGNMENT_LIMIT_MS),
+                    )
+                },
+                enabled = offsetMs > -LYRIC_ALIGNMENT_LIMIT_MS,
+            ) {
+                Text("-250 ms")
+            }
+            TextButton(
+                onClick = { onOffsetChange(0L) },
+                enabled = offsetMs != 0L,
+            ) {
+                Text("归零")
+            }
+            TextButton(
+                onClick = {
+                    onOffsetChange(
+                        (offsetMs + LYRIC_ALIGNMENT_STEP_MS).coerceAtMost(LYRIC_ALIGNMENT_LIMIT_MS),
+                    )
+                },
+                enabled = offsetMs < LYRIC_ALIGNMENT_LIMIT_MS,
+            ) {
+                Text("+250 ms")
+            }
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/LyricsUi.kt
@@ -241,7 +241,7 @@ fun LyricsPanel(state: PlaybackState, fontSize: LyricFontSize, modifier: Modifie
                         Spacer(modifier = Modifier.height(edgeSpacerHeight))
                     }
                 }
-                if (canAdjustLyricsAlignment) {
+                if (canAdjustLyricsAlignment && currentTrack != null) {
                     Row(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -329,7 +329,7 @@ private fun LyricsAlignmentSheetContent(
             value = offsetMs.toFloat(),
             onValueChange = { value ->
                 onOffsetChange(
-                    ((value / LYRIC_ALIGNMENT_STEP_MS).roundToInt() * LYRIC_ALIGNMENT_STEP_MS)
+                    ((value / LYRIC_ALIGNMENT_STEP_MS.toFloat()).roundToInt() * LYRIC_ALIGNMENT_STEP_MS)
                         .coerceIn(-LYRIC_ALIGNMENT_LIMIT_MS, LYRIC_ALIGNMENT_LIMIT_MS),
                 )
             },


### PR DESCRIPTION
## Summary
- allow lyrics alignment tuning whenever the current playback uses a smart replacement source
- replace the floating alignment panel with a Material 3 modal bottom sheet
- add discrete ±250 ms nudges while retaining the ±3 s slider and reset action
- persist offsets by actual playback source + lyrics source so different replacement candidates do not share timing offsets
- keep the lyrics association edit action restricted to manual associations

## Tests
- add coverage for native lyrics offsets on smart replacements
- verify offsets restore independently across replacement sources
- verify manual lyric associations on replacements also use the actual playback source key