### PR TITLE
feat: allow saving app updates to Downloads

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -73,6 +73,11 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".AppUpdateSavePermissionActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
             android:name=".ShareReceiverActivity"
             android:excludeFromRecents="true"
             android:exported="true"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
@@ -137,6 +137,10 @@ internal class AndroidAppUpdateController(
                     return@withLock
                 }
                 if (mutableUiState.value.isUpdateSavedToDownloads) return@withLock
+                if (requiresLegacyDownloadsPermission()) {
+                    requestLegacyDownloadsPermission()
+                    return@withLock
+                }
                 mutableUiState.update {
                     it.copy(
                         isSavingUpdateToDownloads = true,
@@ -414,6 +418,25 @@ internal class AndroidAppUpdateController(
             resolver.delete(uri, null, null)
             throw error
         }
+    }
+
+    private fun requiresLegacyDownloadsPermission(): Boolean =
+        Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+            PackageManager.PERMISSION_GRANTED
+
+    private fun requestLegacyDownloadsPermission() {
+        mutableUiState.update {
+            it.copy(
+                phase = AppUpdatePhase.UpdateAvailable,
+                isSavingUpdateToDownloads = false,
+                message = "需要存储权限以保存安装包到下载文件夹",
+            )
+        }
+        appContext.startActivity(
+            Intent(appContext, AppUpdateSavePermissionActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
     }
 
     @Suppress("DEPRECATION")

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
@@ -1,13 +1,18 @@
 package org.feeluown.mobile
 
+import android.Manifest
 import android.content.ClipData
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import android.provider.Settings
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import java.io.File
 import java.io.IOException
@@ -78,6 +83,8 @@ internal class AndroidAppUpdateController(
                             remoteVersionName = if (channelChanged) null else current.remoteVersionName,
                             publishedAt = if (channelChanged) null else current.publishedAt,
                             releaseNotesUrl = if (channelChanged) null else current.releaseNotesUrl,
+                            isUpdateSavedToDownloads = if (channelChanged) false else current.isUpdateSavedToDownloads,
+                            isSavingUpdateToDownloads = if (channelChanged) false else current.isSavingUpdateToDownloads,
                             message = if (channelChanged) null else current.message,
                         )
                     }
@@ -121,6 +128,38 @@ internal class AndroidAppUpdateController(
         }
     }
 
+    override fun saveToDownloads() {
+        scope.launch {
+            operationMutex.withLock {
+                val manifest = latestManifest
+                if (manifest == null || manifest.versionCode <= installedVersionCode) {
+                    checkForUpdatesLocked(force = true)
+                    return@withLock
+                }
+                if (mutableUiState.value.isUpdateSavedToDownloads) return@withLock
+                mutableUiState.update {
+                    it.copy(
+                        isSavingUpdateToDownloads = true,
+                        message = "正在保存 ${manifest.versionName} 到下载文件夹",
+                    )
+                }
+                runCatching { saveToDownloadsLocked(manifest) }
+                    .onSuccess {
+                        mutableUiState.update {
+                            it.copy(
+                                phase = AppUpdatePhase.UpdateAvailable,
+                                downloadProgress = null,
+                                isUpdateSavedToDownloads = true,
+                                isSavingUpdateToDownloads = false,
+                                message = "安装包已保存到下载文件夹",
+                            )
+                        }
+                    }
+                    .onFailure(::showError)
+            }
+        }
+    }
+
     private suspend fun checkForUpdates(force: Boolean) {
         operationMutex.withLock { checkForUpdatesLocked(force) }
     }
@@ -137,6 +176,7 @@ internal class AndroidAppUpdateController(
                 autoCheckEnabled = settings.autoCheckAppUpdates,
                 phase = AppUpdatePhase.Checking,
                 downloadProgress = null,
+                isSavingUpdateToDownloads = false,
                 message = null,
             )
         }
