### PR TITLE
fix: anchor settings dropdown menus to selected values

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -1595,35 +1595,35 @@ private fun <T> SettingsChoiceRow(
     onSelect: (T) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Box(Modifier.fillMaxWidth()) {
-        SettingsRow(
-            title = title,
-            supportingText = supportingText,
-            leadingContent = leadingContent,
-            enabled = enabled,
-            trailingContent = {
+    SettingsRow(
+        title = title,
+        supportingText = supportingText,
+        leadingContent = leadingContent,
+        enabled = enabled,
+        trailingContent = {
+            Box {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(value, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     Icon(Icons.Filled.KeyboardArrowDown, contentDescription = null)
                 }
-            },
-            onClick = { if (enabled) expanded = true },
-        )
-        DropdownMenu(expanded = expanded && enabled, onDismissRequest = { expanded = false }) {
-            options.forEach { option ->
-                DropdownMenuItem(
-                    text = { Text(optionLabel(option)) },
-                    trailingIcon = if (option == selected) {
-                        { Text("✓", color = MaterialTheme.colorScheme.primary) }
-                    } else null,
-                    onClick = {
-                        expanded = false
-                        onSelect(option)
-                    },
-                )
+                DropdownMenu(expanded = expanded && enabled, onDismissRequest = { expanded = false }) {
+                    options.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(optionLabel(option)) },
+                            trailingIcon = if (option == selected) {
+                                { Text("✓", color = MaterialTheme.colorScheme.primary) }
+                            } else null,
+                            onClick = {
+                                expanded = false
+                                onSelect(option)
+                            },
+                        )
+                    }
+                }
             }
-        }
-    }
+        },
+        onClick = { if (enabled) expanded = true },
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- anchor `SettingsChoiceRow` dropdown menus to the trailing selected-value area instead of the full settings row
- keep the existing whole-row click target while making menus open from the option position
- applies consistently to cache limits, audio quality, theme choices, local scan duration, and other shared choice rows

## Verification
- reviewed the resulting diff to ensure the change is isolated to `SettingsChoiceRow`
- build/tests not run locally; rely on PR CI for Compose compilation and checks