### PR TITLE
fix: support legacy Android update installers

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -92,6 +92,7 @@ jobs:
               :androidApp:compileDebugKotlin
               :androidApp:compileDebugJavaWithJavac
               :androidApp:processDebugResources
+              :androidApp:testDebugUnitTest
             )
           fi
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -133,4 +133,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.lyricon.provider)
+    testImplementation(kotlin("test"))
 }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -133,5 +133,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.lyricon.provider)
-    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit"))
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidAppUpdateController.kt
@@ -1,6 +1,7 @@
 package org.feeluown.mobile
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ContentValues
 import android.content.Context
@@ -502,18 +503,53 @@ internal class AndroidAppUpdateController(
             "${appContext.packageName}.fileprovider",
             apkFile,
         )
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, APK_MIME_TYPE)
+        var lastLaunchError: Throwable? = null
+        androidInstallerIntentActions(Build.VERSION.SDK_INT).forEach { action ->
+            val intent = buildInstallerIntent(action, uri)
+            grantInstallerUriPermission(intent, uri)
+            try {
+                appContext.startActivity(intent)
+                mutableUiState.update {
+                    it.copy(
+                        phase = AppUpdatePhase.Installing,
+                        downloadProgress = null,
+                        message = "已打开系统安装器",
+                    )
+                }
+                return
+            } catch (error: ActivityNotFoundException) {
+                lastLaunchError = error
+            } catch (error: SecurityException) {
+                lastLaunchError = error
+            }
+        }
+        throw IOException("无法打开系统安装器", lastLaunchError)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun buildInstallerIntent(action: AndroidInstallerIntentAction, uri: Uri): Intent =
+        when (action) {
+            AndroidInstallerIntentAction.InstallPackage -> Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
+                data = uri
+            }
+            AndroidInstallerIntentAction.ViewPackage -> Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, APK_MIME_TYPE)
+            }
+        }.apply {
             clipData = ClipData.newRawUri("FuoEvolve update", uri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        appContext.startActivity(intent)
-        mutableUiState.update {
-            it.copy(
-                phase = AppUpdatePhase.Installing,
-                downloadProgress = null,
-                message = "已打开系统安装器",
-            )
+
+    @Suppress("DEPRECATION")
+    private fun grantInstallerUriPermission(intent: Intent, uri: Uri) {
+        packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY).forEach { resolveInfo ->
+            runCatching {
+                appContext.grantUriPermission(
+                    resolveInfo.activityInfo.packageName,
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
         }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidInstallerIntentPolicy.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/update/AndroidInstallerIntentPolicy.kt
@@ -1,0 +1,21 @@
+package org.feeluown.mobile
+
+internal enum class AndroidInstallerIntentAction {
+    InstallPackage,
+    ViewPackage,
+}
+
+internal fun androidInstallerIntentActions(apiLevel: Int): List<AndroidInstallerIntentAction> =
+    if (apiLevel <= ANDROID_P_API_LEVEL) {
+        listOf(
+            AndroidInstallerIntentAction.InstallPackage,
+            AndroidInstallerIntentAction.ViewPackage,
+        )
+    } else {
+        listOf(
+            AndroidInstallerIntentAction.ViewPackage,
+            AndroidInstallerIntentAction.InstallPackage,
+        )
+    }
+
+private const val ANDROID_P_API_LEVEL = 28

--- a/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidInstallerIntentPolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidInstallerIntentPolicyTest.kt
@@ -1,0 +1,46 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AndroidInstallerIntentPolicyTest {
+    @Test
+    fun androidSevenPrefersInstallPackageAction() {
+        assertEquals(
+            listOf(
+                AndroidInstallerIntentAction.InstallPackage,
+                AndroidInstallerIntentAction.ViewPackage,
+            ),
+            androidInstallerIntentActions(apiLevel = 24),
+        )
+    }
+
+    @Test
+    fun androidNineStillPrefersInstallPackageAction() {
+        assertEquals(
+            listOf(
+                AndroidInstallerIntentAction.InstallPackage,
+                AndroidInstallerIntentAction.ViewPackage,
+            ),
+            androidInstallerIntentActions(apiLevel = 28),
+        )
+    }
+
+    @Test
+    fun androidTenAndNewerPreferViewAction() {
+        assertEquals(
+            listOf(
+                AndroidInstallerIntentAction.ViewPackage,
+                AndroidInstallerIntentAction.InstallPackage,
+            ),
+            androidInstallerIntentActions(apiLevel = 29),
+        )
+        assertEquals(
+            listOf(
+                AndroidInstallerIntentAction.ViewPackage,
+                AndroidInstallerIntentAction.InstallPackage,
+            ),
+            androidInstallerIntentActions(apiLevel = 35),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- prefer `ACTION_INSTALL_PACKAGE` on Android 7–9 while keeping `ACTION_VIEW` for Android 10+
- fall back to the alternate installer intent when the preferred action is unavailable or rejected
- explicitly grant the resolved package installer read access to the FileProvider URI
- add API-level policy tests covering Android 7, 9, 10 and current target behavior

## Rationale
Some older Android/package-installer implementations do not reliably launch APK installation through `ACTION_VIEW` with a `content://` URI. Keeping both intent forms behind one compatibility policy preserves current behavior on newer systems while giving Android 7–9 a compatible primary path.