@@ -147,6 +187,9 @@ internal class AndroidAppUpdateController(
             markSuccessfulCheck(channel)
             latestManifest = manifest
             val decision = evaluateAppUpdate(installedVersionCode, channel, manifest.versionCode)
+            val savedToDownloads = decision == AppUpdateDecision.UpdateAvailable && runCatching {
+                withContext(Dispatchers.IO) { isSavedToDownloads(manifest) }
+            }.getOrDefault(false)
             mutableUiState.update { current ->
                 current.copy(
                     phase = when (decision) {
@@ -159,6 +202,7 @@ internal class AndroidAppUpdateController(
                     publishedAt = manifest.publishedAt,
                     releaseNotesUrl = manifest.releaseNotesUrl,
                     downloadProgress = null,
+                    isUpdateSavedToDownloads = savedToDownloads,
                     message = when (decision) {
                         AppUpdateDecision.UpToDate -> "当前已是最新版本"
                         AppUpdateDecision.UpdateAvailable -> "发现新版本 ${manifest.versionName}"
@@ -216,6 +260,23 @@ internal class AndroidAppUpdateController(
     }
 
     private suspend fun downloadAndInstallLocked(manifest: AppUpdateManifest) {
+        val apkFile = obtainValidatedApk(manifest)
+        launchInstaller(apkFile)
+    }
+
+    private suspend fun saveToDownloadsLocked(manifest: AppUpdateManifest) {
+        val apkFile = obtainValidatedApk(manifest)
+        mutableUiState.update {
+            it.copy(
+                phase = AppUpdatePhase.UpdateAvailable,
+                downloadProgress = null,
+                message = "正在保存 ${manifest.versionName} 到下载文件夹",
+            )
+        }
+        withContext(Dispatchers.IO) { saveApkToDownloads(apkFile, manifest) }
+    }
+
+    private suspend fun obtainValidatedApk(manifest: AppUpdateManifest): File {
         val updateDir = File(appContext.cacheDir, UPDATE_CACHE_DIR).apply { mkdirs() }
         val apkFile = File(updateDir, "fuo-evolve-${manifest.versionCode}.apk")
         val validCachedApk = withContext(Dispatchers.IO) {
@@ -230,7 +291,7 @@ internal class AndroidAppUpdateController(
         withContext(Dispatchers.IO) {
             check(validateDownloadedApk(apkFile, manifest)) { "下载的安装包校验失败" }
         }
-        launchInstaller(apkFile)
+        return apkFile
     }
 
     private fun downloadApk(manifest: AppUpdateManifest, apkFile: File) {
@@ -296,6 +357,96 @@ internal class AndroidAppUpdateController(
         }
     }
 
+    private fun isSavedToDownloads(manifest: AppUpdateManifest): Boolean {
+        val fileName = downloadsFileName(manifest)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val projection = arrayOf(MediaStore.MediaColumns.SIZE)
+            val selection = "${MediaStore.MediaColumns.DISPLAY_NAME} = ?"
+            appContext.contentResolver.query(
+                MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                projection,
+                selection,
+                arrayOf(fileName),
+                null,
+            )?.use { cursor ->
+                val sizeIndex = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
+                while (cursor.moveToNext()) {
+                    if (cursor.getLong(sizeIndex) == manifest.apk.size) return true
+                }
+                false
+            } ?: false
+        } else {
+            legacyDownloadsFile(fileName).let { file ->
+                file.isFile && file.length() == manifest.apk.size
+            }
+        }
+    }
+
+    private fun saveApkToDownloads(apkFile: File, manifest: AppUpdateManifest) {
+        if (isSavedToDownloads(manifest)) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            saveApkToMediaStore(apkFile, manifest)
+        } else {
+            saveApkToLegacyDownloads(apkFile, manifest)
+        }
+    }
+
+    private fun saveApkToMediaStore(apkFile: File, manifest: AppUpdateManifest) {
+        val resolver = appContext.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, downloadsFileName(manifest))
+            put(MediaStore.MediaColumns.MIME_TYPE, APK_MIME_TYPE)
+            put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+            ?: throw IOException("无法创建下载文件")
+        try {
+            resolver.openOutputStream(uri, "w")?.use { output ->
+                apkFile.inputStream().buffered().use { input ->
+                    input.copyTo(output, DOWNLOAD_BUFFER_BYTES)
+                }
+            } ?: throw IOException("无法写入下载文件")
+            values.clear()
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        } catch (error: Throwable) {
+            resolver.delete(uri, null, null)
+            throw error
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun saveApkToLegacyDownloads(apkFile: File, manifest: AppUpdateManifest) {
+        if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            throw IOException("保存到下载文件夹需要存储权限")
+        }
+        val target = legacyDownloadsFile(downloadsFileName(manifest))
+        target.parentFile?.let { downloadsDir ->
+            if (!downloadsDir.exists() && !downloadsDir.mkdirs()) {
+                throw IOException("无法创建下载文件夹")
+            }
+        }
+        apkFile.copyTo(target, overwrite = true)
+        if (target.length() != manifest.apk.size) {
+            target.delete()
+            throw IOException("保存的安装包大小不匹配")
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun legacyDownloadsFile(fileName: String): File = File(
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+        fileName,
+    )
+
+    private fun downloadsFileName(manifest: AppUpdateManifest): String {
+        val safeVersionName = manifest.versionName.replace(INVALID_FILE_NAME_CHARS, "_")
+        return "FuoEvolve-$safeVersionName-${manifest.versionCode}.apk"
+    }
+
     private fun validateDownloadedApk(apkFile: File, manifest: AppUpdateManifest): Boolean {
         val archive = readArchivePackageInfo(apkFile) ?: return false
         if (archive.packageName != appContext.packageName) return false
@@ -348,6 +499,7 @@ internal class AndroidAppUpdateController(
             it.copy(
                 phase = AppUpdatePhase.Error,
                 downloadProgress = null,
+                isSavingUpdateToDownloads = false,
                 message = error.message?.takeIf(String::isNotBlank) ?: "更新失败，请稍后重试",
             )
         }
@@ -439,6 +591,7 @@ internal class AndroidAppUpdateController(
         private const val WAITING_FOR_STABLE_MESSAGE =
             "已切换至稳定版。当前版本比最新稳定版更新，将在后续稳定版发布后恢复接收稳定版更新。"
         private val SHA256_REGEX = Regex("^[0-9a-fA-F]{64}$")
+        private val INVALID_FILE_NAME_CHARS = Regex("[^A-Za-z0-9._-]")
 
         private fun lastCheckKey(channel: AppUpdateChannel): String = "last_check_${channel.name.lowercase()}"
     }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/update/AppUpdateSavePermissionActivity.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/update/AppUpdateSavePermissionActivity.kt
@@ -1,0 +1,43 @@
+package org.feeluown.mobile
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+/** Requests the legacy external-storage permission only when saving an update on Android 7–9. */
+internal class AppUpdateSavePermissionActivity : ComponentActivity() {
+    private val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            continueSavingUpdate()
+        } else {
+            (application as FuoEvolveApplication).appViewModel.showFeedback(
+                "未授予存储权限，无法保存安装包到下载文件夹",
+            )
+        }
+        finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P || hasWriteExternalStoragePermission()) {
+            continueSavingUpdate()
+            finish()
+            return
+        }
+        permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    }
+
+    private fun continueSavingUpdate() {
+        (application as FuoEvolveApplication).appUiGraph.settings.saveAppUpdateToDownloads()
+    }
+
+    private fun hasWriteExternalStoragePermission(): Boolean =
+        ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/update/AppUpdateContracts.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/update/AppUpdateContracts.kt
@@ -60,6 +60,8 @@ data class AppUpdateUiState(
     val publishedAt: String? = null,
     val releaseNotesUrl: String? = null,
     val downloadProgress: Float? = null,
+    val isUpdateSavedToDownloads: Boolean = false,
+    val isSavingUpdateToDownloads: Boolean = false,
     val message: String? = null,
 )
 
@@ -69,6 +71,7 @@ interface AppUpdateController {
     fun setAutoCheckEnabled(enabled: Boolean)
     fun checkNow()
     fun downloadAndInstall()
+    fun saveToDownloads()
 }
 
 object NoopAppUpdateController : AppUpdateController {
@@ -78,6 +81,7 @@ object NoopAppUpdateController : AppUpdateController {
     override fun setAutoCheckEnabled(enabled: Boolean) = Unit
     override fun checkNow() = Unit
     override fun downloadAndInstall() = Unit
+    override fun saveToDownloads() = Unit
 }
 
 fun evaluateAppUpdate(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/AppUpdateFeatureSettings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/AppUpdateFeatureSettings.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Check

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/AppUpdateFeatureSettings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/AppUpdateFeatureSettings.kt
@@ -4,15 +4,21 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -30,9 +36,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun AppUpdateFeatureSettings(
@@ -54,7 +62,8 @@ internal fun AppUpdateFeatureSettings(
     }
 
     val operationBusy = update.phase == AppUpdatePhase.Checking ||
-        update.phase == AppUpdatePhase.Downloading
+        update.phase == AppUpdatePhase.Downloading ||
+        update.isSavingUpdateToDownloads
 
     AppUpdateGroup(title = "更新版本") {
         Column(
@@ -92,11 +101,11 @@ internal fun AppUpdateFeatureSettings(
         AppUpdateRow(
             title = "自动检查更新",
             supportingText = "开启后会定期检查新版本。",
-            enabled = update.phase != AppUpdatePhase.Downloading,
+            enabled = !operationBusy,
             trailingContent = {
                 Switch(
                     checked = update.autoCheckEnabled,
-                    enabled = update.phase != AppUpdatePhase.Downloading,
+                    enabled = !operationBusy,
                     onCheckedChange = controller::setAutoCheckAppUpdates,
                 )
             },
@@ -147,12 +156,33 @@ internal fun AppUpdateFeatureSettings(
         }
         Box(modifier = Modifier.fillMaxWidth().padding(FuoSpacing.lg)) {
             when (update.phase) {
-                AppUpdatePhase.UpdateAvailable -> Button(
-                    onClick = controller::downloadAndInstallAppUpdate,
+                AppUpdatePhase.UpdateAvailable -> Row(
                     modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(FuoSpacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(Icons.Filled.Download, contentDescription = null)
-                    Text("立即更新")
+                    Button(
+                        onClick = controller::downloadAndInstallAppUpdate,
+                        enabled = !update.isSavingUpdateToDownloads,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.Filled.Download, contentDescription = null)
+                        Text("立即更新")
+                    }
+                    IconButton(
+                        onClick = controller::saveAppUpdateToDownloads,
+                        enabled = !update.isUpdateSavedToDownloads && !update.isSavingUpdateToDownloads,
+                    ) {
+                        Icon(
+                            imageVector = if (update.isUpdateSavedToDownloads) Icons.Filled.Check else Icons.Filled.SaveAlt,
+                            contentDescription = if (update.isUpdateSavedToDownloads) {
+                                "安装包已保存到下载文件夹"
+                            } else {
+                                "保存安装包到下载文件夹"
+                            },
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
                 }
                 AppUpdatePhase.InstallPermissionRequired -> Button(
                     onClick = controller::downloadAndInstallAppUpdate,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureController.kt
@@ -65,6 +65,7 @@ interface SettingsFeatureController {
     fun setAutoCheckAppUpdates(enabled: Boolean) = Unit
     fun checkAppUpdates() = Unit
     fun downloadAndInstallAppUpdate() = Unit
+    fun saveAppUpdateToDownloads() = Unit
     fun dismissFeedback(feedback: String)
 }
 
@@ -172,6 +173,7 @@ private class BoundSettingsFeatureController(
     override fun setAutoCheckAppUpdates(enabled: Boolean) = appUpdateController.setAutoCheckEnabled(enabled)
     override fun checkAppUpdates() = appUpdateController.checkNow()
     override fun downloadAndInstallAppUpdate() = appUpdateController.downloadAndInstall()
+    override fun saveAppUpdateToDownloads() = appUpdateController.saveToDownloads()
     override fun dismissFeedback(feedback: String) = owner.dismissFeedback(feedback)
 
     private fun toUiState(


### PR DESCRIPTION
## Summary
- add a small save action next to the in-app update button
- save the validated APK to the system Downloads folder without launching the installer
- detect an already-saved APK for the current remote version and show a disabled check icon
- reuse the existing update cache, SHA-256/package/signature validation, and download progress flow
- use MediaStore on Android 10+ with a legacy Downloads fallback on Android 7–9

## Validation
- changes are scoped to app-update contracts, settings presentation/action wiring, and the Android updater
- CI will validate shared/common compilation and Android build/lint
