### PR TITLE
refactor: unify playback startup and restore state

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -161,7 +161,7 @@ class AndroidNativeAudioEngine(
 
         restoredSession = null
         rawAudioQuality = null
-        if (reason.isActiveSelection) {
+        if (reason.clearsDurablePlaybackResume) {
             activePlan = null
             lastPersistedIdentity = null
             lastPersistedPositionMs = 0L
@@ -238,7 +238,6 @@ class AndroidNativeAudioEngine(
             .onFailure { throwable ->
                 startupState.markIdle()
                 activePlan = null
-                playbackResumeStore.clear()
                 Log.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
                 mutableState.value = mutableState.value.copy(
                     status = PlayerStatus.Error,

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -24,6 +24,10 @@ class AndroidNativeAudioEngine(
 ) : PlaybackEngine, PlaybackStartReasonAwareEngine {
     private val playbackResumeStore = AndroidPlaybackResumeStore(context)
     private var restoredSession: AndroidPlaybackResumeSnapshot? = playbackResumeStore.load()
+    private val startupState = PlaybackStartupStateMachine(
+        restoredTrackId = restoredSession?.currentTrack?.id,
+        restoredGeneration = restoredSession?.plan?.generation ?: 0L,
+    )
     private val mutableState = MutableStateFlow(restoredSession?.toPlaybackState() ?: PlaybackState())
     private var rawAudioQuality: String? = null
     private var mediaController: MediaController? = null
@@ -31,10 +35,6 @@ class AndroidNativeAudioEngine(
     private var pendingLockScreenLyrics: PendingLockScreenLyrics? = null
     private var activePlan: PlaybackPlan? = restoredSession?.plan
     private var pendingResumePositionMs: Long? = null
-    private var preparedRestoredSession: AndroidPlaybackResumeSnapshot? = null
-    private var explicitStopRequested = false
-    private var startingPlayback = false
-    private var freshStartPending = false
     private var lastPersistedIdentity: String? = null
     private var lastPersistedPositionMs: Long = restoredSession?.positionMs ?: 0L
     private var restoredRepublishSerial = 0L
@@ -59,46 +59,41 @@ class AndroidNativeAudioEngine(
         }
         scope.launch {
             FuoPlaybackService.playbackState.collect { serviceState ->
-                if (startingPlayback && freshStartPending) {
-                    if (serviceState.isEmptyIdleState()) return@collect
-                    val expectedState = mutableState.value
-                    val expectedTrackId = expectedState.currentTrack?.id
-                    val serviceTrackId = serviceState.currentTrack?.id
-                    val expectedGeneration = expectedState.playbackGeneration
-                    val isFreshGeneration = expectedGeneration > 0L &&
-                        serviceState.playbackGeneration == expectedGeneration
-                    val isExpectedTrack = expectedTrackId == null || serviceTrackId == null ||
-                        expectedTrackId == serviceTrackId
-                    if (!isFreshGeneration || !isExpectedTrack) {
+                val serviceTrackId = serviceState.currentTrack?.logicalPlaybackTrack()?.id
+                when (
+                    startupState.onServiceState(
+                        serviceTrackId = serviceTrackId,
+                        serviceGeneration = serviceState.playbackGeneration,
+                        isEmptyIdleState = serviceState.isEmptyIdleState(),
+                    )
+                ) {
+                    PlaybackServiceStateAction.Ignore -> {
                         Log.d(
                             TAG,
-                            "ignoring stale service state while starting " +
-                                "expectedTrackId=${expectedTrackId.orEmpty()} " +
+                            "ignoring stale service state phase=${startupState.phase} " +
                                 "serviceTrackId=${serviceTrackId.orEmpty()} " +
-                                "expectedGeneration=$expectedGeneration " +
                                 "serviceGeneration=${serviceState.playbackGeneration}",
                         )
                         return@collect
                     }
+
+                    PlaybackServiceStateAction.RepublishRestored -> {
+                        val session = restoredSession ?: playbackResumeStore.load()
+                        if (session != null) {
+                            restoredSession = session
+                            activePlan = session.plan
+                            startupState.markRestored(session.currentTrack.id, session.plan.generation)
+                            publishRestoredState(session)
+                            return@collect
+                        }
+                        startupState.markIdle()
+                    }
+
+                    PlaybackServiceStateAction.Accept -> Unit
                 }
 
-                if (serviceState.isEmptyIdleState() && !explicitStopRequested && !startingPlayback) {
-                    val session = restoredSession ?: playbackResumeStore.load()
-                    if (session != null) {
-                        restoredSession = session
-                        activePlan = session.plan
-                        publishRestoredState(session)
-                        return@collect
-                    }
-                }
-
-                if (!serviceState.isEmptyIdleState()) {
-                    if (serviceState.currentTrack != null) {
-                        startingPlayback = false
-                        freshStartPending = false
-                        restoredSession = null
-                        preparedRestoredSession = null
-                    }
+                if (!serviceState.isEmptyIdleState() && serviceState.currentTrack != null) {
+                    restoredSession = null
                 }
 
                 rawAudioQuality = serviceState.audioQuality
@@ -142,34 +137,29 @@ class AndroidNativeAudioEngine(
         pendingLockScreenLyrics = null
         pendingResumePositionMs = null
 
-        // Only resume-like starts may convert a same-track restart into restoration. Explicit user
-        // selections are new playback transactions even when they happen to select the same track.
         val session = if (reason.mayResumePausedSession) {
             restoredSession ?: playbackResumeStore.load()
         } else {
             null
         }
-        val shouldResumeRestoredSession = mutableState.value.status == PlayerStatus.Paused &&
+        val canResumeRestoredSession = mutableState.value.status == PlayerStatus.Paused &&
             session?.currentTrack?.id == track.id &&
             session.resumePlan() != null
-        if (shouldResumeRestoredSession) {
+        val startupMode = startupState.prepare(
+            trackId = track.id,
+            reason = reason,
+            canResumeRestoredSession = canResumeRestoredSession,
+        )
+        if (startupMode == PlaybackStartupMode.ResumeRestored) {
             val resumedSession = requireNotNull(session)
-            preparedRestoredSession = resumedSession
             restoredSession = resumedSession
             activePlan = resumedSession.plan
-            explicitStopRequested = false
-            startingPlayback = false
-            freshStartPending = false
             connectController()
-            Log.d(TAG, "preserving restored session for prepared trackId=${track.id} reason=$reason")
+            Log.d(TAG, "prepared restored resume trackId=${track.id} reason=$reason")
             return
         }
 
-        preparedRestoredSession = null
         restoredSession = null
-        explicitStopRequested = false
-        startingPlayback = true
-        freshStartPending = true
         rawAudioQuality = null
         if (reason.isActiveSelection) {
             activePlan = null
@@ -201,23 +191,29 @@ class AndroidNativeAudioEngine(
 
     override fun play(plan: PlaybackPlan) {
         val first = plan.requests.firstOrNull() ?: return
-        val preparedSession = preparedRestoredSession
-        if (preparedSession != null && preparedSession.currentTrack.id == first.track.id) {
-            preparedRestoredSession = null
-            restoredSession = preparedSession
-            activePlan = preparedSession.plan
-            Log.d(
-                TAG,
-                "converting stale restart to restored resume trackId=${first.track.id} positionMs=${preparedSession.positionMs}",
-            )
-            resume()
-            return
+        val startupMode = startupState.beginStart(first.track.id, plan.generation)
+        if (startupMode == PlaybackStartupMode.ResumeRestored) {
+            val session = restoredSession
+            if (session != null && session.currentTrack.id == first.track.id) {
+                val livePosition = mediaController
+                    ?.takeIf { controller ->
+                        controller.currentMediaItem?.matchesTrack(first.track.id) == true &&
+                            controller.playbackState != Player.STATE_IDLE
+                    }
+                    ?.currentPosition
+                    ?.coerceAtLeast(0L)
+                if (startRestoredSession(session, plan.generation, livePosition ?: session.positionMs)) {
+                    return
+                }
+            }
+            startupState.beginFreshStart(first.track.id, plan.generation)
         }
 
-        preparedRestoredSession = null
-        explicitStopRequested = false
-        startingPlayback = true
-        freshStartPending = true
+        startFreshPlan(plan)
+    }
+
+    private fun startFreshPlan(plan: PlaybackPlan) {
+        val first = plan.requests.firstOrNull() ?: return
         restoredSession = null
         pendingResumePositionMs = null
         activePlan = plan
@@ -240,8 +236,9 @@ class AndroidNativeAudioEngine(
         persistPlaybackState(forceSession = true)
         runCatching { FuoPlaybackService.play(context, plan.toJson()) }
             .onFailure { throwable ->
-                startingPlayback = false
-                freshStartPending = false
+                startupState.markIdle()
+                activePlan = null
+                playbackResumeStore.clear()
                 Log.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
                 mutableState.value = mutableState.value.copy(
                     status = PlayerStatus.Error,
@@ -252,8 +249,42 @@ class AndroidNativeAudioEngine(
         connectController()
     }
 
+    private fun startRestoredSession(
+        session: AndroidPlaybackResumeSnapshot,
+        generation: Long,
+        resumePositionMs: Long,
+    ): Boolean {
+        val resumePlan = session.resumePlan(generation) ?: return false
+        activePlan = resumePlan
+        restoredSession = session
+        pendingResumePositionMs = resumePositionMs.coerceAtLeast(0L)
+        lastPersistedIdentity = null
+        lastPersistedPositionMs = pendingResumePositionMs ?: 0L
+        mutableState.value = session.toPlaybackState().copy(
+            status = PlayerStatus.Loading,
+            positionMs = pendingResumePositionMs ?: session.positionMs,
+            playbackGeneration = generation,
+            errorMessage = null,
+        )
+        persistPlaybackState(forceSession = true)
+        runCatching { FuoPlaybackService.play(context, resumePlan.toJson()) }
+            .onFailure { throwable ->
+                startupState.markRestored(session.currentTrack.id, session.plan.generation)
+                activePlan = session.plan
+                pendingResumePositionMs = null
+                playbackResumeStore.saveSession(session.plan, session.toPlaybackState())
+                Log.e(TAG, "restore playback service failed trackId=${session.currentTrack.id}", throwable)
+                mutableState.value = session.toPlaybackState().copy(
+                    status = PlayerStatus.Error,
+                    errorMessage = throwable.message ?: "无法恢复播放进度",
+                )
+                return false
+            }
+        connectController()
+        return true
+    }
+
     override fun pause() {
-        freshStartPending = false
         mediaController?.pause()
         FuoPlaybackService.pause(context)
         mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
@@ -261,13 +292,13 @@ class AndroidNativeAudioEngine(
     }
 
     override fun resume() {
-        explicitStopRequested = false
-        preparedRestoredSession = null
-        freshStartPending = false
         val controller = mediaController
-        val canResumeLiveSession = controller?.currentMediaItem != null &&
+        val currentTrackId = mutableState.value.currentTrack?.logicalPlaybackTrack()?.id
+        val canResumeLiveSession = currentTrackId != null &&
+            controller?.currentMediaItem?.matchesTrack(currentTrackId) == true &&
             controller.playbackState != Player.STATE_IDLE
         if (canResumeLiveSession) {
+            startupState.markActive(currentTrackId, mutableState.value.playbackGeneration)
             controller.play()
             FuoPlaybackService.resume(context)
             mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
@@ -275,31 +306,15 @@ class AndroidNativeAudioEngine(
         }
 
         val session = restoredSession ?: playbackResumeStore.load()
-        val resumePlan = session?.resumePlan()
-        if (session != null && resumePlan != null) {
-            activePlan = resumePlan
+        if (session != null && session.resumePlan() != null) {
             restoredSession = session
-            pendingResumePositionMs = session.positionMs.coerceAtLeast(0L)
-            startingPlayback = true
-            lastPersistedIdentity = null
-            lastPersistedPositionMs = session.positionMs
-            mutableState.value = session.toPlaybackState().copy(
-                status = PlayerStatus.Loading,
-                playbackGeneration = resumePlan.generation,
+            startupState.prepare(
+                trackId = session.currentTrack.id,
+                reason = PlaybackStartReason.RESTORE_SESSION,
+                canResumeRestoredSession = true,
             )
-            persistPlaybackState(forceSession = true)
-            runCatching { FuoPlaybackService.play(context, resumePlan.toJson()) }
-                .onFailure { throwable ->
-                    startingPlayback = false
-                    Log.e(TAG, "restore playback service failed trackId=${session.currentTrack.id}", throwable)
-                    mutableState.value = session.toPlaybackState().copy(
-                        status = PlayerStatus.Error,
-                        errorMessage = throwable.message ?: "无法恢复播放进度",
-                    )
-                    return
-                }
-            connectController()
-            return
+            startupState.beginStart(session.currentTrack.id, session.plan.generation)
+            if (startRestoredSession(session, session.plan.generation, session.positionMs)) return
         }
 
         controller?.play()
@@ -310,12 +325,9 @@ class AndroidNativeAudioEngine(
     override fun stop() {
         pendingLockScreenLyrics = null
         pendingResumePositionMs = null
-        preparedRestoredSession = null
         restoredSession = null
         activePlan = null
-        explicitStopRequested = true
-        startingPlayback = false
-        freshStartPending = false
+        startupState.stop()
         lastPersistedIdentity = null
         lastPersistedPositionMs = 0L
         playbackResumeStore.clear()
@@ -343,7 +355,7 @@ class AndroidNativeAudioEngine(
 
     internal fun republishRestoredState() {
         val session = restoredSession ?: return
-        if (explicitStopRequested || startingPlayback) return
+        if (!startupState.canRepublishRestoredState()) return
         restoredRepublishSerial += 1L
         publishRestoredState(session, forceGeneration = true)
     }
@@ -431,6 +443,8 @@ class AndroidNativeAudioEngine(
         val currentItem = controller.currentMediaItem ?: return
         val trackId = mutableState.value.currentTrack?.id ?: restoredSession?.currentTrack?.id
         if (trackId != null && !currentItem.matchesTrack(trackId)) return
+        val expectedGeneration = activePlan?.generation
+        if (expectedGeneration != null && !currentItem.matchesGeneration(expectedGeneration)) return
         controller.seekTo(position)
         pendingResumePositionMs = null
         mutableState.value = mutableState.value.copy(positionMs = position)
@@ -546,6 +560,9 @@ class AndroidNativeAudioEngine(
 
     private fun MediaItem.matchesTrack(trackId: String): Boolean =
         mediaId.endsWith(":$trackId")
+
+    private fun MediaItem.matchesGeneration(generation: Long): Boolean =
+        mediaId.startsWith("$generation:")
 
     private fun buildLockScreenLyricInfo(track: MusicTrack, lineLyrics: String): String =
         JSONObject()

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -181,7 +181,7 @@ class AndroidNativeAudioEngine(
             playbackGeneration = 0L,
             errorMessage = null,
         )
-        if (reason.isActiveSelection) {
+        if (reason.shouldDiscardLiveSession) {
             discardLivePausedSession(track.id)
         }
         connectController()

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -644,6 +644,8 @@ class AndroidNativeAudioEngine(
         private const val TAG = "FuoAudioEngine"
         private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
         private const val POSITION_PERSIST_INTERVAL_MS = 5_000L
-        private val RESTORABLE_STATUSES = setOf(PlayerStatus.Loading, PlayerStatus.Playing, PlayerStatus.Paused)
+        // A session is resumable only after Media3 has established a playable item. Persisting
+        // Loading would turn an asynchronous resolve/start failure into a phantom paused session.
+        private val RESTORABLE_STATUSES = setOf(PlayerStatus.Playing, PlayerStatus.Paused)
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -458,7 +458,7 @@ class AndroidNativeAudioEngine(
         val plan = activePlan ?: return
         val state = mutableState.value
         val track = state.currentTrack ?: return
-        if (state.status !in RESTORABLE_STATUSES) return
+        if (!state.status.isDurablePlaybackResumeStatus()) return
 
         val identity = buildString {
             append(plan.generation)
@@ -644,8 +644,5 @@ class AndroidNativeAudioEngine(
         private const val TAG = "FuoAudioEngine"
         private const val OPLUS_LYRIC_INFO_KEY = "lyricInfo"
         private const val POSITION_PERSIST_INTERVAL_MS = 5_000L
-        // A session is resumable only after Media3 has established a playable item. Persisting
-        // Loading would turn an asynchronous resolve/start failure into a phantom paused session.
-        private val RESTORABLE_STATUSES = setOf(PlayerStatus.Playing, PlayerStatus.Paused)
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
@@ -1,0 +1,5 @@
+package org.feeluown.mobile
+
+/** Only established playback can become a durable resume point. */
+internal fun PlayerStatus.isDurablePlaybackResumeStatus(): Boolean =
+    this == PlayerStatus.Playing || this == PlayerStatus.Paused

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
@@ -3,3 +3,7 @@ package org.feeluown.mobile
 /** Only established playback can become a durable resume point. */
 internal fun PlayerStatus.isDurablePlaybackResumeStatus(): Boolean =
     this == PlayerStatus.Playing || this == PlayerStatus.Paused
+
+/** Only a new logical selection invalidates the previous durable resume point. */
+internal val PlaybackStartReason.clearsDurablePlaybackResume: Boolean
+    get() = isActiveSelection

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
@@ -30,7 +30,7 @@ internal data class AndroidPlaybackResumeSnapshot(
         )
     }
 
-    fun resumePlan(): PlaybackPlan? {
+    fun resumePlan(generation: Long = plan.generation): PlaybackPlan? {
         val requestIndex = plan.requests.indexOfFirst { request ->
             request.track.id == currentTrack.id
         }
@@ -48,7 +48,10 @@ internal data class AndroidPlaybackResumeSnapshot(
         } else {
             currentRequest
         }
-        return plan.copy(requests = remainingRequests)
+        return plan.copy(
+            generation = generation,
+            requests = remainingRequests,
+        )
     }
 }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackRuntime.kt
@@ -34,7 +34,12 @@ internal fun createPlaybackRuntimeSession(
         )
 
     return DefaultPlaybackRuntime(
-        engine = PlaybackRuntimeEngineAdapter(playbackEngine, startFailureSource, scope),
+        engine = PlaybackRuntimeEngineAdapter(
+            playbackEngine = playbackEngine,
+            startFailureSource = startFailureSource,
+            scope = scope,
+            resumePlayback = transportCoordinator::startCurrent,
+        ),
         overlay = overlay,
         queueActions = PlaybackCoordinatorQueueActions(transportCoordinator),
         scope = scope,
@@ -45,6 +50,7 @@ private class PlaybackRuntimeEngineAdapter(
     private val playbackEngine: PlaybackEngine,
     startFailureSource: PlaybackStartFailureSource,
     scope: CoroutineScope,
+    private val resumePlayback: () -> Unit,
 ) : PlaybackRuntimeEngine {
     override val state: StateFlow<PlaybackRuntimeEngineState> = combine(
         playbackEngine.state,
@@ -61,7 +67,9 @@ private class PlaybackRuntimeEngineAdapter(
 
     override fun pause() = playbackEngine.pause()
 
-    override fun resume() = playbackEngine.resume()
+    // Android resume must re-enter PlaybackStartCoordinator so restored and live-paused sessions
+    // share the same explicit RESUME transaction and generation gating.
+    override fun resume() = resumePlayback()
 }
 
 private class PlaybackCoordinatorQueueActions(

--- a/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicyTest.kt
@@ -14,4 +14,15 @@ class AndroidPlaybackResumePolicyTest {
         assertFalse(PlayerStatus.Error.isDurablePlaybackResumeStatus())
         assertFalse(PlayerStatus.Ended.isDurablePlaybackResumeStatus())
     }
+
+    @Test
+    fun onlyNewLogicalSelectionsClearDurableResume() {
+        assertTrue(PlaybackStartReason.USER_SELECTION.clearsDurablePlaybackResume)
+        assertTrue(PlaybackStartReason.PLAYLIST_REPLACE.clearsDurablePlaybackResume)
+        assertFalse(PlaybackStartReason.SOURCE_SWITCH.clearsDurablePlaybackResume)
+        assertFalse(PlaybackStartReason.AUTO_NEXT.clearsDurablePlaybackResume)
+        assertFalse(PlaybackStartReason.RESUME.clearsDurablePlaybackResume)
+        assertFalse(PlaybackStartReason.RESTORE_SESSION.clearsDurablePlaybackResume)
+        assertFalse(PlaybackStartReason.RECOVERY.clearsDurablePlaybackResume)
+    }
 }

--- a/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicyTest.kt
+++ b/androidApp/src/test/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicyTest.kt
@@ -1,0 +1,17 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AndroidPlaybackResumePolicyTest {
+    @Test
+    fun onlyEstablishedPlaybackIsDurable() {
+        assertTrue(PlayerStatus.Playing.isDurablePlaybackResumeStatus())
+        assertTrue(PlayerStatus.Paused.isDurablePlaybackResumeStatus())
+        assertFalse(PlayerStatus.Loading.isDurablePlaybackResumeStatus())
+        assertFalse(PlayerStatus.Idle.isDurablePlaybackResumeStatus())
+        assertFalse(PlayerStatus.Error.isDurablePlaybackResumeStatus())
+        assertFalse(PlayerStatus.Ended.isDurablePlaybackResumeStatus())
+    }
+}

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/ListeningHistoryRecorder.kt
@@ -254,8 +254,10 @@ private fun PlaybackStartReason?.toListeningStartReason(): ListeningStartReason 
     PlaybackStartReason.AUTO_NEXT -> ListeningStartReason.AutoNext
     PlaybackStartReason.RESUME -> ListeningStartReason.Resume
     PlaybackStartReason.RESTORE_SESSION -> ListeningStartReason.RestoreSession
-    PlaybackStartReason.RECOVERY -> ListeningStartReason.Unknown
-    null -> ListeningStartReason.Unknown
+    PlaybackStartReason.SOURCE_SWITCH,
+    PlaybackStartReason.RECOVERY,
+    null,
+    -> ListeningStartReason.Unknown
 }
 
 private fun isQualifiedListening(playedMs: Long, durationMs: Long?): Boolean {

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
@@ -11,6 +11,7 @@ private const val PLAYBACK_START_PLAN_LOOKAHEAD = 8
 enum class PlaybackStartReason {
     USER_SELECTION,
     PLAYLIST_REPLACE,
+    SOURCE_SWITCH,
     AUTO_NEXT,
     RESUME,
     RESTORE_SESSION,
@@ -19,6 +20,9 @@ enum class PlaybackStartReason {
 
     val isActiveSelection: Boolean
         get() = this == USER_SELECTION || this == PLAYLIST_REPLACE
+
+    val shouldDiscardLiveSession: Boolean
+        get() = isActiveSelection || this == SOURCE_SWITCH
 
     val mayResumePausedSession: Boolean
         get() = this == RESUME || this == RESTORE_SESSION
@@ -98,7 +102,7 @@ internal class PlaybackStartCoordinator(
         val transaction = when {
             manualSelection != null -> queue.beginPlaybackTransaction(
                 trackId = logicalTrack.id,
-                reason = PlaybackStartReason.USER_SELECTION,
+                reason = PlaybackStartReason.SOURCE_SWITCH,
                 recordPlaybackStart = false,
             )
             suppressPlaybackRecovery -> queue.beginPlaybackTransaction(
@@ -142,8 +146,8 @@ internal class PlaybackStartCoordinator(
         // Establish the platform playback transaction before publishing the new queue/current-track
         // overlay. Android can still hold a restored paused Media3 session at this point; publishing
         // B first lets runtime observers republish stale A before the engine has invalidated it.
-        // prepareLoading() is therefore the transaction boundary: after it returns, active selections
-        // have discarded the old resumable session and stale service state is generation-gated.
+        // prepareLoading() is therefore the transaction boundary: after it returns, fresh starts
+        // have invalidated the old live session and stale service state is generation-gated.
         val reasonAwareEngine = playbackEngine as? PlaybackStartReasonAwareEngine
         if (reasonAwareEngine != null) {
             reasonAwareEngine.prepareLoading(logicalTrack, startReason)

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartupStateMachine.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartupStateMachine.kt
@@ -1,0 +1,171 @@
+package org.feeluown.mobile
+
+/** Describes whether a playback start should replace or resume the restored platform session. */
+enum class PlaybackStartupMode {
+    Fresh,
+    ResumeRestored,
+}
+
+/** Action a platform engine should take for one state emitted by its playback service/runtime. */
+enum class PlaybackServiceStateAction {
+    Accept,
+    Ignore,
+    RepublishRestored,
+}
+
+sealed interface PlaybackStartupPhase {
+    data object Idle : PlaybackStartupPhase
+
+    data class Restored(
+        val trackId: String,
+        val generation: Long,
+    ) : PlaybackStartupPhase
+
+    data class Prepared(
+        val trackId: String,
+        val mode: PlaybackStartupMode,
+    ) : PlaybackStartupPhase
+
+    data class Starting(
+        val trackId: String,
+        val generation: Long,
+        val mode: PlaybackStartupMode,
+    ) : PlaybackStartupPhase
+
+    data class Active(
+        val trackId: String,
+        val generation: Long,
+    ) : PlaybackStartupPhase
+
+    data object Stopped : PlaybackStartupPhase
+}
+
+/**
+ * Single bootstrap/startup state machine for platform playback engines.
+ *
+ * Persisted-session restore and a new explicit playback transaction are mutually exclusive states.
+ * Service/runtime emissions are accepted only when they belong to the active startup generation,
+ * preventing a stale paused Media3 session from overwriting a new user selection.
+ */
+class PlaybackStartupStateMachine(
+    restoredTrackId: String? = null,
+    restoredGeneration: Long = 0L,
+) {
+    var phase: PlaybackStartupPhase = restoredTrackId
+        ?.let { PlaybackStartupPhase.Restored(it, restoredGeneration) }
+        ?: PlaybackStartupPhase.Idle
+        private set
+
+    fun prepare(
+        trackId: String,
+        reason: PlaybackStartReason,
+        canResumeRestoredSession: Boolean,
+    ): PlaybackStartupMode {
+        val mode = if (reason.mayResumePausedSession && canResumeRestoredSession) {
+            PlaybackStartupMode.ResumeRestored
+        } else {
+            PlaybackStartupMode.Fresh
+        }
+        phase = PlaybackStartupPhase.Prepared(trackId, mode)
+        return mode
+    }
+
+    fun beginStart(trackId: String, generation: Long): PlaybackStartupMode {
+        val mode = (phase as? PlaybackStartupPhase.Prepared)
+            ?.takeIf { it.trackId == trackId }
+            ?.mode
+            ?: PlaybackStartupMode.Fresh
+        phase = PlaybackStartupPhase.Starting(trackId, generation, mode)
+        return mode
+    }
+
+    fun beginFreshStart(trackId: String, generation: Long) {
+        phase = PlaybackStartupPhase.Starting(trackId, generation, PlaybackStartupMode.Fresh)
+    }
+
+    fun markRestored(trackId: String, generation: Long) {
+        phase = PlaybackStartupPhase.Restored(trackId, generation)
+    }
+
+    fun markActive(trackId: String, generation: Long) {
+        phase = PlaybackStartupPhase.Active(trackId, generation)
+    }
+
+    fun markIdle() {
+        phase = PlaybackStartupPhase.Idle
+    }
+
+    fun stop() {
+        phase = PlaybackStartupPhase.Stopped
+    }
+
+    fun canRepublishRestoredState(): Boolean = when (val current = phase) {
+        is PlaybackStartupPhase.Restored -> true
+        is PlaybackStartupPhase.Prepared -> current.mode == PlaybackStartupMode.ResumeRestored
+        else -> false
+    }
+
+    fun onServiceState(
+        serviceTrackId: String?,
+        serviceGeneration: Long,
+        isEmptyIdleState: Boolean,
+    ): PlaybackServiceStateAction = when (val current = phase) {
+        PlaybackStartupPhase.Idle -> PlaybackServiceStateAction.Accept
+
+        is PlaybackStartupPhase.Active -> when {
+            isEmptyIdleState -> PlaybackServiceStateAction.RepublishRestored
+            serviceTrackId != null && serviceTrackId != current.trackId -> PlaybackServiceStateAction.Ignore
+            serviceGeneration != current.generation -> PlaybackServiceStateAction.Ignore
+            else -> PlaybackServiceStateAction.Accept
+        }
+
+        is PlaybackStartupPhase.Restored -> when {
+            isEmptyIdleState -> PlaybackServiceStateAction.RepublishRestored
+            serviceTrackId != null && serviceTrackId != current.trackId -> PlaybackServiceStateAction.Ignore
+            else -> {
+                phase = PlaybackStartupPhase.Active(
+                    trackId = serviceTrackId ?: current.trackId,
+                    generation = serviceGeneration,
+                )
+                PlaybackServiceStateAction.Accept
+            }
+        }
+
+        is PlaybackStartupPhase.Prepared -> {
+            if (current.mode == PlaybackStartupMode.Fresh) {
+                PlaybackServiceStateAction.Ignore
+            } else if (isEmptyIdleState) {
+                PlaybackServiceStateAction.RepublishRestored
+            } else if (serviceTrackId != null && serviceTrackId != current.trackId) {
+                PlaybackServiceStateAction.Ignore
+            } else {
+                // Keep Prepared(ResumeRestored) until beginStart() binds the new transaction generation.
+                PlaybackServiceStateAction.Accept
+            }
+        }
+
+        is PlaybackStartupPhase.Starting -> {
+            if (isEmptyIdleState) {
+                PlaybackServiceStateAction.Ignore
+            } else {
+                val trackMatches = serviceTrackId == null || serviceTrackId == current.trackId
+                val generationMatches = serviceGeneration == current.generation
+                if (!trackMatches || !generationMatches) {
+                    PlaybackServiceStateAction.Ignore
+                } else {
+                    phase = PlaybackStartupPhase.Active(current.trackId, current.generation)
+                    PlaybackServiceStateAction.Accept
+                }
+            }
+        }
+
+        PlaybackStartupPhase.Stopped -> {
+            if (isEmptyIdleState) {
+                phase = PlaybackStartupPhase.Idle
+                PlaybackServiceStateAction.Accept
+            } else {
+                PlaybackServiceStateAction.Ignore
+            }
+        }
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartCoordinatorTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -146,7 +147,10 @@ class PlaybackStartCoordinatorTest {
         )
 
         val transaction = assertNotNull(queue.activePlaybackTransaction())
-        assertEquals(PlaybackStartReason.USER_SELECTION, transaction.reason)
+        assertEquals(PlaybackStartReason.SOURCE_SWITCH, transaction.reason)
+        assertEquals(PlaybackStartReason.SOURCE_SWITCH, engine.preparedReason)
+        assertFalse(transaction.reason.isActiveSelection)
+        assertTrue(transaction.reason.shouldDiscardLiveSession)
         assertEquals(original.id, transaction.targetTrackId)
         assertEquals(transaction.id, assertNotNull(engine.playedPlan).generation)
         assertEquals(historySequenceBeforeSwitch, queue.state.value.playbackStartSequence)

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartupStateMachineTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackStartupStateMachineTest.kt
@@ -1,0 +1,139 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaybackStartupStateMachineTest {
+    @Test
+    fun resumeBindsRestoredSessionToNewTransactionGeneration() {
+        val machine = PlaybackStartupStateMachine(
+            restoredTrackId = "track-a",
+            restoredGeneration = 4L,
+        )
+
+        assertEquals(
+            PlaybackStartupMode.ResumeRestored,
+            machine.prepare(
+                trackId = "track-a",
+                reason = PlaybackStartReason.RESUME,
+                canResumeRestoredSession = true,
+            ),
+        )
+        assertEquals(
+            PlaybackServiceStateAction.RepublishRestored,
+            machine.onServiceState(null, 0L, isEmptyIdleState = true),
+        )
+        assertEquals(PlaybackStartupMode.ResumeRestored, machine.beginStart("track-a", 9L))
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-a", 4L, isEmptyIdleState = false),
+        )
+        assertEquals(
+            PlaybackServiceStateAction.Accept,
+            machine.onServiceState("track-a", 9L, isEmptyIdleState = false),
+        )
+        assertEquals(PlaybackStartupPhase.Active("track-a", 9L), machine.phase)
+    }
+
+    @Test
+    fun activeSelectionNeverResumesSameTrackRestoredSession() {
+        val machine = PlaybackStartupStateMachine(
+            restoredTrackId = "track-a",
+            restoredGeneration = 4L,
+        )
+
+        assertEquals(
+            PlaybackStartupMode.Fresh,
+            machine.prepare(
+                trackId = "track-a",
+                reason = PlaybackStartReason.USER_SELECTION,
+                canResumeRestoredSession = true,
+            ),
+        )
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-a", 4L, isEmptyIdleState = false),
+        )
+        assertEquals(PlaybackStartupMode.Fresh, machine.beginStart("track-a", 10L))
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-a", 4L, isEmptyIdleState = false),
+        )
+        assertEquals(
+            PlaybackServiceStateAction.Accept,
+            machine.onServiceState("track-a", 10L, isEmptyIdleState = false),
+        )
+    }
+
+    @Test
+    fun stoppedPhaseRejectsLateServiceStateUntilIdleAcknowledgement() {
+        val machine = PlaybackStartupStateMachine()
+        machine.beginFreshStart("track-a", 3L)
+        machine.stop()
+
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-a", 3L, isEmptyIdleState = false),
+        )
+        assertEquals(
+            PlaybackServiceStateAction.Accept,
+            machine.onServiceState(null, 0L, isEmptyIdleState = true),
+        )
+        assertEquals(PlaybackStartupPhase.Idle, machine.phase)
+    }
+
+    @Test
+    fun preparedFreshStartRejectsEmptyBootstrapState() {
+        val machine = PlaybackStartupStateMachine(
+            restoredTrackId = "track-a",
+            restoredGeneration = 1L,
+        )
+        machine.prepare(
+            trackId = "track-b",
+            reason = PlaybackStartReason.PLAYLIST_REPLACE,
+            canResumeRestoredSession = false,
+        )
+
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState(null, 0L, isEmptyIdleState = true),
+        )
+    }
+
+    @Test
+    fun restoredAndPreparedResumeRejectDifferentServiceTrack() {
+        val machine = PlaybackStartupStateMachine(
+            restoredTrackId = "track-a",
+            restoredGeneration = 2L,
+        )
+
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-b", 2L, isEmptyIdleState = false),
+        )
+        machine.prepare(
+            trackId = "track-a",
+            reason = PlaybackStartReason.RESUME,
+            canResumeRestoredSession = true,
+        )
+        assertEquals(
+            PlaybackServiceStateAction.Ignore,
+            machine.onServiceState("track-b", 2L, isEmptyIdleState = false),
+        )
+    }
+
+    @Test
+    fun activeSessionRepublishesPersistedStateWhenServiceDropsToEmptyIdle() {
+        val machine = PlaybackStartupStateMachine()
+        machine.beginFreshStart("track-a", 7L)
+        assertEquals(
+            PlaybackServiceStateAction.Accept,
+            machine.onServiceState("track-a", 7L, isEmptyIdleState = false),
+        )
+
+        assertEquals(
+            PlaybackServiceStateAction.RepublishRestored,
+            machine.onServiceState(null, 0L, isEmptyIdleState = true),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a single playback startup state machine covering idle, restored, prepared, starting, active and stopped phases
- route Android paused-session resume back through `PlaybackStartCoordinator` so resume gets an explicit `RESUME` transaction
- replace Android engine startup/restore flag combinations with generation-gated state transitions
- rebind restored playback plans to the current playback transaction generation
- preserve the exact live Media3 position when a paused live session is restarted through the restored plan
- defer the restored seek until the MediaItem for the rebound generation is actually installed
- prevent failed fresh/resume starts from becoming phantom resumable sessions

## Why
PR1 made playback starts explicit transactions and PR2 separated logical queue identity from resolved physical sources. Android startup/restore still relied on several independent flags (`preparedRestoredSession`, `startingPlayback`, `freshStartPending`, `explicitStopRequested`), allowing stale Media3/service state and persisted-session state to race with a new playback transaction.

This PR makes startup/restore one state machine: a start is either a fresh transaction or a restored resume, service emissions are accepted only for the expected generation, and stop blocks late service state until the idle acknowledgement arrives.

## Invariants
- active user selections never resume a same-track restored session
- restored resume uses the current transaction generation instead of the persisted generation
- stale service generations cannot overwrite a prepared/starting/active transaction
- Android media-session resume enters the same `PlaybackStartCoordinator` pipeline as in-app resume
- restored seek cannot be consumed by an old same-track MediaItem from another generation
- a failed start does not leave the failed transaction as a durable resume point

## Tests
- restored resume binds to the new generation
- active selection rejects stale restored state
- stopped phase rejects late service emissions
- prepared fresh start ignores bootstrap idle state
- restored/prepared resume rejects a different service track
- active state republishes persisted playback when the service drops to empty idle
