### PR TITLE
fix: separate page loading from pull refresh

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -5,12 +5,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 /** Shared indeterminate loading treatment for page and content-area loading states. */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
     AnimatedVisibility(visible = visible, modifier = modifier.fillMaxWidth()) {
@@ -18,9 +20,8 @@ fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Center,
         ) {
-            CircularProgressIndicator(
+            CircularWavyProgressIndicator(
                 modifier = Modifier.size(32.dp),
-                strokeWidth = 3.dp,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -47,6 +47,14 @@ fun MineHomeSection(
     val state by home.uiState.collectAsStateWithLifecycle()
     val localMusicState by graph.localMusic.uiState.collectAsStateWithLifecycle()
     val wide = LocalAppLayoutInfo.current.useWideLayout
+    var refreshRequested by remember(state.mineSection) { mutableStateOf(false) }
+    val isLoading = state.isLoading || (state.mineSection == MineSection.LocalMusic && localMusicState.isLoading)
+    val isPullRefreshing = refreshRequested && isLoading
+    val showPageLoading = isLoading && !refreshRequested
+
+    LaunchedEffect(isLoading) {
+        if (!isLoading) refreshRequested = false
+    }
 
     Column(modifier, verticalArrangement = Arrangement.spacedBy(if (wide) 6.dp else 12.dp)) {
         MineOwnerChips(
@@ -54,8 +62,11 @@ fun MineHomeSection(
             includeSecondary = wide,
         )
         PullToRefreshBox(
-            isRefreshing = state.isLoading || (state.mineSection == MineSection.LocalMusic && localMusicState.isLoading),
-            onRefresh = home::refreshMine,
+            isRefreshing = isPullRefreshing,
+            onRefresh = {
+                refreshRequested = true
+                home.refreshMine()
+            },
             modifier = Modifier.weight(1f).fillMaxWidth(),
         ) {
             when (state.mineSection) {
@@ -71,6 +82,10 @@ fun MineHomeSection(
                     modifier = Modifier.fillMaxSize(),
                 )
             }
+            LoadingIndicator(
+                visible = showPageLoading,
+                modifier = Modifier.align(Alignment.Center),
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
@@ -10,7 +10,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -31,10 +36,21 @@ fun ProviderContentHomeFeatureSection(
     val lockedProviders = remember(sections) {
         sections.filter { it.isLoginRequired }.map { it.feature }.distinctBy { it.providerId }
     }
+    var refreshRequested by remember(section) { mutableStateOf(false) }
+    val isPullRefreshing = refreshRequested && state.isLoading
+    val showPageLoading = state.isLoading && !refreshRequested
+
+    LaunchedEffect(state.isLoading) {
+        if (!state.isLoading) refreshRequested = false
+    }
+
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
         PullToRefreshBox(
-            isRefreshing = state.isLoading,
-            onRefresh = { home.refreshHome(section) },
+            isRefreshing = isPullRefreshing,
+            onRefresh = {
+                refreshRequested = true
+                home.refreshHome(section)
+            },
             modifier = Modifier.weight(1f).fillMaxWidth(),
         ) {
             LazyColumn(
@@ -198,6 +214,10 @@ fun ProviderContentHomeFeatureSection(
                     }
                 }
             }
+            LoadingIndicator(
+                visible = showPageLoading,
+                modifier = Modifier.align(Alignment.Center),
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- only show `PullToRefreshBox` refreshing feedback after an actual pull-to-refresh gesture
- show the shared page `LoadingIndicator` for automatic/initial loading instead of reusing pull-refresh feedback
- center automatic page loading inside the remaining content area for Recommend / Explore / Mine
- keep existing loaded content visible while background loading is in progress

## Why
The previous loading UI cleanup changed the indicator style, but Home still bound `PullToRefreshBox.isRefreshing` directly to the generic `isLoading` state. That meant automatic loads and tab/filter changes displayed the pull-refresh indicator even when the user never pulled, so the visual semantics still looked almost unchanged.

This follow-up separates the two states at the UI layer: user pull => pull-refresh indicator; automatic load => shared centered page loading indicator.

## Scope
Only Home Recommend / Explore / Mine loading presentation is changed. No provider loading behavior, playback progress, downloads, or business logic is modified.