### PR TITLE
refactor: separate logical tracks from resolved playback sources

### DIFF
--- a/docs/playback-logical-resolved-boundary.md
+++ b/docs/playback-logical-resolved-boundary.md
@@ -1,0 +1,16 @@
+# Logical track and resolved playback source
+
+Playback has two different identities that must not be represented by the same mutable `MusicTrack`.
+
+- **Logical track**: the queue item the user selected. Queue navigation, history primary identity, lyrics association and track actions use this identity.
+- **Resolved playback source**: the physical media selected to render that logical track. Smart/manual replacement, provider source, URL and replacement score belong here.
+
+The feature playback invariant is:
+
+> `PlaybackQueueController` and `PlaybackState.currentTrack` contain logical identity only. Physical source identity is exposed through `PlaybackState.resolvedSource`.
+
+`MusicTrack` still contains the legacy `original*` / `replacement*` fields for compatibility with provider resolution, Android Media3 session metadata and persisted data created by older versions. Those fields are resolver/platform adapter inputs only and must be normalized with `logicalPlaybackTrack()` before entering queue/business state.
+
+During this migration, platform engines may still emit a replacement-decorated `MusicTrack`. `DefaultPlaybackFeatureOwner` treats this as a compatibility transport format: it derives `ResolvedPlaybackSource`, normalizes the track back to logical identity, then publishes the feature-owned playback state.
+
+This separation intentionally precedes the startup/restore state-machine migration. Queue snapshot and Android resume-session unification remain a separate follow-up so source identity cleanup does not become coupled to persistence restoration behavior.

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
@@ -40,7 +40,7 @@ class ListeningHistoryRecorder(
         state: PlaybackState,
         queueState: PlaybackQueueState?,
     ) {
-        val currentTrack = state.currentTrack
+        val currentTrack = state.currentTrack?.logicalPlaybackTrack()
         val currentPrimary = currentTrack?.logicalListeningResource()
         val currentActive = active
         if (currentActive != null && currentPrimary != null) {
@@ -115,7 +115,7 @@ class ListeningHistoryRecorder(
             currentPartIndex = state.currentPartIndex,
             durationMs = state.durationMs.takeIf { it > 0L } ?: track.durationMs,
             contextSessionKey = listeningContextSessionKey(queueState),
-            resources = track.listeningRelations(queueState),
+            resources = track.listeningRelations(queueState, state.resolvedSource),
             playingSinceMonotonicMs = monotonicMillis(),
         )
         active = session
@@ -138,7 +138,7 @@ class ListeningHistoryRecorder(
         session.durationMs = state.durationMs.takeIf { it > 0L }
             ?: track.durationMs
             ?: session.durationMs
-        session.resources = track.listeningRelations(queueState)
+        session.resources = track.listeningRelations(queueState, state.resolvedSource)
     }
 
     private fun listeningContextSessionKey(queueState: PlaybackQueueState?): String? {
@@ -266,11 +266,15 @@ private fun isQualifiedListening(playedMs: Long, durationMs: Long?): Boolean {
     return playedMs >= threshold
 }
 
-private fun MusicTrack.listeningRelations(queueState: PlaybackQueueState?): List<ListeningResourceRelation> = buildList {
-    val primary = logicalListeningResource()
+private fun MusicTrack.listeningRelations(
+    queueState: PlaybackQueueState?,
+    resolvedSource: ResolvedPlaybackSource?,
+): List<ListeningResourceRelation> = buildList {
+    val logicalTrack = logicalPlaybackTrack()
+    val primary = logicalTrack.logicalListeningResource()
     add(ListeningResourceRelation(primary, ListeningResourceRelationType.Primary))
 
-    artistRefs.forEach { artist ->
+    logicalTrack.artistRefs.forEach { artist ->
         add(
             ListeningResourceRelation(
                 resource = ListeningResourceSnapshot(
@@ -286,8 +290,8 @@ private fun MusicTrack.listeningRelations(queueState: PlaybackQueueState?): List
         )
     }
 
-    albumItemId?.takeIf { it.isNotBlank() }?.let { albumId ->
-        val sourceId = logicalListeningSourceId()
+    logicalTrack.albumItemId?.takeIf { it.isNotBlank() }?.let { albumId ->
+        val sourceId = logicalTrack.logicalListeningSourceId()
         add(
             ListeningResourceRelation(
                 resource = ListeningResourceSnapshot(
@@ -295,15 +299,15 @@ private fun MusicTrack.listeningRelations(queueState: PlaybackQueueState?): List
                     type = ListeningResourceType.Album,
                     sourceId = sourceId,
                     sourceResourceId = albumId,
-                    title = originalAlbum?.takeIf { isSmartReplacement } ?: album,
-                    coverUrl = originalCoverUrl?.takeIf { isSmartReplacement } ?: coverUrl,
+                    title = logicalTrack.album,
+                    coverUrl = logicalTrack.coverUrl,
                 ),
                 relation = ListeningResourceRelationType.Album,
             )
         )
     }
 
-    localDirectoryId?.takeIf { it.isNotBlank() }?.let { directoryId ->
+    logicalTrack.localDirectoryId?.takeIf { it.isNotBlank() }?.let { directoryId ->
         add(
             ListeningResourceRelation(
                 resource = ListeningResourceSnapshot(
@@ -355,9 +359,12 @@ private fun MusicTrack.listeningRelations(queueState: PlaybackQueueState?): List
         }
     }
 
-    resolvedListeningResource()?.let { resolved ->
-        add(ListeningResourceRelation(resolved, ListeningResourceRelationType.ResolvedSource))
-    }
+    resolvedSource
+        ?.takeIf { it.isReplacement || it.trackId != logicalTrack.id || it.source != logicalTrack.source }
+        ?.toListeningResource()
+        ?.let { resolved ->
+            add(ListeningResourceRelation(resolved, ListeningResourceRelationType.ResolvedSource))
+        }
 }.distinctBy { relation -> relation.relation to relation.resource.resourceKey }
 
 private fun PlaybackContextSnapshot.toListeningRelation(): ListeningResourceRelation {
@@ -384,44 +391,44 @@ private fun PlaybackContextSnapshot.toListeningRelation(): ListeningResourceRela
 }
 
 private fun MusicTrack.logicalListeningResource(): ListeningResourceSnapshot {
-    val sourceId = logicalListeningSourceId()
-    val resourceId = originalId?.takeIf { isSmartReplacement && it.isNotBlank() } ?: id
+    val logicalTrack = logicalPlaybackTrack()
+    val sourceId = logicalTrack.logicalListeningSourceId()
     return ListeningResourceSnapshot(
-        resourceKey = listeningResourceKey(ListeningResourceType.Track, sourceId, resourceId),
+        resourceKey = listeningResourceKey(ListeningResourceType.Track, sourceId, logicalTrack.id),
         type = ListeningResourceType.Track,
         sourceId = sourceId,
-        sourceResourceId = resourceId,
-        title = originalTitle?.takeIf { isSmartReplacement && it.isNotBlank() } ?: title,
-        subtitle = originalArtists?.takeIf { isSmartReplacement && it.isNotBlank() } ?: artists,
-        coverUrl = originalCoverUrl?.takeIf { isSmartReplacement } ?: coverUrl,
+        sourceResourceId = logicalTrack.id,
+        title = logicalTrack.title,
+        subtitle = logicalTrack.artists,
+        coverUrl = logicalTrack.coverUrl,
     )
 }
 
-private fun MusicTrack.resolvedListeningResource(): ListeningResourceSnapshot? {
-    val resolvedId = replacementId?.takeIf { it.isNotBlank() } ?: return null
-    val resolvedSource = replacementSource?.takeIf { it.isNotBlank() } ?: return null
-    return ListeningResourceSnapshot(
-        resourceKey = listeningResourceKey(ListeningResourceType.Track, resolvedSource, resolvedId),
-        type = ListeningResourceType.Track,
-        sourceId = resolvedSource,
-        sourceResourceId = resolvedId,
-        title = replacementTitle?.takeIf { it.isNotBlank() } ?: title,
-        subtitle = replacementArtists?.takeIf { it.isNotBlank() } ?: artists,
-        coverUrl = replacementCoverUrl ?: coverUrl,
-    )
-}
-
-private fun MusicTrack.logicalListeningSourceId(): String {
-    if (isSmartReplacement) {
-        originalSource?.takeIf { it.isNotBlank() }?.let { return it }
-    }
-    return source.takeIf { it.isNotBlank() }
+private fun ResolvedPlaybackSource.toListeningResource(): ListeningResourceSnapshot {
+    val sourceId = source.takeIf { it.isNotBlank() }
         ?: when (sourceType) {
             TrackSourceType.LocalMediaStore -> "local"
             TrackSourceType.Downloaded -> "downloaded"
             TrackSourceType.Provider -> "provider"
         }
+    return ListeningResourceSnapshot(
+        resourceKey = listeningResourceKey(ListeningResourceType.Track, sourceId, trackId),
+        type = ListeningResourceType.Track,
+        sourceId = sourceId,
+        sourceResourceId = trackId,
+        title = title,
+        subtitle = artists,
+        coverUrl = coverUrl,
+    )
 }
+
+private fun MusicTrack.logicalListeningSourceId(): String =
+    logicalPlaybackTrack().source.takeIf { it.isNotBlank() }
+        ?: when (logicalPlaybackTrack().sourceType) {
+            TrackSourceType.LocalMediaStore -> "local"
+            TrackSourceType.Downloaded -> "downloaded"
+            TrackSourceType.Provider -> "provider"
+        }
 
 private fun listeningResourceKey(
     type: ListeningResourceType,

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
@@ -42,6 +42,7 @@ data class PlaybackPlan(
 data class PlaybackState(
     val status: PlayerStatus = PlayerStatus.Idle,
     val currentTrack: MusicTrack? = null,
+    val resolvedSource: ResolvedPlaybackSource? = null,
     val positionMs: Long = 0,
     val durationMs: Long = 0,
     val bufferedMs: Long = 0,

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
@@ -98,6 +98,7 @@ private class DefaultPlaybackFeatureOwner(
         scope = scope,
         currentRequestSerial = { playRequestSerial },
         currentTrackId = { queueState.currentTrack()?.id ?: playbackState.value.currentTrack?.id },
+        currentResolvedSource = { playbackState.value.resolvedSource },
         currentLyrics = { playbackState.value.lyrics },
         updateLyrics = { lyrics -> updatePlaybackState { it.copy(lyrics = lyrics) } },
         associationForTrackId = { trackId -> lyricsAssociations[trackId] },
@@ -141,7 +142,7 @@ private class DefaultPlaybackFeatureOwner(
             pendingManualReplacementSwitch = PlaybackOwnerPendingManualReplacement(
                 requestSerial = serial,
                 previousTrack = rollbackTrack,
-                originalTrackId = playbackTrack.originalId ?: playbackTrack.id,
+                originalTrackId = playbackTrack.id,
                 selection = selection,
             )
         },
@@ -180,6 +181,7 @@ private class DefaultPlaybackFeatureOwner(
         smartReplacementProviderIds = ::selectedSmartReplacementProviderIds,
         smartReplacementMinScore = { currentSettings().smartReplacementMinScore.coerceIn(0.0, 1.0) },
         currentTrack = { queueState.currentTrack() ?: playbackState.value.currentTrack },
+        currentResolvedSource = { playbackState.value.resolvedSource },
         startManualReplacement = { track, selection, rollbackTrack ->
             startPlayback(
                 track = track,
@@ -246,7 +248,7 @@ private class DefaultPlaybackFeatureOwner(
         if (playbackState.value.currentTrack?.id == trackId) {
             updatePlaybackState {
                 it.copy(
-                    currentTrack = updatedTrack,
+                    currentTrack = updatedTrack.logicalPlaybackTrack(),
                     lyrics = updatedTrack.lyrics ?: it.lyrics,
                 )
             }
@@ -256,20 +258,29 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun onEngineState(engineState: PlaybackState) {
-        engineState.currentTrack?.let(::synchronizePlaybackTrack)
+        val engineTrack = engineState.currentTrack
+        val logicalEngineTrack = engineTrack?.logicalPlaybackTrack()
+        logicalEngineTrack?.let(::synchronizePlaybackTrack)
         val currentQueueTrackId = queueState.currentTrack()?.id
-        val endAction = lifecycleOwner.evaluate(engineState, currentQueueTrackId)
+        val endAction = lifecycleOwner.evaluate(
+            engineState.copy(currentTrack = logicalEngineTrack),
+            currentQueueTrackId,
+        )
         if (engineState.status == PlayerStatus.Playing) lastRecoveredPlaybackErrorKey = null
 
         val previous = playbackState.value
+        val resolvedSource = engineState.resolvedSource
+            ?: engineTrack?.toLegacyResolvedPlaybackSource()
+            ?: previous.resolvedSource?.takeIf { logicalEngineTrack?.id == previous.currentTrack?.id }
         mutablePlaybackState.value = engineState.copy(
             queue = queueState.displayQueue(),
             queueIndex = queueState.displayQueueIndex(),
-            currentTrack = queueState.currentTrack() ?: engineState.currentTrack,
+            currentTrack = queueState.currentTrack() ?: logicalEngineTrack,
+            resolvedSource = resolvedSource,
             playbackParts = engineState.playbackParts.ifEmpty { playbackParts },
             currentPartIndex = engineState.currentPartIndex.takeIf { it >= 0 } ?: currentPartIndex,
             lyrics = lyricsOwner.mergedLyrics(
-                engineState = engineState,
+                engineState = engineState.copy(currentTrack = logicalEngineTrack),
                 currentQueueTrackId = currentQueueTrackId,
                 previousPlaybackState = previous,
             ),
@@ -288,7 +299,7 @@ private class DefaultPlaybackFeatureOwner(
                 if (suppressPlaybackRecoveryRequestSerial == playRequestSerial) {
                     showManualReplacementRestoreFailure(engineState.errorMessage)
                 } else {
-                    recoverPlaybackEngineError(engineState)
+                    recoverPlaybackEngineError(engineState.copy(currentTrack = logicalEngineTrack))
                 }
             }
         }
@@ -341,10 +352,10 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun MusicTrack.withRememberedReplacement(): MusicTrack {
-        val originalTrack = originalDetailTrackForNavigation()
+        val originalTrack = logicalPlaybackTrack()
         val selection = smartReplacementSelections[originalTrack.id] ?: return this
         if (selection.replacementSource !in selectedSmartReplacementProviderIds()) {
-            return if (isSmartReplacement) originalTrack else this
+            return originalTrack
         }
         return originalTrack.withReplacementSelection(selection)
     }
@@ -373,9 +384,16 @@ private class DefaultPlaybackFeatureOwner(
     private fun commitManualReplacementIfReady(engineState: PlaybackState) {
         val pending = pendingManualReplacementSwitch ?: return
         if (pending.requestSerial != playRequestSerial) return
-        val currentTrack = engineState.currentTrack ?: queueState.currentTrack() ?: return
-        val currentOriginalId = currentTrack.originalId ?: currentTrack.id
-        if (currentOriginalId != pending.originalTrackId || currentTrack.replacementId != pending.selection.replacementId) return
+        val engineTrack = engineState.currentTrack ?: return
+        val logicalTrackId = engineTrack.logicalPlaybackTrack().id
+        val resolvedSource = engineState.resolvedSource ?: engineTrack.toLegacyResolvedPlaybackSource()
+        if (
+            logicalTrackId != pending.originalTrackId ||
+            !resolvedSource.isReplacement ||
+            resolvedSource.trackId != pending.selection.replacementId
+        ) {
+            return
+        }
         smartReplacementSelections = smartReplacementSelections + (pending.originalTrackId to pending.selection)
         pendingManualReplacementSwitch = null
         val nextSelections = smartReplacementSelections
@@ -388,7 +406,7 @@ private class DefaultPlaybackFeatureOwner(
         val previousTrack = pending.previousTrack ?: return true
         startOwner.start(
             track = previousTrack,
-            messageAfterStart = "手动换源失败，已恢复原播放源：${previousTrack.title}",
+            messageAfterStart = "手动换源失败，已恢复原播放源：${previousTrack.logicalPlaybackTrack().title}",
             suppressPlaybackRecovery = true,
         )
         return true
@@ -447,16 +465,17 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun synchronizePlaybackTrack(track: MusicTrack) {
+        val logicalTrack = track.logicalPlaybackTrack()
         val current = queueState.currentTrack()
-        var changed = current != track
-        if (current?.id != track.id) {
-            val upNextIndex = queueState.upNextQueue.indexOfFirst { it.id == track.id }
+        var changed = current != logicalTrack
+        if (current?.id != logicalTrack.id) {
+            val upNextIndex = queueState.upNextQueue.indexOfFirst { it.id == logicalTrack.id }
             if (upNextIndex >= 0) {
                 queueState.currentUpNextTrack = queueState.upNextQueue[upNextIndex]
                 queueState.upNextQueue = queueState.upNextQueue.filterIndexed { index, _ -> index != upNextIndex }
                 queueState.currentIsUpNext = true
             } else {
-                val mainIndex = queueState.mainQueue.indexOfFirst { it.id == track.id }
+                val mainIndex = queueState.mainQueue.indexOfFirst { it.id == logicalTrack.id }
                 if (mainIndex >= 0) {
                     queueState.mainQueueIndex = mainIndex
                     queueState.currentUpNextTrack = null
@@ -465,7 +484,7 @@ private class DefaultPlaybackFeatureOwner(
                 }
             }
         }
-        queueState.updateCurrentTrack(track)
+        queueState.updateCurrentTrack(logicalTrack)
         if (changed) persistPlaybackQueue()
     }
 
@@ -474,7 +493,7 @@ private class DefaultPlaybackFeatureOwner(
             current.copy(
                 queue = queueState.displayQueue(),
                 queueIndex = queueState.displayQueueIndex(),
-                currentTrack = queueState.currentTrack() ?: current.currentTrack,
+                currentTrack = queueState.currentTrack() ?: current.currentTrack?.logicalPlaybackTrack(),
                 playbackParts = playbackParts,
                 currentPartIndex = currentPartIndex,
             )
@@ -488,6 +507,7 @@ private class DefaultPlaybackFeatureOwner(
         updatePlaybackState { current ->
             current.copy(
                 currentTrack = queueState.mainQueue.getOrNull(queueState.mainQueueIndex),
+                resolvedSource = null,
                 queue = queueState.displayQueue(),
                 queueIndex = queueState.displayQueueIndex(),
                 playbackParts = emptyList(),
@@ -502,7 +522,7 @@ private class DefaultPlaybackFeatureOwner(
     }
 
     private fun recoverPlaybackEngineError(engineState: PlaybackState) {
-        val failedTrack = engineState.currentTrack ?: queueState.currentTrack() ?: return
+        val failedTrack = engineState.currentTrack?.logicalPlaybackTrack() ?: queueState.currentTrack() ?: return
         val activeTrackId = queueState.currentTrack()?.id ?: playbackState.value.currentTrack?.id
         if (activeTrackId != null && activeTrackId != failedTrack.id) return
         val errorMessage = engineState.errorMessage.orEmpty()
@@ -546,7 +566,7 @@ private class DefaultPlaybackFeatureOwner(
         throwable: Throwable,
     ): Boolean {
         if (!shouldSkipUnavailable(throwable)) return false
-        queueState.updateCurrentTrack(track.copy(isUnavailable = true))
+        queueState.updateCurrentTrack(track.logicalPlaybackTrack().copy(isUnavailable = true))
         updatePlaybackQueueState()
         persistPlaybackQueue()
         val playableCount = queueState.upNextQueue.size + queueState.mainQueue.size

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackLyricsController.kt
@@ -71,6 +71,7 @@ internal class PlaybackLyricsController(
     private val rememberAssociation: (String, String?) -> Unit,
     private val alignmentOffsetForTrackId: (String) -> Long = { 0L },
     private val rememberAlignmentOffset: (String, Long) -> Unit = { _, _ -> },
+    private val currentResolvedSource: () -> ResolvedPlaybackSource? = { null },
 ) : PlaybackLyricsPort {
     constructor(
         providerRegistryRepository: ProviderRegistryRepository,
@@ -86,6 +87,7 @@ internal class PlaybackLyricsController(
         rememberAssociation: (String, String?) -> Unit,
         alignmentOffsetForTrackId: (String) -> Long = { 0L },
         rememberAlignmentOffset: (String, Long) -> Unit = { _, _ -> },
+        currentResolvedSource: () -> ResolvedPlaybackSource? = { null },
     ) : this(
         repository = ProviderPlaybackLyricsRepository(
             registryRepository = providerRegistryRepository,
@@ -102,6 +104,7 @@ internal class PlaybackLyricsController(
         rememberAssociation = rememberAssociation,
         alignmentOffsetForTrackId = alignmentOffsetForTrackId,
         rememberAlignmentOffset = rememberAlignmentOffset,
+        currentResolvedSource = currentResolvedSource,
     )
 
     private val mutableAssociationState = MutableStateFlow(LyricsAssociationUiState())
@@ -142,7 +145,7 @@ internal class PlaybackLyricsController(
         currentQueueTrackId: String?,
         previousPlaybackState: PlaybackState,
     ): String? {
-        val engineTrackId = engineState.currentTrack?.id
+        val engineTrackId = engineState.currentTrack?.logicalPlaybackTrack()?.id
         val currentId = currentQueueTrackId
             ?: engineTrackId
             ?: previousPlaybackState.currentTrack?.id
@@ -166,12 +169,14 @@ internal class PlaybackLyricsController(
 
     fun maybeLoad(track: MusicTrack?) {
         if (track == null) return
-        val lyricTrack = lyricSourceTrackForPlayback(track)
-        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(track)
+        val logicalTrack = track.logicalPlaybackTrack()
+        val lyricTrack = lyricSourceTrackForPlayback(logicalTrack)
+        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(logicalTrack)
         val associatedTrackId = associationForTrackId(lyricTrack.id)
             ?.trim()
             ?.takeIf { it.isNotBlank() }
-        val defaultAlignmentKey = if (track.isSmartReplacement) {
+        val hasReplacementSource = currentResolvedSource()?.isReplacement == true
+        val defaultAlignmentKey = if (hasReplacementSource) {
             lyricsAlignmentPersistenceKey(playbackSourceTrackId, lyricTrack.id)
         } else {
             null
@@ -185,7 +190,7 @@ internal class PlaybackLyricsController(
         currentAlignmentPersistenceKey = defaultAlignmentKey
 
         if (
-            loadedForTrackId == track.id &&
+            loadedForTrackId == logicalTrack.id &&
             loadedForPlaybackSourceTrackId == playbackSourceTrackId &&
             loadedAssociationTrackId == associatedTrackId
         ) {
@@ -200,7 +205,7 @@ internal class PlaybackLyricsController(
             } ?: 0L
             currentAlignmentPersistenceKey = effectiveAlignmentKey
             if (
-                current.trackId == track.id &&
+                current.trackId == logicalTrack.id &&
                 current.alignmentOffsetMs != effectiveAlignmentOffsetMs
             ) {
                 mutableAssociationState.value = current.copy(
@@ -210,7 +215,7 @@ internal class PlaybackLyricsController(
             return
         }
 
-        loadedForTrackId = track.id
+        loadedForTrackId = logicalTrack.id
         loadedForPlaybackSourceTrackId = playbackSourceTrackId
         loadedAssociationTrackId = associatedTrackId
         val requestSerial = currentRequestSerial()
@@ -218,19 +223,19 @@ internal class PlaybackLyricsController(
 
         if (associatedTrackId != null) {
             mutableAssociationState.value = LyricsAssociationUiState(
-                trackId = track.id,
+                trackId = logicalTrack.id,
             )
             loadJob = scope.launch {
                 val associatedTrack = repository.trackDetail(associatedTrackId)
                 val associatedLyrics = associatedTrack?.let { candidate ->
                     runCatching { repository.lyrics(candidate) }.getOrNull()
                 }?.takeIf { it.isNotBlank() }
-                if (!isCurrent(track, requestSerial)) return@launch
+                if (!isCurrent(logicalTrack, requestSerial)) return@launch
                 if (associatedTrack != null && associatedLyrics != null) {
                     updateLyrics(associatedLyrics)
                     currentAlignmentPersistenceKey = associationAlignmentKey
                     mutableAssociationState.value = LyricsAssociationUiState(
-                        trackId = track.id,
+                        trackId = logicalTrack.id,
                         isManualAssociation = true,
                         associatedTrackId = associatedTrack.id,
                         associatedTrackTitle = associatedTrack.title,
@@ -239,19 +244,19 @@ internal class PlaybackLyricsController(
                     return@launch
                 }
 
-                val fallbackLyrics = track.lyrics
+                val fallbackLyrics = logicalTrack.lyrics
                     ?.takeIf { it.isNotBlank() }
                     ?: runCatching { repository.lyrics(lyricTrack) }
                         .getOrNull()
                         ?.takeIf { it.isNotBlank() }
-                if (!isCurrent(track, requestSerial)) return@launch
+                if (!isCurrent(logicalTrack, requestSerial)) return@launch
                 if (fallbackLyrics != null) updateLyrics(fallbackLyrics)
                 val fallbackAlignmentOffsetMs = defaultAlignmentKey?.let { alignmentKey ->
                     alignmentOffsetForTrackId(alignmentKey).coerceIn(-3_000L, 3_000L)
                 } ?: 0L
                 currentAlignmentPersistenceKey = defaultAlignmentKey
                 mutableAssociationState.value = LyricsAssociationUiState(
-                    trackId = track.id,
+                    trackId = logicalTrack.id,
                     isLyricsUnavailable = fallbackLyrics == null,
                     alignmentOffsetMs = fallbackAlignmentOffsetMs,
                 )
@@ -261,15 +266,15 @@ internal class PlaybackLyricsController(
 
         currentLyrics()?.takeIf { it.isNotBlank() }?.let {
             mutableAssociationState.value = LyricsAssociationUiState(
-                trackId = track.id,
+                trackId = logicalTrack.id,
                 alignmentOffsetMs = alignmentOffsetMs,
             )
             return
         }
-        track.lyrics?.takeIf { it.isNotBlank() }?.let {
+        logicalTrack.lyrics?.takeIf { it.isNotBlank() }?.let {
             updateLyrics(it)
             mutableAssociationState.value = LyricsAssociationUiState(
-                trackId = track.id,
+                trackId = logicalTrack.id,
                 alignmentOffsetMs = alignmentOffsetMs,
             )
             return
@@ -279,10 +284,10 @@ internal class PlaybackLyricsController(
             val lyrics = runCatching {
                 repository.lyrics(lyricTrack)
             }.getOrNull()?.takeIf { it.isNotBlank() }
-            if (!isCurrent(track, requestSerial)) return@launch
+            if (!isCurrent(logicalTrack, requestSerial)) return@launch
             if (lyrics != null) updateLyrics(lyrics)
             mutableAssociationState.value = LyricsAssociationUiState(
-                trackId = track.id,
+                trackId = logicalTrack.id,
                 isLyricsUnavailable = lyrics == null,
                 alignmentOffsetMs = alignmentOffsetMs,
             )
@@ -290,23 +295,25 @@ internal class PlaybackLyricsController(
     }
 
     override fun openAssociationSearch(track: MusicTrack) {
-        associationSearchTrack = track
+        val logicalTrack = track.logicalPlaybackTrack()
+        associationSearchTrack = logicalTrack
         associationQueryEdited = false
-        val sourceTrack = lyricSourceTrackForPlayback(track)
-        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(track)
-        val previous = mutableAssociationState.value.takeIf { it.trackId == track.id }
+        val sourceTrack = lyricSourceTrackForPlayback(logicalTrack)
+        val playbackSourceTrackId = alignmentSourceTrackIdForPlayback(logicalTrack)
+        val previous = mutableAssociationState.value.takeIf { it.trackId == logicalTrack.id }
         val persistedAssociationTrackId = associationForTrackId(sourceTrack.id)
             ?.trim()
             ?.takeIf { it.isNotBlank() }
+        val hasReplacementSource = currentResolvedSource()?.isReplacement == true
         val alignmentKey = when {
             previous?.isManualAssociation == true && previous.associatedTrackId != null ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, previous.associatedTrackId)
-            previous != null && track.isSmartReplacement ->
+            previous != null && hasReplacementSource ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, sourceTrack.id)
             previous != null -> null
             persistedAssociationTrackId != null ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, persistedAssociationTrackId)
-            track.isSmartReplacement ->
+            hasReplacementSource ->
                 lyricsAlignmentPersistenceKey(playbackSourceTrackId, sourceTrack.id)
             else -> null
         }
@@ -317,7 +324,7 @@ internal class PlaybackLyricsController(
             }
             ?: 0L
         mutableAssociationState.value = LyricsAssociationUiState(
-            trackId = track.id,
+            trackId = logicalTrack.id,
             isLyricsUnavailable = previous?.isLyricsUnavailable ?: currentLyrics().isNullOrBlank(),
             isManualAssociation = previous?.isManualAssociation == true,
             associatedTrackId = previous?.associatedTrackId,
@@ -336,13 +343,13 @@ internal class PlaybackLyricsController(
             val keyword = normalizeAssociationSearchKeyword(sourceTrack, rawKeyword)
                 .takeIf { it.isNotBlank() }
                 ?: sourceTrack.title.trim()
-            if (associationSearchTrack?.id != track.id || currentTrackId() != track.id) return@launch
+            if (associationSearchTrack?.id != logicalTrack.id || currentTrackId() != logicalTrack.id) return@launch
             if (associationQueryEdited) {
                 mutableAssociationState.value = mutableAssociationState.value.copy(isSearching = false)
                 return@launch
             }
             mutableAssociationState.value = mutableAssociationState.value.copy(query = keyword)
-            performSearch(track, keyword)
+            performSearch(logicalTrack, keyword)
         }
     }
 
@@ -492,27 +499,9 @@ internal class PlaybackLyricsController(
     }
 
     private fun alignmentSourceTrackIdForPlayback(track: MusicTrack): String {
-        if (!track.isSmartReplacement) return track.id
-        return track.replacementId?.takeIf { it.isNotBlank() } ?: track.id
+        val resolvedSource = currentResolvedSource()?.takeIf { it.isReplacement }
+        return resolvedSource?.trackId?.takeIf { it.isNotBlank() } ?: track.logicalPlaybackTrack().id
     }
 
-    private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack {
-        if (!track.isSmartReplacement) return track
-        val originalId = track.originalId?.takeIf { it.isNotBlank() } ?: return track
-        val originalSource = track.originalSource?.takeIf { it.isNotBlank() }
-            ?: originalId.substringBefore(':').takeIf { it.isNotBlank() }
-            ?: track.source
-        return track.copy(
-            id = originalId,
-            providerId = originalId,
-            source = originalSource,
-            providerName = track.originalProviderName ?: track.providerName,
-            title = track.originalTitle ?: track.title,
-            artists = track.originalArtists ?: track.artists,
-            album = track.originalAlbum ?: track.album,
-            coverUrl = track.originalCoverUrl ?: track.coverUrl,
-            isSmartReplacement = false,
-            lyrics = null,
-        )
-    }
+    private fun lyricSourceTrackForPlayback(track: MusicTrack): MusicTrack = track.logicalPlaybackTrack()
 }

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
@@ -40,19 +40,19 @@ internal class PlaybackQueueController {
 
     var mainQueue: List<MusicTrack>
         get() = mutableState.value.mainQueue
-        set(value) = update { it.copy(mainQueue = value) }
+        set(value) = update { it.copy(mainQueue = value.logicalTracks()) }
     var originalMainQueue: List<MusicTrack>
         get() = mutableState.value.originalMainQueue
-        set(value) = update { it.copy(originalMainQueue = value) }
+        set(value) = update { it.copy(originalMainQueue = value.logicalTracks()) }
     var upNextQueue: List<MusicTrack>
         get() = mutableState.value.upNextQueue
-        set(value) = update { it.copy(upNextQueue = value) }
+        set(value) = update { it.copy(upNextQueue = value.logicalTracks()) }
     var mainQueueIndex: Int
         get() = mutableState.value.mainQueueIndex
         set(value) = update { it.copy(mainQueueIndex = value) }
     var currentUpNextTrack: MusicTrack?
         get() = mutableState.value.currentUpNextTrack
-        set(value) = update { it.copy(currentUpNextTrack = value) }
+        set(value) = update { it.copy(currentUpNextTrack = value?.logicalPlaybackTrack()) }
     var currentIsUpNext: Boolean
         get() = mutableState.value.currentIsUpNext
         set(value) = update { it.copy(currentIsUpNext = value) }
@@ -120,16 +120,17 @@ internal class PlaybackQueueController {
     }
 
     fun updateCurrentTrack(track: MusicTrack) {
+        val logicalTrack = track.logicalPlaybackTrack()
         val current = mutableState.value
         when {
-            current.currentIsUpNext -> update { it.copy(currentUpNextTrack = track) }
+            current.currentIsUpNext -> update { it.copy(currentUpNextTrack = logicalTrack) }
             current.mainQueueIndex in current.mainQueue.indices -> update { snapshot ->
                 snapshot.copy(
                     mainQueue = snapshot.mainQueue.mapIndexed { index, item ->
-                        if (index == snapshot.mainQueueIndex) track else item
+                        if (index == snapshot.mainQueueIndex) logicalTrack else item
                     },
                     originalMainQueue = snapshot.originalMainQueue.map { item ->
-                        if (item.id == track.id) track else item
+                        if (item.id == logicalTrack.id) logicalTrack else item
                     },
                 )
             }
@@ -142,19 +143,22 @@ internal class PlaybackQueueController {
      * An already-started playback transaction is intentionally preserved across hydration. A resume
      * may begin from the independently restored engine state before the durable queue snapshot arrives;
      * resetting its transaction here would make an in-flight provider result look stale.
+     * Legacy snapshots may still contain replacement-decorated tracks; hydration normalizes them back
+     * to logical queue identity before they become observable.
      *
      * @return true when the snapshot was applied, false when a newer live queue mutation won the race.
      */
     fun restore(snapshot: PlaybackQueueSnapshot): Boolean {
         if (startupDirty) return false
         val current = mutableState.value
+        val mainQueue = snapshot.mainQueue.logicalTracks()
         applyingStartupSnapshot = true
         try {
             mutableState.value = PlaybackQueueState(
-                mainQueue = snapshot.mainQueue,
-                originalMainQueue = snapshot.originalMainQueue,
-                upNextQueue = snapshot.upNextQueue,
-                mainQueueIndex = snapshot.queueIndex.coerceIn(-1, snapshot.mainQueue.lastIndex),
+                mainQueue = mainQueue,
+                originalMainQueue = snapshot.originalMainQueue.logicalTracks(),
+                upNextQueue = snapshot.upNextQueue.logicalTracks(),
+                mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex),
                 shuffleEnabled = snapshot.shuffleEnabled,
                 repeatMode = snapshot.repeatMode,
                 isFmQueue = snapshot.isFmQueue,
@@ -198,6 +202,8 @@ internal class PlaybackQueueController {
         mutableState.update { current -> transform(current) }
     }
 }
+
+private fun List<MusicTrack>.logicalTracks(): List<MusicTrack> = map(MusicTrack::logicalPlaybackTrack)
 
 /** Read-only projection used by app/player presentation outside the playback module. */
 fun PlaybackQueueState.currentTrack(): MusicTrack? =

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackReplacementController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackReplacementController.kt
@@ -16,6 +16,7 @@ internal class PlaybackReplacementController(
     private val smartReplacementProviderIds: () -> Set<String>,
     private val smartReplacementMinScore: () -> Double,
     private val currentTrack: () -> MusicTrack?,
+    private val currentResolvedSource: () -> ResolvedPlaybackSource?,
     private val startManualReplacement: (MusicTrack, SmartReplacementSelection, MusicTrack) -> Unit,
     private val closePlayer: () -> Unit,
     private val openTrackDetail: (MusicTrack) -> Unit,
@@ -30,8 +31,8 @@ internal class PlaybackReplacementController(
     private var candidatesJob: Job? = null
 
     override fun loadReplacementCandidates(track: MusicTrack) {
-        val originalTrack = track.originalDetailTrackForNavigation()
-        val trackId = originalTrack.id
+        val logicalTrack = track.logicalPlaybackTrack()
+        val trackId = logicalTrack.id
         candidatesJob?.cancel()
         mutableReplacementCandidateState.value = ReplacementCandidateState(
             trackId = trackId,
@@ -41,7 +42,7 @@ internal class PlaybackReplacementController(
             runCatching {
                 withTimeout(30_000) {
                     playbackRepository.replacementCandidates(
-                        track = originalTrack,
+                        track = logicalTrack,
                         smartReplacementProviderIds = smartReplacementProviderIds(),
                         smartReplacementMinScore = smartReplacementMinScore(),
                     )
@@ -60,7 +61,7 @@ internal class PlaybackReplacementController(
                 if (replacementCandidateState.trackId == trackId) {
                     mutableReplacementCandidateState.value = ReplacementCandidateState(
                         trackId = trackId,
-                        errorMessage = failureMessage(throwable, "查询失败", originalTrack.source),
+                        errorMessage = failureMessage(throwable, "查询失败", logicalTrack.source),
                     )
                 }
             }
@@ -68,21 +69,30 @@ internal class PlaybackReplacementController(
     }
 
     override fun selectReplacementCandidate(track: MusicTrack, candidate: ReplacementCandidate) {
-        val previousTrack = currentTrack() ?: return
-        val originalTrack = track.originalDetailTrackForNavigation()
+        val previousLogicalTrack = currentTrack()?.logicalPlaybackTrack() ?: return
+        val previousResolvedSource = currentResolvedSource()
+        val rollbackTrack = if (previousResolvedSource?.isReplacement == true) {
+            previousLogicalTrack.withReplacementSelection(previousResolvedSource.toSmartReplacementSelection())
+        } else {
+            previousLogicalTrack
+        }
+        val logicalTrack = track.logicalPlaybackTrack()
         val selection = candidate.toSmartReplacementSelection()
         mutableReplacementCandidateState.value = replacementCandidateState.copy(isLoading = false)
         startManualReplacement(
-            originalTrack.withReplacementSelection(selection),
+            logicalTrack,
             selection,
-            previousTrack,
+            rollbackTrack,
         )
     }
 
     override fun openReplacementTrackDetail(track: MusicTrack) {
-        val detailTrack = track.replacementDetailTrackForNavigation() ?: return
+        val logicalTrack = track.logicalPlaybackTrack()
+        val source = currentResolvedSource()
+            ?.takeIf { it.isReplacement }
+            ?: return
         closePlayer()
-        openTrackDetail(detailTrack)
+        openTrackDetail(source.toNavigationTrack(logicalTrack))
     }
 }
 
@@ -99,101 +109,68 @@ internal fun ReplacementCandidate.toSmartReplacementSelection(): SmartReplacemen
         replacementScore = score,
     )
 
-internal fun MusicTrack.withReplacementSelection(selection: SmartReplacementSelection): MusicTrack = copy(
-    id = id,
-    providerId = providerId ?: id,
-    sourceType = TrackSourceType.Provider,
-    localUri = null,
-    isSmartReplacement = true,
-    originalId = id,
-    originalTitle = title,
-    originalArtists = artists,
-    originalAlbum = album,
-    originalSource = source,
-    originalProviderName = providerName,
-    originalCoverUrl = coverUrl,
-    replacementId = selection.replacementId,
-    replacementTitle = selection.replacementTitle,
-    replacementArtists = selection.replacementArtists,
-    replacementAlbum = selection.replacementAlbum,
-    replacementSource = selection.replacementSource,
-    replacementProviderName = selection.replacementProviderName,
-    replacementCoverUrl = selection.replacementCoverUrl,
-    replacementStrategy = "user_selected",
-    replacementScore = selection.replacementScore,
-    isUnavailable = false,
-)
+private fun ResolvedPlaybackSource.toSmartReplacementSelection(): SmartReplacementSelection =
+    SmartReplacementSelection(
+        replacementId = trackId,
+        replacementTitle = title,
+        replacementArtists = artists,
+        replacementAlbum = album,
+        replacementSource = source,
+        replacementProviderName = providerName,
+        replacementCoverUrl = coverUrl,
+        replacementDurationMs = durationMs,
+        replacementScore = replacementScore ?: 0.0,
+    )
 
-/** Reconstructs the provider-native track represented by a smart-replacement playback item. */
-fun MusicTrack.originalDetailTrackForNavigation(): MusicTrack {
-    if (!isSmartReplacement) return this
-    val detailId = originalId ?: providerId ?: id
-    val detailSource = originalSource
-        ?: detailId.substringBefore(':').takeIf { it.isNotBlank() }
-        ?: source
-    return copy(
-        id = detailId,
-        title = originalTitle ?: title,
-        artists = originalArtists ?: artists,
-        album = originalAlbum ?: album,
-        source = detailSource,
+/**
+ * Compatibility resolver input for providers that still consume replacement metadata on MusicTrack.
+ * The returned value must never be stored in PlaybackQueueController or exposed as currentTrack.
+ */
+internal fun MusicTrack.withReplacementSelection(selection: SmartReplacementSelection): MusicTrack {
+    val logicalTrack = logicalPlaybackTrack()
+    return logicalTrack.copy(
+        providerId = logicalTrack.providerId ?: logicalTrack.id,
         sourceType = TrackSourceType.Provider,
         localUri = null,
-        coverUrl = originalCoverUrl ?: coverUrl,
-        providerId = detailId,
-        providerName = originalProviderName ?: detailSource,
-        isSmartReplacement = false,
-        originalId = null,
-        originalTitle = null,
-        originalArtists = null,
-        originalAlbum = null,
-        originalSource = null,
-        originalProviderName = null,
-        originalCoverUrl = null,
-        replacementId = null,
-        replacementTitle = null,
-        replacementArtists = null,
-        replacementAlbum = null,
-        replacementSource = null,
-        replacementProviderName = null,
-        replacementCoverUrl = null,
-        replacementStrategy = null,
-        replacementScore = null,
+        isSmartReplacement = true,
+        originalId = logicalTrack.id,
+        originalTitle = logicalTrack.title,
+        originalArtists = logicalTrack.artists,
+        originalAlbum = logicalTrack.album,
+        originalSource = logicalTrack.source,
+        originalProviderName = logicalTrack.providerName,
+        originalCoverUrl = logicalTrack.coverUrl,
+        replacementId = selection.replacementId,
+        replacementTitle = selection.replacementTitle,
+        replacementArtists = selection.replacementArtists,
+        replacementAlbum = selection.replacementAlbum,
+        replacementSource = selection.replacementSource,
+        replacementProviderName = selection.replacementProviderName,
+        replacementCoverUrl = selection.replacementCoverUrl,
+        replacementStrategy = "user_selected",
+        replacementScore = selection.replacementScore,
+        isUnavailable = false,
     )
 }
 
+/** Reconstructs the provider-native logical track from legacy replacement-decorated state. */
+fun MusicTrack.originalDetailTrackForNavigation(): MusicTrack = logicalPlaybackTrack()
+
+/** Legacy compatibility helper; new playback UI should use PlaybackState.resolvedSource. */
 internal fun MusicTrack.replacementDetailTrackForNavigation(): MusicTrack? {
     val detailId = replacementId?.takeIf { it.isNotBlank() } ?: return null
     val detailSource = replacementSource
         ?: detailId.substringBefore(':').takeIf { it.isNotBlank() }
         ?: return null
-    return copy(
+    return MusicTrack(
         id = detailId,
         title = replacementTitle ?: title,
         artists = replacementArtists ?: artists,
         album = replacementAlbum ?: album,
         source = detailSource,
         sourceType = TrackSourceType.Provider,
-        localUri = null,
         coverUrl = replacementCoverUrl ?: coverUrl,
         providerId = detailId,
         providerName = replacementProviderName ?: detailSource,
-        isSmartReplacement = false,
-        originalId = null,
-        originalTitle = null,
-        originalArtists = null,
-        originalAlbum = null,
-        originalSource = null,
-        originalProviderName = null,
-        originalCoverUrl = null,
-        replacementId = null,
-        replacementTitle = null,
-        replacementArtists = null,
-        replacementAlbum = null,
-        replacementSource = null,
-        replacementProviderName = null,
-        replacementCoverUrl = null,
-        replacementStrategy = null,
-        replacementScore = null,
     )
 }

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
@@ -53,6 +53,7 @@ internal class PlaybackStartCoordinator(
     private val scope: CoroutineScope,
     private val currentPlaybackState: () -> PlaybackState,
     private val publishPlaybackState: (PlaybackState) -> Unit,
+    /** Builds the physical resolver input without changing logical queue identity. */
     private val prepareTrack: (MusicTrack) -> MusicTrack,
     private val unavailablePlaybackPolicy: () -> UnavailablePlaybackPolicy,
     private val smartReplacementProviderIds: () -> Set<String>,
@@ -87,23 +88,28 @@ internal class PlaybackStartCoordinator(
         messageAfterStart: String? = null,
         suppressPlaybackRecovery: Boolean = false,
     ) {
-        prepareSleepTimer(track.id)
-        val playbackTrack = if (manualSelection != null) track else prepareTrack(track)
+        val logicalTrack = track.logicalPlaybackTrack()
+        prepareSleepTimer(logicalTrack.id)
+        val preparedResolveTrack = when {
+            manualSelection != null -> logicalTrack.withReplacementSelection(manualSelection)
+            suppressPlaybackRecovery && track.isSmartReplacement -> track
+            else -> prepareTrack(logicalTrack)
+        }
         val transaction = when {
             manualSelection != null -> queue.beginPlaybackTransaction(
-                trackId = playbackTrack.id,
+                trackId = logicalTrack.id,
                 reason = PlaybackStartReason.USER_SELECTION,
                 recordPlaybackStart = false,
             )
             suppressPlaybackRecovery -> queue.beginPlaybackTransaction(
-                trackId = playbackTrack.id,
+                trackId = logicalTrack.id,
                 reason = PlaybackStartReason.RECOVERY,
                 recordPlaybackStart = false,
             )
             else -> queue.activePlaybackTransaction()
-                ?.takeIf { it.targetTrackId == playbackTrack.id }
+                ?.takeIf { it.targetTrackId == logicalTrack.id }
                 ?: queue.beginPlaybackTransaction(
-                    trackId = playbackTrack.id,
+                    trackId = logicalTrack.id,
                     reason = PlaybackStartReason.RECOVERY,
                     recordPlaybackStart = false,
                 )
@@ -113,12 +119,12 @@ internal class PlaybackStartCoordinator(
         _startFailure.value = null
         onRequestStarted(serial, suppressPlaybackRecovery)
         manualSelection?.let { selection ->
-            onManualSelectionStarted(serial, playbackTrack, selection, rollbackTrack)
+            onManualSelectionStarted(serial, logicalTrack, selection, rollbackTrack)
         }
 
         val previousPlaybackState = currentPlaybackState()
         val isManualSourceSwitch = manualSelection != null &&
-            previousPlaybackState.currentTrack?.id == playbackTrack.id
+            previousPlaybackState.currentTrack?.id == logicalTrack.id
         val preservedLyrics = previousPlaybackState.lyrics
             ?.takeIf { isManualSourceSwitch && it.isNotBlank() }
 
@@ -128,7 +134,7 @@ internal class PlaybackStartCoordinator(
             setPlaybackParts(emptyList())
             setCurrentPartIndex(-1)
         }
-        queue.updateCurrentTrack(playbackTrack)
+        queue.updateCurrentTrack(logicalTrack)
         if (!isManualSourceSwitch) {
             resetLyricsForPlaybackRequest()
         }
@@ -140,40 +146,41 @@ internal class PlaybackStartCoordinator(
         // have discarded the old resumable session and stale service state is generation-gated.
         val reasonAwareEngine = playbackEngine as? PlaybackStartReasonAwareEngine
         if (reasonAwareEngine != null) {
-            reasonAwareEngine.prepareLoading(playbackTrack, startReason)
+            reasonAwareEngine.prepareLoading(logicalTrack, startReason)
         } else {
-            playbackEngine.prepareLoading(playbackTrack)
+            playbackEngine.prepareLoading(logicalTrack)
         }
 
         publishPlaybackState(
             currentPlaybackState().copy(
                 status = PlayerStatus.Loading,
-                currentTrack = playbackTrack,
+                currentTrack = logicalTrack,
+                resolvedSource = null,
                 queue = queue.displayQueue(),
                 queueIndex = queue.displayQueueIndex(),
                 positionMs = 0,
                 playbackParts = playbackParts(),
                 currentPartIndex = requestedPartIndex.takeIf { isPlaybackPartRequest } ?: -1,
-                lyrics = preservedLyrics ?: playbackTrack.lyrics,
+                lyrics = preservedLyrics ?: logicalTrack.lyrics,
                 playbackGeneration = transaction.id,
                 errorMessage = null,
             )
         )
         persistQueue()
         setLoading(true)
-        setMessage(messageAfterStart ?: "正在播放：${track.title}")
+        setMessage(messageAfterStart ?: "正在播放：${logicalTrack.title}")
 
         val resolveTrack = requestedPartIndex
             ?.let { index -> playbackParts().getOrNull(index) }
-            ?.toTrack(playbackTrack)
-            ?: playbackTrack
-        maybeLoadLyrics(playbackTrack)
+            ?.toTrack(preparedResolveTrack)
+            ?: preparedResolveTrack
+        maybeLoadLyrics(logicalTrack)
 
         if (!playbackEngine.resolvesResourcesInternally) {
             resolveAndStart(
                 serial = serial,
                 transaction = transaction,
-                playbackTrack = playbackTrack,
+                logicalTrack = logicalTrack,
                 resolveTrack = resolveTrack,
                 skippedUnavailableCount = skippedUnavailableCount,
                 requestedPartIndex = requestedPartIndex,
@@ -189,7 +196,7 @@ internal class PlaybackStartCoordinator(
                 requests = buildList {
                     add(
                         PlaybackRequest(
-                            track = playbackTrack,
+                            track = logicalTrack,
                             resolveTrack = resolveTrack,
                             requestedPartIndex = requestedPartIndex,
                             unavailablePolicy = unavailablePlaybackPolicy(),
@@ -204,10 +211,11 @@ internal class PlaybackStartCoordinator(
                         .drop(1)
                         .take(PLAYBACK_START_PLAN_LOOKAHEAD)
                         .forEach { queuedTrack ->
-                            val nextTrack = prepareTrack(queuedTrack)
+                            val logicalQueuedTrack = queuedTrack.logicalPlaybackTrack()
                             add(
                                 PlaybackRequest(
-                                    track = nextTrack,
+                                    track = logicalQueuedTrack,
+                                    resolveTrack = prepareTrack(logicalQueuedTrack),
                                     unavailablePolicy = unavailablePlaybackPolicy(),
                                     smartReplacementProviderIds = smartReplacementProviderIds(),
                                     smartReplacementMinScore = smartReplacementMinScore(),
@@ -224,7 +232,7 @@ internal class PlaybackStartCoordinator(
     private fun resolveAndStart(
         serial: Long,
         transaction: PlaybackTransaction,
-        playbackTrack: MusicTrack,
+        logicalTrack: MusicTrack,
         resolveTrack: MusicTrack,
         skippedUnavailableCount: Int,
         requestedPartIndex: Int?,
@@ -266,13 +274,26 @@ internal class PlaybackStartCoordinator(
                 }
                 setPlaybackParts(nextParts)
                 setCurrentPartIndex(nextPartIndex)
-                val playableTrack = playbackTrack.withResolvedPayload(payload, manualSelection != null)
-                queue.updateCurrentTrack(playableTrack)
-                playbackEngine.play(playableTrack, payload)
+                val resolvedSource = payload.toResolvedPlaybackSource(
+                    logicalTrack = logicalTrack,
+                    resolveTrack = resolveTrack,
+                    selectedReplacement = manualSelection != null,
+                )
+                val sourceAwareEngine = playbackEngine as? ResolvedPlaybackSourceAwareEngine
+                if (sourceAwareEngine != null) {
+                    sourceAwareEngine.playResolved(
+                        logicalTrack = logicalTrack,
+                        resolveTrack = resolveTrack,
+                        payload = payload,
+                    )
+                } else {
+                    playbackEngine.play(logicalTrack, payload)
+                }
                 publishPlaybackState(
                     currentPlaybackState().copy(
                         status = PlayerStatus.Loading,
-                        currentTrack = playableTrack,
+                        currentTrack = logicalTrack,
+                        resolvedSource = resolvedSource,
                         queue = queue.displayQueue(),
                         queueIndex = queue.displayQueueIndex(),
                         lyrics = payload.lyrics?.takeIf { it.isNotBlank() } ?: currentPlaybackState().lyrics,
@@ -282,23 +303,23 @@ internal class PlaybackStartCoordinator(
                         playbackGeneration = transaction.id,
                     )
                 )
-                maybeLoadLyrics(playableTrack)
+                maybeLoadLyrics(logicalTrack)
                 persistQueue()
                 setMessage(
                     messageAfterStart
-                        ?: currentPlaybackPartLabel(playableTrack)
-                        ?: "${playableTrack.title} - ${playableTrack.artists}"
+                        ?: currentPlaybackPartLabel(logicalTrack)
+                        ?: "${logicalTrack.title} - ${logicalTrack.artists}"
                 )
                 prefetchQueue()
             }.onFailure { throwable ->
                 if (serial == currentRequestSerial() && queue.activePlaybackTransaction()?.id == transaction.id) {
                     _startFailure.value = PlaybackStartFailure(
-                        trackId = playbackTrack.id,
+                        trackId = logicalTrack.id,
                         message = failureMessage(throwable),
                     )
                     onStartFailure(
                         serial,
-                        playbackTrack,
+                        logicalTrack,
                         skippedUnavailableCount,
                         manualSelection,
                         throwable,
@@ -357,63 +378,3 @@ private fun PlaybackPart.toTrack(parent: MusicTrack): MusicTrack = parent.copy(
     durationMs = durationMs ?: parent.durationMs,
     providerId = id,
 )
-
-private fun MusicTrack.withResolvedPayload(
-    payload: PlaybackPayload,
-    manualSelection: Boolean,
-): MusicTrack {
-    val isMultipartPlayback = payload.parts.isNotEmpty()
-    val isSmartReplacementPlayback = payload.isSmartReplacement || manualSelection
-    return copy(
-        title = if (isMultipartPlayback) title else payload.title.ifBlank { title },
-        artists = payload.artists.ifBlank { artists },
-        album = payload.album.ifBlank { album },
-        source = if (isSmartReplacementPlayback) {
-            payload.originalSource?.takeIf { it.isNotBlank() } ?: source
-        } else {
-            payload.source.ifBlank { source }
-        },
-        coverUrl = payload.coverUrl ?: coverUrl,
-        durationMs = if (isMultipartPlayback) durationMs else payload.durationMs ?: durationMs,
-        providerName = if (isSmartReplacementPlayback) {
-            payload.providerName ?: payload.replacementProviderName ?: providerName
-        } else {
-            payload.providerName ?: providerName
-        },
-        providerId = if (isSmartReplacementPlayback) payload.originalId ?: providerId else providerId,
-        isSmartReplacement = isSmartReplacementPlayback,
-        originalId = payload.originalId.takeIf { isSmartReplacementPlayback }
-            ?: originalId.takeIf { isSmartReplacementPlayback },
-        originalTitle = payload.originalTitle.takeIf { isSmartReplacementPlayback }
-            ?: originalTitle.takeIf { isSmartReplacementPlayback },
-        originalArtists = payload.originalArtists.takeIf { isSmartReplacementPlayback }
-            ?: originalArtists.takeIf { isSmartReplacementPlayback },
-        originalAlbum = payload.originalAlbum.takeIf { isSmartReplacementPlayback }
-            ?: originalAlbum.takeIf { isSmartReplacementPlayback },
-        originalSource = payload.originalSource.takeIf { isSmartReplacementPlayback }
-            ?: originalSource.takeIf { isSmartReplacementPlayback },
-        originalProviderName = payload.originalProviderName.takeIf { isSmartReplacementPlayback }
-            ?: originalProviderName.takeIf { isSmartReplacementPlayback },
-        originalCoverUrl = payload.originalCoverUrl.takeIf { isSmartReplacementPlayback }
-            ?: originalCoverUrl.takeIf { isSmartReplacementPlayback },
-        replacementId = payload.replacementId.takeIf { isSmartReplacementPlayback }
-            ?: replacementId.takeIf { isSmartReplacementPlayback },
-        replacementTitle = payload.replacementTitle.takeIf { isSmartReplacementPlayback }
-            ?: replacementTitle.takeIf { isSmartReplacementPlayback },
-        replacementArtists = payload.replacementArtists.takeIf { isSmartReplacementPlayback }
-            ?: replacementArtists.takeIf { isSmartReplacementPlayback },
-        replacementAlbum = payload.replacementAlbum.takeIf { isSmartReplacementPlayback }
-            ?: replacementAlbum.takeIf { isSmartReplacementPlayback },
-        replacementSource = payload.replacementSource.takeIf { isSmartReplacementPlayback }
-            ?: replacementSource.takeIf { isSmartReplacementPlayback },
-        replacementProviderName = payload.replacementProviderName.takeIf { isSmartReplacementPlayback }
-            ?: replacementProviderName.takeIf { isSmartReplacementPlayback },
-        replacementCoverUrl = payload.replacementCoverUrl.takeIf { isSmartReplacementPlayback }
-            ?: replacementCoverUrl.takeIf { isSmartReplacementPlayback },
-        replacementStrategy = payload.replacementStrategy.takeIf { isSmartReplacementPlayback }
-            ?: replacementStrategy.takeIf { isSmartReplacementPlayback },
-        replacementScore = payload.replacementScore.takeIf { isSmartReplacementPlayback }
-            ?: replacementScore.takeIf { isSmartReplacementPlayback },
-        isUnavailable = false,
-    )
-}

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ResolvedPlaybackSource.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ResolvedPlaybackSource.kt
@@ -1,0 +1,179 @@
+package org.feeluown.mobile
+
+/**
+ * Physical media selected for one logical queue track.
+ *
+ * Queue identity must stay on [PlaybackState.currentTrack]. Provider replacement,
+ * downloaded/local media and other physical playback choices live here instead of
+ * mutating the logical [MusicTrack] stored in the queue.
+ */
+data class ResolvedPlaybackSource(
+    val trackId: String,
+    val title: String,
+    val artists: String,
+    val album: String,
+    val source: String,
+    val sourceType: TrackSourceType,
+    val providerName: String? = null,
+    val coverUrl: String? = null,
+    val durationMs: Long? = null,
+    val url: String? = null,
+    val isReplacement: Boolean = false,
+    val replacementStrategy: String? = null,
+    val replacementScore: Double? = null,
+)
+
+fun PlaybackPayload.toResolvedPlaybackSource(
+    logicalTrack: MusicTrack,
+    resolveTrack: MusicTrack = logicalTrack,
+    selectedReplacement: Boolean = false,
+): ResolvedPlaybackSource {
+    val replacement = isSmartReplacement ||
+        selectedReplacement ||
+        !replacementId.isNullOrBlank() ||
+        resolveTrack.isSmartReplacement ||
+        !resolveTrack.replacementId.isNullOrBlank()
+    val partSpecificResolver = resolveTrack.id
+        .takeIf { it.isNotBlank() && it != logicalTrack.id }
+    return ResolvedPlaybackSource(
+        trackId = if (replacement) {
+            partSpecificResolver
+                ?: replacementId?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementId?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.id
+        } else {
+            resolveTrack.id
+        },
+        title = if (replacement) {
+            resolveTrack.title.takeIf { partSpecificResolver != null && it.isNotBlank() }
+                ?: replacementTitle?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementTitle?.takeIf { it.isNotBlank() }
+                ?: title.ifBlank { logicalTrack.title }
+        } else {
+            title.ifBlank { logicalTrack.title }
+        },
+        artists = if (replacement) {
+            replacementArtists?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementArtists?.takeIf { it.isNotBlank() }
+                ?: artists.ifBlank { logicalTrack.artists }
+        } else {
+            artists.ifBlank { logicalTrack.artists }
+        },
+        album = if (replacement) {
+            replacementAlbum?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementAlbum?.takeIf { it.isNotBlank() }
+                ?: album.ifBlank { logicalTrack.album }
+        } else {
+            album.ifBlank { logicalTrack.album }
+        },
+        source = if (replacement) {
+            replacementSource?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementSource?.takeIf { it.isNotBlank() }
+                ?: source.ifBlank { resolveTrack.source }
+        } else {
+            source.ifBlank { resolveTrack.source }
+        },
+        sourceType = if (replacement) TrackSourceType.Provider else resolveTrack.sourceType,
+        providerName = if (replacement) {
+            replacementProviderName?.takeIf { it.isNotBlank() }
+                ?: resolveTrack.replacementProviderName?.takeIf { it.isNotBlank() }
+                ?: providerName?.takeIf { it.isNotBlank() }
+        } else {
+            providerName?.takeIf { it.isNotBlank() } ?: resolveTrack.providerName
+        },
+        coverUrl = if (replacement) {
+            replacementCoverUrl ?: resolveTrack.replacementCoverUrl ?: coverUrl ?: logicalTrack.coverUrl
+        } else {
+            coverUrl ?: logicalTrack.coverUrl
+        },
+        durationMs = durationMs ?: resolveTrack.durationMs ?: logicalTrack.durationMs,
+        url = url.takeIf { it.isNotBlank() },
+        isReplacement = replacement,
+        replacementStrategy = if (replacement) {
+            replacementStrategy ?: resolveTrack.replacementStrategy
+        } else {
+            null
+        },
+        replacementScore = if (replacement) {
+            replacementScore ?: resolveTrack.replacementScore
+        } else {
+            null
+        },
+    )
+}
+
+/** Adapts platform states that still encode resolved-source metadata on MusicTrack. */
+fun MusicTrack.toLegacyResolvedPlaybackSource(): ResolvedPlaybackSource {
+    val replacement = isSmartReplacement || !replacementId.isNullOrBlank()
+    return ResolvedPlaybackSource(
+        trackId = if (replacement) replacementId?.takeIf { it.isNotBlank() } ?: id else id,
+        title = if (replacement) replacementTitle?.takeIf { it.isNotBlank() } ?: title else title,
+        artists = if (replacement) replacementArtists?.takeIf { it.isNotBlank() } ?: artists else artists,
+        album = if (replacement) replacementAlbum?.takeIf { it.isNotBlank() } ?: album else album,
+        source = if (replacement) replacementSource?.takeIf { it.isNotBlank() } ?: source else source,
+        sourceType = if (replacement) TrackSourceType.Provider else sourceType,
+        providerName = if (replacement) replacementProviderName ?: providerName else providerName,
+        coverUrl = if (replacement) replacementCoverUrl ?: coverUrl else coverUrl,
+        durationMs = durationMs,
+        isReplacement = replacement,
+        replacementStrategy = replacementStrategy.takeIf { replacement },
+        replacementScore = replacementScore.takeIf { replacement },
+    )
+}
+
+/**
+ * Converts legacy replacement-decorated tracks back to the logical queue identity.
+ * Replacement fields remain on [MusicTrack] only as a compatibility input to provider resolution.
+ */
+fun MusicTrack.logicalPlaybackTrack(): MusicTrack {
+    val hasReplacementMetadata = isSmartReplacement ||
+        !originalId.isNullOrBlank() ||
+        !replacementId.isNullOrBlank()
+    if (!hasReplacementMetadata) return this
+    val logicalId = originalId?.takeIf { it.isNotBlank() } ?: id
+    val logicalSource = originalSource?.takeIf { it.isNotBlank() }
+        ?: logicalId.substringBefore(':').takeIf { it.isNotBlank() }
+        ?: source
+    return copy(
+        id = logicalId,
+        title = originalTitle ?: title,
+        artists = originalArtists ?: artists,
+        album = originalAlbum ?: album,
+        source = logicalSource,
+        sourceType = TrackSourceType.Provider,
+        coverUrl = originalCoverUrl ?: coverUrl,
+        localUri = null,
+        providerId = logicalId,
+        providerName = originalProviderName,
+        isSmartReplacement = false,
+        originalId = null,
+        originalTitle = null,
+        originalArtists = null,
+        originalAlbum = null,
+        originalSource = null,
+        originalProviderName = null,
+        originalCoverUrl = null,
+        replacementId = null,
+        replacementTitle = null,
+        replacementArtists = null,
+        replacementAlbum = null,
+        replacementSource = null,
+        replacementProviderName = null,
+        replacementCoverUrl = null,
+        replacementStrategy = null,
+        replacementScore = null,
+    )
+}
+
+fun ResolvedPlaybackSource.toNavigationTrack(logicalTrack: MusicTrack): MusicTrack = MusicTrack(
+    id = trackId,
+    title = title.ifBlank { logicalTrack.title },
+    artists = artists.ifBlank { logicalTrack.artists },
+    album = album.ifBlank { logicalTrack.album },
+    source = source,
+    sourceType = sourceType,
+    coverUrl = coverUrl ?: logicalTrack.coverUrl,
+    durationMs = durationMs,
+    providerId = trackId,
+    providerName = providerName ?: source,
+)

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ResolvedPlaybackSourceAwareEngine.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ResolvedPlaybackSourceAwareEngine.kt
@@ -1,0 +1,17 @@
+package org.feeluown.mobile
+
+/**
+ * Optional capability for direct-resolution engines that need both identities of one start.
+ *
+ * [logicalTrack] is the queue/business identity. [resolveTrack] is the concrete resolver input
+ * (for example a downloaded copy, multipart item, or replacement-decorated compatibility track).
+ * Implementations must keep [PlaybackState.currentTrack] logical and publish physical identity via
+ * [PlaybackState.resolvedSource].
+ */
+interface ResolvedPlaybackSourceAwareEngine {
+    fun playResolved(
+        logicalTrack: MusicTrack,
+        resolveTrack: MusicTrack,
+        payload: PlaybackPayload,
+    )
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ListeningHistoryRecorderTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ListeningHistoryRecorderTest.kt
@@ -205,25 +205,46 @@ class ListeningHistoryRecorderTest {
         var wallClock = 3_000_000L
         var monotonicClock = 0L
         val recorder = ListeningHistoryRecorder(sink, backgroundScope, { wallClock }, { monotonicClock })
-        val track = track(durationMs = 180_000L).copy(
-            id = "replacement-runtime-id",
+        val track = MusicTrack(
+            id = "netease-song-1",
+            title = "Original Song",
+            artists = "Original Artist",
+            album = "Original Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            durationMs = 180_000L,
+            providerId = "netease-song-1",
+        )
+        val resolvedSource = ResolvedPlaybackSource(
+            trackId = "BV1-replacement",
+            title = "Replacement Video",
+            artists = "Uploader",
+            album = "",
             source = "bilibili",
-            isSmartReplacement = true,
-            originalId = "netease-song-1",
-            originalTitle = "Original Song",
-            originalArtists = "Original Artist",
-            originalAlbum = "Original Album",
-            originalSource = "netease",
-            replacementId = "BV1-replacement",
-            replacementTitle = "Replacement Video",
-            replacementArtists = "Uploader",
-            replacementSource = "bilibili",
+            sourceType = TrackSourceType.Provider,
+            isReplacement = true,
         )
 
-        recorder.onPlaybackState(PlaybackState(PlayerStatus.Playing, track, durationMs = 180_000L), PlaybackQueueState())
+        recorder.onPlaybackState(
+            PlaybackState(
+                PlayerStatus.Playing,
+                track,
+                resolvedSource = resolvedSource,
+                durationMs = 180_000L,
+            ),
+            PlaybackQueueState(),
+        )
         monotonicClock += 90_000L
         wallClock += 90_000L
-        recorder.onPlaybackState(PlaybackState(PlayerStatus.Ended, track, durationMs = 180_000L), PlaybackQueueState())
+        recorder.onPlaybackState(
+            PlaybackState(
+                PlayerStatus.Ended,
+                track,
+                resolvedSource = resolvedSource,
+                durationMs = 180_000L,
+            ),
+            PlaybackQueueState(),
+        )
         runCurrent()
 
         val record = sink.records.last()

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ListeningHistoryResolvedSourceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ListeningHistoryResolvedSourceTest.kt
@@ -1,0 +1,71 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ListeningHistoryResolvedSourceTest {
+    @Test
+    fun replacementIsRecordedAsResolvedRelationWhilePrimaryStaysLogical() = runTest {
+        val sink = RecordingListeningSink()
+        var wallClock = 1_000L
+        var monotonicClock = 0L
+        val recorder = ListeningHistoryRecorder(
+            sink = sink,
+            scope = backgroundScope,
+            nowMillis = { wallClock },
+            monotonicMillis = { monotonicClock },
+        )
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Artist",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+            durationMs = 120_000L,
+        )
+        val queueState = PlaybackQueueState(
+            mainQueue = listOf(logical),
+            mainQueueIndex = 0,
+            lastPlaybackStartReason = PlaybackStartReason.USER_SELECTION,
+            playbackStartSequence = 1L,
+        )
+        recorder.onPlaybackState(
+            state = PlaybackState(
+                status = PlayerStatus.Playing,
+                currentTrack = logical,
+                resolvedSource = ResolvedPlaybackSource(
+                    trackId = "qqmusic:physical",
+                    title = "Physical",
+                    artists = "Artist",
+                    album = "",
+                    source = "qqmusic",
+                    sourceType = TrackSourceType.Provider,
+                    providerName = "QQ Music",
+                    isReplacement = true,
+                ),
+                durationMs = 120_000L,
+            ),
+            queueState = queueState,
+        )
+        testScheduler.runCurrent()
+
+        val record = assertNotNull(sink.records.lastOrNull())
+        assertEquals("Track:7:netease:netease:logical", record.primaryResourceKey)
+        val resolved = assertNotNull(
+            record.resources.firstOrNull { it.relation == ListeningResourceRelationType.ResolvedSource }
+        )
+        assertEquals("qqmusic", resolved.resource.sourceId)
+        assertEquals("qqmusic:physical", resolved.resource.sourceResourceId)
+    }
+
+    private class RecordingListeningSink : ListeningHistorySink {
+        val records = mutableListOf<ListeningHistoryRecord>()
+        override suspend fun upsert(record: ListeningHistoryRecord) {
+            records += record
+        }
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackDirectResolvedEngineContractTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackDirectResolvedEngineContractTest.kt
@@ -1,0 +1,127 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class PlaybackDirectResolvedEngineContractTest {
+    @Test
+    fun directEngineReceivesLogicalTrackAndActualResolverInputSeparately() = runTest {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+        )
+        val downloaded = logical.copy(
+            sourceType = TrackSourceType.Downloaded,
+            localUri = "file:///song.mp3",
+        )
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(logical)
+            mainQueueIndex = 0
+        }
+        val engine = SourceAwareEngine()
+        var state = PlaybackState()
+        var serial = 0L
+        val coordinator = PlaybackStartCoordinator(
+            queue = queue,
+            playbackEngine = engine,
+            playbackRepository = UnusedRepository,
+            scope = this,
+            currentPlaybackState = { state },
+            publishPlaybackState = { state = it },
+            prepareTrack = { downloaded },
+            unavailablePlaybackPolicy = { UnavailablePlaybackPolicy.Skip },
+            smartReplacementProviderIds = { emptySet() },
+            smartReplacementMinScore = { 0.7 },
+            nextRequestSerial = { ++serial },
+            currentRequestSerial = { serial },
+            playbackParts = { emptyList() },
+            setPlaybackParts = {},
+            currentPartIndex = { -1 },
+            setCurrentPartIndex = {},
+            prepareSleepTimer = {},
+            resetLyricsForPlaybackRequest = {},
+            maybeLoadLyrics = {},
+            persistQueue = {},
+            setLoading = {},
+            setMessage = {},
+            failureMessage = { it.message.orEmpty() },
+            onRequestStarted = { _, _ -> },
+            onManualSelectionStarted = { _, _, _, _ -> },
+            onStartFailure = { _, _, _, _, throwable -> throw throwable },
+            prefetchQueue = {},
+        )
+
+        coordinator.start(logical)
+        advanceUntilIdle()
+
+        assertEquals(logical, assertNotNull(engine.logicalTrack))
+        assertEquals(TrackSourceType.Provider, engine.logicalTrack?.sourceType)
+        assertEquals(downloaded, assertNotNull(engine.resolveTrack))
+        assertEquals(TrackSourceType.Downloaded, engine.resolveTrack?.sourceType)
+        assertEquals("file:///song.mp3", engine.payload?.url)
+        assertEquals(logical, queue.currentTrack())
+        assertEquals(TrackSourceType.Downloaded, state.resolvedSource?.sourceType)
+    }
+
+    private class SourceAwareEngine : PlaybackEngine, ResolvedPlaybackSourceAwareEngine {
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState())
+        var logicalTrack: MusicTrack? = null
+        var resolveTrack: MusicTrack? = null
+        var payload: PlaybackPayload? = null
+
+        override fun play(track: MusicTrack, payload: PlaybackPayload) {
+            error("source-aware direct playback should use playResolved")
+        }
+
+        override fun playResolved(
+            logicalTrack: MusicTrack,
+            resolveTrack: MusicTrack,
+            payload: PlaybackPayload,
+        ) {
+            this.logicalTrack = logicalTrack
+            this.resolveTrack = resolveTrack
+            this.payload = payload
+        }
+
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun stop() = Unit
+        override fun seekTo(positionMs: Long) = Unit
+    }
+
+    private object UnusedRepository : ProviderPlaybackRepository {
+        override suspend fun resolve(
+            track: MusicTrack,
+            unavailablePolicy: UnavailablePlaybackPolicy,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+        ): PlaybackPayload = error("local resolver input should bypass provider resolution")
+
+        override suspend fun resolveSelectedReplacement(
+            track: MusicTrack,
+            smartReplacementUseOriginalMetadata: Boolean,
+            smartReplacementUseOriginalLyrics: Boolean,
+            smartReplacementProviderIds: Set<String>,
+        ): PlaybackPayload = error("unused")
+
+        override suspend fun replacementCandidates(
+            track: MusicTrack,
+            smartReplacementProviderIds: Set<String>,
+            smartReplacementMinScore: Double,
+        ): List<ReplacementCandidate> = emptyList()
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLogicalSourceDocumentationTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLogicalSourceDocumentationTest.kt
@@ -1,0 +1,36 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackLogicalSourceDocumentationTest {
+    @Test
+    fun resolverCompatibilityTrackIsExplicitlyDifferentFromLogicalTrack() {
+        val logical = MusicTrack(
+            id = "netease:1",
+            title = "Song",
+            artists = "Artist",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:1",
+        )
+        val resolverInput = logical.withReplacementSelection(
+            SmartReplacementSelection(
+                replacementId = "qqmusic:1",
+                replacementTitle = "Song",
+                replacementArtists = "Artist",
+                replacementSource = "qqmusic",
+                replacementScore = 0.9,
+            )
+        )
+
+        assertTrue(resolverInput.isSmartReplacement)
+        assertEquals("qqmusic:1", resolverInput.replacementId)
+        val normalized = resolverInput.logicalPlaybackTrack()
+        assertEquals(logical.id, normalized.id)
+        assertFalse(normalized.isSmartReplacement)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsReplacementAlignmentTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackLyricsReplacementAlignmentTest.kt
@@ -12,7 +12,7 @@ class PlaybackLyricsReplacementAlignmentTest {
     @Test
     fun nativeLyricsOffsetUsesActualReplacementSource() = runTest {
         val original = providerTrack("netease:original", "原曲", "netease")
-        val replacement = replacementTrack(original, "ytmusic:replacement-a")
+        val source = replacementSource("ytmusic:replacement-a")
         val rememberedOffsets = mutableListOf<Pair<String, Long>>()
         var currentLyrics: String? = null
         val controller = PlaybackLyricsController(
@@ -21,15 +21,16 @@ class PlaybackLyricsReplacementAlignmentTest {
             ),
             scope = this,
             currentRequestSerial = { 1L },
-            currentTrackId = { replacement.id },
+            currentTrackId = { original.id },
             currentLyrics = { currentLyrics },
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { null },
             rememberAssociation = { _, _ -> },
             rememberAlignmentOffset = { key, offsetMs -> rememberedOffsets += key to offsetMs },
+            currentResolvedSource = { source },
         )
 
-        controller.maybeLoad(replacement)
+        controller.maybeLoad(original)
         advanceUntilIdle()
         controller.updateAlignmentOffset(750L)
 
@@ -44,9 +45,7 @@ class PlaybackLyricsReplacementAlignmentTest {
     @Test
     fun switchingReplacementSourceRestoresEachSourcesOffset() = runTest {
         val original = providerTrack("netease:original", "原曲", "netease")
-        val replacementA = replacementTrack(original, "ytmusic:replacement-a")
-        val replacementB = replacementTrack(original, "qqmusic:replacement-b")
-        var currentTrack = replacementA
+        var currentSource = replacementSource("ytmusic:replacement-a")
         var currentLyrics: String? = null
         val savedOffsets = mapOf(
             lyricsAlignmentPersistenceKey("ytmusic:replacement-a", original.id) to 750L,
@@ -58,20 +57,21 @@ class PlaybackLyricsReplacementAlignmentTest {
             ),
             scope = this,
             currentRequestSerial = { 1L },
-            currentTrackId = { currentTrack.id },
+            currentTrackId = { original.id },
             currentLyrics = { currentLyrics },
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { null },
             rememberAssociation = { _, _ -> },
             alignmentOffsetForTrackId = { savedOffsets[it] ?: 0L },
+            currentResolvedSource = { currentSource },
         )
 
-        controller.maybeLoad(currentTrack)
+        controller.maybeLoad(original)
         advanceUntilIdle()
         assertEquals(750L, controller.associationState.value.alignmentOffsetMs)
 
-        currentTrack = replacementB
-        controller.maybeLoad(currentTrack)
+        currentSource = replacementSource("qqmusic:replacement-b")
+        controller.maybeLoad(original)
         advanceUntilIdle()
 
         assertEquals(-500L, controller.associationState.value.alignmentOffsetMs)
@@ -80,7 +80,7 @@ class PlaybackLyricsReplacementAlignmentTest {
     @Test
     fun manualAssociationOnReplacementAlsoUsesActualPlaybackSource() = runTest {
         val original = providerTrack("netease:original", "原曲", "netease")
-        val replacement = replacementTrack(original, "ytmusic:replacement-a")
+        val source = replacementSource("ytmusic:replacement-a")
         val associated = providerTrack("qqmusic:lyrics", "歌词歌曲", "qqmusic")
         val rememberedOffsets = mutableListOf<Pair<String, Long>>()
         val alignmentKey = lyricsAlignmentPersistenceKey("ytmusic:replacement-a", associated.id)
@@ -92,16 +92,17 @@ class PlaybackLyricsReplacementAlignmentTest {
             ),
             scope = this,
             currentRequestSerial = { 1L },
-            currentTrackId = { replacement.id },
+            currentTrackId = { original.id },
             currentLyrics = { currentLyrics },
             updateLyrics = { currentLyrics = it },
             associationForTrackId = { if (it == original.id) associated.id else null },
             rememberAssociation = { _, _ -> },
             alignmentOffsetForTrackId = { if (it == alignmentKey) 1_000L else 0L },
             rememberAlignmentOffset = { key, offsetMs -> rememberedOffsets += key to offsetMs },
+            currentResolvedSource = { source },
         )
 
-        controller.maybeLoad(replacement)
+        controller.maybeLoad(original)
         advanceUntilIdle()
 
         assertTrue(controller.associationState.value.isManualAssociation)
@@ -123,21 +124,15 @@ class PlaybackLyricsReplacementAlignmentTest {
         providerName = source,
     )
 
-    private fun replacementTrack(original: MusicTrack, replacementId: String) = original.copy(
-        isSmartReplacement = true,
-        originalId = original.id,
-        originalTitle = original.title,
-        originalArtists = original.artists,
-        originalAlbum = original.album,
-        originalSource = original.source,
-        originalProviderName = original.providerName,
-        originalCoverUrl = original.coverUrl,
-        replacementId = replacementId,
-        replacementTitle = "替代音源",
-        replacementArtists = "artist",
-        replacementAlbum = "",
-        replacementSource = replacementId.substringBefore(':'),
-        replacementProviderName = replacementId.substringBefore(':'),
+    private fun replacementSource(id: String) = ResolvedPlaybackSource(
+        trackId = id,
+        title = "替代音源",
+        artists = "artist",
+        album = "",
+        source = id.substringBefore(':'),
+        sourceType = TrackSourceType.Provider,
+        providerName = id.substringBefore(':'),
+        isReplacement = true,
     )
 
     private class FakePlaybackLyricsRepository(

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackManualReplacementLyricsTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackManualReplacementLyricsTest.kt
@@ -44,15 +44,13 @@ class PlaybackManualReplacementLyricsTest {
         )
 
         assertEquals(lyrics, fixture.playbackState.lyrics)
-        assertEquals(replacement, fixture.playbackState.currentTrack)
+        assertEquals(original, fixture.playbackState.currentTrack)
         assertEquals(0, fixture.lyricsResetCount)
-        assertEquals(replacement, fixture.lastLyricsLoadTrack)
-        assertTrue(
-            assertNotNull(fixture.engine.playedPlan)
-                .requests
-                .first()
-                .resolveOnlySelectedReplacement,
-        )
+        assertEquals(original, fixture.lastLyricsLoadTrack)
+        val request = assertNotNull(fixture.engine.playedPlan).requests.first()
+        assertTrue(request.resolveOnlySelectedReplacement)
+        assertEquals(original, request.track)
+        assertEquals(replacement, request.resolveTrack)
     }
 
     @Test

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueRestoreLogicalIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueRestoreLogicalIdentityTest.kt
@@ -1,0 +1,49 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PlaybackQueueRestoreLogicalIdentityTest {
+    @Test
+    fun restoreNormalizesLegacyReplacementDecoratedSnapshot() {
+        val legacy = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Artist",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+            isSmartReplacement = true,
+            originalId = "netease:logical",
+            originalTitle = "Logical",
+            originalArtists = "Artist",
+            originalSource = "netease",
+            replacementId = "bilibili:physical",
+            replacementTitle = "Physical",
+            replacementArtists = "Artist",
+            replacementSource = "bilibili",
+        )
+        val controller = PlaybackQueueController()
+
+        assertTrue(
+            controller.restore(
+                PlaybackQueueSnapshot(
+                    mainQueue = listOf(legacy),
+                    originalMainQueue = listOf(legacy),
+                    queueIndex = 0,
+                )
+            )
+        )
+
+        val current = requireNotNull(controller.currentTrack())
+        assertEquals("netease:logical", current.id)
+        assertEquals("netease", current.source)
+        assertFalse(current.isSmartReplacement)
+        assertNull(current.replacementId)
+        assertEquals(current, controller.snapshot().mainQueue.single())
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackReplacementRollbackSourceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackReplacementRollbackSourceTest.kt
@@ -1,0 +1,89 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaybackReplacementRollbackSourceTest {
+    @Test
+    fun manualSwitchCarriesPreviousResolvedReplacementIntoRollbackInput() = runTest {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Artist",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+        )
+        var rollbackTrack: MusicTrack? = null
+        val controller = PlaybackReplacementController(
+            playbackRepository = object : ProviderPlaybackRepository {
+                override suspend fun resolve(
+                    track: MusicTrack,
+                    unavailablePolicy: UnavailablePlaybackPolicy,
+                    smartReplacementProviderIds: Set<String>,
+                    smartReplacementMinScore: Double,
+                    smartReplacementUseOriginalMetadata: Boolean,
+                    smartReplacementUseOriginalLyrics: Boolean,
+                ): PlaybackPayload = error("unused")
+
+                override suspend fun resolveSelectedReplacement(
+                    track: MusicTrack,
+                    smartReplacementUseOriginalMetadata: Boolean,
+                    smartReplacementUseOriginalLyrics: Boolean,
+                    smartReplacementProviderIds: Set<String>,
+                ): PlaybackPayload = error("unused")
+
+                override suspend fun replacementCandidates(
+                    track: MusicTrack,
+                    smartReplacementProviderIds: Set<String>,
+                    smartReplacementMinScore: Double,
+                ): List<ReplacementCandidate> = emptyList()
+            },
+            scope = backgroundScope,
+            smartReplacementProviderIds = { setOf("qqmusic") },
+            smartReplacementMinScore = { 0.8 },
+            currentTrack = { logical },
+            currentResolvedSource = {
+                ResolvedPlaybackSource(
+                    trackId = "qqmusic:previous",
+                    title = "Previous",
+                    artists = "Artist",
+                    album = "",
+                    source = "qqmusic",
+                    sourceType = TrackSourceType.Provider,
+                    providerName = "QQ Music",
+                    isReplacement = true,
+                    replacementScore = 0.95,
+                )
+            },
+            startManualReplacement = { _, _, rollback -> rollbackTrack = rollback },
+            closePlayer = {},
+            openTrackDetail = {},
+            failureMessage = { throwable, fallback, _ -> throwable.message ?: fallback },
+        )
+
+        controller.selectReplacementCandidate(
+            logical,
+            ReplacementCandidate(
+                track = MusicTrack(
+                    id = "qqmusic:new",
+                    title = "New",
+                    artists = "Artist",
+                    album = "",
+                    source = "qqmusic",
+                    sourceType = TrackSourceType.Provider,
+                    providerId = "qqmusic:new",
+                ),
+                score = 0.99,
+            ),
+        )
+
+        val rollback = requireNotNull(rollbackTrack)
+        assertEquals(logical.id, rollback.logicalPlaybackTrack().id)
+        assertTrue(rollback.isSmartReplacement)
+        assertEquals("qqmusic:previous", rollback.replacementId)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceAdapterTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceAdapterTest.kt
@@ -1,0 +1,37 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaybackResolvedSourceAdapterTest {
+    @Test
+    fun legacyEngineTrackProjectsPhysicalReplacementSource() {
+        val engineTrack = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Artist",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+            isSmartReplacement = true,
+            originalId = "netease:logical",
+            originalTitle = "Logical",
+            originalArtists = "Artist",
+            originalSource = "netease",
+            replacementId = "bilibili:physical",
+            replacementTitle = "Physical",
+            replacementArtists = "Artist",
+            replacementSource = "bilibili",
+            replacementProviderName = "Bilibili",
+        )
+
+        val source = engineTrack.toLegacyResolvedPlaybackSource()
+
+        assertTrue(source.isReplacement)
+        assertEquals("bilibili:physical", source.trackId)
+        assertEquals("bilibili", source.source)
+        assertEquals("Bilibili", source.providerName)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceIdentityTest.kt
@@ -1,0 +1,30 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaybackResolvedSourceIdentityTest {
+    @Test
+    fun logicalAndPhysicalIdsMayDifferByDesign() {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Song",
+            artists = "",
+            album = "",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+        )
+        val source = ResolvedPlaybackSource(
+            trackId = "qqmusic:physical",
+            title = "Song",
+            artists = "",
+            album = "",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            isReplacement = true,
+        )
+
+        assertEquals("netease:logical", logical.id)
+        assertEquals("qqmusic:physical", source.trackId)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceLifecycleTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceLifecycleTest.kt
@@ -1,0 +1,25 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class PlaybackResolvedSourceLifecycleTest {
+    @Test
+    fun newLogicalStartMayClearResolvedSourceBeforeResolution() {
+        val previous = PlaybackState(
+            resolvedSource = ResolvedPlaybackSource(
+                trackId = "qqmusic:old",
+                title = "Old",
+                artists = "",
+                album = "",
+                source = "qqmusic",
+                sourceType = TrackSourceType.Provider,
+                isReplacement = true,
+            ),
+        )
+
+        val loading = previous.copy(resolvedSource = null)
+
+        assertNull(loading.resolvedSource)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceLocalTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceLocalTest.kt
@@ -1,0 +1,38 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PlaybackResolvedSourceLocalTest {
+    @Test
+    fun downloadedResolverInputDoesNotChangeLogicalProviderIdentity() {
+        val logical = MusicTrack(
+            id = "netease:1",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:1",
+        )
+        val downloaded = logical.copy(
+            sourceType = TrackSourceType.Downloaded,
+            localUri = "file:///song.mp3",
+        )
+        val payload = PlaybackPayload(
+            url = "file:///song.mp3",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+        )
+
+        val source = payload.toResolvedPlaybackSource(logical, downloaded)
+
+        assertEquals("netease:1", logical.id)
+        assertEquals(TrackSourceType.Provider, logical.sourceType)
+        assertEquals(TrackSourceType.Downloaded, source.sourceType)
+        assertFalse(source.isReplacement)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceModelTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceModelTest.kt
@@ -1,0 +1,27 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaybackResolvedSourceModelTest {
+    @Test
+    fun resolvedSourceCarriesPhysicalMetadata() {
+        val source = ResolvedPlaybackSource(
+            trackId = "qqmusic:1",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            providerName = "QQ Music",
+            url = "https://example.test/song.mp3",
+            replacementStrategy = "user_selected",
+            replacementScore = 0.97,
+            isReplacement = true,
+        )
+
+        assertEquals("qqmusic:1", source.trackId)
+        assertEquals("https://example.test/song.mp3", source.url)
+        assertEquals("user_selected", source.replacementStrategy)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceMultipartTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceMultipartTest.kt
@@ -1,0 +1,76 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackResolvedSourceMultipartTest {
+    @Test
+    fun replacementPartsDoNotChangeLogicalQueueTrack() {
+        val logical = logicalTrack()
+        val controller = PlaybackQueueController().apply {
+            mainQueue = listOf(logical)
+            mainQueueIndex = 0
+        }
+        val payload = replacementPayload()
+
+        val source = payload.toResolvedPlaybackSource(logical)
+
+        assertTrue(source.isReplacement)
+        assertEquals("bilibili:video", source.trackId)
+        assertEquals("netease:logical", controller.currentTrack()?.id)
+        assertFalse(controller.currentTrack()?.isSmartReplacement == true)
+    }
+
+    @Test
+    fun selectedReplacementPartUsesPartSpecificPhysicalIdentity() {
+        val logical = logicalTrack()
+        val resolverInput = logical.withReplacementSelection(
+            SmartReplacementSelection(
+                replacementId = "bilibili:video",
+                replacementTitle = "Physical",
+                replacementArtists = "Artist",
+                replacementSource = "bilibili",
+            )
+        ).copy(
+            id = "bilibili:video:p2",
+            title = "P2",
+            providerId = "bilibili:video:p2",
+        )
+
+        val source = replacementPayload().toResolvedPlaybackSource(logical, resolverInput)
+
+        assertTrue(source.isReplacement)
+        assertEquals("bilibili:video:p2", source.trackId)
+        assertEquals("P2", source.title)
+        assertEquals("bilibili", source.source)
+    }
+
+    private fun logicalTrack(): MusicTrack = MusicTrack(
+        id = "netease:logical",
+        title = "Logical",
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+        providerId = "netease:logical",
+    )
+
+    private fun replacementPayload(): PlaybackPayload = PlaybackPayload(
+        url = "https://example.test/p1.mp3",
+        title = "Physical",
+        artists = "Artist",
+        album = "Physical album",
+        source = "bilibili",
+        isSmartReplacement = true,
+        replacementId = "bilibili:video",
+        replacementTitle = "Physical",
+        replacementArtists = "Artist",
+        replacementSource = "bilibili",
+        parts = listOf(
+            PlaybackPart(id = "bilibili:video:p1", title = "P1"),
+            PlaybackPart(id = "bilibili:video:p2", title = "P2"),
+        ),
+    )
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceNonReplacementTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceNonReplacementTest.kt
@@ -1,0 +1,34 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PlaybackResolvedSourceNonReplacementTest {
+    @Test
+    fun ordinaryPayloadProducesNonReplacementSource() {
+        val logical = MusicTrack(
+            id = "netease:1",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:1",
+        )
+        val payload = PlaybackPayload(
+            url = "https://example.test/song.mp3",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            providerName = "NetEase Cloud Music",
+        )
+
+        val source = payload.toResolvedPlaybackSource(logical)
+
+        assertFalse(source.isReplacement)
+        assertEquals(logical.id, source.trackId)
+        assertEquals("netease", source.source)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceSelectionTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResolvedSourceSelectionTest.kt
@@ -1,0 +1,45 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlaybackResolvedSourceSelectionTest {
+    @Test
+    fun selectedReplacementIsPhysicalEvenWhenPayloadOmitsSmartFlag() {
+        val logical = MusicTrack(
+            id = "netease:1",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:1",
+        )
+        val resolverInput = logical.copy(
+            isSmartReplacement = true,
+            originalId = logical.id,
+            originalTitle = logical.title,
+            originalArtists = logical.artists,
+            originalSource = logical.source,
+            replacementId = "qqmusic:1",
+            replacementTitle = "Song",
+            replacementArtists = "Artist",
+            replacementSource = "qqmusic",
+        )
+        val payload = PlaybackPayload(
+            url = "https://example.test/song.mp3",
+            title = "Song",
+            artists = "Artist",
+            album = "Album",
+            source = "qqmusic",
+            replacementId = "qqmusic:1",
+            replacementSource = "qqmusic",
+        )
+
+        val source = payload.toResolvedPlaybackSource(logical, resolverInput)
+
+        assertTrue(source.isReplacement)
+        assertEquals("qqmusic:1", source.trackId)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackSourceNavigationTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackSourceNavigationTest.kt
@@ -1,0 +1,36 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaybackSourceNavigationTest {
+    @Test
+    fun resolvedSourceBuildsProviderNativeDetailTrack() {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Logical artist",
+            album = "Logical album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+        )
+        val source = ResolvedPlaybackSource(
+            trackId = "qqmusic:physical",
+            title = "Physical",
+            artists = "Physical artist",
+            album = "Album",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            providerName = "QQ Music",
+            isReplacement = true,
+        )
+
+        val detail = source.toNavigationTrack(logical)
+
+        assertEquals("qqmusic:physical", detail.id)
+        assertEquals("Physical", detail.title)
+        assertEquals("qqmusic", detail.source)
+        assertEquals("QQ Music", detail.providerName)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 
 class PlaybackStartCoordinatorTest {
     @Test
-    fun directResolutionStartsEngineAndPublishesResolvedTrack() = runTest {
+    fun directResolutionKeepsLogicalTrackAndPublishesResolvedSource() = runTest {
         val track = track("netease:1")
         val payload = payload(title = "Resolved title")
         val queue = PlaybackQueueController().apply {
@@ -32,10 +32,11 @@ class PlaybackStartCoordinatorTest {
         assertEquals(track, engine.preparedTrack)
         assertEquals(1, repository.resolveCalls)
         assertEquals(payload, engine.playedPayload)
-        assertEquals("Resolved title", engine.playedTrack?.title)
-        assertEquals("Resolved title", queue.currentTrack()?.title)
+        assertEquals(track, engine.playedTrack)
+        assertEquals(track, queue.currentTrack())
         assertEquals(PlayerStatus.Loading, fixture.playbackState.status)
-        assertEquals("Resolved title", fixture.playbackState.currentTrack?.title)
+        assertEquals(track, fixture.playbackState.currentTrack)
+        assertEquals("Resolved title", fixture.playbackState.resolvedSource?.title)
         assertEquals(queue.activePlaybackTransaction()?.id, fixture.playbackState.playbackGeneration)
         assertNull(fixture.coordinator.startFailure.value)
         assertEquals(0, fixture.failureCount)

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartLogicalSourceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartLogicalSourceTest.kt
@@ -1,0 +1,130 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PlaybackStartLogicalSourceTest {
+    @Test
+    fun manualReplacementKeepsPlanTrackLogicalAndResolverTrackPhysical() = runTest {
+        val logical = track("netease:logical", "Logical")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(logical)
+            mainQueueIndex = 0
+        }
+        val engine = PlanEngine()
+        val fixture = fixture(queue, engine)
+        val selection = SmartReplacementSelection(
+            replacementId = "qqmusic:physical",
+            replacementTitle = "Physical",
+            replacementArtists = "Artist",
+            replacementSource = "qqmusic",
+            replacementProviderName = "QQ Music",
+            replacementScore = 0.99,
+        )
+
+        fixture.start(
+            track = logical,
+            manualSelection = selection,
+            rollbackTrack = logical,
+        )
+
+        val request = assertNotNull(engine.plan).requests.first()
+        assertEquals(logical.id, request.track.id)
+        assertFalse(request.track.isSmartReplacement)
+        assertEquals(logical.id, queue.currentTrack()?.id)
+        assertFalse(queue.currentTrack()?.isSmartReplacement == true)
+        assertTrue(request.resolveTrack.isSmartReplacement)
+        assertEquals("qqmusic:physical", request.resolveTrack.replacementId)
+    }
+
+    private fun TestScope.fixture(
+        queue: PlaybackQueueController,
+        engine: PlanEngine,
+    ): PlaybackStartCoordinator {
+        var serial = 0L
+        var state = PlaybackState()
+        return PlaybackStartCoordinator(
+            queue = queue,
+            playbackEngine = engine,
+            playbackRepository = object : ProviderPlaybackRepository {
+                override suspend fun resolve(
+                    track: MusicTrack,
+                    unavailablePolicy: UnavailablePlaybackPolicy,
+                    smartReplacementProviderIds: Set<String>,
+                    smartReplacementMinScore: Double,
+                    smartReplacementUseOriginalMetadata: Boolean,
+                    smartReplacementUseOriginalLyrics: Boolean,
+                ): PlaybackPayload = error("unused")
+
+                override suspend fun resolveSelectedReplacement(
+                    track: MusicTrack,
+                    smartReplacementUseOriginalMetadata: Boolean,
+                    smartReplacementUseOriginalLyrics: Boolean,
+                    smartReplacementProviderIds: Set<String>,
+                ): PlaybackPayload = error("unused")
+
+                override suspend fun replacementCandidates(
+                    track: MusicTrack,
+                    smartReplacementProviderIds: Set<String>,
+                    smartReplacementMinScore: Double,
+                ): List<ReplacementCandidate> = emptyList()
+            },
+            scope = this,
+            currentPlaybackState = { state },
+            publishPlaybackState = { state = it },
+            prepareTrack = { it },
+            unavailablePlaybackPolicy = { UnavailablePlaybackPolicy.SmartReplace },
+            smartReplacementProviderIds = { setOf("qqmusic") },
+            smartReplacementMinScore = { 0.8 },
+            nextRequestSerial = { ++serial },
+            currentRequestSerial = { serial },
+            playbackParts = { emptyList() },
+            setPlaybackParts = {},
+            currentPartIndex = { -1 },
+            setCurrentPartIndex = {},
+            prepareSleepTimer = {},
+            resetLyricsForPlaybackRequest = {},
+            maybeLoadLyrics = {},
+            persistQueue = {},
+            setLoading = {},
+            setMessage = {},
+            failureMessage = { it.message.orEmpty() },
+            onRequestStarted = { _, _ -> },
+            onManualSelectionStarted = { _, _, _, _ -> },
+            onStartFailure = { _, _, _, _, _ -> },
+            prefetchQueue = {},
+        )
+    }
+
+    private fun track(id: String, title: String): MusicTrack = MusicTrack(
+        id = id,
+        title = title,
+        artists = "Artist",
+        album = "Album",
+        source = id.substringBefore(':'),
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+    )
+
+    private class PlanEngine : PlaybackEngine {
+        override val state: StateFlow<PlaybackState> = MutableStateFlow(PlaybackState())
+        override val resolvesResourcesInternally: Boolean = true
+        var plan: PlaybackPlan? = null
+
+        override fun play(track: MusicTrack, payload: PlaybackPayload) = Unit
+        override fun play(plan: PlaybackPlan) {
+            this.plan = plan
+        }
+        override fun pause() = Unit
+        override fun resume() = Unit
+        override fun stop() = Unit
+        override fun seekTo(positionMs: Long) = Unit
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStateLogicalIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStateLogicalIdentityTest.kt
@@ -1,0 +1,38 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackStateLogicalIdentityTest {
+    @Test
+    fun resolvedSourceCanChangeWithoutChangingLogicalTrack() {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Logical",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+        )
+        val state = PlaybackState(
+            currentTrack = logical,
+            resolvedSource = ResolvedPlaybackSource(
+                trackId = "bilibili:physical",
+                title = "Physical",
+                artists = "Artist",
+                album = "",
+                source = "bilibili",
+                sourceType = TrackSourceType.Provider,
+                isReplacement = true,
+            ),
+        )
+
+        assertEquals("netease:logical", state.currentTrack?.id)
+        assertFalse(state.currentTrack?.isSmartReplacement == true)
+        assertEquals("bilibili:physical", state.resolvedSource?.trackId)
+        assertTrue(state.resolvedSource?.isReplacement == true)
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ResolvedPlaybackSourceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/ResolvedPlaybackSourceTest.kt
@@ -1,0 +1,107 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ResolvedPlaybackSourceTest {
+    @Test
+    fun legacyReplacementNormalizesBackToLogicalTrack() {
+        val decorated = replacementTrack()
+
+        val logical = decorated.logicalPlaybackTrack()
+
+        assertEquals("netease:logical", logical.id)
+        assertEquals("Logical title", logical.title)
+        assertEquals("netease", logical.source)
+        assertFalse(logical.isSmartReplacement)
+        assertNull(logical.replacementId)
+        assertNull(logical.originalId)
+    }
+
+    @Test
+    fun queueNeverStoresReplacementDecoratedTrack() {
+        val controller = PlaybackQueueController()
+        controller.mainQueue = listOf(replacementTrack())
+        controller.mainQueueIndex = 0
+
+        val current = controller.currentTrack()!!
+
+        assertEquals("netease:logical", current.id)
+        assertFalse(current.isSmartReplacement)
+        assertNull(current.replacementId)
+        assertEquals(listOf("netease:logical"), controller.snapshot().mainQueue.map { it.id })
+    }
+
+    @Test
+    fun payloadKeepsPhysicalReplacementOutsideLogicalTrack() {
+        val logical = MusicTrack(
+            id = "netease:logical",
+            title = "Logical title",
+            artists = "Logical artist",
+            album = "Logical album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+        )
+        val resolveTrack = logical.copy(
+            isSmartReplacement = true,
+            originalId = logical.id,
+            originalTitle = logical.title,
+            originalArtists = logical.artists,
+            originalSource = logical.source,
+            replacementId = "qqmusic:physical",
+            replacementTitle = "Physical title",
+            replacementArtists = "Physical artist",
+            replacementSource = "qqmusic",
+            replacementProviderName = "QQ Music",
+        )
+        val payload = PlaybackPayload(
+            url = "https://example.test/audio.mp3",
+            title = "Physical title",
+            artists = "Physical artist",
+            album = "Physical album",
+            source = "qqmusic",
+            replacementId = "qqmusic:physical",
+            replacementTitle = "Physical title",
+            replacementArtists = "Physical artist",
+            replacementSource = "qqmusic",
+            replacementProviderName = "QQ Music",
+        )
+
+        val resolved = payload.toResolvedPlaybackSource(logical, resolveTrack)
+
+        assertEquals("netease:logical", logical.id)
+        assertFalse(logical.isSmartReplacement)
+        assertTrue(resolved.isReplacement)
+        assertEquals("qqmusic:physical", resolved.trackId)
+        assertEquals("qqmusic", resolved.source)
+        assertEquals("QQ Music", resolved.providerName)
+    }
+
+    private fun replacementTrack(): MusicTrack = MusicTrack(
+        id = "netease:logical",
+        title = "Logical title",
+        artists = "Logical artist",
+        album = "Logical album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+        providerId = "netease:logical",
+        providerName = "NetEase Cloud Music",
+        isSmartReplacement = true,
+        originalId = "netease:logical",
+        originalTitle = "Logical title",
+        originalArtists = "Logical artist",
+        originalSource = "netease",
+        originalProviderName = "NetEase Cloud Music",
+        replacementId = "qqmusic:physical",
+        replacementTitle = "Physical title",
+        replacementArtists = "Physical artist",
+        replacementSource = "qqmusic",
+        replacementProviderName = "QQ Music",
+        replacementStrategy = "user_selected",
+        replacementScore = 0.98,
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiOwners.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiOwners.kt
@@ -30,8 +30,10 @@ class DefaultPlaybackNavigationPort : PlaybackNavigationPort {
 
 /**
  * Reads rich presentation directly from the playback engine/settings owners and overlays durable
- * queue metadata for the active track. The queue remains the source of restored/local metadata,
- * while the engine remains the runtime identity authority during a real transition.
+ * logical queue metadata for the active track. Platform engines may still expose legacy decorated
+ * tracks during the migration; physical source identity is projected separately through
+ * [resolvedSource]. A presentation-only compatibility decoration keeps existing player UI working
+ * without allowing replacement metadata back into playback business state.
  */
 class DefaultPlaybackPresentationPort(
     private val playbackEngine: PlaybackEngine,
@@ -55,7 +57,10 @@ class DefaultPlaybackPresentationPort(
         get() = resolvePlaybackPresentationTrack(
             engineTrack = playbackState.currentTrack,
             queueTrack = queuePort.currentQueueTrack,
-        )
+        )?.withResolvedPresentation(resolvedSource)
+    override val resolvedSource: ResolvedPlaybackSource?
+        get() = playbackState.resolvedSource
+            ?: playbackState.currentTrack?.toLegacyResolvedPlaybackSource()
     override val playbackParts: List<PlaybackPart>
         get() = playbackState.playbackParts
     override val currentPartIndex: Int
@@ -82,17 +87,43 @@ class DefaultPlaybackPresentationPort(
 }
 
 /**
- * Resolve the rich track shown by player UI without letting stale engine metadata hide durable
- * queue state. During a real track transition where the identities differ, the engine remains the
- * runtime authority; for the same identity, the queue copy wins because it carries restored or
- * locally edited metadata.
+ * Resolve the logical track shown by player UI without allowing physical replacement metadata from
+ * the engine to become business identity. The queue wins for the active logical identity because it
+ * carries restored/local edits; engine-only states are normalized back to logical identity.
  */
 internal fun resolvePlaybackPresentationTrack(
     engineTrack: MusicTrack?,
     queueTrack: MusicTrack?,
-): MusicTrack? = when {
-    engineTrack == null -> queueTrack
-    queueTrack == null -> engineTrack
-    engineTrack.id == queueTrack.id -> queueTrack
-    else -> engineTrack
+): MusicTrack? {
+    val logicalEngineTrack = engineTrack?.logicalPlaybackTrack()
+    val logicalQueueTrack = queueTrack?.logicalPlaybackTrack()
+    return when {
+        logicalEngineTrack == null -> logicalQueueTrack
+        logicalQueueTrack == null -> logicalEngineTrack
+        logicalEngineTrack.id == logicalQueueTrack.id -> logicalQueueTrack
+        else -> logicalEngineTrack
+    }
+}
+
+private fun MusicTrack.withResolvedPresentation(source: ResolvedPlaybackSource?): MusicTrack {
+    val resolved = source?.takeIf { it.isReplacement } ?: return this
+    return copy(
+        isSmartReplacement = true,
+        originalId = id,
+        originalTitle = title,
+        originalArtists = artists,
+        originalAlbum = album,
+        originalSource = this.source,
+        originalProviderName = providerName,
+        originalCoverUrl = coverUrl,
+        replacementId = resolved.trackId,
+        replacementTitle = resolved.title,
+        replacementArtists = resolved.artists,
+        replacementAlbum = resolved.album,
+        replacementSource = resolved.source,
+        replacementProviderName = resolved.providerName,
+        replacementCoverUrl = resolved.coverUrl,
+        replacementStrategy = resolved.replacementStrategy,
+        replacementScore = resolved.replacementScore,
+    )
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/playback/PlaybackUiPort.kt
@@ -28,6 +28,8 @@ data class ArtistTargetPickerUiState(
 /** Rich playback presentation that intentionally stays outside the narrow PlaybackSession API. */
 interface PlaybackPresentationPort {
     val currentTrack: MusicTrack?
+    val resolvedSource: ResolvedPlaybackSource?
+        get() = null
     val playbackParts: List<PlaybackPart>
     val currentPartIndex: Int
     val lyricFontSize: LyricFontSize

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ResolvedSourcePresentationBoundaryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ResolvedSourcePresentationBoundaryTest.kt
@@ -1,0 +1,36 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ResolvedSourcePresentationBoundaryTest {
+    @Test
+    fun presentationResolverAlwaysReturnsLogicalIdentity() {
+        val engineTrack = MusicTrack(
+            id = "netease:logical",
+            title = "Physical display",
+            artists = "Artist",
+            album = "Album",
+            source = "qqmusic",
+            sourceType = TrackSourceType.Provider,
+            providerId = "netease:logical",
+            isSmartReplacement = true,
+            originalId = "netease:logical",
+            originalTitle = "Logical title",
+            originalArtists = "Artist",
+            originalSource = "netease",
+            replacementId = "qqmusic:physical",
+            replacementTitle = "Physical display",
+            replacementArtists = "Artist",
+            replacementSource = "qqmusic",
+        )
+
+        val resolved = resolvePlaybackPresentationTrack(engineTrack, null)!!
+
+        assertEquals("netease:logical", resolved.id)
+        assertEquals("Logical title", resolved.title)
+        assertEquals("netease", resolved.source)
+        assertFalse(resolved.isSmartReplacement)
+    }
+}

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosNativeAudioEngine.kt
@@ -11,7 +11,7 @@ class IosNativeAudioEngine(
     scope: CoroutineScope,
     private val output: IosAudioOutput,
     settingsRepository: AppSettingsRepository,
-) : PlaybackEngine {
+) : PlaybackEngine, ResolvedPlaybackSourceAwareEngine {
     private val mutableState = MutableStateFlow(PlaybackState())
     private var rawAudioQuality: String? = null
 
@@ -37,19 +37,34 @@ class IosNativeAudioEngine(
         rawAudioQuality = null
         mutableState.value = PlaybackState(
             status = PlayerStatus.Loading,
-            currentTrack = track,
+            currentTrack = track.logicalPlaybackTrack(),
+            resolvedSource = null,
             durationMs = track.durationMs ?: 0,
             lyrics = track.lyrics,
         )
     }
 
     override fun play(track: MusicTrack, payload: PlaybackPayload) {
+        playResolved(
+            logicalTrack = track.logicalPlaybackTrack(),
+            resolveTrack = track,
+            payload = payload,
+        )
+    }
+
+    override fun playResolved(
+        logicalTrack: MusicTrack,
+        resolveTrack: MusicTrack,
+        payload: PlaybackPayload,
+    ) {
+        val normalizedLogicalTrack = logicalTrack.logicalPlaybackTrack()
         output.play(payload.url, payload.headers, payload.title, payload.artists, payload.album)
         rawAudioQuality = payload.audioQuality
         mutableState.value = PlaybackState(
             status = PlayerStatus.Loading,
-            currentTrack = track,
-            durationMs = payload.durationMs ?: track.durationMs ?: 0,
+            currentTrack = normalizedLogicalTrack,
+            resolvedSource = payload.toResolvedPlaybackSource(normalizedLogicalTrack, resolveTrack),
+            durationMs = payload.durationMs ?: normalizedLogicalTrack.durationMs ?: 0,
             lyrics = payload.lyrics,
             audioQuality = normalizedAudioQualityLabel(rawAudioQuality, null),
             playbackParts = payload.parts,


### PR DESCRIPTION
## Summary
- introduce `ResolvedPlaybackSource` as the physical media identity selected for one logical queue track
- keep queue/current playback identity logical while provider replacement, downloaded/local source and resolved URL metadata live separately
- split `PlaybackRequest.track` (logical identity) from `resolveTrack` (resolver input)
- normalize legacy replacement-decorated engine states before they can update feature queue state
- expose resolved-source metadata through playback presentation without persisting it into the durable queue
- preserve current provider/Media3 compatibility so PR3 can handle restore/runtime state-machine cleanup independently

## Why
Playback reliability bugs have repeatedly come from conflating two different concepts in one `MusicTrack`: the item the user selected in the logical queue and the concrete source currently used to play it. Smart replacement and manual source switching could therefore rewrite queue/current-track identity, which then affected next/previous behavior, lyrics association, listening history and restore logic.

PR1 made playback starts explicit transactions. This PR establishes the second boundary: Queue decides **what** is playing; resolution decides **where it is played from**.

## Invariants
- `PlaybackQueueController` stores logical tracks only
- `PlaybackState.currentTrack` is the logical playback identity at the feature boundary
- `ResolvedPlaybackSource` carries the concrete source/provider/media identity
- provider replacement metadata may still exist on resolver input tracks for compatibility, but those tracks must not be written back into Queue
- Android/iOS legacy engine state may be adapted at the feature boundary during migration; PR3 will own the deeper restore/runtime cleanup

## Compatibility
- existing queue persistence format remains readable
- existing smart-replacement settings remain unchanged
- provider resolution APIs remain compatible
- Android Media3 metadata/resume format is not redesigned in this PR
- existing FullPlayer replacement UI is kept through a temporary presentation compatibility projection

## Tests
- logical-track normalization from legacy replacement metadata
- resolved-source projection for automatic/manual replacement
- manual source selection keeps the plan/queue logical while resolver input stays physical
- downloaded/local source projection
- multipart replacement identity separation
- listening-history logical vs resolved source relations
- replacement navigation uses the resolved source instead of queue identity
