### PR TITLE
feat: add desktop WebView provider login

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -306,16 +306,24 @@ jobs:
             fi
           done < <(find "$ROOT/app" -name '*.dylib' -type f)
 
+      - name: Prepare architecture-specific macOS artifact names
+        run: |
+          ROOT=desktopApp/build/compose/binaries/main-release
+          DMG="$(find "$ROOT/dmg" -maxdepth 1 -name '*.dmg' -print -quit)"
+          PKG="$(find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit)"
+          test -n "$DMG" && test -n "$PKG"
+          mv "$DMG" "$ROOT/dmg/FuoEvolve-macos-${{ matrix.arch }}.dmg"
+          mv "$PKG" "$ROOT/pkg/FuoEvolve-macos-${{ matrix.arch }}.pkg"
+
       - name: Report macOS package sizes
         run: |
-          du -h desktopApp/build/compose/binaries/main-release/dmg/*.dmg
-          du -h desktopApp/build/compose/binaries/main-release/pkg/*.pkg
+          du -h desktopApp/build/compose/binaries/main-release/dmg/FuoEvolve-macos-${{ matrix.arch }}.dmg
+          du -h desktopApp/build/compose/binaries/main-release/pkg/FuoEvolve-macos-${{ matrix.arch }}.pkg
 
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-macos-${{ matrix.arch }}.dmg
-          path: desktopApp/build/compose/binaries/main-release/dmg/*.dmg
+          path: desktopApp/build/compose/binaries/main-release/dmg/FuoEvolve-macos-${{ matrix.arch }}.dmg
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -323,8 +331,7 @@ jobs:
       - name: Upload macOS PKG
         uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-macos-${{ matrix.arch }}.pkg
-          path: desktopApp/build/compose/binaries/main-release/pkg/*.pkg
+          path: desktopApp/build/compose/binaries/main-release/pkg/FuoEvolve-macos-${{ matrix.arch }}.pkg
           archive: false
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -86,7 +86,7 @@ jobs:
           java -version
           jpackage --version
 
-      - name: Cache Windows Rust bridge
+      - name: Cache Windows Rust native components
         uses: actions/cache@v4
         with:
           path: |
@@ -94,7 +94,9 @@ jobs:
             ~/.cargo/git
             desktopApp/native/windows-smtc/Cargo.lock
             desktopApp/native/windows-smtc/target
-          key: desktop-rust-windows-x64-${{ hashFiles('desktopApp/native/windows-smtc/Cargo.toml', 'desktopApp/native/windows-smtc/src/**') }}
+            desktopApp/native/web-login/Cargo.lock
+            desktopApp/native/web-login/target
+          key: desktop-rust-windows-x64-${{ hashFiles('desktopApp/native/windows-smtc/Cargo.toml', 'desktopApp/native/windows-smtc/src/**', 'desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/src/**') }}
           restore-keys: |
             desktop-rust-windows-x64-
 
@@ -135,6 +137,7 @@ jobs:
           if (-not (Get-ChildItem "$root\exe" -Filter *.exe -ErrorAction SilentlyContinue)) { throw "EXE installer was not produced" }
           if (-not (Get-ChildItem "$root\app" -Recurse -File -Include mpv-2.dll,libmpv-2.dll,mpv.dll -ErrorAction SilentlyContinue)) { throw "Bundled libmpv DLL is missing" }
           if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter fuoevolve_smtc_bridge.dll -ErrorAction SilentlyContinue)) { throw "SMTC bridge is missing" }
+          if (-not (Get-ChildItem "$root\app" -Recurse -File -Filter fuoevolve-web-login.exe -ErrorAction SilentlyContinue)) { throw "WebView login helper is missing" }
           $runtimeRelease = Get-ChildItem "$root\app" -Recurse -File -Filter release -ErrorAction SilentlyContinue |
             Where-Object { $_.FullName -match '[\\/]runtime[\\/]release$' } |
             Select-Object -First 1
@@ -229,7 +232,7 @@ jobs:
           java -version
           jpackage --version
 
-      - name: Cache macOS Rust bridge
+      - name: Cache macOS Rust native components
         uses: actions/cache@v4
         with:
           path: |
@@ -237,7 +240,9 @@ jobs:
             ~/.cargo/git
             desktopApp/native/macos-now-playing/Cargo.lock
             desktopApp/native/macos-now-playing/target
-          key: desktop-rust-macos-${{ matrix.arch }}-${{ hashFiles('desktopApp/native/macos-now-playing/Cargo.toml', 'desktopApp/native/macos-now-playing/src/**') }}
+            desktopApp/native/web-login/Cargo.lock
+            desktopApp/native/web-login/target
+          key: desktop-rust-macos-${{ matrix.arch }}-${{ hashFiles('desktopApp/native/macos-now-playing/Cargo.toml', 'desktopApp/native/macos-now-playing/src/**', 'desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/src/**') }}
           restore-keys: |
             desktop-rust-macos-${{ matrix.arch }}-
 
@@ -284,6 +289,7 @@ jobs:
           find "$ROOT/pkg" -maxdepth 1 -name '*.pkg' -print -quit | grep -q . || { echo "PKG was not produced" >&2; exit 1; }
           find "$ROOT/app" -name libmpv.dylib -print -quit | grep -q . || { echo "Bundled libmpv dylib is missing" >&2; exit 1; }
           find "$ROOT/app" -name libfuoevolve_now_playing_bridge.dylib -print -quit | grep -q . || { echo "Now Playing bridge is missing" >&2; exit 1; }
+          find "$ROOT/app" -name fuoevolve-web-login -type f -perm -u+x -print -quit | grep -q . || { echo "WebView login helper is missing" >&2; exit 1; }
           RUNTIME_RELEASE="$(find "$ROOT/app" -path '*/Contents/runtime/Contents/Home/release' -print -quit)"
           if [[ -z "$RUNTIME_RELEASE" ]]; then
             echo "Bundled JVM runtime release marker is missing" >&2
@@ -326,7 +332,7 @@ jobs:
   linux-system:
     name: Package Linux DEB RPM and Arch
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 75
 
     steps:
       - name: Checkout
@@ -368,7 +374,7 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
 
-      - name: Cache Linux system Rust bridge
+      - name: Cache Linux system Rust native components
         uses: actions/cache@v4
         with:
           path: |
@@ -376,17 +382,20 @@ jobs:
             ~/.cargo/git
             desktopApp/native/linux-tray/Cargo.lock
             desktopApp/native/linux-tray/target
