### PR TITLE
build: add desktop packaging pipelines

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -98,6 +98,7 @@ jobs:
             "-Dorg.gradle.java.installations.paths=$env:FUO_JDK17,$env:JAVA_HOME" `
             --no-configuration-cache `
             --warning-mode all `
+            :desktopApp:createDistributable `
             :desktopApp:packageMsi `
             :desktopApp:packageExe
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -195,6 +196,7 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=bundled \
             -Pfuoevolve.packageLibmpvDir="${{ github.workspace }}/build/desktop-native/macos/mpv" \
+            :desktopApp:createDistributable \
             :desktopApp:packageDmg \
             :desktopApp:packagePkg
 
@@ -205,7 +207,7 @@ jobs:
           find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q .
           find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q .
           find "$ROOT/app" -name libfuoevolve_now_playing_bridge.dylib -print -quit | grep -q .
-          find "$ROOT/app" -path '*/runtime/bin/java' -print -quit | grep -q .
+          find "$ROOT/app" -path '*/Contents/runtime/Contents/Home/bin/java' -print -quit | grep -q .
           while IFS= read -r dylib; do
             if otool -L "$dylib" | tail -n +2 | grep -E '/(opt/homebrew|usr/local)/(Cellar|opt)/'; then
               echo "Packaged dylib still references Homebrew: $dylib" >&2
@@ -292,7 +294,7 @@ jobs:
           fi
           APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
           test -x "$LAUNCHER"
-          test -x "$APP_IMAGE/runtime/bin/java"
+          test -x "$APP_IMAGE/lib/runtime/bin/java"
           TRAY_BRIDGE="$(find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit)"
           test -n "$TRAY_BRIDGE"
           if [[ -n "$(find "$APP_IMAGE" -name 'libmpv.so*' -print -quit)" ]]; then
@@ -409,7 +411,7 @@ jobs:
           fi
           APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
           test -x "$LAUNCHER"
-          test -x "$APP_IMAGE/runtime/bin/java"
+          test -x "$APP_IMAGE/lib/runtime/bin/java"
           VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
           echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -1,0 +1,421 @@
+name: Desktop Packaging
+
+"on":
+  pull_request:
+    paths:
+      - "desktopApp/build.gradle.kts"
+      - "desktopApp/packaging/**"
+      - "desktopApp/native/**"
+      - "androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+      - "gradle/**"
+      - ".github/workflows/desktop-packaging.yml"
+  push:
+    branches:
+      - master
+    tags:
+      - "[0-9]*"
+    paths:
+      - "desktopApp/build.gradle.kts"
+      - "desktopApp/packaging/**"
+      - "desktopApp/native/**"
+      - "androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+      - "gradle/**"
+      - ".github/workflows/desktop-packaging.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  windows-x64:
+    name: Package Windows x64 MSI and EXE
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Git refs for Gradle versioning
+        shell: pwsh
+        run: |
+          git show-ref --verify --quiet refs/heads/master
+          if ($LASTEXITCODE -ne 0) {
+            git branch master origin/master
+          }
+
+      - name: Set up compile JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Remember compile JDK
+        shell: pwsh
+        run: Add-Content -Path $env:GITHUB_ENV -Value "FUO_JDK17=$env:JAVA_HOME"
+
+      - name: Set up bundled JetBrains Runtime JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: jetbrains
+          java-version: "21"
+          java-package: jdk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Set up Rust stable
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustc --version
+          cargo --version
+          java -version
+          jpackage --version
+
+      - name: Prepare pinned Windows libmpv runtime
+        shell: pwsh
+        run: >-
+          ./desktopApp/packaging/windows/prepare-libmpv.ps1
+          -OutputDir "${{ github.workspace }}\build\desktop-native\windows\mpv"
+
+      - name: Build self-contained Windows installers
+        shell: pwsh
+        run: |
+          $libmpv = "${{ github.workspace }}\build\desktop-native\windows\mpv"
+          & .\gradlew.bat `
+            "-Dorg.gradle.java.installations.paths=$env:FUO_JDK17,$env:JAVA_HOME" `
+            --no-configuration-cache `
+            --warning-mode all `
+            -Pfuoevolve.packageProfile=bundled `
+            "-Pfuoevolve.packageLibmpvDir=$libmpv" `
+            :desktopApp:packageMsi `
+            :desktopApp:packageExe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Verify Windows package closure
+        shell: pwsh
+        run: |
+          $root = "desktopApp\build\compose\binaries\main"
+          if (-not (Get-ChildItem "$root\msi" -Filter *.msi -ErrorAction SilentlyContinue)) { throw "MSI was not produced" }
+          if (-not (Get-ChildItem "$root\exe" -Filter *.exe -ErrorAction SilentlyContinue)) { throw "EXE installer was not produced" }
+          if (-not (Get-ChildItem "$root\app" -Recurse -File -Include mpv-2.dll,libmpv-2.dll,mpv.dll -ErrorAction SilentlyContinue)) { throw "Bundled libmpv DLL is missing" }
+          if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter fuoevolve_smtc_bridge.dll -ErrorAction SilentlyContinue)) { throw "SMTC bridge is missing" }
+          if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter java.exe -ErrorAction SilentlyContinue | Where-Object FullName -Match "runtime")) { throw "Bundled JVM runtime is missing" }
+
+      - name: Upload Windows installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-windows-x64
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            desktopApp/build/compose/binaries/main/msi/*.msi
+            desktopApp/build/compose/binaries/main/exe/*.exe
+
+  macos:
+    name: Package macOS ${{ matrix.arch }} DMG and PKG
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+            uname_arch: arm64
+          - arch: x64
+            runner: macos-15-intel
+            uname_arch: x86_64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = "${{ matrix.uname_arch }}"
+
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
+
+      - name: Set up compile JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Remember compile JDK
+        run: echo "FUO_JDK17=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Set up bundled JetBrains Runtime JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: jetbrains
+          java-version: "21"
+          java-package: jdk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Set up Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustc --version
+          cargo --version
+          java -version
+          jpackage --version
+
+      - name: Prepare relocatable macOS libmpv runtime
+        run: >-
+          bash desktopApp/packaging/macos/prepare-libmpv.sh
+          "${{ github.workspace }}/build/desktop-native/macos/mpv"
+
+      - name: Build self-contained macOS installers
+        run: |
+          ./gradlew \
+            "-Dorg.gradle.java.installations.paths=$FUO_JDK17,$JAVA_HOME" \
+            --no-configuration-cache \
+            --warning-mode all \
+            -Pfuoevolve.packageProfile=bundled \
+            -Pfuoevolve.packageLibmpvDir="${{ github.workspace }}/build/desktop-native/macos/mpv" \
+            :desktopApp:packageDmg \
+            :desktopApp:packagePkg
+
+      - name: Verify macOS package closure
+        run: |
+          ROOT=desktopApp/build/compose/binaries/main
+          find "$ROOT/dmg" -maxdepth 1 -name '*.dmg' -print -quit | grep -q .
+          find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q .
+          find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q .
+          find "$ROOT/app" -name libfuoevolve_now_playing_bridge.dylib -print -quit | grep -q .
+          find "$ROOT/app" -path '*/runtime/bin/java' -print -quit | grep -q .
+          while IFS= read -r dylib; do
+            if otool -L "$dylib" | tail -n +2 | grep -E '/(opt/homebrew|usr/local)/(Cellar|opt)/'; then
+              echo "Packaged dylib still references Homebrew: $dylib" >&2
+              exit 1
+            fi
+          done < <(find "$ROOT/app" -name '*.dylib' -type f)
+
+      - name: Upload macOS installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-macos-${{ matrix.arch }}
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            desktopApp/build/compose/binaries/main/dmg/*.dmg
+            desktopApp/build/compose/binaries/main/pkg/*.pkg
+
+  linux-system:
+    name: Package Linux DEB RPM and Arch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
+
+      - name: Set up compile JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Remember compile JDK
+        run: echo "FUO_JDK17=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Set up bundled JetBrains Runtime JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: jetbrains
+          java-version: "21"
+          java-package: jdk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Set up Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
+      - name: Install native packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fakeroot rpm
+          java -version
+          jpackage --version
+          docker --version
+
+      - name: Create Linux app image with system native dependency profile
+        id: app
+        run: |
+          ./gradlew \
+            "-Dorg.gradle.java.installations.paths=$FUO_JDK17,$JAVA_HOME" \
+            --no-configuration-cache \
+            --warning-mode all \
+            -Pfuoevolve.packageProfile=system \
+            :desktopApp:createDistributable
+          APP_IMAGE="$(find desktopApp/build/compose/binaries/main/app -mindepth 1 -maxdepth 1 -type d -name 'FuoEvolve*' -print -quit)"
+          test -n "$APP_IMAGE"
+          VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
+          echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          find "$APP_IMAGE" -path '*/runtime/bin/java' -print -quit | grep -q .
+          find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit | grep -q .
+          if find "$APP_IMAGE" -name 'libmpv.so*' -print -quit | grep -q .; then
+            echo "System Linux app image must not bundle libmpv" >&2
+            exit 1
+          fi
+
+      - name: Build DEB and RPM packages
+        run: |
+          mkdir -p build/desktop-packages/system
+          bash desktopApp/packaging/linux/package-system.sh deb "${{ steps.app.outputs.app_image }}" "${{ steps.app.outputs.version }}" build/desktop-packages/system
+          bash desktopApp/packaging/linux/package-system.sh rpm "${{ steps.app.outputs.app_image }}" "${{ steps.app.outputs.version }}" build/desktop-packages/system
+
+      - name: Build Arch Linux package
+        run: >-
+          bash desktopApp/packaging/linux/package-arch.sh
+          "${{ steps.app.outputs.app_image }}"
+          "${{ steps.app.outputs.version }}"
+          build/desktop-packages/system
+
+      - name: Verify Linux package metadata
+        run: |
+          DEB="$(find build/desktop-packages/system -name '*.deb' -print -quit)"
+          RPM="$(find build/desktop-packages/system -name '*.rpm' -print -quit)"
+          ARCH="$(find build/desktop-packages/system -name '*.pkg.tar.zst' -print -quit)"
+          test -n "$DEB" && test -n "$RPM" && test -n "$ARCH"
+          dpkg-deb -I "$DEB" | tee build/desktop-packages/system/deb-info.txt
+          grep -q 'libmpv2' build/desktop-packages/system/deb-info.txt
+          rpm -qp --requires "$RPM" | tee build/desktop-packages/system/rpm-requires.txt
+          grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
+          tar -tf "$ARCH" | grep -q 'opt/fuoevolve/bin/FuoEvolve'
+
+      - name: Upload Linux distro packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-linux-system-x64
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            build/desktop-packages/system/*.deb
+            build/desktop-packages/system/*.rpm
+            build/desktop-packages/system/*.pkg.tar.zst
+            build/desktop-packages/system/*-info.txt
+            build/desktop-packages/system/*-requires.txt
+
+  linux-appimage:
+    name: Package portable Linux AppImage
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Git refs for Gradle versioning
+        run: |
+          if ! git show-ref --verify --quiet refs/heads/master; then
+            git branch master origin/master
+          fi
+
+      - name: Set up compile JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Remember compile JDK
+        run: echo "FUO_JDK17=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Set up bundled JetBrains Runtime JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: jetbrains
+          java-version: "21"
+          java-package: jdk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Set up Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
+      - name: Install portable native dependency inputs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmpv1 libsecret-1-0 patchelf pax-utils
+          ldconfig -p | grep libmpv
+          ldconfig -p | grep libsecret-1
+
+      - name: Create Linux app image
+        id: app
+        run: |
+          ./gradlew \
+            "-Dorg.gradle.java.installations.paths=$FUO_JDK17,$JAVA_HOME" \
+            --no-configuration-cache \
+            --warning-mode all \
+            -Pfuoevolve.packageProfile=system \
+            :desktopApp:createDistributable
+          APP_IMAGE="$(find desktopApp/build/compose/binaries/main/app -mindepth 1 -maxdepth 1 -type d -name 'FuoEvolve*' -print -quit)"
+          test -n "$APP_IMAGE"
+          VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
+          echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build self-contained AppImage
+        run: |
+          mkdir -p build/desktop-packages/appimage
+          bash desktopApp/packaging/linux/package-appimage.sh \
+            "${{ steps.app.outputs.app_image }}" \
+            "${{ steps.app.outputs.version }}" \
+            build/desktop-packages/appimage
+          APPIMAGE="$(find build/desktop-packages/appimage -name '*.AppImage' -print -quit)"
+          test -n "$APPIMAGE"
+          file "$APPIMAGE"
+          sha256sum "$APPIMAGE" | tee "$APPIMAGE.sha256"
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-linux-appimage-x64
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            build/desktop-packages/appimage/*.AppImage
+            build/desktop-packages/appimage/*.sha256

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -119,15 +119,21 @@ jobs:
           if (-not (Test-Path (Join-Path $runtimeRoot "lib\modules"))) { throw "Bundled JVM runtime modules image is missing" }
           if (-not (Select-String -Path $runtimeRelease.FullName -Pattern '^JAVA_VERSION="21\.' -Quiet)) { throw "Bundled JVM runtime is not Java 21" }
 
-      - name: Upload Windows installers
+      - name: Upload Windows MSI
         uses: actions/upload-artifact@v4
         with:
-          name: fuoevolve-windows-x64
+          name: fuoevolve-windows-x64-msi
           retention-days: 14
           if-no-files-found: error
-          path: |
-            desktopApp/build/compose/binaries/main/msi/*.msi
-            desktopApp/build/compose/binaries/main/exe/*.exe
+          path: desktopApp/build/compose/binaries/main/msi/*.msi
+
+      - name: Upload Windows EXE
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-windows-x64-exe
+          retention-days: 14
+          if-no-files-found: error
+          path: desktopApp/build/compose/binaries/main/exe/*.exe
 
   macos:
     name: Package macOS ${{ matrix.arch }} DMG and PKG
@@ -229,15 +235,21 @@ jobs:
             fi
           done < <(find "$ROOT/app" -name '*.dylib' -type f)
 
-      - name: Upload macOS installers
+      - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         with:
-          name: fuoevolve-macos-${{ matrix.arch }}
+          name: fuoevolve-macos-${{ matrix.arch }}-dmg
           retention-days: 14
           if-no-files-found: error
-          path: |
-            desktopApp/build/compose/binaries/main/dmg/*.dmg
-            desktopApp/build/compose/binaries/main/pkg/*.pkg
+          path: desktopApp/build/compose/binaries/main/dmg/*.dmg
+
+      - name: Upload macOS PKG
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-macos-${{ matrix.arch }}-pkg
+          retention-days: 14
+          if-no-files-found: error
+          path: desktopApp/build/compose/binaries/main/pkg/*.pkg
 
   linux-system:
     name: Package Linux DEB RPM and Arch
@@ -352,18 +364,29 @@ jobs:
           grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
           tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
 
-      - name: Upload Linux distro packages
+      - name: Upload Linux DEB
         uses: actions/upload-artifact@v4
         with:
-          name: fuoevolve-linux-system-x64
+          name: fuoevolve-linux-x64-deb
           retention-days: 14
           if-no-files-found: error
-          path: |
-            build/desktop-packages/system/*.deb
-            build/desktop-packages/system/*.rpm
-            build/desktop-packages/system/*.pkg.tar.zst
-            build/desktop-packages/system/*-info.txt
-            build/desktop-packages/system/*-requires.txt
+          path: build/desktop-packages/system/*.deb
+
+      - name: Upload Linux RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-linux-x64-rpm
+          retention-days: 14
+          if-no-files-found: error
+          path: build/desktop-packages/system/*.rpm
+
+      - name: Upload Arch Linux package
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-linux-x64-arch
+          retention-days: 14
+          if-no-files-found: error
+          path: build/desktop-packages/system/*.pkg.tar.zst
 
   linux-appimage:
     name: Package portable Linux AppImage
@@ -464,6 +487,12 @@ jobs:
           name: fuoevolve-linux-appimage-x64
           retention-days: 14
           if-no-files-found: error
-          path: |
-            build/desktop-packages/appimage/*.AppImage
-            build/desktop-packages/appimage/*.sha256
+          path: build/desktop-packages/appimage/*.AppImage
+
+      - name: Upload AppImage checksum
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-linux-appimage-x64-sha256
+          retention-days: 14
+          if-no-files-found: error
+          path: build/desktop-packages/appimage/*.sha256

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
       - name: Set up Rust stable
         shell: pwsh
@@ -82,7 +84,27 @@ jobs:
           java -version
           jpackage --version
 
+      - name: Cache Windows Rust bridge
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktopApp/native/windows-smtc/Cargo.lock
+            desktopApp/native/windows-smtc/target
+          key: desktop-rust-windows-x64-${{ hashFiles('desktopApp/native/windows-smtc/Cargo.toml', 'desktopApp/native/windows-smtc/src/**') }}
+          restore-keys: |
+            desktop-rust-windows-x64-
+
+      - name: Cache pinned Windows libmpv runtime
+        id: windows-libmpv-cache
+        uses: actions/cache@v4
+        with:
+          path: build/desktop-native/windows/mpv
+          key: desktop-windows-libmpv-x64-${{ hashFiles('desktopApp/packaging/native-deps.lock', 'desktopApp/packaging/windows/prepare-libmpv.ps1') }}
+
       - name: Prepare pinned Windows libmpv runtime
+        if: steps.windows-libmpv-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: >-
           ./desktopApp/packaging/windows/prepare-libmpv.ps1
@@ -187,6 +209,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
       - name: Set up Rust stable
         run: |
@@ -197,10 +221,41 @@ jobs:
           java -version
           jpackage --version
 
+      - name: Cache macOS Rust bridge
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktopApp/native/macos-now-playing/Cargo.lock
+            desktopApp/native/macos-now-playing/target
+          key: desktop-rust-macos-${{ matrix.arch }}-${{ hashFiles('desktopApp/native/macos-now-playing/Cargo.toml', 'desktopApp/native/macos-now-playing/src/**') }}
+          restore-keys: |
+            desktop-rust-macos-${{ matrix.arch }}-
+
+      - name: Cache relocatable macOS libmpv runtime
+        id: macos-libmpv-cache
+        uses: actions/cache@v4
+        with:
+          path: build/desktop-native/macos/mpv
+          key: desktop-macos-libmpv-${{ matrix.arch }}-${{ hashFiles('desktopApp/packaging/native-deps.lock', 'desktopApp/packaging/macos/prepare-libmpv.sh') }}
+
       - name: Prepare relocatable macOS libmpv runtime
+        if: steps.macos-libmpv-cache.outputs.cache-hit != 'true'
         run: >-
           bash desktopApp/packaging/macos/prepare-libmpv.sh
           "${{ github.workspace }}/build/desktop-native/macos/mpv"
+
+      - name: Verify relocatable macOS libmpv runtime
+        run: |
+          LIBMPV_DIR="${{ github.workspace }}/build/desktop-native/macos/mpv"
+          test -f "$LIBMPV_DIR/libmpv.dylib" || { echo "Cached macOS libmpv runtime is incomplete" >&2; exit 1; }
+          while IFS= read -r dylib; do
+            if otool -L "$dylib" | tail -n +2 | grep -E '/(opt/homebrew|usr/local)/(Cellar|opt)/' >/dev/null; then
+              echo "Cached macOS libmpv runtime is not relocatable: $dylib" >&2
+              exit 1
+            fi
+          done < <(find "$LIBMPV_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
 
       - name: Build self-contained macOS installers
         run: |
@@ -292,11 +347,25 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
       - name: Set up Rust stable
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
+
+      - name: Cache Linux system Rust bridge
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktopApp/native/linux-tray/Cargo.lock
+            desktopApp/native/linux-tray/target
+          key: desktop-rust-linux-system-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**') }}
+          restore-keys: |
+            desktop-rust-linux-system-x64-
 
       - name: Install native packaging tools
         run: |
@@ -432,11 +501,25 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
       - name: Set up Rust stable
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
+
+      - name: Cache Linux AppImage Rust bridge
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktopApp/native/linux-tray/Cargo.lock
+            desktopApp/native/linux-tray/target
+          key: desktop-rust-linux-appimage-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**') }}
+          restore-keys: |
+            desktop-rust-linux-appimage-x64-
 
       - name: Install portable native dependency inputs
         run: |

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -318,7 +318,7 @@ jobs:
           grep -q 'libmpv2' build/desktop-packages/system/deb-info.txt
           rpm -qp --requires "$RPM" | tee build/desktop-packages/system/rpm-requires.txt
           grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
-          tar -tf "$ARCH" | grep -q 'opt/fuoevolve/bin/FuoEvolve'
+          tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
 
       - name: Upload Linux distro packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -283,8 +283,15 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
             :desktopApp:createDistributable
-          APP_IMAGE="desktopApp/build/compose/binaries/main/app"
-          test -x "$APP_IMAGE/bin/FuoEvolve"
+          APP_ROOT="desktopApp/build/compose/binaries/main/app"
+          LAUNCHER="$(find "$APP_ROOT" -mindepth 2 -maxdepth 3 -type f -path '*/bin/FuoEvolve' -print -quit)"
+          if [[ -z "$LAUNCHER" ]]; then
+            echo "Unable to locate Compose Linux launcher under $APP_ROOT" >&2
+            find "$APP_ROOT" -maxdepth 3 -type f -print >&2
+            exit 1
+          fi
+          APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
+          test -x "$LAUNCHER"
           test -x "$APP_IMAGE/runtime/bin/java"
           TRAY_BRIDGE="$(find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit)"
           test -n "$TRAY_BRIDGE"
