### PR TITLE
fix: float mini player over route content

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -55,6 +55,7 @@ internal fun AppShell(
         CompositionLocalProvider(
             LocalPlaybackSession provides uiGraph.playbackSession,
             LocalPlaybackUiPort provides playback,
+            LocalPlaybackMiniPlayerHostedByShell provides true,
             LocalLocalMusicUiGraph provides LocalMusicUiGraph(
                 feature = uiGraph.localMusic,
                 playbackQueue = playback.queue,
@@ -95,6 +96,15 @@ internal fun AppShell(
                                     platform = platform,
                                     modifier = Modifier.fillMaxSize(),
                                 )
+                                if (miniPlayerVisible) {
+                                    Box(
+                                        modifier = Modifier
+                                            .align(Alignment.BottomCenter)
+                                            .navigationBarsPadding(),
+                                    ) {
+                                        PlaybackMiniPlayerOverlay()
+                                    }
+                                }
                                 AppGlobalOverlays(uiGraph)
                                 val feedbackModifier = Modifier
                                     .align(Alignment.BottomCenter)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -56,7 +56,7 @@ val LocalProviderTrackActionPort = staticCompositionLocalOf<ProviderTrackActionP
     error("ProviderTrackActionPort is not provided")
 }
 val LocalLocalMusicActionPort = staticCompositionLocalOf<LocalMusicActionPort> {
-    error("LocalMusicActionPort is not provided")
+    error("LocalLocalMusicActionPort is not provided")
 }
 val LocalPlaybackLyricsPort = staticCompositionLocalOf<PlaybackLyricsPort> {
     error("PlaybackLyricsPort is not provided")
@@ -64,6 +64,13 @@ val LocalPlaybackLyricsPort = staticCompositionLocalOf<PlaybackLyricsPort> {
 val LocalReplacementActionPort = staticCompositionLocalOf<ReplacementActionPort> {
     error("ReplacementActionPort is not provided")
 }
+
+/**
+ * Route scaffolds still declare the mini player as a bottom bar. When the app shell owns the
+ * floating player, those legacy slots intentionally emit no layout so route content can continue
+ * underneath the rounded player card.
+ */
+internal val LocalPlaybackMiniPlayerHostedByShell = staticCompositionLocalOf { false }
 
 @Composable
 fun ProvideNarrowPlaybackUi(
@@ -131,6 +138,18 @@ fun ProvideNarrowPlaybackUi(
 /** Controller-free MiniPlayer entry point used by app/feature screens. */
 @Composable
 fun PlaybackMiniPlayer() {
+    if (LocalPlaybackMiniPlayerHostedByShell.current) return
+    PlaybackMiniPlayerContent()
+}
+
+/** Floating MiniPlayer hosted by the app shell above route content. */
+@Composable
+internal fun PlaybackMiniPlayerOverlay() {
+    PlaybackMiniPlayerContent()
+}
+
+@Composable
+private fun PlaybackMiniPlayerContent() {
     val graph = LocalPlaybackUiPort.current
     PlaybackDynamicColorTheme(emphasis = PlaybackColorEmphasis.Ambient) {
         RuntimeMiniPlayer(

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiComposition.kt
@@ -56,7 +56,7 @@ val LocalProviderTrackActionPort = staticCompositionLocalOf<ProviderTrackActionP
     error("ProviderTrackActionPort is not provided")
 }
 val LocalLocalMusicActionPort = staticCompositionLocalOf<LocalMusicActionPort> {
-    error("LocalLocalMusicActionPort is not provided")
+    error("LocalMusicActionPort is not provided")
 }
 val LocalPlaybackLyricsPort = staticCompositionLocalOf<PlaybackLyricsPort> {
     error("PlaybackLyricsPort is not provided")


### PR DESCRIPTION
## 问题
迷你播放器虽然自身外层已经是透明的，但它仍然作为各页面 `Scaffold.bottomBar` 参与布局。`Scaffold` 因此会为 bottom bar 预留整块区域，圆角和外边距后面露出的其实是 Scaffold 的 surface 背景，而不是页面内容。

## 调整
- 由 `AppShell` 统一承载迷你播放器浮层，直接绘制在当前路由内容之上。
- AppShell 承载时让现有页面里的 legacy `bottomBar` 入口不再产生布局高度，页面内容可以自然延伸到播放器后方。
- 浮层增加 `navigationBarsPadding()`，避免手势导航条压在播放器内容上。
- 保持全屏播放器、视频全屏和各路由现有的 mini player 可见性策略不变。

这样播放器卡片本身仍使用当前 MD3 容器色，但圆角外侧和 8dp/4dp 外边距区域是真正透明的，会看到下面的页面内容。