-          key: desktop-rust-linux-system-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**') }}
+            desktopApp/native/web-login/Cargo.lock
+            desktopApp/native/web-login/target
+          key: desktop-rust-linux-system-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**', 'desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/src/**') }}
           restore-keys: |
             desktop-rust-linux-system-x64-
 
-      - name: Install native packaging tools
+      - name: Install native packaging tools and WebKitGTK
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot rpm
+          sudo apt-get install -y fakeroot rpm libwebkit2gtk-4.1-dev
           java -version
           jpackage --version
           docker --version
+          pkg-config --modversion webkit2gtk-4.1
 
       - name: Create minified Linux app image with system native dependency profile
         id: app
@@ -417,6 +426,8 @@ jobs:
           grep -Eq '^JAVA_VERSION="21\.' "$RUNTIME_RELEASE" || { echo "Bundled JVM runtime is not Java 21" >&2; exit 1; }
           TRAY_BRIDGE="$(find "$APP_IMAGE" -name libfuoevolve_linux_tray_bridge.so -print -quit)"
           test -n "$TRAY_BRIDGE"
+          WEB_LOGIN_HELPER="$(find "$APP_IMAGE" -name fuoevolve-web-login -type f -perm -u+x -print -quit)"
+          test -n "$WEB_LOGIN_HELPER" || { echo "WebView login helper is missing" >&2; exit 1; }
           if [[ -n "$(find "$APP_IMAGE" -name 'libmpv.so*' -print -quit)" ]]; then
             echo "System Linux app image must not bundle libmpv" >&2
             exit 1
@@ -446,9 +457,12 @@ jobs:
           test -n "$DEB" && test -n "$RPM" && test -n "$ARCH"
           dpkg-deb -I "$DEB" | tee build/desktop-packages/system/deb-info.txt
           grep -q 'libmpv2' build/desktop-packages/system/deb-info.txt
+          grep -q 'libwebkit2gtk-4.1-0' build/desktop-packages/system/deb-info.txt
           rpm -qp --requires "$RPM" | tee build/desktop-packages/system/rpm-requires.txt
           grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
+          grep -q 'libwebkit2gtk-4.1.so.0' build/desktop-packages/system/rpm-requires.txt
           tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
+          tar -xOf "$ARCH" .PKGINFO | grep -q 'depend = webkit2gtk-4.1'
 
       - name: Report Linux package sizes
         run: du -h build/desktop-packages/system/*.deb build/desktop-packages/system/*.rpm build/desktop-packages/system/*.pkg.tar.zst
@@ -483,7 +497,7 @@ jobs:
   linux-appimage:
     name: Package portable Linux AppImage
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Checkout
@@ -525,7 +539,7 @@ jobs:
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
 
-      - name: Cache Linux AppImage Rust bridge
+      - name: Cache Linux AppImage Rust native components
         uses: actions/cache@v4
         with:
           path: |
@@ -533,16 +547,20 @@ jobs:
             ~/.cargo/git
             desktopApp/native/linux-tray/Cargo.lock
             desktopApp/native/linux-tray/target
-          key: desktop-rust-linux-appimage-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**') }}
+            desktopApp/native/web-login/Cargo.lock
+            desktopApp/native/web-login/target
+          key: desktop-rust-linux-appimage-x64-${{ hashFiles('desktopApp/native/linux-tray/Cargo.toml', 'desktopApp/native/linux-tray/src/**', 'desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/src/**') }}
           restore-keys: |
             desktop-rust-linux-appimage-x64-
 
       - name: Install portable native dependency inputs
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpv1 libsecret-1-0 patchelf pax-utils
+          sudo apt-get install -y libmpv1 libsecret-1-0 libwebkit2gtk-4.1-dev glib-networking patchelf pax-utils
           ldconfig -p | grep libmpv
           ldconfig -p | grep libsecret-1
+          pkg-config --modversion webkit2gtk-4.1
+          find /usr/lib -path '*/webkit2gtk-4.1/WebKitNetworkProcess' -print -quit | grep -q .
 
       - name: Create minified Linux app image
         id: app
@@ -571,6 +589,7 @@ jobs:
           RUNTIME_ROOT="${RUNTIME_RELEASE%/release}"
           test -f "$RUNTIME_ROOT/lib/modules" || { echo "Bundled JVM runtime modules image is missing" >&2; exit 1; }
           grep -Eq '^JAVA_VERSION="21\.' "$RUNTIME_RELEASE" || { echo "Bundled JVM runtime is not Java 21" >&2; exit 1; }
+          find "$APP_IMAGE" -name fuoevolve-web-login -type f -perm -u+x -print -quit | grep -q . || { echo "WebView login helper is missing" >&2; exit 1; }
           VERSION="$(./gradlew -q :desktopApp:printDesktopPackageVersion | tail -n 1)"
           echo "app_image=$APP_IMAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -41,9 +41,9 @@ permissions:
 
 jobs:
   test:
-    name: Compile Linux desktop and StatusNotifier tray bridge
+    name: Compile Linux desktop, tray and WebView login helper
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
       - name: Checkout
@@ -73,8 +73,16 @@ jobs:
           rustc --version
           cargo --version
 
+      - name: Install Linux WebKitGTK build dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev
+
       - name: Compile Rust StatusNotifier tray bridge
         run: cargo build --manifest-path desktopApp/native/linux-tray/Cargo.toml --release
+
+      - name: Test Rust WebView login helper
+        run: cargo test --manifest-path desktopApp/native/web-login/Cargo.toml --release
 
       - name: Compile Linux desktop foundation
         run: >-
@@ -86,9 +94,9 @@ jobs:
           :shared:desktopTest
 
   windows-smtc:
-    name: Compile Windows desktop and Rust SMTC bridge
+    name: Compile Windows desktop, SMTC and WebView login helper
     runs-on: windows-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -125,6 +133,10 @@ jobs:
         shell: pwsh
         run: cargo build --manifest-path desktopApp/native/windows-smtc/Cargo.toml --release
 
+      - name: Test Rust WebView login helper
+        shell: pwsh
+        run: cargo test --manifest-path desktopApp/native/web-login/Cargo.toml --release
+
       - name: Compile Windows desktop foundation
         shell: pwsh
         run: >-
@@ -136,9 +148,9 @@ jobs:
           :shared:desktopTest
 
   macos-now-playing:
-    name: Compile macOS desktop and Rust Now Playing bridge
+    name: Compile macOS desktop, Now Playing and WebView login helper
     runs-on: macos-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -172,6 +184,9 @@ jobs:
 
       - name: Compile Rust Now Playing bridge
         run: cargo build --manifest-path desktopApp/native/macos-now-playing/Cargo.toml --release
+
+      - name: Test Rust WebView login helper
+        run: cargo test --manifest-path desktopApp/native/web-login/Cargo.toml --release
 
       - name: Compile macOS desktop foundation
         run: >-

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -168,6 +168,11 @@ val prepareDesktopPackageResources by tasks.registering(Sync::class) {
     dependsOn(buildDesktopWebLoginHelper)
     from(desktopWebLoginExecutable) {
         into("$packagedNativeRoot/helpers")
+        if (!isWindowsHost) {
+            filePermissions {
+                unix("755")
+            }
+        }
     }
     into(packagedResourcesRoot)
 
@@ -214,6 +219,18 @@ val prepareDesktopPackageResources by tasks.registering(Sync::class) {
             )
         }
     }
