### PR TITLE
fix: suppress detail hero while full player handles back

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -79,8 +79,12 @@ internal fun AppShell(
                     isLoading = isPlaybackLoading,
                 ) {
                     SharedTransitionLayout(Modifier.fillMaxSize()) {
+                        // NavDisplay may start predictive-pop visuals before onBack is dispatched.
+                        // While the full player owns Back, keep underlying routes out of the shared
+                        // transition scope so their resource-cover Hero cannot render above it.
+                        val appSharedTransitionScope = if (playback.isFullPlayerOpen) null else this
                         CompositionLocalProvider(
-                            LocalAppSharedTransitionScope provides this,
+                            LocalAppSharedTransitionScope provides appSharedTransitionScope,
                             LocalResourceHeroCoordinator provides resourceHeroCoordinator,
                         ) {
                             Box(Modifier.fillMaxSize()) {


### PR DESCRIPTION
## Summary
- disable the app-level resource Hero scope while the full-screen player is open
- keep the full player on its existing overlay enter/exit motion
- prevent NavDisplay predictive-pop preparation from lifting the underlying playlist/detail cover above the player

## Why
The app back coordinator correctly dismisses the full player before popping the current detail route, but NavDisplay can begin predictive-pop visuals before its `onBack` callback is dispatched. Because resource covers participate in the outer `SharedTransitionLayout`, that Hero could render above the full-player overlay even though the route was not actually being closed.

## Verification
Target scenario: playlist detail -> open full player -> Back. Back should close only the full player; the playlist detail remains in place and no resource-cover Hero is shown over the player.