@@ -393,8 +400,15 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
             :desktopApp:createDistributable
-          APP_IMAGE="desktopApp/build/compose/binaries/main/app"
-          test -x "$APP_IMAGE/bin/FuoEvolve"
+          APP_ROOT="desktopApp/build/compose/binaries/main/app"
+          LAUNCHER="$(find "$APP_ROOT" -mindepth 2 -maxdepth 3 -type f -path '*/bin/FuoEvolve' -print -quit)"
+          if [[ -z "$LAUNCHER" ]]; then
+            echo "Unable to locate Compose Linux launcher under $APP_ROOT" >&2
+            find "$APP_ROOT" -maxdepth 3 -type f -print >&2
+            exit 1
+          fi
+          APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
+          test -x "$LAUNCHER"
           test -x "$APP_IMAGE/runtime/bin/java"
           VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
           echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -4,6 +4,7 @@ name: Desktop Packaging
   pull_request:
     paths:
       - "desktopApp/build.gradle.kts"
+      - "desktopApp/compose-desktop.pro"
       - "desktopApp/packaging/**"
       - "desktopApp/native/**"
       - "androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
@@ -16,6 +17,7 @@ name: Desktop Packaging
       - "[0-9]*"
     paths:
       - "desktopApp/build.gradle.kts"
+      - "desktopApp/compose-desktop.pro"
       - "desktopApp/packaging/**"
       - "desktopApp/native/**"
       - "androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
@@ -110,7 +112,7 @@ jobs:
           ./desktopApp/packaging/windows/prepare-libmpv.ps1
           -OutputDir "${{ github.workspace }}\build\desktop-native\windows\mpv"
 
-      - name: Build self-contained Windows installers
+      - name: Build minified self-contained Windows installers
         shell: pwsh
         env:
           FUOEVOLVE_PACKAGE_PROFILE: bundled