+
+    doLast {
+        if (!isWindowsHost) {
+            val stagedHelper = packagedResourcesRoot.get().asFile
+                .resolve("$packagedNativeRoot/helpers/$desktopWebLoginExecutableName")
+            if (!stagedHelper.isFile || !stagedHelper.canExecute()) {
+                throw GradleException(
+                    "Staged desktop web login helper is not executable: ${stagedHelper.absolutePath}",
+                )
+            }
+        }
+    }
 }
 
 val nativePackageTaskNames = setOf(
@@ -246,8 +263,26 @@ tasks.matching { it.name == "prepareAppResources" }.configureEach {
 // a provider declaration survives while its implementation class was removed.
 tasks.matching { it.name == "createReleaseDistributable" }.configureEach {
     doLast {
+        val appRoot = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile
+        if (!isWindowsHost) {
+            val packagedHelper = appRoot.walkTopDown()
+                .firstOrNull { file -> file.isFile && file.name == desktopWebLoginExecutableName }
+                ?: throw GradleException(
+                    "Release image is missing desktop web login helper under ${appRoot.absolutePath}",
+                )
+            if (!packagedHelper.canExecute() && !packagedHelper.setExecutable(true, false)) {
+                throw GradleException(
+                    "Failed to mark release web login helper executable: ${packagedHelper.absolutePath}",
+                )
+            }
+            if (!packagedHelper.canExecute()) {
+                throw GradleException(
+                    "Release web login helper is not executable: ${packagedHelper.absolutePath}",
+                )
+            }
+        }
         verifyServiceProviderInReleaseImage(
-            appRoot = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile,
+            appRoot = appRoot,
             serviceClassName = "io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider",
             providerClassName = "io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider",
         )

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -124,8 +124,20 @@ val buildLinuxTrayBridge by tasks.registering(Exec::class) {
     commandLine("cargo", "build", "--release")
 }
 
+val desktopWebLoginExecutableName = if (isWindowsHost) "fuoevolve-web-login.exe" else "fuoevolve-web-login"
+val desktopWebLoginExecutable = layout.projectDirectory.file(
+    "native/web-login/target/release/$desktopWebLoginExecutableName",
+)
+val buildDesktopWebLoginHelper by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Build the isolated system-WebView login helper used by the desktop runtime."
+    workingDir(layout.projectDirectory.dir("native/web-login"))
+    commandLine("cargo", "build", "--release")
+}
+
 if (isWindowsHost || isMacHost || isLinuxHost) {
     tasks.matching { it.name == "run" }.configureEach {
+        dependsOn(buildDesktopWebLoginHelper)
         if (isWindowsHost) dependsOn(buildWindowsSmtcBridge)
         if (isMacHost) dependsOn(buildMacNowPlayingBridge)
         if (isLinuxHost) dependsOn(buildLinuxTrayBridge)
@@ -145,13 +157,17 @@ val expectedLibMpvNames = when {
 
 val prepareDesktopPackageResources by tasks.registering(Sync::class) {
     group = "distribution"
-    description = "Stage the platform bridge and optional bundled libmpv runtime for desktop packages."
+    description = "Stage desktop native bridges, web login helper and optional bundled libmpv runtime."
     inputs.property("packageProfile", desktopPackageProfile)
     if (bundlesLibMpv) {
         inputs.property("libmpvBundle", packageLibMpvDirPath.orElse("<unset>"))
         from(packageLibMpvDir) {
             into("$packagedNativeRoot/mpv")
         }
+    }
+    dependsOn(buildDesktopWebLoginHelper)
+    from(desktopWebLoginExecutable) {
+        into("$packagedNativeRoot/helpers")
     }
     into(packagedResourcesRoot)
 
@@ -179,6 +195,9 @@ val prepareDesktopPackageResources by tasks.registering(Sync::class) {
     }
 
     doFirst {
+        if (!desktopWebLoginExecutable.asFile.isFile) {
+            throw GradleException("Desktop web login helper was not built: ${desktopWebLoginExecutable.asFile}")
+        }
         if (!bundlesLibMpv) return@doFirst
         val source = packageLibMpvDir.orNull
             ?: throw GradleException(
@@ -264,6 +283,7 @@ compose.desktop {
     application {
         mainClass = "org.feeluown.mobile.desktop.MainKt"
         val appDir = "\$APPDIR"
+        jvmArgs += "-Dfuoevolve.appdir=$appDir"
         jvmArgs += "-Djna.library.path=" + listOf(
             "$appDir/resources/native/mpv",
             "$appDir/resources/native/bridges",

--- a/desktopApp/native/web-login/Cargo.toml
+++ b/desktopApp/native/web-login/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fuoevolve-web-login"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.80"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tao = "=0.36.0"
+wry = "=0.56.1"

--- a/desktopApp/native/web-login/src/main.rs
+++ b/desktopApp/native/web-login/src/main.rs
@@ -1,0 +1,187 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::io::{self, Read, Write};
+use std::time::{Duration, Instant};
+use tao::{
+    dpi::LogicalSize,
+    event::{Event, StartCause, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+use wry::{NewWindowResponse, WebViewBuilder};
+
+const COOKIE_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoginRequest {
+    provider_id: String,
+    provider_name: String,
+    login_url: String,
+    cookie_key_groups: Vec<Vec<String>>,
+    user_agent: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum LoginResponse {
+    Success { cookies: BTreeMap<String, String> },
+    Cancelled,
+    Error { message: String },
+}
+
+fn main() {
+    match read_request().and_then(run) {
+        Ok(()) => {}
+        Err(error) => {
+            emit_response(&LoginResponse::Error {
+                message: error.to_string(),
+            });
+            std::process::exit(1);
+        }
+    }
+}
+
+fn read_request() -> Result<LoginRequest, Box<dyn Error>> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    if input.trim().is_empty() {
+        return Err("missing login request on stdin".into());
+    }
+    let request: LoginRequest = serde_json::from_str(&input)?;
+    if request.provider_id.trim().is_empty() {
+        return Err("providerId is required".into());
+    }
+    if request.login_url.trim().is_empty() {
+        return Err("loginUrl is required".into());
+    }
+    Ok(request)
+}
+
+fn run(request: LoginRequest) -> Result<(), Box<dyn Error>> {
+    let event_loop = EventLoop::new();
+    let title = if request.provider_name.trim().is_empty() {
+        format!("FuoEvolve 登录 - {}", request.provider_id)
+    } else {
+        format!("FuoEvolve 登录 - {}", request.provider_name)
+    };
+    let window = WindowBuilder::new()
+        .with_title(title)
+        .with_inner_size(LogicalSize::new(1024.0, 720.0))
+        .with_min_inner_size(LogicalSize::new(720.0, 520.0))
+        .build(&event_loop)?;
+
+    let mut builder = WebViewBuilder::new()
+        .with_url(request.login_url.clone())
+        .with_incognito(true)
+        .with_clipboard(true)
+        .with_new_window_req_handler(|_, _| NewWindowResponse::Allow);
+    if let Some(user_agent) = request.user_agent.as_deref().filter(|value| !value.is_empty()) {
+        builder = builder.with_user_agent(user_agent);
+    }
+
+    #[cfg(target_os = "linux")]
+    let webview = {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+        builder.build_gtk(window.gtk_window())?
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let webview = builder.build(&window)?;
+
+    let cookie_key_groups = request.cookie_key_groups;
+    let mut next_cookie_poll = Instant::now();
+    let mut finished = false;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::WaitUntil(next_cookie_poll);
+
+        match event {
+            Event::NewEvents(StartCause::ResumeTimeReached { .. }) | Event::MainEventsCleared => {
+                if finished || Instant::now() < next_cookie_poll {
+                    return;
+                }
+                next_cookie_poll = Instant::now() + COOKIE_POLL_INTERVAL;
+                match webview.cookies() {
+                    Ok(cookies) => {
+                        let cookies = cookies
+                            .into_iter()
+                            .filter(|cookie| !cookie.name().is_empty() && !cookie.value().is_empty())
+                            .map(|cookie| (cookie.name().to_owned(), cookie.value().to_owned()))
+                            .collect::<BTreeMap<_, _>>();
+                        if has_required_cookies(&cookies, &cookie_key_groups) {
+                            emit_response(&LoginResponse::Success { cookies });
+                            finished = true;
+                            *control_flow = ControlFlow::Exit;
+                        }
+                    }
+                    Err(error) => {
+                        // Diagnostics must never include cookie values.
+                        eprintln!("unable to read WebView cookies: {error}");
+                    }
+                }
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                if !finished {
+                    emit_response(&LoginResponse::Cancelled);
+                    finished = true;
+                }
+                *control_flow = ControlFlow::Exit;
+            }
+            _ => {}
+        }
+    });
+}
+
+fn has_required_cookies(
+    cookies: &BTreeMap<String, String>,
+    cookie_key_groups: &[Vec<String>],
+) -> bool {
+    !cookie_key_groups.is_empty()
+        && cookie_key_groups.iter().any(|group| {
+            !group.is_empty()
+                && group
+                    .iter()
+                    .all(|key| cookies.get(key).is_some_and(|value| !value.is_empty()))
+        })
+}
+
+fn emit_response(response: &LoginResponse) {
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    if serde_json::to_writer(&mut output, response).is_ok() {
+        let _ = writeln!(output);
+        let _ = output.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_cookie_group_matches_any_complete_group() {
+        let cookies = BTreeMap::from([
+            ("MUSIC_U".to_string(), "secret".to_string()),
+            ("other".to_string(), "value".to_string()),
+        ]);
+        assert!(has_required_cookies(
+            &cookies,
+            &[vec!["MUSIC_U".to_string()], vec!["a".to_string(), "b".to_string()]],
+        ));
+    }
+
+    #[test]
+    fn incomplete_cookie_groups_do_not_match() {
+        let cookies = BTreeMap::from([("a".to_string(), "value".to_string())]);
+        assert!(!has_required_cookies(
+            &cookies,
+            &[vec!["a".to_string(), "b".to_string()]],
+        ));
+    }
+}

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -70,10 +70,20 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 APPDIR="$WORK_DIR/FuoEvolve.AppDir"
 BUNDLED_APP="$APPDIR/usr/lib/fuoevolve"
 NATIVE_LIB_DIR="$BUNDLED_APP/resources/native/mpv"
-mkdir -p "$NATIVE_LIB_DIR"
+WEBVIEW_ROOT="$BUNDLED_APP/resources/native/webview"
+WEBVIEW_LIB_DIR="$WEBVIEW_ROOT/lib"
+WEBKIT_RUNTIME_DIR="$WEBVIEW_ROOT/webkit2gtk-4.1"
+GIO_MODULE_DIR="$WEBVIEW_ROOT/gio/modules"
+mkdir -p "$NATIVE_LIB_DIR" "$WEBVIEW_LIB_DIR" "$WEBKIT_RUNTIME_DIR" "$GIO_MODULE_DIR"
 # Copy the contents of the Compose app image into the runtime root. Copying the source directory
 # itself into the already-created BUNDLED_APP directory would add an unintended FuoEvolve/ layer.
 cp -a "$APP_IMAGE/." "$BUNDLED_APP/"
+
+WEB_LOGIN_HELPER="$BUNDLED_APP/resources/native/helpers/fuoevolve-web-login"
+if [[ ! -x "$WEB_LOGIN_HELPER" ]]; then
+  echo "Compose app image is missing the desktop WebView login helper" >&2
+  exit 1
+fi
 
 is_base_system_library() {
   local name="$1"
@@ -81,8 +91,8 @@ is_base_system_library() {
     ld-linux*.so*|ld-*.so*|libc.so.*|libm.so.*|libpthread.so.*|libdl.so.*|librt.so.*|libresolv.so.*|libutil.so.*|libnss_*.so.*)
       return 0
       ;;
-    # OpenGL/driver-facing libraries must match the host graphics stack. libmpv runs audio-only in
-    # FuoEvolve, so keep these as host ABI dependencies rather than shipping a Mesa/driver snapshot.
+    # OpenGL/driver-facing libraries must match the host graphics stack. Keep these as host ABI
+    # dependencies rather than shipping a Mesa/driver snapshot into the portable image.
     libGL.so.*|libGLX.so.*|libOpenGL.so.*|libEGL.so.*|libdrm.so.*|libgbm.so.*)
       return 0
       ;;
@@ -92,14 +102,15 @@ is_base_system_library() {
   esac
 }
 
-copy_library() {
+copy_library_to() {
   local source="$1"
+  local destination_dir="$2"
   local name
   name="$(basename "$source")"
   if is_base_system_library "$name"; then
     return
   fi
-  local destination="$NATIVE_LIB_DIR/$name"
+  local destination="$destination_dir/$name"
   if [[ -f "$destination" ]]; then
     local old_sha new_sha
     old_sha="$(sha256sum "$destination" | awk '{print $1}')"
@@ -113,14 +124,21 @@ copy_library() {
   cp -L "$source" "$destination"
 }
 
-# lddtree resolves transitive ELF closures that JNA cannot discover from the Java launcher.
+copy_elf_closure() {
+  local root="$1"
+  local destination_dir="$2"
+  while IFS= read -r library; do
+    [[ -f "$library" ]] || continue
+    [[ "$library" == "$root" ]] && continue
+    copy_library_to "$library" "$destination_dir"
+  done < <(lddtree -l "$root" | awk '!seen[$0]++')
+}
+
 # libmpv contributes codecs/audio clients; libsecret is bundled as a client library while the
 # Secret Service D-Bus daemon itself remains a host service.
 for root_library in "$LIBMPV" "$LIBSECRET"; do
-  while IFS= read -r library; do
-    [[ -f "$library" ]] || continue
-    copy_library "$library"
-  done < <(lddtree -l "$root_library" | awk '!seen[$0]++')
+  copy_library_to "$root_library" "$NATIVE_LIB_DIR"
+  copy_elf_closure "$root_library" "$NATIVE_LIB_DIR"
 done
 
 BUNDLED_LIBMPV="$(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -name 'libmpv.so.*' -print -quit)"
@@ -135,17 +153,64 @@ if [[ -z "$BUNDLED_LIBSECRET" ]]; then
 fi
 ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$NATIVE_LIB_DIR/libmpv.so"
 
+# wry links to WebKitGTK on Linux. Bundle both the helper's ELF closure and WebKit's separately
+# executed subprocesses; the latter are not visible from the helper's normal DT_NEEDED graph.
+copy_elf_closure "$WEB_LOGIN_HELPER" "$WEBVIEW_LIB_DIR"
+SYSTEM_WEBKIT_RUNTIME_DIR="$(dirname "$(find /usr/lib /lib -type f -path '*/webkit2gtk-4.1/WebKitNetworkProcess' -print -quit 2>/dev/null || true)")"
+if [[ -z "$SYSTEM_WEBKIT_RUNTIME_DIR" || ! -x "$SYSTEM_WEBKIT_RUNTIME_DIR/WebKitNetworkProcess" ]]; then
+  echo "WebKitGTK 4.1 subprocess runtime was not found" >&2
+  exit 1
+fi
+
+for process_name in WebKitNetworkProcess WebKitWebProcess WebKitGPUProcess; do
+  process_path="$SYSTEM_WEBKIT_RUNTIME_DIR/$process_name"
+  [[ -x "$process_path" ]] || continue
+  cp -L "$process_path" "$WEBKIT_RUNTIME_DIR/$process_name"
+  chmod +x "$WEBKIT_RUNTIME_DIR/$process_name"
+  copy_elf_closure "$process_path" "$WEBVIEW_LIB_DIR"
+done
+
+SYSTEM_INJECTED_BUNDLE="$(find "$SYSTEM_WEBKIT_RUNTIME_DIR" -type f -name 'libwebkit2gtkinjectedbundle.so' -print -quit 2>/dev/null || true)"
+if [[ -z "$SYSTEM_INJECTED_BUNDLE" || ! -f "$SYSTEM_INJECTED_BUNDLE" ]]; then
+  echo "WebKitGTK injected bundle was not found" >&2
+  exit 1
+fi
+mkdir -p "$WEBKIT_RUNTIME_DIR/injected-bundle"
+cp -L "$SYSTEM_INJECTED_BUNDLE" "$WEBKIT_RUNTIME_DIR/injected-bundle/libwebkit2gtkinjectedbundle.so"
+copy_elf_closure "$SYSTEM_INJECTED_BUNDLE" "$WEBVIEW_LIB_DIR"
+
+# HTTPS support is dynamically discovered by GIO and therefore is not part of WebKit's direct ELF
+# closure. Bundle the GLib TLS module and make it discoverable through GIO_EXTRA_MODULES.
+SYSTEM_GIO_TLS_MODULE="$(find /usr/lib /lib -type f -path '*/gio/modules/libgiognutls.so' -print -quit 2>/dev/null || true)"
+if [[ -z "$SYSTEM_GIO_TLS_MODULE" || ! -f "$SYSTEM_GIO_TLS_MODULE" ]]; then
+  echo "GLib GnuTLS module was not found; install glib-networking" >&2
+  exit 1
+fi
+cp -L "$SYSTEM_GIO_TLS_MODULE" "$GIO_MODULE_DIR/libgiognutls.so"
+copy_elf_closure "$SYSTEM_GIO_TLS_MODULE" "$WEBVIEW_LIB_DIR"
+
 while IFS= read -r library; do
   patchelf --set-rpath '$ORIGIN' "$library" 2>/dev/null || true
-done < <(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -print)
+done < <(find "$NATIVE_LIB_DIR" "$WEBVIEW_LIB_DIR" -maxdepth 1 -type f -print)
+while IFS= read -r executable; do
+  patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../../lib' "$executable" 2>/dev/null || true
+done < <(find "$WEBKIT_RUNTIME_DIR" -maxdepth 1 -type f -perm -u+x -print)
+patchelf --set-rpath '$ORIGIN/../../lib' "$WEBKIT_RUNTIME_DIR/injected-bundle/libwebkit2gtkinjectedbundle.so" 2>/dev/null || true
+patchelf --set-rpath '$ORIGIN/../../lib' "$GIO_MODULE_DIR/libgiognutls.so" 2>/dev/null || true
 
 cat > "$APPDIR/AppRun" <<'APPRUN'
 #!/bin/sh
 set -e
 APPDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-NATIVE_LIB_DIR="$APPDIR/usr/lib/fuoevolve/resources/native/mpv"
-export LD_LIBRARY_PATH="$NATIVE_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-exec "$APPDIR/usr/lib/fuoevolve/bin/FuoEvolve" "$@"
+APP_ROOT="$APPDIR/usr/lib/fuoevolve"
+NATIVE_LIB_DIR="$APP_ROOT/resources/native/mpv"
+WEBVIEW_ROOT="$APP_ROOT/resources/native/webview"
+WEBVIEW_LIB_DIR="$WEBVIEW_ROOT/lib"
+export LD_LIBRARY_PATH="$NATIVE_LIB_DIR:$WEBVIEW_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export WEBKIT_EXEC_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1"
+export WEBKIT_INJECTED_BUNDLE_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1/injected-bundle"
+export GIO_EXTRA_MODULES="$WEBVIEW_ROOT/gio/modules${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
+exec "$APP_ROOT/bin/FuoEvolve" "$@"
 APPRUN
 chmod +x "$APPDIR/AppRun"
 
@@ -200,6 +265,22 @@ chmod +x "$OUTPUT_FILE"
   }
   find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -name 'libsecret-1.so.0*' -print -quit | grep -q . || {
     echo "Packaged AppImage is missing bundled libsecret" >&2
+    exit 1
+  }
+  test -x squashfs-root/usr/lib/fuoevolve/resources/native/helpers/fuoevolve-web-login || {
+    echo "Packaged AppImage is missing the WebView login helper" >&2
+    exit 1
+  }
+  test -x squashfs-root/usr/lib/fuoevolve/resources/native/webview/webkit2gtk-4.1/WebKitNetworkProcess || {
+    echo "Packaged AppImage is missing the WebKit network process" >&2
+    exit 1
+  }
+  test -f squashfs-root/usr/lib/fuoevolve/resources/native/webview/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so || {
+    echo "Packaged AppImage is missing the WebKit injected bundle" >&2
+    exit 1
+  }
+  test -f squashfs-root/usr/lib/fuoevolve/resources/native/webview/gio/modules/libgiognutls.so || {
+    echo "Packaged AppImage is missing the GIO TLS module" >&2
     exit 1
   }
 )

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -79,9 +79,13 @@ mkdir -p "$NATIVE_LIB_DIR" "$WEBVIEW_LIB_DIR" "$WEBKIT_RUNTIME_DIR" "$GIO_MODULE
 # itself into the already-created BUNDLED_APP directory would add an unintended FuoEvolve/ layer.
 cp -a "$APP_IMAGE/." "$BUNDLED_APP/"
 
-WEB_LOGIN_HELPER="$BUNDLED_APP/resources/native/helpers/fuoevolve-web-login"
-if [[ ! -x "$WEB_LOGIN_HELPER" ]]; then
+# Compose may change the relative nesting of appResources between plugin versions. The helper was
+# already validated in the source app image, so resolve it by identity instead of duplicating an
+# internal Compose path assumption here.
+WEB_LOGIN_HELPER="$(find "$BUNDLED_APP" -type f -name fuoevolve-web-login -perm -u+x -print -quit 2>/dev/null || true)"
+if [[ -z "$WEB_LOGIN_HELPER" ]]; then
   echo "Compose app image is missing the desktop WebView login helper" >&2
+  find "$BUNDLED_APP" -type f -name 'fuoevolve-web-login*' -print >&2 || true
   exit 1
 fi
 
@@ -267,7 +271,7 @@ chmod +x "$OUTPUT_FILE"
     echo "Packaged AppImage is missing bundled libsecret" >&2
     exit 1
   }
-  test -x squashfs-root/usr/lib/fuoevolve/resources/native/helpers/fuoevolve-web-login || {
+  find squashfs-root/usr/lib/fuoevolve -type f -name fuoevolve-web-login -perm -u+x -print -quit | grep -q . || {
     echo "Packaged AppImage is missing the WebView login helper" >&2
     exit 1
   }

--- a/desktopApp/packaging/linux/package-arch.sh
+++ b/desktopApp/packaging/linux/package-arch.sh
@@ -57,7 +57,7 @@ pkgdesc='A cross-platform multi-source music player based on FeelUOwn'
 arch=('x86_64')
 url='https://github.com/feeluown/FuoEvolve'
 license=('GPL-3.0-only')
-depends=('mpv' 'libsecret')
+depends=('mpv' 'libsecret' 'webkit2gtk-4.1')
 options=('!strip')
 source=('FuoEvolve.tar.gz' 'fuoevolve.desktop' 'fuoevolve.png')
 sha256sums=('$APP_SHA' '$DESKTOP_SHA' '$ICON_SHA')
@@ -73,7 +73,7 @@ package() {
 EOF
 
 # makepkg intentionally runs as a non-root user; the package itself retains distro-managed
-# dependencies on mpv/libsecret while the Compose app image keeps its bundled JBR runtime.
+# dependencies on mpv/libsecret/WebKitGTK while the Compose app image keeps its bundled JBR runtime.
 # The bind-mounted work directory must be returned to the host runner's numeric ownership before
 # Docker exits, otherwise chown-ing it to the container-only builder user makes host cleanup fail.
 HOST_UID="$(id -u)"

--- a/desktopApp/packaging/linux/package-system.sh
+++ b/desktopApp/packaging/linux/package-system.sh
@@ -41,14 +41,15 @@ COMMON_ARGS=(
 )
 
 if [[ "$PACKAGE_TYPE" == "deb" ]]; then
-  # Debian 12/13 and Ubuntu 24.04+ expose libmpv through libmpv2.
-  PACKAGE_DEPS="libmpv2, libsecret-1-0"
+  # Debian/Ubuntu provide playback and credential libraries through the system package manager.
+  # WebKitGTK 4.1 supplies the native Wayland/X11 WebView used only by provider login windows.
+  PACKAGE_DEPS="libmpv2, libsecret-1-0, libwebkit2gtk-4.1-0"
   "$JAVA_HOME/bin/jpackage" "${COMMON_ARGS[@]}" \
     --linux-package-deps "$PACKAGE_DEPS"
 else
   # Depend on ELF capabilities rather than Fedora package names so compatible RPM distributions
-  # may satisfy the dependency from their own libmpv/libsecret package naming.
-  PACKAGE_DEPS="libmpv.so.2()(64bit), libsecret-1.so.0()(64bit)"
+  # may satisfy the dependencies from their own package naming.
+  PACKAGE_DEPS="libmpv.so.2()(64bit), libsecret-1.so.0()(64bit), libwebkit2gtk-4.1.so.0()(64bit)"
   "$JAVA_HOME/bin/jpackage" "${COMMON_ARGS[@]}" \
     --linux-package-deps "$PACKAGE_DEPS" \
     --linux-rpm-license-type "GPL-3.0-only"

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNonBlockingUriHandler.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNonBlockingUriHandler.kt
@@ -1,0 +1,35 @@
+package org.feeluown.mobile.desktop
+
+import androidx.compose.ui.platform.UriHandler
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Desktop URI launching may synchronously wait for the OS browser launcher (notably xdg-open on
+ * Linux). Keep that work off the Compose UI dispatcher so opening OAuth/release-note links cannot
+ * freeze the application window.
+ */
+internal class DesktopNonBlockingUriHandler(
+    private val delegate: UriHandler,
+    private val executor: ExecutorService = createUriExecutor(),
+) : UriHandler, AutoCloseable {
+    override fun openUri(uri: String) {
+        executor.execute {
+            runCatching { delegate.openUri(uri) }
+                .onFailure { error ->
+                    System.err.println(
+                        "FuoEvolve: failed to open external URI: ${error.message ?: error::class.simpleName}",
+                    )
+                }
+        }
+    }
+
+    override fun close() {
+        executor.shutdownNow()
+    }
+}
+
+private fun createUriExecutor(): ExecutorService =
+    Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "fuoevolve-external-uri").apply { isDaemon = true }
+    }

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
@@ -3,6 +3,8 @@ package org.feeluown.mobile.desktop
 import com.microsoft.credentialstorage.SecretStore
 import com.microsoft.credentialstorage.StorageProvider
 import com.microsoft.credentialstorage.StorageProvider.SecureOption
+import com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretBackedTokenStore
+import com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretLibrary
 import com.microsoft.credentialstorage.model.StoredToken
 import com.microsoft.credentialstorage.model.StoredTokenType
 import java.security.MessageDigest
@@ -131,9 +133,22 @@ private class MicrosoftDesktopSecretStore(
 }
 
 private fun createMicrosoftSecretStore(): DesktopSecretStore? =
-    StorageProvider.getTokenStorage(true, SecureOption.REQUIRED)
-        ?.takeIf { it.isSecure }
-        ?.let(::MicrosoftDesktopSecretStore)
+    if (System.getProperty("os.name") == "Linux") {
+        createLinuxLibSecretStore()
+    } else {
+        StorageProvider.getTokenStorage(true, SecureOption.REQUIRED)
+            ?.takeIf { it.isSecure }
+            ?.let(::MicrosoftDesktopSecretStore)
+    }
+
+private fun createLinuxLibSecretStore(): DesktopSecretStore? = runCatching {
+    // StorageProvider performs a preflight that rejects a locked default collection before
+    // normal libsecret interaction can display the system unlock prompt. Use its underlying
+    // libsecret store directly on Linux instead: reads request SECRET_SEARCH_UNLOCK and writes
+    // use libsecret's default collection, so the Secret Service can handle user interaction.
+    LibSecretLibrary.INSTANCE
+    MicrosoftDesktopSecretStore(LibSecretBackedTokenStore())
+}.getOrNull()
 
 private data class DesktopCredentialManifest(
     val generation: String,

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -1,11 +1,13 @@
 package org.feeluown.mobile.desktop
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
@@ -73,7 +75,20 @@ fun main() {
             installDesktopPlaybackSessionIntegrationFactory { playbackSession ->
                 createDesktopSystemMediaSessionForWindow(playbackSession, window)
             }
-            DesktopAppHost()
+
+            // Compose's desktop UriHandler is synchronous. On Linux the OS browser launcher may
+            // block while xdg-open/desktop integration resolves the target application, so never
+            // invoke it directly from the Compose UI dispatcher.
+            val platformUriHandler = LocalUriHandler.current
+            val nonBlockingUriHandler = remember(platformUriHandler) {
+                DesktopNonBlockingUriHandler(platformUriHandler)
+            }
+            DisposableEffect(nonBlockingUriHandler) {
+                onDispose(nonBlockingUriHandler::close)
+            }
+            CompositionLocalProvider(LocalUriHandler provides nonBlockingUriHandler) {
+                DesktopAppHost()
+            }
         }
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
@@ -35,6 +35,7 @@ fun DesktopAppHost() {
 
 private class DesktopAppContainer {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val webLoginLauncher = DesktopWebLoginLauncher()
     private val providerCredentialStore = createDesktopProviderCredentialStore()
     private val providerGraph = createFuoProviderGraph(
         credentials = providerCredentialStore,
@@ -95,7 +96,7 @@ private class DesktopAppContainer {
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
+                selectedProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }
@@ -373,7 +374,17 @@ private class DesktopAppContainer {
     )
 
     fun openProviderWebLogin(provider: ProviderInfo) {
-        appViewModel.showFeedback("${provider.providerName} 的桌面网页登录将在后续开发阶段接入")
+        scope.launch {
+            when (val result = webLoginLauncher.open(provider)) {
+                is DesktopWebLoginResult.Success -> {
+                    providerAuthFeatureController.loginWithCookies(provider.providerId, result.cookiesJson)
+                }
+                DesktopWebLoginResult.Cancelled -> Unit
+                is DesktopWebLoginResult.Failure -> {
+                    appViewModel.showFeedback(result.message)
+                }
+            }
+        }
     }
 
     fun logoutProvider(provider: ProviderInfo) {
@@ -384,6 +395,7 @@ private class DesktopAppContainer {
         if (playbackSessionIntegration.isInitialized()) {
             playbackSessionIntegration.value.close()
         }
+        webLoginLauncher.close()
         scope.cancel()
         desktopDownloadRepository.close()
         playbackEngine.close()

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
@@ -96,7 +96,7 @@ private class DesktopAppContainer {
             },
             initialState = SearchUiState(
                 searchScope = initialSettings.searchScope,
-                selectedProviderId = initialSettings.selectedSearchProviderId,
+                selectedSearchProviderId = initialSettings.selectedSearchProviderId,
             ),
         )
     }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -1,8 +1,11 @@
 package org.feeluown.mobile
 
 import java.io.File
+import java.io.Reader
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -34,6 +37,7 @@ private data class DesktopWebLoginResponse(
 internal class DesktopWebLoginLauncher : AutoCloseable {
     private val json = Json { ignoreUnknownKeys = true }
     private val activeProcesses = ConcurrentHashMap.newKeySet<Process>()
+    private val activeProviderIds = ConcurrentHashMap.newKeySet<String>()
 
     suspend fun open(provider: ProviderInfo): DesktopWebLoginResult = withContext(Dispatchers.IO) {
         val config = provider.loginConfig
@@ -44,53 +48,70 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
         val helper = resolveHelper()
             ?: return@withContext DesktopWebLoginResult.Failure("桌面网页登录组件未找到，请重新安装应用")
 
-        val request = DesktopWebLoginRequest(
-            providerId = provider.providerId,
-            providerName = provider.providerName,
-            loginUrl = config.loginUrl,
-            cookieKeyGroups = config.cookieKeyGroups,
-            userAgent = loginUserAgent(provider.providerId),
-        )
+        if (!activeProviderIds.add(provider.providerId)) {
+            return@withContext DesktopWebLoginResult.Failure("${provider.providerName} 网页登录正在进行中")
+        }
 
-        runCatching {
-            val process = ProcessBuilder(helper.absolutePath).start()
-            activeProcesses += process
-            try {
-                process.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
-                    writer.write(json.encodeToString(request))
-                    writer.newLine()
-                }
+        try {
+            val request = DesktopWebLoginRequest(
+                providerId = provider.providerId,
+                providerName = provider.providerName,
+                loginUrl = config.loginUrl,
+                cookieKeyGroups = config.cookieKeyGroups,
+                userAgent = loginUserAgent(provider.providerId),
+            )
 
-                // The helper emits exactly one JSON response and never logs cookie values to stderr.
-                val responseLine = process.inputStream.bufferedReader(Charsets.UTF_8).readLine().orEmpty()
-                val exitCode = process.waitFor()
-                val diagnostics = process.errorStream.bufferedReader(Charsets.UTF_8).readText().trim()
-
-                if (responseLine.isBlank()) {
-                    val detail = diagnostics.take(240).ifBlank { "退出码 $exitCode" }
-                    return@runCatching DesktopWebLoginResult.Failure("网页登录组件启动失败：$detail")
-                }
-                val response = json.decodeFromString<DesktopWebLoginResponse>(responseLine)
-                when (response.status) {
-                    "success" -> {
-                        if (response.cookies.isEmpty()) {
-                            DesktopWebLoginResult.Failure("网页登录完成，但未获取到 Cookie")
-                        } else {
-                            DesktopWebLoginResult.Success(json.encodeToString(response.cookies))
-                        }
+            runCatching {
+                val process = ProcessBuilder(helper.absolutePath).start()
+                activeProcesses += process
+                coroutineScope {
+                    val diagnosticsDeferred = async(Dispatchers.IO) {
+                        runCatching {
+                            process.errorStream.bufferedReader(Charsets.UTF_8).use(::readDiagnosticTail)
+                        }.getOrDefault("")
                     }
-                    "cancelled" -> DesktopWebLoginResult.Cancelled
-                    "error" -> DesktopWebLoginResult.Failure(
-                        response.message?.takeIf { it.isNotBlank() } ?: "网页登录组件发生错误",
-                    )
-                    else -> DesktopWebLoginResult.Failure("网页登录组件返回了未知状态")
+                    try {
+                        process.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
+                            writer.write(json.encodeToString(request))
+                            writer.newLine()
+                        }
+
+                        // Drain stderr concurrently so native WebView diagnostics cannot fill the
+                        // process pipe and block the helper while the user is still logging in.
+                        val responseLine = process.inputStream.bufferedReader(Charsets.UTF_8).readLine().orEmpty()
+                        val exitCode = process.waitFor()
+                        val diagnostics = diagnosticsDeferred.await().trim()
+
+                        if (responseLine.isBlank()) {
+                            val detail = diagnostics.takeLast(240).ifBlank { "退出码 $exitCode" }
+                            return@coroutineScope DesktopWebLoginResult.Failure("网页登录组件启动失败：$detail")
+                        }
+                        val response = json.decodeFromString<DesktopWebLoginResponse>(responseLine)
+                        when (response.status) {
+                            "success" -> {
+                                if (response.cookies.isEmpty()) {
+                                    DesktopWebLoginResult.Failure("网页登录完成，但未获取到 Cookie")
+                                } else {
+                                    DesktopWebLoginResult.Success(json.encodeToString(response.cookies))
+                                }
+                            }
+                            "cancelled" -> DesktopWebLoginResult.Cancelled
+                            "error" -> DesktopWebLoginResult.Failure(
+                                response.message?.takeIf { it.isNotBlank() } ?: "网页登录组件发生错误",
+                            )
+                            else -> DesktopWebLoginResult.Failure("网页登录组件返回了未知状态")
+                        }
+                    } finally {
+                        activeProcesses -= process
+                        if (process.isAlive) process.destroyForcibly()
+                        diagnosticsDeferred.cancel()
+                    }
                 }
-            } finally {
-                activeProcesses -= process
-                if (process.isAlive) process.destroyForcibly()
+            }.getOrElse { error ->
+                DesktopWebLoginResult.Failure(error.message ?: "无法启动桌面网页登录")
             }
-        }.getOrElse { error ->
-            DesktopWebLoginResult.Failure(error.message ?: "无法启动桌面网页登录")
+        } finally {
+            activeProviderIds -= provider.providerId
         }
     }
 
@@ -99,6 +120,7 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
             if (process.isAlive) process.destroyForcibly()
         }
         activeProcesses.clear()
+        activeProviderIds.clear()
     }
 
     private fun resolveHelper(): File? {
@@ -142,11 +164,28 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
         if (providerId == "bilibili") MOBILE_USER_AGENT else DESKTOP_USER_AGENT
 
     private companion object {
+        const val MAX_DIAGNOSTIC_CHARS = 8 * 1024
+        const val DIAGNOSTIC_BUFFER_CHARS = 1024
+
         const val DESKTOP_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
         const val MOBILE_USER_AGENT =
             "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+
+        fun readDiagnosticTail(reader: Reader): String {
+            val tail = StringBuilder()
+            val buffer = CharArray(DIAGNOSTIC_BUFFER_CHARS)
+            while (true) {
+                val count = reader.read(buffer)
+                if (count < 0) break
+                tail.append(buffer, 0, count)
+                if (tail.length > MAX_DIAGNOSTIC_CHARS) {
+                    tail.delete(0, tail.length - MAX_DIAGNOSTIC_CHARS)
+                }
+            }
+            return tail.toString()
+        }
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -105,17 +105,35 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
         val executableName = if (isWindows()) "fuoevolve-web-login.exe" else "fuoevolve-web-login"
         val appDir = System.getProperty("fuoevolve.appdir")
             ?.takeIf { it.isNotBlank() && !it.contains("\$APPDIR") }
+            ?.let(::File)
         val userDir = File(System.getProperty("user.dir").orEmpty().ifBlank { "." })
-        return buildList {
+
+        val directCandidates = buildList {
             if (appDir != null) {
+                // Current Compose layout. Keep this fast path, but do not make runtime correctness
+                // depend on the exact resource nesting used by a particular Compose plugin version.
                 add(File(appDir, "resources/native/helpers/$executableName"))
             }
             // Development fallbacks for `./gradlew :desktopApp:run` from either repository root
             // or the desktopApp project directory.
             add(File(userDir, "desktopApp/native/web-login/target/release/$executableName"))
             add(File(userDir, "native/web-login/target/release/$executableName"))
-        }.firstOrNull { candidate -> candidate.isFile && (isWindows() || candidate.canExecute()) }
+        }
+        directCandidates.firstOrNull(::isUsableHelper)?.let { return it }
+
+        // Native distributions may relocate app resources while preserving their contents. Search
+        // only below the installed app root and only when the direct path did not match.
+        return appDir
+            ?.takeIf { it.isDirectory }
+            ?.walkTopDown()
+            ?.maxDepth(6)
+            ?.firstOrNull { candidate ->
+                candidate.name == executableName && isUsableHelper(candidate)
+            }
     }
+
+    private fun isUsableHelper(candidate: File): Boolean =
+        candidate.isFile && (isWindows() || candidate.canExecute())
 
     private fun isWindows(): Boolean =
         System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true)

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -1,0 +1,133 @@
+package org.feeluown.mobile
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal sealed interface DesktopWebLoginResult {
+    data class Success(val cookiesJson: String) : DesktopWebLoginResult
+    data object Cancelled : DesktopWebLoginResult
+    data class Failure(val message: String) : DesktopWebLoginResult
+}
+
+@Serializable
+private data class DesktopWebLoginRequest(
+    val providerId: String,
+    val providerName: String,
+    val loginUrl: String,
+    val cookieKeyGroups: List<List<String>>,
+    val userAgent: String? = null,
+)
+
+@Serializable
+private data class DesktopWebLoginResponse(
+    val status: String,
+    val cookies: Map<String, String> = emptyMap(),
+    val message: String? = null,
+)
+
+internal class DesktopWebLoginLauncher : AutoCloseable {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val activeProcesses = ConcurrentHashMap.newKeySet<Process>()
+
+    suspend fun open(provider: ProviderInfo): DesktopWebLoginResult = withContext(Dispatchers.IO) {
+        val config = provider.loginConfig
+            ?: return@withContext DesktopWebLoginResult.Failure("${provider.providerName} 未配置网页登录地址")
+        if (config.cookieKeyGroups.isEmpty()) {
+            return@withContext DesktopWebLoginResult.Failure("${provider.providerName} 未配置登录 Cookie 判定规则")
+        }
+        val helper = resolveHelper()
+            ?: return@withContext DesktopWebLoginResult.Failure("桌面网页登录组件未找到，请重新安装应用")
+
+        val request = DesktopWebLoginRequest(
+            providerId = provider.providerId,
+            providerName = provider.providerName,
+            loginUrl = config.loginUrl,
+            cookieKeyGroups = config.cookieKeyGroups,
+            userAgent = loginUserAgent(provider.providerId),
+        )
+
+        runCatching {
+            val process = ProcessBuilder(helper.absolutePath).start()
+            activeProcesses += process
+            try {
+                process.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
+                    writer.write(json.encodeToString(request))
+                    writer.newLine()
+                }
+
+                // The helper emits exactly one JSON response and never logs cookie values to stderr.
+                val responseLine = process.inputStream.bufferedReader(Charsets.UTF_8).readLine().orEmpty()
+                val exitCode = process.waitFor()
+                val diagnostics = process.errorStream.bufferedReader(Charsets.UTF_8).readText().trim()
+
+                if (responseLine.isBlank()) {
+                    val detail = diagnostics.take(240).ifBlank { "退出码 $exitCode" }
+                    return@runCatching DesktopWebLoginResult.Failure("网页登录组件启动失败：$detail")
+                }
+                val response = json.decodeFromString<DesktopWebLoginResponse>(responseLine)
+                when (response.status) {
+                    "success" -> {
+                        if (response.cookies.isEmpty()) {
+                            DesktopWebLoginResult.Failure("网页登录完成，但未获取到 Cookie")
+                        } else {
+                            DesktopWebLoginResult.Success(json.encodeToString(response.cookies))
+                        }
+                    }
+                    "cancelled" -> DesktopWebLoginResult.Cancelled
+                    "error" -> DesktopWebLoginResult.Failure(
+                        response.message?.takeIf { it.isNotBlank() } ?: "网页登录组件发生错误",
+                    )
+                    else -> DesktopWebLoginResult.Failure("网页登录组件返回了未知状态")
+                }
+            } finally {
+                activeProcesses -= process
+                if (process.isAlive) process.destroyForcibly()
+            }
+        }.getOrElse { error ->
+            DesktopWebLoginResult.Failure(error.message ?: "无法启动桌面网页登录")
+        }
+    }
+
+    override fun close() {
+        activeProcesses.toList().forEach { process ->
+            if (process.isAlive) process.destroyForcibly()
+        }
+        activeProcesses.clear()
+    }
+
+    private fun resolveHelper(): File? {
+        val executableName = if (isWindows()) "fuoevolve-web-login.exe" else "fuoevolve-web-login"
+        val appDir = System.getProperty("fuoevolve.appdir")
+            ?.takeIf { it.isNotBlank() && !it.contains("\$APPDIR") }
+        val userDir = File(System.getProperty("user.dir").orEmpty().ifBlank { "." })
+        return buildList {
+            if (appDir != null) {
+                add(File(appDir, "resources/native/helpers/$executableName"))
+            }
+            // Development fallbacks for `./gradlew :desktopApp:run` from either repository root
+            // or the desktopApp project directory.
+            add(File(userDir, "desktopApp/native/web-login/target/release/$executableName"))
+            add(File(userDir, "native/web-login/target/release/$executableName"))
+        }.firstOrNull { candidate -> candidate.isFile && (isWindows() || candidate.canExecute()) }
+    }
+
+    private fun isWindows(): Boolean =
+        System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true)
+
+    private fun loginUserAgent(providerId: String): String =
+        if (providerId == "bilibili") MOBILE_USER_AGENT else DESKTOP_USER_AGENT
+
+    private companion object {
+        const val DESKTOP_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        const val MOBILE_USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+    }
+}


### PR DESCRIPTION
## Summary
- add a native desktop web-login helper using system WebViews: WebView2 on Windows, WKWebView on macOS, and WebKitGTK 4.1 on Linux
- use the GTK WebView path on Linux so Wayland sessions stay native rather than falling back to XWayland
- pass provider login configuration over a stdin/stdout JSON protocol without putting credentials in process arguments or logs
- capture cookies from an isolated/incognito WebView session and return them to the existing `loginWithCookies` provider auth flow
- package the helper into Windows/macOS/Linux distributions and preserve its executable permissions through Compose packaging
- make the AppImage self-contained for WebKitGTK, including WebKit subprocesses, injected bundles, TLS modules, and required ELF dependency closure
- declare WebKitGTK dependencies for DEB/RPM/Arch system packages
- support locked Linux Secret Service/keyring sessions by using libsecret directly instead of rejecting the store during provider preflight
- extend desktop tests and packaging validation for the helper and platform dependency closure

## Stack
This PR is intentionally based on `feat/desktop-packaging` / #167 so it can reuse the desktop native packaging foundation. Retarget to `master` after #167 lands.

## Validation
- Desktop Tests #124: Windows, macOS, and Linux passed
- Desktop Packaging #41: Windows MSI/EXE, macOS arm64/x64 DMG/PKG, Linux DEB/RPM/Arch, and self-contained AppImage passed
- macOS raw artifacts use architecture-specific filenames so arm64/x64 uploads do not collide
- Android APK check passed

## Notes
The login WebView uses the operating system WebView runtime instead of bundling Chromium/JCEF. Linux system packages use the distribution WebKitGTK runtime; AppImage bundles the required WebKitGTK runtime closure.