### PR TITLE
refactor: make playback starts explicit transactions

### DIFF
--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -122,6 +122,16 @@ val checkPlaybackFeatureBoundaries = tasks.register("checkPlaybackFeatureBoundar
             }
         }
 
+        listOf(
+            "pendingPlaybackStartReason",
+            "markNextPlaybackStart",
+            "consumePlaybackStartReason",
+        ).forEach { retiredSymbol ->
+            check(!Regex("\\b${Regex.escape(retiredSymbol)}\\b").containsMatchIn(featureSourceText)) {
+                "Playback starts must use explicit PlaybackTransaction; retired implicit channel restored: $retiredSymbol"
+            }
+        }
+
         val restored = retiredSharedPlaybackBusinessFiles.filter { it.isFile }
         check(restored.isEmpty()) {
             buildString {

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
@@ -254,6 +254,7 @@ private fun PlaybackStartReason?.toListeningStartReason(): ListeningStartReason 
     PlaybackStartReason.AUTO_NEXT -> ListeningStartReason.AutoNext
     PlaybackStartReason.RESUME -> ListeningStartReason.Resume
     PlaybackStartReason.RESTORE_SESSION -> ListeningStartReason.RestoreSession
+    PlaybackStartReason.RECOVERY -> ListeningStartReason.Unknown
     null -> ListeningStartReason.Unknown
 }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
@@ -20,6 +20,8 @@ data class PlaybackQueueState(
     val repeatMode: RepeatMode = RepeatMode.QUEUE,
     val isFmQueue: Boolean = false,
     val shuffleBeforeFm: Boolean? = null,
+    val activePlaybackTransaction: PlaybackTransaction? = null,
+    val playbackTransactionSequence: Long = 0L,
     val lastPlaybackStartReason: PlaybackStartReason? = null,
     val playbackStartSequence: Long = 0L,
 )
@@ -73,22 +75,38 @@ internal class PlaybackQueueController {
         get() = mutableState.value.shuffleBeforeFm
         set(value) = update { it.copy(shuffleBeforeFm = value) }
 
-    private var pendingPlaybackStartReason: PlaybackStartReason? = null
-
     fun currentTrack(): MusicTrack? = mutableState.value.currentTrack()
 
     fun displayQueue(): List<MusicTrack> = mutableState.value.displayQueue()
 
     fun displayQueueIndex(): Int = if (currentTrack() != null) 0 else -1
 
-    fun markNextPlaybackStart(reason: PlaybackStartReason) {
-        pendingPlaybackStartReason = reason
-        updateEphemeral { current ->
-            current.copy(
-                lastPlaybackStartReason = reason,
-                playbackStartSequence = current.playbackStartSequence + 1L,
+    fun activePlaybackTransaction(): PlaybackTransaction? = mutableState.value.activePlaybackTransaction
+
+    fun beginPlaybackTransaction(
+        trackId: String,
+        reason: PlaybackStartReason,
+        recordPlaybackStart: Boolean = true,
+    ): PlaybackTransaction {
+        val current = mutableState.value
+        val transaction = PlaybackTransaction(
+            id = current.playbackTransactionSequence + 1L,
+            reason = reason,
+            targetTrackId = trackId,
+        )
+        updateEphemeral { state ->
+            state.copy(
+                activePlaybackTransaction = transaction,
+                playbackTransactionSequence = transaction.id,
+                lastPlaybackStartReason = if (recordPlaybackStart) reason else state.lastPlaybackStartReason,
+                playbackStartSequence = if (recordPlaybackStart) {
+                    state.playbackStartSequence + 1L
+                } else {
+                    state.playbackStartSequence
+                },
             )
         }
+        return transaction
     }
 
     /** Starts a new logical playback-context session without making it part of durable queue state. */
@@ -100,10 +118,6 @@ internal class PlaybackQueueController {
             )
         }
     }
-
-    fun consumePlaybackStartReason(): PlaybackStartReason =
-        pendingPlaybackStartReason?.also { pendingPlaybackStartReason = null }
-            ?: PlaybackStartReason.AUTO_NEXT
 
     fun updateCurrentTrack(track: MusicTrack) {
         val current = mutableState.value
@@ -123,16 +137,17 @@ internal class PlaybackQueueController {
     }
 
     /**
-     * Applies the persisted startup queue only if no live queue mutation happened first.
+     * Applies the persisted startup queue only if no live durable queue mutation happened first.
      *
-     * Mutation history is tracked monotonically rather than inferred from current values so user
-     * actions that return the queue to its defaults (for example clearing an already-empty queue or
-     * toggling shuffle twice) still invalidate a delayed startup snapshot.
+     * An already-started playback transaction is intentionally preserved across hydration. A resume
+     * may begin from the independently restored engine state before the durable queue snapshot arrives;
+     * resetting its transaction here would make an in-flight provider result look stale.
      *
-     * @return true when the snapshot was applied, false when a newer live mutation won the race.
+     * @return true when the snapshot was applied, false when a newer live queue mutation won the race.
      */
     fun restore(snapshot: PlaybackQueueSnapshot): Boolean {
         if (startupDirty) return false
+        val current = mutableState.value
         applyingStartupSnapshot = true
         try {
             mutableState.value = PlaybackQueueState(
@@ -144,8 +159,11 @@ internal class PlaybackQueueController {
                 repeatMode = snapshot.repeatMode,
                 isFmQueue = snapshot.isFmQueue,
                 shuffleBeforeFm = snapshot.shuffleBeforeFm,
+                activePlaybackTransaction = current.activePlaybackTransaction,
+                playbackTransactionSequence = current.playbackTransactionSequence,
+                lastPlaybackStartReason = current.lastPlaybackStartReason,
+                playbackStartSequence = current.playbackStartSequence,
             )
-            pendingPlaybackStartReason = null
         } finally {
             applyingStartupSnapshot = false
         }

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
@@ -474,7 +474,7 @@ internal class PlaybackQueueCoordinator(
         requestedPartIndex: Int?,
         reason: PlaybackStartReason,
     ) {
-        queueState.markNextPlaybackStart(reason)
+        queueState.beginPlaybackTransaction(track.id, reason)
         startPlayback(track, skippedUnavailableCount, requestedPartIndex)
     }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
@@ -14,6 +14,7 @@ enum class PlaybackStartReason {
     AUTO_NEXT,
     RESUME,
     RESTORE_SESSION,
+    RECOVERY,
     ;
 
     val isActiveSelection: Boolean
@@ -22,6 +23,13 @@ enum class PlaybackStartReason {
     val mayResumePausedSession: Boolean
         get() = this == RESUME || this == RESTORE_SESSION
 }
+
+/** Stable identity for one playback start from intent through engine generation. */
+data class PlaybackTransaction(
+    val id: Long,
+    val reason: PlaybackStartReason,
+    val targetTrackId: String,
+)
 
 /** Optional engine capability for distinguishing a fresh selection from session resume. */
 interface PlaybackStartReasonAwareEngine {
@@ -79,12 +87,31 @@ internal class PlaybackStartCoordinator(
         messageAfterStart: String? = null,
         suppressPlaybackRecovery: Boolean = false,
     ) {
-        val startReason = queue.consumePlaybackStartReason()
         prepareSleepTimer(track.id)
+        val playbackTrack = if (manualSelection != null) track else prepareTrack(track)
+        val transaction = when {
+            manualSelection != null -> queue.beginPlaybackTransaction(
+                trackId = playbackTrack.id,
+                reason = PlaybackStartReason.USER_SELECTION,
+                recordPlaybackStart = false,
+            )
+            suppressPlaybackRecovery -> queue.beginPlaybackTransaction(
+                trackId = playbackTrack.id,
+                reason = PlaybackStartReason.RECOVERY,
+                recordPlaybackStart = false,
+            )
+            else -> queue.activePlaybackTransaction()
+                ?.takeIf { it.targetTrackId == playbackTrack.id }
+                ?: queue.beginPlaybackTransaction(
+                    trackId = playbackTrack.id,
+                    reason = PlaybackStartReason.RECOVERY,
+                    recordPlaybackStart = false,
+                )
+        }
+        val startReason = transaction.reason
         val serial = nextRequestSerial()
         _startFailure.value = null
         onRequestStarted(serial, suppressPlaybackRecovery)
-        val playbackTrack = if (manualSelection != null) track else prepareTrack(track)
         manualSelection?.let { selection ->
             onManualSelectionStarted(serial, playbackTrack, selection, rollbackTrack)
         }
@@ -128,6 +155,7 @@ internal class PlaybackStartCoordinator(
                 playbackParts = playbackParts(),
                 currentPartIndex = requestedPartIndex.takeIf { isPlaybackPartRequest } ?: -1,
                 lyrics = preservedLyrics ?: playbackTrack.lyrics,
+                playbackGeneration = transaction.id,
                 errorMessage = null,
             )
         )
@@ -144,6 +172,7 @@ internal class PlaybackStartCoordinator(
         if (!playbackEngine.resolvesResourcesInternally) {
             resolveAndStart(
                 serial = serial,
+                transaction = transaction,
                 playbackTrack = playbackTrack,
                 resolveTrack = resolveTrack,
                 skippedUnavailableCount = skippedUnavailableCount,
@@ -156,7 +185,7 @@ internal class PlaybackStartCoordinator(
 
         playbackEngine.play(
             PlaybackPlan(
-                generation = serial,
+                generation = transaction.id,
                 requests = buildList {
                     add(
                         PlaybackRequest(
@@ -194,6 +223,7 @@ internal class PlaybackStartCoordinator(
 
     private fun resolveAndStart(
         serial: Long,
+        transaction: PlaybackTransaction,
         playbackTrack: MusicTrack,
         resolveTrack: MusicTrack,
         skippedUnavailableCount: Int,
@@ -222,6 +252,7 @@ internal class PlaybackStartCoordinator(
                         )
                     }
                 if (serial != currentRequestSerial()) return@playRequest
+                if (queue.activePlaybackTransaction()?.id != transaction.id) return@playRequest
                 // The legacy direct-resolution path cleared recovery suppression once
                 // media resolution succeeded, before engine playback started.
                 onRequestStarted(serial, false)
@@ -248,6 +279,7 @@ internal class PlaybackStartCoordinator(
                         audioQuality = payload.audioQuality,
                         playbackParts = playbackParts(),
                         currentPartIndex = currentPartIndex(),
+                        playbackGeneration = transaction.id,
                     )
                 )
                 maybeLoadLyrics(playableTrack)
@@ -259,7 +291,7 @@ internal class PlaybackStartCoordinator(
                 )
                 prefetchQueue()
             }.onFailure { throwable ->
-                if (serial == currentRequestSerial()) {
+                if (serial == currentRequestSerial() && queue.activePlaybackTransaction()?.id == transaction.id) {
                     _startFailure.value = PlaybackStartFailure(
                         trackId = playbackTrack.id,
                         message = failureMessage(throwable),
@@ -273,7 +305,9 @@ internal class PlaybackStartCoordinator(
                     )
                 }
             }
-            if (serial == currentRequestSerial()) setLoading(false)
+            if (serial == currentRequestSerial() && queue.activePlaybackTransaction()?.id == transaction.id) {
+                setLoading(false)
+            }
         }
     }
 

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueControllerTest.kt
@@ -90,7 +90,7 @@ class PlaybackQueueControllerTest {
             mainQueue = listOf(firstNew, secondNew)
             mainQueueIndex = 0
             queuePlaylistId = "playlist:new"
-            markNextPlaybackStart(PlaybackStartReason.PLAYLIST_REPLACE)
+            beginPlaybackTransaction(firstNew.id, PlaybackStartReason.PLAYLIST_REPLACE)
         }
 
         assertFalse(controller.restore(oldSnapshot))
@@ -98,7 +98,8 @@ class PlaybackQueueControllerTest {
         assertEquals(listOf(firstNew, secondNew), controller.mainQueue)
         assertEquals(firstNew, controller.currentTrack())
         assertEquals("playlist:new", controller.queuePlaylistId)
-        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, controller.consumePlaybackStartReason())
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, controller.activePlaybackTransaction()?.reason)
+        assertEquals(firstNew.id, controller.activePlaybackTransaction()?.targetTrackId)
     }
 
     @Test
@@ -154,21 +155,36 @@ class PlaybackQueueControllerTest {
     }
 
     @Test
-    fun resumeIntentStillAllowsStartupQueueRestore() {
+    fun resumeTransactionSurvivesStartupQueueHydration() {
         val restoredTrack = track("netease:old", "Restored")
         val oldSnapshot = PlaybackQueueController().apply {
             mainQueue = listOf(restoredTrack)
             mainQueueIndex = 0
         }.snapshot()
-        val controller = PlaybackQueueController().apply {
-            markNextPlaybackStart(PlaybackStartReason.RESUME)
-        }
+        val controller = PlaybackQueueController()
+        val transaction = controller.beginPlaybackTransaction(restoredTrack.id, PlaybackStartReason.RESUME)
 
         assertTrue(controller.restore(oldSnapshot))
 
         assertEquals(listOf(restoredTrack), controller.mainQueue)
         assertEquals(restoredTrack, controller.currentTrack())
-        assertEquals(PlaybackStartReason.AUTO_NEXT, controller.consumePlaybackStartReason())
+        assertEquals(transaction, controller.activePlaybackTransaction())
+        assertEquals(transaction.id, controller.state.value.playbackStartSequence)
+        assertEquals(transaction.reason, controller.state.value.lastPlaybackStartReason)
+    }
+
+    @Test
+    fun playbackTransactionsAreMonotonicAndObservable() {
+        val controller = PlaybackQueueController()
+
+        val first = controller.beginPlaybackTransaction("track:a", PlaybackStartReason.USER_SELECTION)
+        val second = controller.beginPlaybackTransaction("track:b", PlaybackStartReason.AUTO_NEXT)
+
+        assertEquals(1L, first.id)
+        assertEquals(2L, second.id)
+        assertEquals(second, controller.activePlaybackTransaction())
+        assertEquals(PlaybackStartReason.AUTO_NEXT, controller.state.value.lastPlaybackStartReason)
+        assertEquals(2L, controller.state.value.playbackStartSequence)
     }
 
     @Test

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
@@ -36,6 +36,7 @@ class PlaybackStartCoordinatorTest {
         assertEquals("Resolved title", queue.currentTrack()?.title)
         assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
         assertEquals("Resolved title", fixture.playbackState.currentTrack?.title)
+        assertEquals(queue.activePlaybackTransaction()?.id, fixture.playbackState.playbackGeneration)
         assertNull(fixture.coordinator.startFailure.value)
         assertEquals(0, fixture.failureCount)
     }
@@ -63,13 +64,15 @@ class PlaybackStartCoordinatorTest {
     }
 
     @Test
-    fun internalResolutionBuildsPlanWithoutCallingProviderResolver() = runTest {
+    fun internalResolutionUsesPlaybackTransactionAsPlanGeneration() = runTest {
         val current = track("netease:1")
         val next = track("netease:2")
         val queue = PlaybackQueueController().apply {
             mainQueue = listOf(current, next)
             mainQueueIndex = 0
         }
+        queue.beginPlaybackTransaction("unused", PlaybackStartReason.AUTO_NEXT)
+        val transaction = queue.beginPlaybackTransaction(current.id, PlaybackStartReason.USER_SELECTION)
         val engine = FakePlaybackEngine(resolvesInternally = true)
         val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
         val fixture = fixture(queue, engine, repository)
@@ -77,7 +80,8 @@ class PlaybackStartCoordinatorTest {
         fixture.coordinator.start(current)
 
         val plan = assertNotNull(engine.playedPlan)
-        assertEquals(1L, plan.generation)
+        assertEquals(transaction.id, plan.generation)
+        assertEquals(transaction.id, fixture.playbackState.playbackGeneration)
         assertEquals(listOf(current.id, next.id), plan.requests.map { it.track.id })
         assertEquals(0, repository.resolveCalls)
         assertNull(fixture.coordinator.startFailure.value)
@@ -90,7 +94,7 @@ class PlaybackStartCoordinatorTest {
         val queue = PlaybackQueueController().apply {
             mainQueue = listOf(selected)
             mainQueueIndex = 0
-            markNextPlaybackStart(PlaybackStartReason.PLAYLIST_REPLACE)
+            beginPlaybackTransaction(selected.id, PlaybackStartReason.PLAYLIST_REPLACE)
         }
         val engine = FakePlaybackEngine(resolvesInternally = true)
         val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
@@ -112,6 +116,63 @@ class PlaybackStartCoordinatorTest {
         assertTrue(published)
         assertEquals(selected, fixture.playbackState.currentTrack)
         assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
+        assertEquals(queue.activePlaybackTransaction()?.id, fixture.playbackState.playbackGeneration)
+    }
+
+    @Test
+    fun manualSourceSelectionCreatesFreshTransactionWithoutRestartingListeningHistory() = runTest {
+        val original = track("netease:1")
+        val selection = SmartReplacementSelection(
+            replacementId = "qqmusic:replacement",
+            replacementTitle = "Replacement",
+            replacementArtists = "Artist",
+            replacementSource = "qqmusic",
+        )
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(original)
+            mainQueueIndex = 0
+            beginPlaybackTransaction(original.id, PlaybackStartReason.AUTO_NEXT)
+        }
+        val historySequenceBeforeSwitch = queue.state.value.playbackStartSequence
+        val engine = FakePlaybackEngine(resolvesInternally = true)
+        val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
+        val fixture = fixture(queue, engine, repository)
+
+        fixture.coordinator.start(
+            track = original.withReplacementSelection(selection),
+            manualSelection = selection,
+            rollbackTrack = original,
+        )
+
+        val transaction = assertNotNull(queue.activePlaybackTransaction())
+        assertEquals(PlaybackStartReason.USER_SELECTION, transaction.reason)
+        assertEquals(original.id, transaction.targetTrackId)
+        assertEquals(transaction.id, assertNotNull(engine.playedPlan).generation)
+        assertEquals(historySequenceBeforeSwitch, queue.state.value.playbackStartSequence)
+    }
+
+    @Test
+    fun recoveryStartIsFreshAndDoesNotRestartListeningHistory() = runTest {
+        val original = track("netease:1")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(original)
+            mainQueueIndex = 0
+            beginPlaybackTransaction(original.id, PlaybackStartReason.USER_SELECTION)
+        }
+        val historySequenceBeforeRecovery = queue.state.value.playbackStartSequence
+        val engine = FakePlaybackEngine(resolvesInternally = true)
+        val repository = FakePlaybackRepository(resolveError = IllegalStateException("resolver should not be called"))
+        val fixture = fixture(queue, engine, repository)
+
+        fixture.coordinator.start(
+            track = original,
+            suppressPlaybackRecovery = true,
+        )
+
+        val transaction = assertNotNull(queue.activePlaybackTransaction())
+        assertEquals(PlaybackStartReason.RECOVERY, transaction.reason)
+        assertEquals(historySequenceBeforeRecovery, queue.state.value.playbackStartSequence)
+        assertEquals(PlaybackStartReason.RECOVERY, engine.preparedReason)
     }
 
     private fun TestScope.fixture(

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartReasonTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class PlaybackStartReasonTest {
     @Test
@@ -17,10 +18,10 @@ class PlaybackStartReasonTest {
             mainQueueIndex = 0
         }
         var startedTrack: MusicTrack? = null
-        var startReason: PlaybackStartReason? = null
+        var transaction: PlaybackTransaction? = null
         val coordinator = coordinator(queue) { track, _, _ ->
             startedTrack = track
-            startReason = queue.consumePlaybackStartReason()
+            transaction = queue.activePlaybackTransaction()
         }
 
         coordinator.playPlaylistTracks(
@@ -30,7 +31,9 @@ class PlaybackStartReasonTest {
         )
 
         assertEquals(selected, startedTrack)
-        assertEquals(PlaybackStartReason.USER_SELECTION, startReason)
+        assertEquals(PlaybackStartReason.USER_SELECTION, transaction?.reason)
+        assertEquals(selected.id, transaction?.targetTrackId)
+        assertEquals(1L, transaction?.id)
         assertEquals(selected, queue.currentTrack())
         assertEquals("playlist:new", queue.queuePlaylistId)
     }
@@ -45,10 +48,10 @@ class PlaybackStartReasonTest {
             mainQueueIndex = 0
         }
         var startedTrack: MusicTrack? = null
-        var startReason: PlaybackStartReason? = null
+        var transaction: PlaybackTransaction? = null
         val coordinator = coordinator(queue) { track, _, _ ->
             startedTrack = track
-            startReason = queue.consumePlaybackStartReason()
+            transaction = queue.activePlaybackTransaction()
         }
 
         coordinator.playAllPlaylistTracks(
@@ -57,7 +60,8 @@ class PlaybackStartReasonTest {
         )
 
         assertEquals(first, startedTrack)
-        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, startReason)
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, transaction?.reason)
+        assertEquals(first.id, transaction?.targetTrackId)
         assertEquals(first, queue.currentTrack())
     }
 
@@ -71,7 +75,7 @@ class PlaybackStartReasonTest {
             mainQueueIndex = 0
         }
         var startedTrack: MusicTrack? = null
-        var startReason: PlaybackStartReason? = null
+        var transaction: PlaybackTransaction? = null
         var playbackStarted = false
         val coordinator = coordinator(
             queue = queue,
@@ -84,7 +88,7 @@ class PlaybackStartReasonTest {
             onStart = { track, _, _ ->
                 playbackStarted = true
                 startedTrack = track
-                startReason = queue.consumePlaybackStartReason()
+                transaction = queue.activePlaybackTransaction()
             },
         )
 
@@ -94,7 +98,8 @@ class PlaybackStartReasonTest {
         )
 
         assertEquals(first, startedTrack)
-        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, startReason)
+        assertEquals(PlaybackStartReason.PLAYLIST_REPLACE, transaction?.reason)
+        assertEquals(first.id, transaction?.targetTrackId)
     }
 
     @Test
@@ -105,20 +110,20 @@ class PlaybackStartReasonTest {
             mainQueueIndex = 0
         }
         var startedTrack: MusicTrack? = null
-        var startReason: PlaybackStartReason? = null
+        var transaction: PlaybackTransaction? = null
         val coordinator = coordinator(queue) { track, _, _ ->
             startedTrack = track
-            startReason = queue.consumePlaybackStartReason()
+            transaction = queue.activePlaybackTransaction()
         }
 
         coordinator.startCurrent()
 
         assertEquals(pausedTrack, startedTrack)
-        assertEquals(PlaybackStartReason.RESUME, startReason)
+        assertEquals(PlaybackStartReason.RESUME, transaction?.reason)
     }
 
     @Test
-    fun automaticNextUsesAutoNextReason() = runTest {
+    fun automaticNextUsesAutoNextReasonAndNewTransaction() = runTest {
         val first = track("track:a")
         val second = track("track:b")
         val queue = PlaybackQueueController().apply {
@@ -126,17 +131,19 @@ class PlaybackStartReasonTest {
             mainQueueIndex = 0
             repeatMode = RepeatMode.OFF
         }
+        val firstTransaction = queue.beginPlaybackTransaction(first.id, PlaybackStartReason.USER_SELECTION)
         var startedTrack: MusicTrack? = null
-        var startReason: PlaybackStartReason? = null
+        var nextTransaction: PlaybackTransaction? = null
         val coordinator = coordinator(queue) { track, _, _ ->
             startedTrack = track
-            startReason = queue.consumePlaybackStartReason()
+            nextTransaction = queue.activePlaybackTransaction()
         }
 
         coordinator.next()
 
         assertEquals(second, startedTrack)
-        assertEquals(PlaybackStartReason.AUTO_NEXT, startReason)
+        assertEquals(PlaybackStartReason.AUTO_NEXT, nextTransaction?.reason)
+        assertEquals(firstTransaction.id + 1L, assertNotNull(nextTransaction).id)
     }
 
     private fun TestScope.coordinator(


### PR DESCRIPTION
## Summary
- replace the queue's pending/consume playback-start reason channel with an explicit `PlaybackTransaction`
- give every playback start a stable transaction identity containing `id`, `reason`, and `targetTrackId`
- keep engine-transaction sequencing separate from listening-history start sequencing, so manual source switches and rollback/recovery do not become fake new listens
- preserve an in-flight playback transaction across delayed startup queue hydration
- propagate transaction id into `PlaybackState.playbackGeneration` and `PlaybackPlan.generation`
- reject stale direct-resolution results when either the request serial or active playback transaction no longer matches
- classify manual source switches as fresh `USER_SELECTION` engine transactions and source-switch rollback as fresh `RECOVERY` transactions

## Why
Recent playback reliability fixes have repeatedly depended on ordering between queue state, restored sessions, provider resolution, and engine state. The previous `markNextPlaybackStart()` / `consumePlaybackStartReason()` channel made playback intent implicit and one-shot. It also could not represent source-only restarts that bypass `PlaybackQueueCoordinator`.

This PR makes each playback start an observable transaction without changing the queue persistence format or the logical/resolved track model yet.

## Semantics
- queue selection / playlist replacement / auto-next / resume create a transaction and preserve their existing listening-history start semantics
- manual source switching creates a new engine transaction but does not increment `playbackStartSequence`, because the logical listen is unchanged
- source-switch rollback/recovery also creates a fresh engine transaction without restarting listening history
- startup queue hydration may replace durable queue fields, but it preserves an already-active playback transaction so an in-flight direct provider resolution is not incorrectly discarded
- `lastPlaybackStartReason` / `playbackStartSequence` remain compatibility projections for listening history; `playbackTransactionSequence` is the independent engine-transaction sequence

## Compatibility
- playback queue persistence format is unchanged
- existing Android reason-aware Media3 handling remains in place
- provider resolution, smart replacement policy, multipart behavior, and UI contracts are unchanged
- this PR does not yet split logical track identity from resolved playback source; that remains the next architecture step

## Tests
- playback transactions are monotonic and observable
- user selection / playlist replacement / resume / auto-next create the expected transaction reason and target
- playback plans use transaction id as their generation
- direct-resolution presentation carries the same generation
- manual source switching creates an explicit fresh transaction without changing listening-history sequence
- recovery starts are fresh and history-neutral
- active resume transaction survives delayed queue hydration
- existing delayed-startup-restore regression coverage remains intact