### PR TITLE
ci: validate release AAR metadata in pull requests

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -87,6 +87,7 @@ jobs:
 
           if [ "$VALIDATE_ANDROID_APP" = "true" ]; then
             tasks+=(
+              :shared:checkReleaseAarMetadata
               :androidApp:compileDebugKotlin
               :androidApp:compileDebugJavaWithJavac
               :androidApp:processDebugResources


### PR DESCRIPTION
## Summary
- add `:shared:checkReleaseAarMetadata` to PR-only Android validation
- keep the existing lightweight Debug compile checks
- do not run `assembleRelease` or build signed APKs for pull requests

## Why
The master Release build can fail on library AAR metadata constraints that are not exercised by the current PR Debug compile validation. Running the shared Release metadata task catches compileSdk/minCompileSdk dependency mismatches without paying the cost of a full Release APK build.

## Note
The current master state still contains the existing `shared compileSdk 36` vs dependency `compileSdk 37` mismatch, so this new check is expected to expose that existing failure until the SDK mismatch itself is fixed.