### PR TITLE
fix: unify page loading UI on latest Compose stack

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -48,7 +48,7 @@ val hasFuoSigningConfig = listOf(
 ).all { !it.isNullOrBlank() }
 android {
     namespace = "org.feeluown.mobile"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "org.feeluown.mobile"

--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
 
 android {
     namespace = "org.feeluown.mobile.feature.playback"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,9 @@ org.gradle.caching=true
 org.gradle.parallel=true
 # org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true
+# AGP 9 transition: keep the current Kotlin Android/KMP integration while the
+# Android KMP plugin and built-in Kotlin migration are handled separately.
+android.builtInKotlin=false
+android.newDsl=false
 kotlin.native.ignoreDisabledTargets=true
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.13.2"
+agp = "9.1.0"
 compose = "1.12.0"
-kotlin = "2.3.20"
+kotlin = "2.4.10"
 media3 = "1.6.1"
 activityCompose = "1.10.1"
 coreKtx = "1.15.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-compose = "1.11.1"
+compose = "1.12.0"
 kotlin = "2.3.20"
 media3 = "1.6.1"
 activityCompose = "1.10.1"
@@ -28,7 +28,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
-compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.11.0-alpha07" }
+compose-material3-expressive = { module = "org.jetbrains.compose.material3:material3", version = "1.12.0-alpha03" }
 material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
 androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/persistence/listening/build.gradle.kts
+++ b/persistence/listening/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 
 android {
     namespace = "org.feeluown.mobile.persistence.listening"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 24

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -1,0 +1,27 @@
+package org.feeluown.mobile
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/** Shared indeterminate loading treatment for page and content-area loading states. */
+@Composable
+fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
+    AnimatedVisibility(visible = visible, modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                strokeWidth = 3.dp,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -282,8 +282,7 @@ private fun HomeNavigationTabs(
     pagerState: PagerState,
     compact: Boolean,
     height: Dp,
-    onClick: (Int, HomeSection) -> Unit = { _, _ -> },
-    onSectionClick: (Int, HomeSection) -> Unit = onClick,
+    onSectionClick: (Int, HomeSection) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val pagerPosition = (

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
@@ -30,10 +31,10 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -82,8 +83,16 @@ private val HomeRailCompactItemHeight = 48.dp
 
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
-    AnimatedVisibility(visible = visible) {
-        LinearProgressIndicator(modifier = modifier.fillMaxWidth())
+    AnimatedVisibility(visible = visible, modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                strokeWidth = 3.dp,
+            )
+        }
     }
 }
 
@@ -166,10 +175,6 @@ fun HomeScreen(
             modifier = Modifier.fillMaxSize().padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(if (layoutInfo.useWideLayout) 6.dp else 8.dp),
         ) {
-            LoadingIndicator(
-                visible = state.isLoading,
-                modifier = Modifier.padding(horizontal = if (layoutInfo.useWideLayout) 8.dp else 16.dp),
-            )
             HomeSectionPager(
                 home = home,
                 sections = HomePrimarySections,
@@ -277,7 +282,8 @@ private fun HomeNavigationTabs(
     pagerState: PagerState,
     compact: Boolean,
     height: Dp,
-    onSectionClick: (Int, HomeSection) -> Unit,
+    onClick: (Int, HomeSection) -> Unit = { _, _ -> },
+    onSectionClick: (Int, HomeSection) -> Unit = onClick,
     modifier: Modifier = Modifier,
 ) {
     val pagerPosition = (

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package org.feeluown.mobile
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
@@ -31,7 +30,6 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -80,21 +78,6 @@ private val HomeRailCompactHeightThreshold = 400.dp
 private val HomeRailRecognitionHeightThreshold = 320.dp
 private val HomeRailExpandedItemHeight = 64.dp
 private val HomeRailCompactItemHeight = 48.dp
-
-@Composable
-fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
-    AnimatedVisibility(visible = visible, modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center,
-        ) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(32.dp),
-                strokeWidth = 3.dp,
-            )
-        }
-    }
-}
 
 @Composable
 fun HomeScreen(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ListeningHistoryMineContent.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ListeningHistoryMineContent.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -197,7 +196,7 @@ internal fun ListeningHistoryMineContent(
             }
         }
 
-        if (isLoading) LinearProgressIndicator(Modifier.fillMaxWidth())
+        LoadingIndicator(isLoading)
         errorMessage?.let { ProviderContentMessage(it) }
 
         when (tab) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailRoutes.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderDetailRoutes.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
@@ -297,6 +296,7 @@ fun ProviderPlaylistDetailRoute(playlist: ProviderPlaylist, category: ProviderFe
                 modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                LoadingIndicator(state.isLoading)
                 ProviderDetailHeader(
                     track = displayPlaylist.toDisplayTrack(),
                     title = displayPlaylist.title.ifBlank { "未命名歌单" },
@@ -339,11 +339,6 @@ fun ProviderPlaylistDetailRoute(playlist: ProviderPlaylist, category: ProviderFe
                     onItemVisible = owner::prefetchIfNeeded,
                     canRemove = owner::canRemove,
                     onRemove = owner::remove,
-                )
-            }
-            if (state.isLoading) {
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth().align(Alignment.TopCenter),
                 )
             }
         }
@@ -492,6 +487,7 @@ fun ProviderMediaItemDetailRoute(item: ProviderMediaItem) {
                 modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                LoadingIndicator(state.isLoading)
                 ProviderDetailHeader(
                     track = displayItem.toDisplayTrack(),
                     title = displayItem.title.ifBlank { if (isArtist) "未知歌手" else "未知专辑" },
@@ -561,11 +557,6 @@ fun ProviderMediaItemDetailRoute(item: ProviderMediaItem) {
                         onItemVisible = owner::prefetchTracksIfNeeded,
                     )
                 }
-            }
-            if (state.isLoading) {
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth().align(Alignment.TopCenter),
-                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -311,7 +310,7 @@ private fun SettingsMainPage(
         },
     ) { paddingValues ->
         Column(Modifier.fillMaxSize().padding(paddingValues)) {
-            if (settings.isBusy || catalog.isLoading) LinearProgressIndicator(Modifier.fillMaxWidth())
+            LoadingIndicator(settings.isBusy || catalog.isLoading)
             if (useWideLayout) {
                 Row(
                     modifier = Modifier.fillMaxSize().padding(horizontal = FuoSpacing.lg, vertical = FuoSpacing.md),
@@ -411,7 +410,7 @@ private fun SettingsScaffold(
         },
     ) { paddingValues ->
         Column(Modifier.fillMaxSize().padding(paddingValues)) {
-            if (isLoading) LinearProgressIndicator(Modifier.fillMaxWidth())
+            LoadingIndicator(isLoading)
             content(Modifier.weight(1f).fillMaxWidth())
         }
     }


### PR DESCRIPTION
## Summary
- remove the duplicate Home-level loading bar so refreshable Home sections use pull-to-refresh as their only refresh feedback
- standardize generic indeterminate page/content loading on one shared Material 3 `LoadingIndicator`
- apply the shared loading treatment across:
  - search and existing provider feature/track detail screens
  - listening history
  - provider playlist detail
  - provider artist/album detail
  - settings main page and settings sub-pages
- move `LoadingIndicator` out of `HomeScreen.kt` into `core/ui/FuoLoadingIndicator.kt` so it is a real shared UI primitive
- keep semantic-specific progress feedback unchanged:
  - Home Recommend / Explore / Mine keep `PullToRefreshBox`
  - mini-player/player buffering and play-button busy states remain local playback feedback
  - lyric association dialog search remains a local operation spinner
  - app update/download/playback progress remains determinate progress UI
- upgrade to the latest officially compatible Compose Multiplatform stack:
  - Compose Multiplatform 1.12.0
  - JetBrains Material3 1.12.0-alpha03 (Jetpack Material3 1.5.0-alpha22)
  - Kotlin 2.4.10
  - Android Gradle Plugin 9.1.0
  - Gradle 9.3.1
  - compileSdk 37
- keep targetSdk at 35 so this UI/toolchain update does not opt into unrelated Android runtime behavior changes
- keep AGP 9 built-in Kotlin/new DSL disabled temporarily; the Android-KMP plugin migration should be handled separately from this UI change

## Rationale
Material 3 separates refresh interaction feedback, generic indeterminate loading, local control busy states, and determinate progress. The app previously mixed top linear page loaders with pull-to-refresh and other local indicators. This PR makes the semantics consistent instead of mechanically replacing every progress component with one visual.

A repository-wide scan of `LinearProgressIndicator`, `CircularProgressIndicator`, `isLoading`/`isBusy`, and pull-to-refresh usage found no remaining page-level linear loaders after these changes. Remaining progress indicators are intentionally tied to playback buffering/control state or measurable update/download/playback progress.

The newer Jetpack Material3 alpha26/27 morphing `LoadingIndicator` and its dedicated pull-to-refresh integration are newer than the Material3 alpha22 version currently mapped by Compose Multiplatform 1.12.0, so this PR does not introduce Android-only dependencies into `commonMain` just to reach those APIs.

## Validation
- latest head: `36d150fea44c7ca53686b964db11c3080a289805`
- architecture boundary checks passed
- Android unit tests and coverage passed
- PR Android app compile/resource validation passed with compileSdk 37
- latest successful workflow run: https://github.com/feeluown/FuoEvolve/actions/runs/33383164710