@@ -120,15 +122,15 @@ jobs:
             "-Dorg.gradle.java.installations.paths=$env:FUO_JDK17,$env:JAVA_HOME" `
             --no-configuration-cache `
             --warning-mode all `
-            :desktopApp:createDistributable `
-            :desktopApp:packageMsi `
-            :desktopApp:packageExe
+            :desktopApp:createReleaseDistributable `
+            :desktopApp:packageReleaseMsi `
+            :desktopApp:packageReleaseExe
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Verify Windows package closure
         shell: pwsh
         run: |
-          $root = "desktopApp\build\compose\binaries\main"
+          $root = "desktopApp\build\compose\binaries\main-release"
           if (-not (Get-ChildItem "$root\msi" -Filter *.msi -ErrorAction SilentlyContinue)) { throw "MSI was not produced" }
           if (-not (Get-ChildItem "$root\exe" -Filter *.exe -ErrorAction SilentlyContinue)) { throw "EXE installer was not produced" }
           if (-not (Get-ChildItem "$root\app" -Recurse -File -Include mpv-2.dll,libmpv-2.dll,mpv.dll -ErrorAction SilentlyContinue)) { throw "Bundled libmpv DLL is missing" }
@@ -141,11 +143,17 @@ jobs:
           if (-not (Test-Path (Join-Path $runtimeRoot "lib\modules"))) { throw "Bundled JVM runtime modules image is missing" }
           if (-not (Select-String -Path $runtimeRelease.FullName -Pattern '^JAVA_VERSION="21\.' -Quiet)) { throw "Bundled JVM runtime is not Java 21" }
 
+      - name: Report Windows package sizes
+        shell: pwsh
+        run: |
+          Get-ChildItem "desktopApp\build\compose\binaries\main-release\msi\*.msi", "desktopApp\build\compose\binaries\main-release\exe\*.exe" |
+            ForEach-Object { Write-Host ("{0}: {1:N2} MiB" -f $_.Name, ($_.Length / 1MB)) }
+
       - name: Upload Windows MSI
         uses: actions/upload-artifact@v7
         with:
           name: fuoevolve-windows-x64.msi
-          path: desktopApp/build/compose/binaries/main/msi/*.msi
+          path: desktopApp/build/compose/binaries/main-release/msi/*.msi
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -154,7 +162,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: fuoevolve-windows-x64.exe
-          path: desktopApp/build/compose/binaries/main/exe/*.exe
+          path: desktopApp/build/compose/binaries/main-release/exe/*.exe
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -257,7 +265,7 @@ jobs:
             fi
           done < <(find "$LIBMPV_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
 
-      - name: Build self-contained macOS installers
+      - name: Build minified self-contained macOS installers
         run: |
           ./gradlew \
             "-Dorg.gradle.java.installations.paths=$FUO_JDK17,$JAVA_HOME" \
@@ -265,13 +273,13 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=bundled \
             -Pfuoevolve.packageLibmpvDir="${{ github.workspace }}/build/desktop-native/macos/mpv" \
-            :desktopApp:createDistributable \
-            :desktopApp:packageDmg \
-            :desktopApp:packagePkg
+            :desktopApp:createReleaseDistributable \
+            :desktopApp:packageReleaseDmg \
+            :desktopApp:packageReleasePkg
 
       - name: Verify macOS package closure
         run: |
-          ROOT=desktopApp/build/compose/binaries/main
+          ROOT=desktopApp/build/compose/binaries/main-release
           find "$ROOT/dmg" -maxdepth 1 -name '*.dmg' -print -quit | grep -q . || { echo "DMG was not produced" >&2; exit 1; }
           find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q . || { echo "PKG was not produced" >&2; exit 1; }
           find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q . || { echo "Bundled libmpv dylib is missing" >&2; exit 1; }
@@ -292,11 +300,16 @@ jobs:
             fi
           done < <(find "$ROOT/app" -name '*.dylib' -type f)
 
+      - name: Report macOS package sizes
+        run: |
+          du -h desktopApp/build/compose/binaries/main-release/dmg/*.dmg
+          du -h desktopApp/build/compose/binaries/main-release/pkg/*.pkg
+
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v7
         with:
           name: fuoevolve-macos-${{ matrix.arch }}.dmg
-          path: desktopApp/build/compose/binaries/main/dmg/*.dmg
+          path: desktopApp/build/compose/binaries/main-release/dmg/*.dmg
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -305,7 +318,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: fuoevolve-macos-${{ matrix.arch }}.pkg
-          path: desktopApp/build/compose/binaries/main/pkg/*.pkg
+          path: desktopApp/build/compose/binaries/main-release/pkg/*.pkg
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -375,7 +388,7 @@ jobs:
           jpackage --version
           docker --version
 
-      - name: Create Linux app image with system native dependency profile
+      - name: Create minified Linux app image with system native dependency profile
         id: app
         run: |
           ./gradlew \
@@ -383,8 +396,8 @@ jobs:
             --no-configuration-cache \
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
-            :desktopApp:createDistributable
-          APP_ROOT="desktopApp/build/compose/binaries/main/app"
+            :desktopApp:createReleaseDistributable
+          APP_ROOT="desktopApp/build/compose/binaries/main-release/app"
           LAUNCHER="$(find "$APP_ROOT" -mindepth 2 -maxdepth 3 -type f -path '*/bin/FuoEvolve' -print -quit)"
           if [[ -z "$LAUNCHER" ]]; then
             echo "Unable to locate Compose Linux launcher under $APP_ROOT" >&2
@@ -436,6 +449,9 @@ jobs:
           rpm -qp --requires "$RPM" | tee build/desktop-packages/system/rpm-requires.txt
           grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
           tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
+
+      - name: Report Linux package sizes
+        run: du -h build/desktop-packages/system/*.deb build/desktop-packages/system/*.rpm build/desktop-packages/system/*.pkg.tar.zst
 
       - name: Upload Linux DEB
         uses: actions/upload-artifact@v7
@@ -528,7 +544,7 @@ jobs:
           ldconfig -p | grep libmpv
           ldconfig -p | grep libsecret-1
 
-      - name: Create Linux app image
+      - name: Create minified Linux app image
         id: app
         run: |
           ./gradlew \
@@ -536,8 +552,8 @@ jobs:
             --no-configuration-cache \
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
-            :desktopApp:createDistributable
-          APP_ROOT="desktopApp/build/compose/binaries/main/app"
+            :desktopApp:createReleaseDistributable
+          APP_ROOT="desktopApp/build/compose/binaries/main-release/app"
           LAUNCHER="$(find "$APP_ROOT" -mindepth 2 -maxdepth 3 -type f -path '*/bin/FuoEvolve' -print -quit)"
           if [[ -z "$LAUNCHER" ]]; then
             echo "Unable to locate Compose Linux launcher under $APP_ROOT" >&2
@@ -570,6 +586,9 @@ jobs:
           test -n "$APPIMAGE"
           file "$APPIMAGE"
           sha256sum "$APPIMAGE" | tee "$APPIMAGE.sha256"
+
+      - name: Report AppImage size
+        run: du -h build/desktop-packages/appimage/*.AppImage
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -111,7 +111,13 @@ jobs:
           if (-not (Get-ChildItem "$root\exe" -Filter *.exe -ErrorAction SilentlyContinue)) { throw "EXE installer was not produced" }
           if (-not (Get-ChildItem "$root\app" -Recurse -File -Include mpv-2.dll,libmpv-2.dll,mpv.dll -ErrorAction SilentlyContinue)) { throw "Bundled libmpv DLL is missing" }
           if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter fuoevolve_smtc_bridge.dll -ErrorAction SilentlyContinue)) { throw "SMTC bridge is missing" }
-          if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter java.exe -ErrorAction SilentlyContinue | Where-Object FullName -Match "runtime")) { throw "Bundled JVM runtime is missing" }
+          $runtimeRelease = Get-ChildItem "$root\app" -Recurse -File -Filter release -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '[\\/]runtime[\\/]release$' } |
+            Select-Object -First 1
+          if (-not $runtimeRelease) { throw "Bundled JVM runtime release marker is missing" }
+          $runtimeRoot = $runtimeRelease.Directory.FullName
+          if (-not (Test-Path (Join-Path $runtimeRoot "lib\modules"))) { throw "Bundled JVM runtime modules image is missing" }
+          if (-not (Select-String -Path $runtimeRelease.FullName -Pattern '^JAVA_VERSION="21\.' -Quiet)) { throw "Bundled JVM runtime is not Java 21" }
 
       - name: Upload Windows installers
         uses: actions/upload-artifact@v4
@@ -203,11 +209,19 @@ jobs:
       - name: Verify macOS package closure
         run: |
           ROOT=desktopApp/build/compose/binaries/main
-          find "$ROOT/dmg" -maxdepth 1 -name '*.dmg' -print -quit | grep -q .
-          find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q .
-          find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q .
-          find "$ROOT/app" -name libfuoevolve_now_playing_bridge.dylib -print -quit | grep -q .
-          find "$ROOT/app" -path '*/Contents/runtime/Contents/Home/bin/java' -print -quit | grep -q .
+          find "$ROOT/dmg" -maxdepth 1 -name '*.dmg' -print -quit | grep -q . || { echo "DMG was not produced" >&2; exit 1; }
+          find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q . || { echo "PKG was not produced" >&2; exit 1; }
+          find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q . || { echo "Bundled libmpv dylib is missing" >&2; exit 1; }
+          find "$ROOT/app" -name libfuoevolve_now_playing_bridge.dylib -print -quit | grep -q . || { echo "Now Playing bridge is missing" >&2; exit 1; }
+          RUNTIME_RELEASE="$(find "$ROOT/app" -path '*/Contents/runtime/Contents/Home/release' -print -quit)"
+          if [[ -z "$RUNTIME_RELEASE" ]]; then
+            echo "Bundled JVM runtime release marker is missing" >&2
+            find "$ROOT/app" -maxdepth 6 -type f -name release -print >&2
+            exit 1
+          fi
+          RUNTIME_HOME="${RUNTIME_RELEASE%/release}"
+          test -f "$RUNTIME_HOME/lib/modules" || { echo "Bundled JVM runtime modules image is missing" >&2; exit 1; }
+          grep -Eq '^JAVA_VERSION="21\.' "$RUNTIME_RELEASE" || { echo "Bundled JVM runtime is not Java 21" >&2; exit 1; }
           while IFS= read -r dylib; do
             if otool -L "$dylib" | tail -n +2 | grep -E '/(opt/homebrew|usr/local)/(Cellar|opt)/'; then
               echo "Packaged dylib still references Homebrew: $dylib" >&2
@@ -294,7 +308,15 @@ jobs:
           fi
           APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
           test -x "$LAUNCHER"
-          test -x "$APP_IMAGE/lib/runtime/bin/java"
+          RUNTIME_RELEASE="$(find "$APP_IMAGE" -path '*/runtime/release' -print -quit)"
+          if [[ -z "$RUNTIME_RELEASE" ]]; then
+            echo "Bundled JVM runtime release marker is missing" >&2
+            find "$APP_IMAGE" -maxdepth 5 -type f -name release -print >&2
+            exit 1
+          fi
+          RUNTIME_ROOT="${RUNTIME_RELEASE%/release}"
+          test -f "$RUNTIME_ROOT/lib/modules" || { echo "Bundled JVM runtime modules image is missing" >&2; exit 1; }
+          grep -Eq '^JAVA_VERSION="21\.' "$RUNTIME_RELEASE" || { echo "Bundled JVM runtime is not Java 21" >&2; exit 1; }
           TRAY_BRIDGE="$(find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit)"
           test -n "$TRAY_BRIDGE"
           if [[ -n "$(find "$APP_IMAGE" -name 'libmpv.so*' -print -quit)" ]]; then
@@ -411,7 +433,15 @@ jobs:
           fi
           APP_IMAGE="${LAUNCHER%/bin/FuoEvolve}"
           test -x "$LAUNCHER"
-          test -x "$APP_IMAGE/lib/runtime/bin/java"
+          RUNTIME_RELEASE="$(find "$APP_IMAGE" -path '*/runtime/release' -print -quit)"
+          if [[ -z "$RUNTIME_RELEASE" ]]; then
+            echo "Bundled JVM runtime release marker is missing" >&2
+            find "$APP_IMAGE" -maxdepth 5 -type f -name release -print >&2
+            exit 1
+          fi
+          RUNTIME_ROOT="${RUNTIME_RELEASE%/release}"
+          test -f "$RUNTIME_ROOT/lib/modules" || { echo "Bundled JVM runtime modules image is missing" >&2; exit 1; }
+          grep -Eq '^JAVA_VERSION="21\.' "$RUNTIME_RELEASE" || { echo "Bundled JVM runtime is not Java 21" >&2; exit 1; }
           VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
           echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -120,20 +120,22 @@ jobs:
           if (-not (Select-String -Path $runtimeRelease.FullName -Pattern '^JAVA_VERSION="21\.' -Quiet)) { throw "Bundled JVM runtime is not Java 21" }
 
       - name: Upload Windows MSI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-windows-x64-msi
+          name: fuoevolve-windows-x64.msi
+          path: desktopApp/build/compose/binaries/main/msi/*.msi
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: desktopApp/build/compose/binaries/main/msi/*.msi
 
       - name: Upload Windows EXE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-windows-x64-exe
+          name: fuoevolve-windows-x64.exe
+          path: desktopApp/build/compose/binaries/main/exe/*.exe
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: desktopApp/build/compose/binaries/main/exe/*.exe
 
   macos:
     name: Package macOS ${{ matrix.arch }} DMG and PKG
@@ -236,20 +238,22 @@ jobs:
           done < <(find "$ROOT/app" -name '*.dylib' -type f)
 
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-macos-${{ matrix.arch }}-dmg
+          name: fuoevolve-macos-${{ matrix.arch }}.dmg
+          path: desktopApp/build/compose/binaries/main/dmg/*.dmg
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: desktopApp/build/compose/binaries/main/dmg/*.dmg
 
       - name: Upload macOS PKG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-macos-${{ matrix.arch }}-pkg
+          name: fuoevolve-macos-${{ matrix.arch }}.pkg
+          path: desktopApp/build/compose/binaries/main/pkg/*.pkg
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: desktopApp/build/compose/binaries/main/pkg/*.pkg
 
   linux-system:
     name: Package Linux DEB RPM and Arch
@@ -365,28 +369,31 @@ jobs:
           tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
 
       - name: Upload Linux DEB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-x64-deb
+          name: fuoevolve-linux-x64.deb
+          path: build/desktop-packages/system/*.deb
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: build/desktop-packages/system/*.deb
 
       - name: Upload Linux RPM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-x64-rpm
+          name: fuoevolve-linux-x64.rpm
+          path: build/desktop-packages/system/*.rpm
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: build/desktop-packages/system/*.rpm
 
       - name: Upload Arch Linux package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-x64-arch
+          name: fuoevolve-linux-x64.pkg.tar.zst
+          path: build/desktop-packages/system/*.pkg.tar.zst
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: build/desktop-packages/system/*.pkg.tar.zst
 
   linux-appimage:
     name: Package portable Linux AppImage
@@ -482,17 +489,19 @@ jobs:
           sha256sum "$APPIMAGE" | tee "$APPIMAGE.sha256"
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-appimage-x64
+          name: fuoevolve-linux-x64.AppImage
+          path: build/desktop-packages/appimage/*.AppImage
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: build/desktop-packages/appimage/*.AppImage
 
       - name: Upload AppImage checksum
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-appimage-x64-sha256
+          name: fuoevolve-linux-x64.AppImage.sha256
+          path: build/desktop-packages/appimage/*.sha256
+          archive: false
           retention-days: 14
           if-no-files-found: error
-          path: build/desktop-packages/appimage/*.sha256

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -283,17 +283,18 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
             :desktopApp:createDistributable
-          APP_IMAGE="$(find desktopApp/build/compose/binaries/main/app -mindepth 1 -maxdepth 1 -type d -name 'FuoEvolve*' -print -quit)"
-          test -n "$APP_IMAGE"
-          VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
-          echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          find "$APP_IMAGE" -path '*/runtime/bin/java' -print -quit | grep -q .
-          find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit | grep -q .
-          if find "$APP_IMAGE" -name 'libmpv.so*' -print -quit | grep -q .; then
+          APP_IMAGE="desktopApp/build/compose/binaries/main/app"
+          test -x "$APP_IMAGE/bin/FuoEvolve"
+          test -x "$APP_IMAGE/runtime/bin/java"
+          TRAY_BRIDGE="$(find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit)"
+          test -n "$TRAY_BRIDGE"
+          if [[ -n "$(find "$APP_IMAGE" -name 'libmpv.so*' -print -quit)" ]]; then
             echo "System Linux app image must not bundle libmpv" >&2
             exit 1
           fi
+          VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
+          echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build DEB and RPM packages
         run: |
@@ -392,8 +393,9 @@ jobs:
             --warning-mode all \
             -Pfuoevolve.packageProfile=system \
             :desktopApp:createDistributable
-          APP_IMAGE="$(find desktopApp/build/compose/binaries/main/app -mindepth 1 -maxdepth 1 -type d -name 'FuoEvolve*' -print -quit)"
-          test -n "$APP_IMAGE"
+          APP_IMAGE="desktopApp/build/compose/binaries/main/app"
+          test -x "$APP_IMAGE/bin/FuoEvolve"
+          test -x "$APP_IMAGE/runtime/bin/java"
           VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
           echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -90,14 +90,14 @@ jobs:
 
       - name: Build self-contained Windows installers
         shell: pwsh
+        env:
+          FUOEVOLVE_PACKAGE_PROFILE: bundled
+          FUOEVOLVE_PACKAGE_LIBMPV_DIR: ${{ github.workspace }}\build\desktop-native\windows\mpv
         run: |
-          $libmpv = "${{ github.workspace }}\build\desktop-native\windows\mpv"
           & .\gradlew.bat `
             "-Dorg.gradle.java.installations.paths=$env:FUO_JDK17,$env:JAVA_HOME" `
             --no-configuration-cache `
             --warning-mode all `
-            -Pfuoevolve.packageProfile=bundled `
-            "-Pfuoevolve.packageLibmpvDir=$libmpv" `
             :desktopApp:packageMsi `
             :desktopApp:packageExe
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -211,6 +211,10 @@ compose.desktop {
         ).joinToString(File.pathSeparator)
 
         nativeDistributions {
+            // JNA and credential-secure-storage reach sun.misc.Unsafe through jdk.unsupported.
+            // jdeps cannot reliably see that reflective dependency, so keep the module explicitly.
+            modules("jdk.unsupported")
+
             when {
                 isWindowsHost -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)
                 isMacHost -> targetFormats(TargetFormat.Dmg, TargetFormat.Pkg)

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -170,6 +170,11 @@ val nativePackageTaskNames = setOf(
 tasks.matching { it.name in nativePackageTaskNames }.configureEach {
     dependsOn(prepareDesktopPackageResources)
 }
+// Compose's app resources task consumes appResourcesRootDir. Make that relationship explicit
+// so Gradle 9 task validation sees the staged native resources as a declared dependency.
+tasks.matching { it.name == "prepareAppResources" }.configureEach {
+    dependsOn(prepareDesktopPackageResources)
+}
 
 tasks.register("printDesktopPackageVersion") {
     group = "distribution"

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.io.File
+import java.util.zip.ZipFile
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Sync
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
@@ -20,6 +21,51 @@ fun gitOutput(vararg args: String): String? = runCatching {
     }.standardOutput.asText.get().trim()
     output.takeIf { it.isNotBlank() }
 }.getOrNull()
+
+fun verifyServiceProviderInReleaseImage(
+    appRoot: File,
+    serviceClassName: String,
+    providerClassName: String,
+) {
+    val jars = appRoot.walkTopDown()
+        .filter { file -> file.isFile && file.extension.equals("jar", ignoreCase = true) }
+        .toList()
+    if (jars.isEmpty()) {
+        throw GradleException("No application JARs found in release image: ${appRoot.absolutePath}")
+    }
+
+    val serviceEntryName = "META-INF/services/$serviceClassName"
+    val providerEntryName = providerClassName.replace('.', '/') + ".class"
+    var serviceDeclaresProvider = false
+    var providerClassPresent = false
+
+    jars.forEach { jar ->
+        ZipFile(jar).use { zip ->
+            if (zip.getEntry(providerEntryName) != null) {
+                providerClassPresent = true
+            }
+            zip.getEntry(serviceEntryName)?.let { entry ->
+                val declaresProvider = zip.getInputStream(entry).bufferedReader().use { reader ->
+                    reader.lineSequence()
+                        .map { line -> line.substringBefore('#').trim() }
+                        .any { line -> line == providerClassName }
+                }
+                serviceDeclaresProvider = serviceDeclaresProvider || declaresProvider
+            }
+        }
+    }
+
+    if (!serviceDeclaresProvider) {
+        throw GradleException(
+            "Release image is missing ServiceLoader declaration for $providerClassName in $serviceEntryName",
+        )
+    }
+    if (!providerClassPresent) {
+        throw GradleException(
+            "Release shrink removed ServiceLoader provider class $providerClassName",
+        )
+    }
+}
 
 val desktopPackageVersion = gitOutput("describe", "--tags", "--match", "[0-9]*", "--abbrev=0")
     ?.let { tag -> Regex("\\d+\\.\\d+\\.\\d+").find(tag)?.value }
@@ -174,6 +220,19 @@ tasks.matching { it.name in nativePackageTaskNames }.configureEach {
 // so Gradle 9 task validation sees the staged native resources as a declared dependency.
 tasks.matching { it.name == "prepareAppResources" }.configureEach {
     dependsOn(prepareDesktopPackageResources)
+}
+
+// ProGuard cannot infer java.util.ServiceLoader entry points from META-INF/services resources.
+// Verify the final minified image, not just the unshrunk compile classpath, so packaging fails if
+// a provider declaration survives while its implementation class was removed.
+tasks.matching { it.name == "createReleaseDistributable" }.configureEach {
+    doLast {
+        verifyServiceProviderInReleaseImage(
+            appRoot = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile,
+            serviceClassName = "io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider",
+            providerClassName = "io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider",
+        )
+    }
 }
 
 tasks.register("printDesktopPackageVersion") {

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -210,6 +210,14 @@ compose.desktop {
             "$appDir/resources/native/bridges",
         ).joinToString(File.pathSeparator)
 
+        buildTypes.release.proguard {
+            // Phase 1 size optimization: remove unused JVM/Compose dependency code while keeping
+            // obfuscation disabled so stack traces and native/reflection boundaries stay readable.
+            optimize.set(true)
+            obfuscate.set(false)
+            configurationFiles.from(project.file("compose-desktop.pro"))
+        }
+
         nativeDistributions {
             // These dependencies are reached reflectively by desktop-only libraries and are not
             // always discovered by jdeps: JNA/credential storage uses sun.misc.Unsafe, while
@@ -219,8 +227,8 @@ compose.desktop {
             when {
                 isWindowsHost -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)
                 isMacHost -> targetFormats(TargetFormat.Dmg, TargetFormat.Pkg)
-                // Linux distro packages are produced from createDistributable by dedicated scripts
-                // so their dependency metadata can use each distribution's package manager.
+                // Linux distro packages are produced from createReleaseDistributable by dedicated
+                // scripts so dependency metadata can use each distribution's package manager.
                 isLinuxHost -> Unit
             }
             packageName = "FuoEvolve"

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -211,9 +211,10 @@ compose.desktop {
         ).joinToString(File.pathSeparator)
 
         nativeDistributions {
-            // JNA and credential-secure-storage reach sun.misc.Unsafe through jdk.unsupported.
-            // jdeps cannot reliably see that reflective dependency, so keep the module explicitly.
-            modules("jdk.unsupported")
+            // These dependencies are reached reflectively by desktop-only libraries and are not
+            // always discovered by jdeps: JNA/credential storage uses sun.misc.Unsafe, while
+            // dbus-java uses com.sun.security.auth.module.UnixSystem for the MPRIS Unix identity.
+            modules("jdk.unsupported", "jdk.security.auth")
 
             when {
                 isWindowsHost -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -37,7 +37,8 @@ val packageResourceOs = when {
 }
 
 val defaultPackageProfile = if (isLinuxHost) "system" else "bundled"
-val desktopPackageProfile = providers.gradleProperty("fuoevolve.packageProfile")
+val desktopPackageProfile = providers.environmentVariable("FUOEVOLVE_PACKAGE_PROFILE")
+    .orElse(providers.gradleProperty("fuoevolve.packageProfile"))
     .orElse(defaultPackageProfile)
     .map { value -> value.lowercase() }
     .get()

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -36,6 +36,23 @@ val packageResourceOs = when {
     else -> "common"
 }
 
+val defaultPackageProfile = if (isLinuxHost) "system" else "bundled"
+val desktopPackageProfile = providers.gradleProperty("fuoevolve.packageProfile")
+    .orElse(defaultPackageProfile)
+    .map { value -> value.lowercase() }
+    .get()
+if (desktopPackageProfile !in setOf("bundled", "system")) {
+    throw GradleException(
+        "Unsupported desktop package profile '$desktopPackageProfile'. Use bundled or system.",
+    )
+}
+if (!isLinuxHost && desktopPackageProfile != "bundled") {
+    throw GradleException(
+        "Windows and macOS packages must use the bundled native dependency profile.",
+    )
+}
+val bundlesLibMpv = desktopPackageProfile == "bundled"
+
 val buildWindowsSmtcBridge by tasks.registering(Exec::class) {
     group = "build"
     description = "Build the Rust Windows SMTC bridge used by the desktop runtime."
@@ -81,13 +98,15 @@ val expectedLibMpvNames = when {
 
 val prepareDesktopPackageResources by tasks.registering(Sync::class) {
     group = "distribution"
-    description = "Stage relocatable libmpv and platform bridges for native desktop packages."
-    inputs.property("libmpvBundle", packageLibMpvDirPath.orElse("<unset>"))
-    into(packagedResourcesRoot)
-
-    from(packageLibMpvDir) {
-        into("$packagedNativeRoot/mpv")
+    description = "Stage the platform bridge and optional bundled libmpv runtime for desktop packages."
+    inputs.property("packageProfile", desktopPackageProfile)
+    if (bundlesLibMpv) {
+        inputs.property("libmpvBundle", packageLibMpvDirPath.orElse("<unset>"))
+        from(packageLibMpvDir) {
+            into("$packagedNativeRoot/mpv")
+        }
     }
+    into(packagedResourcesRoot)
 
     when {
         isWindowsHost -> {
@@ -113,9 +132,10 @@ val prepareDesktopPackageResources by tasks.registering(Sync::class) {
     }
 
     doFirst {
+        if (!bundlesLibMpv) return@doFirst
         val source = packageLibMpvDir.orNull
             ?: throw GradleException(
-                "Native desktop packaging requires FUOEVOLVE_PACKAGE_LIBMPV_DIR " +
+                "Bundled desktop packaging requires FUOEVOLVE_PACKAGE_LIBMPV_DIR " +
                     "(or -Pfuoevolve.packageLibmpvDir) pointing to a relocatable libmpv runtime bundle.",
             )
         if (!source.isDirectory) {
@@ -139,13 +159,25 @@ val nativePackageTaskNames = setOf(
     "packageReleaseDistributionForCurrentOS",
     "packageDmg",
     "packageReleaseDmg",
+    "packagePkg",
+    "packageReleasePkg",
     "packageMsi",
     "packageReleaseMsi",
-    "packageDeb",
-    "packageReleaseDeb",
+    "packageExe",
+    "packageReleaseExe",
 )
 tasks.matching { it.name in nativePackageTaskNames }.configureEach {
     dependsOn(prepareDesktopPackageResources)
+}
+
+tasks.register("printDesktopPackageVersion") {
+    group = "distribution"
+    doLast { println(desktopPackageVersion) }
+}
+
+tasks.register("printDesktopPackageProfile") {
+    group = "distribution"
+    doLast { println(desktopPackageProfile) }
 }
 
 dependencies {
@@ -173,7 +205,13 @@ compose.desktop {
         ).joinToString(File.pathSeparator)
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            when {
+                isWindowsHost -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)
+                isMacHost -> targetFormats(TargetFormat.Dmg, TargetFormat.Pkg)
+                // Linux distro packages are produced from createDistributable by dedicated scripts
+                // so their dependency metadata can use each distribution's package manager.
+                isLinuxHost -> Unit
+            }
             packageName = "FuoEvolve"
             packageVersion = desktopPackageVersion
             description = "A cross-platform multi-source music player based on FeelUOwn"

--- a/desktopApp/compose-desktop.pro
+++ b/desktopApp/compose-desktop.pro
@@ -23,6 +23,15 @@
 -keep interface org.freedesktop.dbus.** { *; }
 -dontwarn org.freedesktop.dbus.**
 
+# OkHttp ships adapters for optional runtimes/providers which are intentionally absent
+# from this JVM desktop distribution. Their guarded references are safe to omit.
+-dontwarn org.graalvm.nativeimage.**
+-dontwarn com.oracle.svm.core.annotate.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.jsse.**
+-dontwarn org.openjsse.**
+-dontwarn android.util.Log
+
 # FuoEvolve's native interfaces and JNA Structure subclasses live in this package.
 # Keeping the thin desktop host layer avoids removing methods only called from native code;
 # the much larger shared/features/provider dependency graph remains shrinkable.

--- a/desktopApp/compose-desktop.pro
+++ b/desktopApp/compose-desktop.pro
@@ -23,6 +23,11 @@
 -keep interface org.freedesktop.dbus.** { *; }
 -dontwarn org.freedesktop.dbus.**
 
+# Ktor discovers kotlinx.serialization format integrations through java.util.ServiceLoader.
+# ProGuard keeps META-INF/services resources but cannot infer that their implementation
+# classes are runtime entry points, so preserve the JSON provider explicitly.
+-keep class io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider { *; }
+
 # OkHttp ships adapters for optional runtimes/providers which are intentionally absent
 # from this JVM desktop distribution. Their guarded references are safe to omit.
 -dontwarn org.graalvm.nativeimage.**

--- a/desktopApp/compose-desktop.pro
+++ b/desktopApp/compose-desktop.pro
@@ -1,0 +1,29 @@
+# FuoEvolve desktop release shrink rules.
+#
+# Compose supplies its own default desktop rules. Keep the desktop/native integration
+# boundaries conservative for the first release-shrinking phase because JNA, DBus and
+# the credential store use reflection, native proxies and platform-selected providers
+# that static analysis cannot fully discover.
+
+# Preserve metadata commonly consumed by reflection/proxy libraries.
+-keepattributes Signature,InnerClasses,EnclosingMethod,*Annotation*
+
+# JNA resolves Library methods and Structure fields dynamically against native symbols.
+-keep class com.sun.jna.** { *; }
+-keep interface * extends com.sun.jna.Library { *; }
+-keep class * extends com.sun.jna.Structure { *; }
+-dontwarn com.sun.jna.**
+
+# The credential storage library selects Windows/macOS/Linux implementations at runtime.
+-keep class com.microsoft.credentialstorage.** { *; }
+-keep interface com.microsoft.credentialstorage.** { *; }
+
+# dbus-java creates DBus proxies dynamically and discovers transport/provider classes.
+-keep class org.freedesktop.dbus.** { *; }
+-keep interface org.freedesktop.dbus.** { *; }
+-dontwarn org.freedesktop.dbus.**
+
+# FuoEvolve's native interfaces and JNA Structure subclasses live in this package.
+# Keeping the thin desktop host layer avoids removing methods only called from native code;
+# the much larger shared/features/provider dependency graph remains shrinkable.
+-keep class org.feeluown.mobile.desktop.** { *; }

--- a/desktopApp/compose-desktop.pro
+++ b/desktopApp/compose-desktop.pro
@@ -5,6 +5,11 @@
 # the credential store use reflection, native proxies and platform-selected providers
 # that static analysis cannot fully discover.
 
+# Keep shrinking enabled, but disable ProGuard bytecode optimization. The optimizer has
+# confirmed Kotlin/Compose JVM verifier issues and can rewrite valid Kotlin library bytecode
+# into methods that fail JVM verification (observed with Okio's buffered sink bridge).
+-dontoptimize
+
 # Preserve metadata commonly consumed by reflection/proxy libraries.
 -keepattributes Signature,InnerClasses,EnclosingMethod,*Annotation*
 

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <compose-app-image> <version> <output-dir>" >&2
+  exit 2
+fi
+
+APP_IMAGE="$(realpath "$1")"
+VERSION="$2"
+OUTPUT_DIR="$(mkdir -p "$3" && realpath "$3")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LOCK_FILE="$SCRIPT_DIR/../native-deps.lock"
+ICON="$REPO_ROOT/androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+
+if [[ ! -d "$APP_IMAGE" || ! -x "$APP_IMAGE/bin/FuoEvolve" ]]; then
+  echo "invalid Compose app image: $APP_IMAGE" >&2
+  exit 1
+fi
+for command in lddtree patchelf curl sha256sum; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "$command is required for AppImage packaging" >&2
+    exit 1
+  }
+done
+
+lock_value() {
+  local key="$1"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$LOCK_FILE"
+}
+
+download_verified() {
+  local url="$1"
+  local expected_sha="$2"
+  local output="$3"
+  curl --fail --location --retry 3 --output "$output" "$url"
+  local actual_sha
+  actual_sha="$(sha256sum "$output" | awk '{print $1}')"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "SHA-256 mismatch for $url: expected $expected_sha, got $actual_sha" >&2
+    exit 1
+  fi
+}
+
+LIBMPV="$(ldconfig -p 2>/dev/null | awk '/libmpv\.so/{print $NF; exit}')"
+if [[ -z "$LIBMPV" || ! -f "$LIBMPV" ]]; then
+  LIBMPV="$(find /usr/lib /lib -type f -name 'libmpv.so.*' 2>/dev/null | head -n 1 || true)"
+fi
+if [[ -z "$LIBMPV" || ! -f "$LIBMPV" ]]; then
+  echo "A distribution libmpv package must be installed before building the AppImage" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+APPDIR="$WORK_DIR/FuoEvolve.AppDir"
+BUNDLED_APP="$APPDIR/usr/lib/fuoevolve"
+MPV_DIR="$BUNDLED_APP/resources/native/mpv"
+mkdir -p "$APPDIR/usr/lib" "$MPV_DIR"
+cp -a "$APP_IMAGE" "$BUNDLED_APP"
+
+is_base_system_library() {
+  local name="$1"
+  case "$name" in
+    ld-linux*.so*|ld-*.so*|libc.so.*|libm.so.*|libpthread.so.*|libdl.so.*|librt.so.*|libresolv.so.*|libutil.so.*|libnss_*.so.*)
+      return 0
+      ;;
+    # OpenGL/driver-facing libraries must match the host graphics stack. libmpv runs audio-only in
+    # FuoEvolve, so keep these as host ABI dependencies rather than shipping a Mesa/driver snapshot.
+    libGL.so.*|libGLX.so.*|libOpenGL.so.*|libEGL.so.*|libdrm.so.*|libgbm.so.*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+copy_library() {
+  local source="$1"
+  local name
+  name="$(basename "$source")"
+  if is_base_system_library "$name"; then
+    return
+  fi
+  local destination="$MPV_DIR/$name"
+  if [[ -f "$destination" ]]; then
+    local old_sha new_sha
+    old_sha="$(sha256sum "$destination" | awk '{print $1}')"
+    new_sha="$(sha256sum "$source" | awk '{print $1}')"
+    if [[ "$old_sha" != "$new_sha" ]]; then
+      echo "Conflicting ELF library basename while collecting AppImage closure: $name" >&2
+      exit 1
+    fi
+    return
+  fi
+  cp -L "$source" "$destination"
+}
+
+# lddtree resolves the transitive ELF closure, including ffmpeg/codec/audio client libraries that
+# JNA cannot discover statically from the Java launcher.
+while IFS= read -r library; do
+  [[ -f "$library" ]] || continue
+  copy_library "$library"
+done < <(lddtree -l "$LIBMPV" | awk '!seen[$0]++')
+
+BUNDLED_LIBMPV="$(find "$MPV_DIR" -maxdepth 1 -type f -name 'libmpv.so.*' -print -quit)"
+if [[ -z "$BUNDLED_LIBMPV" ]]; then
+  echo "libmpv was not copied into the AppImage dependency closure" >&2
+  exit 1
+fi
+ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$MPV_DIR/libmpv.so"
+
+while IFS= read -r library; do
+  patchelf --set-rpath '$ORIGIN' "$library" 2>/dev/null || true
+done < <(find "$MPV_DIR" -maxdepth 1 -type f -print)
+
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/bin/sh
+set -e
+APPDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+MPV_DIR="$APPDIR/usr/lib/fuoevolve/resources/native/mpv"
+export LD_LIBRARY_PATH="$MPV_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$APPDIR/usr/lib/fuoevolve/bin/FuoEvolve" "$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+cat > "$APPDIR/fuoevolve.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=FuoEvolve
+Comment=A cross-platform multi-source music player based on FeelUOwn
+Exec=FuoEvolve %U
+Icon=fuoevolve
+Terminal=false
+Categories=AudioVideo;Audio;Player;
+StartupNotify=true
+X-AppImage-Version=$VERSION
+EOF
+cp "$ICON" "$APPDIR/fuoevolve.png"
+ln -sfn fuoevolve.png "$APPDIR/.DirIcon"
+
+TOOL_URL="$(lock_value appimagetool.x64.url)"
+TOOL_SHA="$(lock_value appimagetool.x64.sha256)"
+RUNTIME_URL="$(lock_value appimage.runtime.x64.url)"
+RUNTIME_SHA="$(lock_value appimage.runtime.x64.sha256)"
+if [[ -z "$TOOL_URL" || -z "$TOOL_SHA" || -z "$RUNTIME_URL" || -z "$RUNTIME_SHA" ]]; then
+  echo "AppImage tool/runtime pins are incomplete in $LOCK_FILE" >&2
+  exit 1
+fi
+
+APPIMAGETOOL="$WORK_DIR/appimagetool.AppImage"
+RUNTIME="$WORK_DIR/runtime-x86_64"
+download_verified "$TOOL_URL" "$TOOL_SHA" "$APPIMAGETOOL"
+download_verified "$RUNTIME_URL" "$RUNTIME_SHA" "$RUNTIME"
+chmod +x "$APPIMAGETOOL"
+
+OUTPUT_FILE="$OUTPUT_DIR/FuoEvolve-$VERSION-linux-x86_64.AppImage"
+ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" \
+  --runtime-file "$RUNTIME" \
+  "$APPDIR" \
+  "$OUTPUT_FILE"
+chmod +x "$OUTPUT_FILE"
+
+# Validate that the resulting image is structurally extractable without relying on FUSE.
+(
+  cd "$WORK_DIR"
+  "$OUTPUT_FILE" --appimage-extract >/dev/null
+  test -x squashfs-root/usr/lib/fuoevolve/bin/FuoEvolve
+  test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libmpv.so
+)
+
+printf 'Built self-contained AppImage: %s\n' "$OUTPUT_FILE"

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -43,12 +43,25 @@ download_verified() {
   fi
 }
 
-LIBMPV="$(ldconfig -p 2>/dev/null | awk '/libmpv\.so/{print $NF; exit}')"
-if [[ -z "$LIBMPV" || ! -f "$LIBMPV" ]]; then
-  LIBMPV="$(find /usr/lib /lib -type f -name 'libmpv.so.*' 2>/dev/null | head -n 1 || true)"
-fi
+find_shared_library() {
+  local pattern="$1"
+  local fallback_name="$2"
+  local result
+  result="$(ldconfig -p 2>/dev/null | awk -v pattern="$pattern" '$0 ~ pattern {print $NF; exit}')"
+  if [[ -z "$result" || ! -f "$result" ]]; then
+    result="$(find /usr/lib /lib -type f -name "$fallback_name" 2>/dev/null | head -n 1 || true)"
+  fi
+  printf '%s' "$result"
+}
+
+LIBMPV="$(find_shared_library 'libmpv\.so' 'libmpv.so.*')"
+LIBSECRET="$(find_shared_library 'libsecret-1\.so\.0' 'libsecret-1.so.0*')"
 if [[ -z "$LIBMPV" || ! -f "$LIBMPV" ]]; then
   echo "A distribution libmpv package must be installed before building the AppImage" >&2
+  exit 1
+fi
+if [[ -z "$LIBSECRET" || ! -f "$LIBSECRET" ]]; then
+  echo "A distribution libsecret package must be installed before building the AppImage" >&2
   exit 1
 fi
 
@@ -56,8 +69,8 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 APPDIR="$WORK_DIR/FuoEvolve.AppDir"
 BUNDLED_APP="$APPDIR/usr/lib/fuoevolve"
-MPV_DIR="$BUNDLED_APP/resources/native/mpv"
-mkdir -p "$APPDIR/usr/lib" "$MPV_DIR"
+NATIVE_LIB_DIR="$BUNDLED_APP/resources/native/mpv"
+mkdir -p "$APPDIR/usr/lib" "$NATIVE_LIB_DIR"
 cp -a "$APP_IMAGE" "$BUNDLED_APP"
 
 is_base_system_library() {
@@ -84,7 +97,7 @@ copy_library() {
   if is_base_system_library "$name"; then
     return
   fi
-  local destination="$MPV_DIR/$name"
+  local destination="$NATIVE_LIB_DIR/$name"
   if [[ -f "$destination" ]]; then
     local old_sha new_sha
     old_sha="$(sha256sum "$destination" | awk '{print $1}')"
@@ -98,30 +111,38 @@ copy_library() {
   cp -L "$source" "$destination"
 }
 
-# lddtree resolves the transitive ELF closure, including ffmpeg/codec/audio client libraries that
-# JNA cannot discover statically from the Java launcher.
-while IFS= read -r library; do
-  [[ -f "$library" ]] || continue
-  copy_library "$library"
-done < <(lddtree -l "$LIBMPV" | awk '!seen[$0]++')
+# lddtree resolves transitive ELF closures that JNA cannot discover from the Java launcher.
+# libmpv contributes codecs/audio clients; libsecret is bundled as a client library while the
+# Secret Service D-Bus daemon itself remains a host service.
+for root_library in "$LIBMPV" "$LIBSECRET"; do
+  while IFS= read -r library; do
+    [[ -f "$library" ]] || continue
+    copy_library "$library"
+  done < <(lddtree -l "$root_library" | awk '!seen[$0]++')
+done
 
-BUNDLED_LIBMPV="$(find "$MPV_DIR" -maxdepth 1 -type f -name 'libmpv.so.*' -print -quit)"
+BUNDLED_LIBMPV="$(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -name 'libmpv.so.*' -print -quit)"
+BUNDLED_LIBSECRET="$(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -name 'libsecret-1.so.0*' -print -quit)"
 if [[ -z "$BUNDLED_LIBMPV" ]]; then
   echo "libmpv was not copied into the AppImage dependency closure" >&2
   exit 1
 fi
-ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$MPV_DIR/libmpv.so"
+if [[ -z "$BUNDLED_LIBSECRET" ]]; then
+  echo "libsecret was not copied into the AppImage dependency closure" >&2
+  exit 1
+fi
+ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$NATIVE_LIB_DIR/libmpv.so"
 
 while IFS= read -r library; do
   patchelf --set-rpath '$ORIGIN' "$library" 2>/dev/null || true
-done < <(find "$MPV_DIR" -maxdepth 1 -type f -print)
+done < <(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -print)
 
 cat > "$APPDIR/AppRun" <<'APPRUN'
 #!/bin/sh
 set -e
 APPDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-MPV_DIR="$APPDIR/usr/lib/fuoevolve/resources/native/mpv"
-export LD_LIBRARY_PATH="$MPV_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+NATIVE_LIB_DIR="$APPDIR/usr/lib/fuoevolve/resources/native/mpv"
+export LD_LIBRARY_PATH="$NATIVE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 exec "$APPDIR/usr/lib/fuoevolve/bin/FuoEvolve" "$@"
 APPRUN
 chmod +x "$APPDIR/AppRun"
@@ -169,6 +190,7 @@ chmod +x "$OUTPUT_FILE"
   "$OUTPUT_FILE" --appimage-extract >/dev/null
   test -x squashfs-root/usr/lib/fuoevolve/bin/FuoEvolve
   test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libmpv.so
+  find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -name 'libsecret-1.so.0*' -print -quit | grep -q .
 )
 
 printf 'Built self-contained AppImage: %s\n' "$OUTPUT_FILE"

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -54,8 +54,8 @@ find_shared_library() {
   printf '%s' "$result"
 }
 
-LIBMPV="$(find_shared_library 'libmpv\.so' 'libmpv.so.*')"
-LIBSECRET="$(find_shared_library 'libsecret-1\.so\.0' 'libsecret-1.so.0*')"
+LIBMPV="$(find_shared_library 'libmpv[.]so' 'libmpv.so.*')"
+LIBSECRET="$(find_shared_library 'libsecret-1[.]so[.]0' 'libsecret-1.so.0*')"
 if [[ -z "$LIBMPV" || ! -f "$LIBMPV" ]]; then
   echo "A distribution libmpv package must be installed before building the AppImage" >&2
   exit 1
@@ -70,8 +70,10 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 APPDIR="$WORK_DIR/FuoEvolve.AppDir"
 BUNDLED_APP="$APPDIR/usr/lib/fuoevolve"
 NATIVE_LIB_DIR="$BUNDLED_APP/resources/native/mpv"
-mkdir -p "$APPDIR/usr/lib" "$NATIVE_LIB_DIR"
-cp -a "$APP_IMAGE" "$BUNDLED_APP"
+mkdir -p "$NATIVE_LIB_DIR"
+# Copy the contents of the Compose app image into the runtime root. Copying the source directory
+# itself into the already-created BUNDLED_APP directory would add an unintended FuoEvolve/ layer.
+cp -a "$APP_IMAGE/." "$BUNDLED_APP/"
 
 is_base_system_library() {
   local name="$1"
@@ -188,9 +190,18 @@ chmod +x "$OUTPUT_FILE"
 (
   cd "$WORK_DIR"
   "$OUTPUT_FILE" --appimage-extract >/dev/null
-  test -x squashfs-root/usr/lib/fuoevolve/bin/FuoEvolve
-  test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libmpv.so
-  find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -name 'libsecret-1.so.0*' -print -quit | grep -q .
+  test -x squashfs-root/usr/lib/fuoevolve/bin/FuoEvolve || {
+    echo "Packaged AppImage is missing the FuoEvolve launcher at the expected root" >&2
+    exit 1
+  }
+  test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libmpv.so || {
+    echo "Packaged AppImage is missing the bundled libmpv loader alias" >&2
+    exit 1
+  }
+  find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -name 'libsecret-1.so.0*' -print -quit | grep -q . || {
+    echo "Packaged AppImage is missing bundled libsecret" >&2
+    exit 1
+  }
 )
 
 printf 'Built self-contained AppImage: %s\n' "$OUTPUT_FILE"

--- a/desktopApp/packaging/linux/package-arch.sh
+++ b/desktopApp/packaging/linux/package-arch.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <compose-app-image> <version> <output-dir>" >&2
+  exit 2
+fi
+
+APP_IMAGE="$(realpath "$1")"
+VERSION="$2"
+OUTPUT_DIR="$(mkdir -p "$3" && realpath "$3")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ICON="$REPO_ROOT/androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+
+if [[ ! -d "$APP_IMAGE" || ! -x "$APP_IMAGE/bin/FuoEvolve" ]]; then
+  echo "invalid Compose app image: $APP_IMAGE" >&2
+  exit 1
+fi
+if [[ ! -f "$ICON" ]]; then
+  echo "desktop package icon is missing: $ICON" >&2
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to build the Arch package in a clean Arch environment" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cp -a "$APP_IMAGE" "$WORK_DIR/FuoEvolve"
+tar -C "$WORK_DIR" -czf "$WORK_DIR/FuoEvolve.tar.gz" FuoEvolve
+rm -rf "$WORK_DIR/FuoEvolve"
+cp "$ICON" "$WORK_DIR/fuoevolve.png"
+cat > "$WORK_DIR/fuoevolve.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=FuoEvolve
+Comment=A cross-platform multi-source music player based on FeelUOwn
+Exec=/opt/fuoevolve/bin/FuoEvolve %U
+Icon=fuoevolve
+Terminal=false
+Categories=AudioVideo;Audio;Player;
+StartupNotify=true
+DESKTOP
+
+APP_SHA="$(sha256sum "$WORK_DIR/FuoEvolve.tar.gz" | awk '{print $1}')"
+DESKTOP_SHA="$(sha256sum "$WORK_DIR/fuoevolve.desktop" | awk '{print $1}')"
+ICON_SHA="$(sha256sum "$WORK_DIR/fuoevolve.png" | awk '{print $1}')"
+
+cat > "$WORK_DIR/PKGBUILD" <<EOF
+pkgname=fuoevolve
+pkgver=$VERSION
+pkgrel=1
+pkgdesc='A cross-platform multi-source music player based on FeelUOwn'
+arch=('x86_64')
+url='https://github.com/feeluown/FuoEvolve'
+license=('GPL-3.0-only')
+depends=('mpv' 'libsecret')
+options=('!strip')
+source=('FuoEvolve.tar.gz' 'fuoevolve.desktop' 'fuoevolve.png')
+sha256sums=('$APP_SHA' '$DESKTOP_SHA' '$ICON_SHA')
+
+package() {
+  install -d "\$pkgdir/opt/fuoevolve"
+  cp -a "\$srcdir/FuoEvolve/." "\$pkgdir/opt/fuoevolve/"
+  install -Dm644 "\$srcdir/fuoevolve.desktop" "\$pkgdir/usr/share/applications/fuoevolve.desktop"
+  install -Dm644 "\$srcdir/fuoevolve.png" "\$pkgdir/usr/share/icons/hicolor/192x192/apps/fuoevolve.png"
+  install -d "\$pkgdir/usr/bin"
+  ln -s /opt/fuoevolve/bin/FuoEvolve "\$pkgdir/usr/bin/fuoevolve"
+}
+EOF
+
+# makepkg intentionally runs as a non-root user; the package itself retains distro-managed
+# dependencies on mpv/libsecret while the Compose app image keeps its bundled JBR runtime.
+docker run --rm -v "$WORK_DIR:/work" archlinux:latest bash -lc '
+  set -e
+  pacman -Syu --noconfirm --needed base-devel namcap
+  useradd -m builder
+  chown -R builder:builder /work
+  su builder -c "cd /work && makepkg --nodeps --noconfirm --cleanbuild"
+  namcap /work/*.pkg.tar.zst || true
+  chmod a+r /work/*.pkg.tar.zst
+'
+
+PACKAGE_FILE="$(find "$WORK_DIR" -maxdepth 1 -type f -name 'fuoevolve-*.pkg.tar.zst' -print -quit)"
+if [[ -z "$PACKAGE_FILE" ]]; then
+  echo "Arch package was not produced" >&2
+  exit 1
+fi
+cp "$PACKAGE_FILE" "$OUTPUT_DIR/"
+printf 'Built Arch package: %s\n' "$OUTPUT_DIR/$(basename "$PACKAGE_FILE")"

--- a/desktopApp/packaging/linux/package-arch.sh
+++ b/desktopApp/packaging/linux/package-arch.sh
@@ -74,8 +74,20 @@ EOF
 
 # makepkg intentionally runs as a non-root user; the package itself retains distro-managed
 # dependencies on mpv/libsecret while the Compose app image keeps its bundled JBR runtime.
-docker run --rm -v "$WORK_DIR:/work" archlinux:latest bash -lc '
+# The bind-mounted work directory must be returned to the host runner's numeric ownership before
+# Docker exits, otherwise chown-ing it to the container-only builder user makes host cleanup fail.
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+docker run --rm \
+  -e HOST_UID="$HOST_UID" \
+  -e HOST_GID="$HOST_GID" \
+  -v "$WORK_DIR:/work" \
+  archlinux:latest bash -lc '
   set -e
+  restore_host_ownership() {
+    chown -R "$HOST_UID:$HOST_GID" /work || true
+  }
+  trap restore_host_ownership EXIT
   pacman -Syu --noconfirm --needed base-devel namcap
   useradd -m builder
   chown -R builder:builder /work

--- a/desktopApp/packaging/linux/package-system.sh
+++ b/desktopApp/packaging/linux/package-system.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <deb|rpm> <compose-app-image> <version> <output-dir>" >&2
+  exit 2
+fi
+
+PACKAGE_TYPE="$1"
+APP_IMAGE="$2"
+VERSION="$3"
+OUTPUT_DIR="$4"
+
+if [[ "$PACKAGE_TYPE" != "deb" && "$PACKAGE_TYPE" != "rpm" ]]; then
+  echo "unsupported Linux package type: $PACKAGE_TYPE" >&2
+  exit 2
+fi
+if [[ ! -d "$APP_IMAGE" || ! -x "$APP_IMAGE/bin/FuoEvolve" ]]; then
+  echo "invalid Compose app image: $APP_IMAGE" >&2
+  exit 1
+fi
+if [[ ! -x "$JAVA_HOME/bin/jpackage" ]]; then
+  echo "jpackage is unavailable from JAVA_HOME=$JAVA_HOME" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+COMMON_ARGS=(
+  --type "$PACKAGE_TYPE"
+  --app-image "$APP_IMAGE"
+  --dest "$OUTPUT_DIR"
+  --name FuoEvolve
+  --app-version "$VERSION"
+  --vendor FeelUOwn
+  --description "A cross-platform multi-source music player based on FeelUOwn"
+  --linux-package-name fuoevolve
+  --linux-shortcut
+  --linux-menu-group AudioVideo
+  --linux-app-category AudioVideo
+)
+
+if [[ "$PACKAGE_TYPE" == "deb" ]]; then
+  # Debian 12/13 and Ubuntu 24.04+ expose libmpv through libmpv2.
+  PACKAGE_DEPS="libmpv2, libsecret-1-0"
+  "$JAVA_HOME/bin/jpackage" "${COMMON_ARGS[@]}" \
+    --linux-package-deps "$PACKAGE_DEPS"
+else
+  # Depend on ELF capabilities rather than Fedora package names so compatible RPM distributions
+  # may satisfy the dependency from their own libmpv/libsecret package naming.
+  PACKAGE_DEPS="libmpv.so.2()(64bit), libsecret-1.so.0()(64bit)"
+  "$JAVA_HOME/bin/jpackage" "${COMMON_ARGS[@]}" \
+    --linux-package-deps "$PACKAGE_DEPS" \
+    --linux-rpm-license-type "GPL-3.0-only"
+fi
+
+printf 'Built %s package with external dependencies: %s\n' "$PACKAGE_TYPE" "$PACKAGE_DEPS"
+find "$OUTPUT_DIR" -maxdepth 1 -type f -print

--- a/desktopApp/packaging/macos/prepare-libmpv.sh
+++ b/desktopApp/packaging/macos/prepare-libmpv.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <output-dir>" >&2
+  exit 2
+fi
+
+OUTPUT_DIR="$1"
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required to prepare the macOS libmpv bundle" >&2
+  exit 1
+fi
+
+brew list mpv >/dev/null 2>&1 || brew install mpv
+brew list dylibbundler >/dev/null 2>&1 || brew install dylibbundler
+
+MPV_PREFIX="$(brew --prefix mpv)"
+SOURCE_LIB="$MPV_PREFIX/lib/libmpv.dylib"
+if [[ ! -f "$SOURCE_LIB" ]]; then
+  echo "Homebrew mpv did not provide $SOURCE_LIB" >&2
+  exit 1
+fi
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+cp -L "$SOURCE_LIB" "$OUTPUT_DIR/libmpv.dylib"
+
+# Rewrite non-system dependencies to @loader_path and copy the full dylib closure next to libmpv.
+dylibbundler \
+  -od \
+  -b \
+  -x "$OUTPUT_DIR/libmpv.dylib" \
+  -d "$OUTPUT_DIR" \
+  -p "@loader_path/"
+install_name_tool -id "@loader_path/libmpv.dylib" "$OUTPUT_DIR/libmpv.dylib"
+
+# A relocatable bundle must not retain references to the Homebrew prefix/Cellar.
+while IFS= read -r dylib; do
+  if otool -L "$dylib" | tail -n +2 | grep -E '/(opt/homebrew|usr/local)/(Cellar|opt)/' >/dev/null; then
+    echo "Non-relocatable Homebrew dependency remains in $dylib:" >&2
+    otool -L "$dylib" >&2
+    exit 1
+  fi
+done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
+
+{
+  echo "Source: Homebrew mpv $(brew list --versions mpv | head -n 1)"
+  echo "Homebrew prefix: $MPV_PREFIX"
+  echo "Purpose: bundled relocatable libmpv runtime for the FuoEvolve macOS desktop package"
+} > "$OUTPUT_DIR/FUOEVOLVE_LIBMPV_SOURCE.txt"
+
+printf 'Prepared macOS libmpv bundle (%s) at %s\n' "$(uname -m)" "$OUTPUT_DIR"
+ls -lh "$OUTPUT_DIR"

--- a/desktopApp/packaging/macos/prepare-libmpv.sh
+++ b/desktopApp/packaging/macos/prepare-libmpv.sh
@@ -20,9 +20,17 @@ if [[ ! -f "$LOCK_FILE" ]]; then
   exit 1
 fi
 
-PINNED_MPV_VERSION="$(awk -F= '$1 == "mpv.version" { print $2; exit }' "$LOCK_FILE")"
+case "$(uname -m)" in
+  arm64) MPV_VERSION_KEY="macos.arm64.mpv.version" ;;
+  x86_64) MPV_VERSION_KEY="macos.x64.mpv.version" ;;
+  *)
+    echo "Unsupported macOS packaging architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+PINNED_MPV_VERSION="$(awk -F= -v key="$MPV_VERSION_KEY" '$1 == key { print $2; exit }' "$LOCK_FILE")"
 if [[ -z "$PINNED_MPV_VERSION" ]]; then
-  echo "mpv.version is missing from $LOCK_FILE" >&2
+  echo "$MPV_VERSION_KEY is missing from $LOCK_FILE" >&2
   exit 1
 fi
 
@@ -31,8 +39,8 @@ brew list dylibbundler >/dev/null 2>&1 || brew install dylibbundler
 
 INSTALLED_MPV_VERSION="$(brew list --versions mpv | awk '{ print $2; exit }')"
 if [[ "$INSTALLED_MPV_VERSION" != "$PINNED_MPV_VERSION" ]]; then
-  echo "Homebrew resolved mpv $INSTALLED_MPV_VERSION but packaging is pinned to $PINNED_MPV_VERSION in $LOCK_FILE" >&2
-  echo "Update the packaging lock deliberately before shipping a different macOS libmpv runtime." >&2
+  echo "Homebrew resolved mpv $INSTALLED_MPV_VERSION for $(uname -m) but packaging is pinned to $PINNED_MPV_VERSION in $LOCK_FILE" >&2
+  echo "Update the architecture-specific packaging lock deliberately before shipping a different macOS libmpv runtime." >&2
   exit 1
 fi
 
@@ -74,6 +82,7 @@ done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
 
 {
   echo "Source: Homebrew mpv $INSTALLED_MPV_VERSION"
+  echo "Pinned version key: $MPV_VERSION_KEY"
   echo "Pinned version: $PINNED_MPV_VERSION"
   echo "Homebrew prefix: $MPV_PREFIX"
   echo "Purpose: bundled relocatable libmpv runtime for the FuoEvolve macOS desktop package"

--- a/desktopApp/packaging/macos/prepare-libmpv.sh
+++ b/desktopApp/packaging/macos/prepare-libmpv.sh
@@ -7,15 +7,34 @@ if [[ $# -ne 1 ]]; then
 fi
 
 OUTPUT_DIR="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCK_FILE="$SCRIPT_DIR/../native-deps.lock"
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 if ! command -v brew >/dev/null 2>&1; then
   echo "Homebrew is required to prepare the macOS libmpv bundle" >&2
   exit 1
 fi
+if [[ ! -f "$LOCK_FILE" ]]; then
+  echo "Native dependency lock file is missing: $LOCK_FILE" >&2
+  exit 1
+fi
+
+PINNED_MPV_VERSION="$(awk -F= '$1 == "mpv.version" { print $2; exit }' "$LOCK_FILE")"
+if [[ -z "$PINNED_MPV_VERSION" ]]; then
+  echo "mpv.version is missing from $LOCK_FILE" >&2
+  exit 1
+fi
 
 brew list mpv >/dev/null 2>&1 || brew install mpv
 brew list dylibbundler >/dev/null 2>&1 || brew install dylibbundler
+
+INSTALLED_MPV_VERSION="$(brew list --versions mpv | awk '{ print $2; exit }')"
+if [[ "$INSTALLED_MPV_VERSION" != "$PINNED_MPV_VERSION" ]]; then
+  echo "Homebrew resolved mpv $INSTALLED_MPV_VERSION but packaging is pinned to $PINNED_MPV_VERSION in $LOCK_FILE" >&2
+  echo "Update the packaging lock deliberately before shipping a different macOS libmpv runtime." >&2
+  exit 1
+fi
 
 MPV_PREFIX="$(brew --prefix mpv)"
 SOURCE_LIB="$MPV_PREFIX/lib/libmpv.dylib"
@@ -54,7 +73,8 @@ while IFS= read -r dylib; do
 done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
 
 {
-  echo "Source: Homebrew mpv $(brew list --versions mpv | head -n 1)"
+  echo "Source: Homebrew mpv $INSTALLED_MPV_VERSION"
+  echo "Pinned version: $PINNED_MPV_VERSION"
   echo "Homebrew prefix: $MPV_PREFIX"
   echo "Purpose: bundled relocatable libmpv runtime for the FuoEvolve macOS desktop package"
 } > "$OUTPUT_DIR/FUOEVOLVE_LIBMPV_SOURCE.txt"

--- a/desktopApp/packaging/macos/prepare-libmpv.sh
+++ b/desktopApp/packaging/macos/prepare-libmpv.sh
@@ -24,18 +24,25 @@ if [[ ! -f "$SOURCE_LIB" ]]; then
   exit 1
 fi
 
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+WORKING_LIB="$WORK_DIR/libmpv.dylib"
+cp -L "$SOURCE_LIB" "$WORKING_LIB"
+
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
-cp -L "$SOURCE_LIB" "$OUTPUT_DIR/libmpv.dylib"
 
-# Rewrite non-system dependencies to @loader_path and copy the full dylib closure next to libmpv.
+# dylibbundler clears its dependency output directory before copying dependencies. Keep the root
+# libmpv dylib in a separate working directory while it is rewritten, then move it next to the
+# collected dylibs once the dependency closure is complete.
 dylibbundler \
   -od \
   -b \
-  -x "$OUTPUT_DIR/libmpv.dylib" \
+  -x "$WORKING_LIB" \
   -d "$OUTPUT_DIR" \
   -p "@loader_path/"
-install_name_tool -id "@loader_path/libmpv.dylib" "$OUTPUT_DIR/libmpv.dylib"
+install_name_tool -id "@loader_path/libmpv.dylib" "$WORKING_LIB"
+mv "$WORKING_LIB" "$OUTPUT_DIR/libmpv.dylib"
 
 # A relocatable bundle must not retain references to the Homebrew prefix/Cellar.
 while IFS= read -r dylib; do

--- a/desktopApp/packaging/native-deps.lock
+++ b/desktopApp/packaging/native-deps.lock
@@ -1,7 +1,7 @@
 # Native dependency inputs used by desktop packaging CI.
 # Keep immutable release URLs and SHA-256 values here so packaging does not silently follow latest assets.
 
-mpv.version=0.41.0
+mpv.version=0.41.0_6
 
 # shinchiro/mpv-winbuild-cmake development archive contains the libmpv DLL + development runtime.
 windows.x64.libmpv.url=https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260902/mpv-dev-x86_64-20260902-git-174b638f29.7z

--- a/desktopApp/packaging/native-deps.lock
+++ b/desktopApp/packaging/native-deps.lock
@@ -1,0 +1,14 @@
+# Native dependency inputs used by desktop packaging CI.
+# Keep immutable release URLs and SHA-256 values here so packaging does not silently follow latest assets.
+
+mpv.version=0.41.0
+
+# shinchiro/mpv-winbuild-cmake development archive contains the libmpv DLL + development runtime.
+windows.x64.libmpv.url=https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260902/mpv-dev-x86_64-20260902-git-174b638f29.7z
+windows.x64.libmpv.sha256=f23fbdee1864958df65886b56b1d640a319a4430df89aaa4417473d9d581c57f
+
+# AppImage tooling is pinned independently of the Linux distribution packages used to collect libmpv.
+appimagetool.x64.url=https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+appimagetool.x64.sha256=ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0
+appimage.runtime.x64.url=https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-x86_64
+appimage.runtime.x64.sha256=2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d

--- a/desktopApp/packaging/native-deps.lock
+++ b/desktopApp/packaging/native-deps.lock
@@ -1,7 +1,10 @@
 # Native dependency inputs used by desktop packaging CI.
 # Keep immutable release URLs and SHA-256 values here so packaging does not silently follow latest assets.
 
-mpv.version=0.41.0_6
+# GitHub's macOS arm64/x64 runner images currently carry different Homebrew core snapshots,
+# so pin the exact formula revision per architecture instead of silently accepting either.
+macos.arm64.mpv.version=0.41.0_6
+macos.x64.mpv.version=0.41.0_8
 
 # shinchiro/mpv-winbuild-cmake development archive contains the libmpv DLL + development runtime.
 windows.x64.libmpv.url=https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260902/mpv-dev-x86_64-20260902-git-174b638f29.7z

--- a/desktopApp/packaging/windows/prepare-libmpv.ps1
+++ b/desktopApp/packaging/windows/prepare-libmpv.ps1
@@ -1,0 +1,79 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDir
+)
+
+$ErrorActionPreference = "Stop"
+
+$lockFile = Join-Path $PSScriptRoot "..\native-deps.lock"
+$entries = @{}
+Get-Content $lockFile | ForEach-Object {
+    $line = $_.Trim()
+    if ($line -eq "" -or $line.StartsWith("#")) { return }
+    $parts = $line -split "=", 2
+    if ($parts.Length -eq 2) {
+        $entries[$parts[0].Trim()] = $parts[1].Trim()
+    }
+}
+
+$url = $entries["windows.x64.libmpv.url"]
+$expectedSha = $entries["windows.x64.libmpv.sha256"]
+if (-not $url -or -not $expectedSha) {
+    throw "Windows libmpv URL/SHA is missing from $lockFile"
+}
+
+$sevenZip = (Get-Command 7z -ErrorAction Stop).Source
+$workDir = Join-Path ([System.IO.Path]::GetTempPath()) ("fuoevolve-libmpv-" + [Guid]::NewGuid())
+$archive = Join-Path $workDir "libmpv.7z"
+$extractDir = Join-Path $workDir "extract"
+New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+
+try {
+    Write-Host "Downloading pinned Windows libmpv bundle"
+    Invoke-WebRequest -Uri $url -OutFile $archive
+    $actualSha = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha -ne $expectedSha.ToLowerInvariant()) {
+        throw "Windows libmpv SHA-256 mismatch: expected $expectedSha, got $actualSha"
+    }
+
+    & $sevenZip x $archive "-o$extractDir" -y | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "7-Zip failed to extract the Windows libmpv archive"
+    }
+
+    $dlls = Get-ChildItem -Path $extractDir -Recurse -File -Filter "*.dll"
+    if (-not $dlls) {
+        throw "Pinned Windows libmpv archive did not contain any DLL files"
+    }
+
+    New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+    foreach ($dll in $dlls) {
+        $destination = Join-Path $OutputDir $dll.Name
+        if (Test-Path $destination) {
+            $existingSha = (Get-FileHash -Path $destination -Algorithm SHA256).Hash
+            $candidateSha = (Get-FileHash -Path $dll.FullName -Algorithm SHA256).Hash
+            if ($existingSha -ne $candidateSha) {
+                throw "Conflicting DLL name while flattening libmpv bundle: $($dll.Name)"
+            }
+            continue
+        }
+        Copy-Item -Path $dll.FullName -Destination $destination
+    }
+
+    $expectedNames = @("mpv-2.dll", "libmpv-2.dll", "mpv.dll")
+    if (-not ($expectedNames | Where-Object { Test-Path (Join-Path $OutputDir $_) })) {
+        throw "Pinned archive did not contain a supported libmpv DLL name: $($expectedNames -join ', ')"
+    }
+
+    @"
+Source: $url
+SHA-256: $expectedSha
+Purpose: bundled libmpv runtime for the FuoEvolve Windows desktop package
+"@ | Set-Content -Path (Join-Path $OutputDir "FUOEVOLVE_LIBMPV_SOURCE.txt") -Encoding UTF8
+
+    Write-Host "Prepared Windows libmpv bundle at $OutputDir"
+    Get-ChildItem $OutputDir | Select-Object Name, Length
+}
+finally {
+    Remove-Item -Path $workDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/docs/desktop-packaging.md
+++ b/docs/desktop-packaging.md
@@ -1,0 +1,60 @@
+# Desktop packaging
+
+This document defines the installable desktop artifact matrix and native dependency policy.
+
+## Artifact matrix
+
+| Target | Artifact | JVM | libmpv / native dependencies |
+| --- | --- | --- | --- |
+| Windows x64 | MSI + EXE | bundled JetBrains Runtime | bundled relocatable libmpv + SMTC Rust bridge |
+| macOS arm64 | DMG + PKG | bundled JetBrains Runtime | bundled relocatable libmpv + Now Playing Rust bridge |
+| macOS x64 | DMG + PKG | bundled JetBrains Runtime | bundled relocatable libmpv + Now Playing Rust bridge |
+| Debian / Ubuntu x64 | DEB | bundled JetBrains Runtime | distribution `libmpv2` + `libsecret-1-0`; Linux tray bridge bundled |
+| RPM x64 | RPM | bundled JetBrains Runtime | distribution providers of `libmpv.so.2` + `libsecret-1.so.0`; Linux tray bridge bundled |
+| Arch Linux x64 | `.pkg.tar.zst` | bundled JetBrains Runtime | distribution `mpv` + `libsecret`; Linux tray bridge bundled |
+| Portable Linux x64 | AppImage | bundled JetBrains Runtime | bundled libmpv/libsecret client dependency closures + Linux tray bridge |
+
+The JVM is intentionally bundled for every platform, including distribution-native Linux packages. This keeps the Compose/AWT runtime under application control and is required for the native-Wayland runtime baseline. Linux package managers are used for native libraries where they provide a stable ABI and dependency resolution.
+
+## Packaging profiles
+
+`desktopApp` exposes two explicit Gradle profiles through `-Pfuoevolve.packageProfile`:
+
+- `bundled`: stage a relocatable libmpv runtime together with the platform Rust bridge. Windows and macOS require this profile.
+- `system`: stage the Linux Rust tray bridge only. libmpv and libsecret are resolved from the target distribution. This profile is Linux-only.
+
+Bundled packaging requires `FUOEVOLVE_PACKAGE_LIBMPV_DIR` or `-Pfuoevolve.packageLibmpvDir=<path>`. The directory must contain a loadable libmpv library and all non-system native dependencies needed by that build.
+
+## Native inputs
+
+Immutable externally downloaded packaging tools are recorded in `desktopApp/packaging/native-deps.lock` with SHA-256 hashes.
+
+- Windows libmpv is downloaded from a pinned `mpv-winbuild-cmake` development archive and verified before extraction.
+- macOS libmpv is sourced from the runner's Homebrew bottle and converted into a relocatable dylib closure with `dylibbundler`; packaging fails if Homebrew/Cellar absolute references remain.
+- AppImage tooling and its type-2 runtime are pinned by URL and SHA-256.
+- Linux AppImage libmpv/libsecret inputs come from the Ubuntu build baseline, then `lddtree` collects their transitive ELF closure. glibc, the dynamic loader, and graphics-driver-facing ABI libraries remain host dependencies.
+
+## CI
+
+`.github/workflows/desktop-packaging.yml` builds real installable artifacts on their native operating systems:
+
+1. Windows x64 builds the Rust SMTC bridge, prepares pinned libmpv, then runs Compose `packageMsi` and `packageExe`.
+2. macOS arm64 and Intel jobs build the Now Playing bridge, create a relocatable libmpv bundle, then run `packageDmg` and `packagePkg`.
+3. Ubuntu 24.04 creates a `system` Compose app image and repackages it as DEB/RPM; the same app image is passed to a clean Arch container for `makepkg`.
+4. Ubuntu 22.04 creates a lower-glibc-baseline app image and converts it to an AppImage with bundled libmpv/libsecret client libraries.
+
+Each job validates package output and dependency policy instead of treating a successful `jpackage` invocation as sufficient.
+
+## Signing and release
+
+PR packaging artifacts are intentionally unsigned CI validation outputs. Production release publication must add:
+
+- Windows Authenticode signing for the application/native DLLs and installers.
+- macOS Developer ID signing, hardened runtime as required, notarization, and stapling for both architectures.
+- release checksums for all artifacts.
+
+Unsigned PR artifacts must not be presented as production-ready downloads.
+
+## Linux Wayland
+
+Distribution and AppImage packaging must keep the Linux application window on the JetBrains Runtime Wayland toolkit and must never introduce an AWT/X11 tray fallback. Linux tray integration remains StatusNotifierItem/D-Bus. A later packaging smoke step must launch the packaged application under a native Wayland compositor and fail if it resolves to XWayland.


### PR DESCRIPTION
## Summary

Implement installable desktop packaging on top of the desktop foundation merged in #166.

- split desktop native dependency packaging into explicit `bundled` and Linux-only `system` profiles
- make Windows x64 packages self-contained with bundled JetBrains Runtime, pinned libmpv runtime and the Rust SMTC bridge
- make macOS arm64/x64 packages self-contained with bundled JetBrains Runtime, relocatable libmpv dylib closure and the Rust Now Playing bridge
- build Linux DEB/RPM/Arch packages from one Compose app image with bundled JetBrains Runtime while keeping libmpv/libsecret as distribution-managed native dependencies
- build a portable Linux AppImage with bundled JetBrains Runtime plus libmpv/libsecret ELF dependency closures and the Rust StatusNotifier bridge
- pin downloaded Windows/AppImage native inputs with SHA-256 checks
- add a dedicated Desktop Packaging workflow that produces and validates real installers on native runners

## Artifact matrix

- Windows x64: MSI + EXE
- macOS arm64: DMG + PKG
- macOS x64: DMG + PKG
- Debian/Ubuntu x64: DEB
- RPM x64: RPM
- Arch Linux x64: `.pkg.tar.zst`
- portable Linux x64: AppImage

## Dependency policy

The JVM is bundled on every platform, including distro-native Linux packages, so the Compose desktop runtime remains controlled by the application and can use the required JetBrains Runtime Wayland toolkit.

Windows/macOS always use the `bundled` native profile. Linux distro packages use the `system` profile and declare libmpv/libsecret dependencies through their package manager. AppImage starts from the Linux app image but bundles the libmpv/libsecret client ELF closures; glibc, the dynamic loader, graphics-driver ABI and system services remain host dependencies.

## Validation

The new workflow validates installers and package contents rather than only compiling packaging configuration. PR artifacts are intentionally unsigned; production signing/notarization and a native-Wayland packaged smoke test remain follow-ups.