### PR TITLE
feat: complete desktop P0 persistence

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalPlaylistRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidLocalPlaylistRepository.kt
@@ -5,184 +5,72 @@ import java.io.File
 import java.io.FileOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 class AndroidLocalPlaylistRepository(
     context: Context,
-) : LocalPlaylistRepository {
-    private val collectionsDirectory = File(context.applicationContext.filesDir, COLLECTIONS_DIRECTORY)
-    private val mutex = Mutex()
+) : LocalPlaylistRepository by FileBackedLocalPlaylistRepository(
+    storage = AndroidLocalPlaylistFileStorage(
+        directory = File(context.applicationContext.filesDir, COLLECTIONS_DIRECTORY),
+    ),
+) {
+    private companion object {
+        const val COLLECTIONS_DIRECTORY = "collections"
+    }
+}
 
-    override suspend fun list(): List<LocalPlaylist> = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            ensureDirectory()
-            collectionsDirectory.listFiles()
-                .orEmpty()
-                .filter { it.isFile && it.extension.equals(FILE_EXTENSION, ignoreCase = true) }
-                .sortedBy { it.name }
-                .mapNotNull(::readPlaylist)
-        }
+/** Android owns filesystem mechanics; playlist semantics live in common code. */
+private class AndroidLocalPlaylistFileStorage(
+    private val directory: File,
+) : LocalPlaylistFileStorage {
+    override suspend fun listFileNames(): List<String> = withContext(Dispatchers.IO) {
+        ensureDirectory()
+        directory.listFiles()
+            .orEmpty()
+            .filter(File::isFile)
+            .map(File::getName)
     }
 
-    override suspend fun create(title: String): LocalPlaylistOperationResult = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            val normalizedTitle = title.trim()
-            if (normalizedTitle.isBlank()) {
-                return@withLock LocalPlaylistOperationResult(false, "歌单名称不能为空")
+    override suspend fun readText(fileName: String): String? = withContext(Dispatchers.IO) {
+        val target = fileFor(fileName)
+        if (!target.isFile) return@withContext null
+        target.readText(Charsets.UTF_8)
+    }
+
+    override suspend fun writeTextAtomically(fileName: String, content: String) = withContext(Dispatchers.IO) {
+        ensureDirectory()
+        val target = fileFor(fileName)
+        val temp = File(directory, ".${target.name}.${System.nanoTime()}.tmp")
+        try {
+            FileOutputStream(temp).use { output ->
+                output.write(content.toByteArray(Charsets.UTF_8))
+                output.fd.sync()
             }
-            ensureDirectory()
-            val fileName = uniqueFileName(normalizedTitle)
-            val playlist = LocalPlaylist(
-                id = fileName,
-                fileName = fileName,
-                title = normalizedTitle,
-            )
-            writePlaylist(playlist)
-            LocalPlaylistOperationResult(true, "已新建歌单：$normalizedTitle", playlist)
-        }
-    }
-
-    override suspend fun delete(playlist: LocalPlaylist): LocalPlaylistOperationResult = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            val target = fileFor(playlist.fileName)
-            if (!target.exists() || !target.delete()) {
-                return@withLock LocalPlaylistOperationResult(false, "删除歌单失败：${playlist.title}")
-            }
-            LocalPlaylistOperationResult(true, "已删除歌单：${playlist.title}")
-        }
-    }
-
-    override suspend fun addTrack(
-        playlist: LocalPlaylist,
-        track: LocalPlaylistTrack,
-    ): LocalPlaylistOperationResult = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            val current = readPlaylist(fileFor(playlist.fileName))
-                ?: return@withLock LocalPlaylistOperationResult(false, "歌单不存在")
-            if (current.tracks.any { it.uri == track.uri }) {
-                return@withLock LocalPlaylistOperationResult(false, "歌曲已在歌单中", current)
-            }
-            val updated = current.copy(tracks = current.tracks + track)
-            writePlaylist(updated)
-            LocalPlaylistOperationResult(true, "已添加到：${current.title}", updated)
-        }
-    }
-
-    override suspend fun removeTrack(
-        playlist: LocalPlaylist,
-        uri: String,
-    ): LocalPlaylistOperationResult = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            val current = readPlaylist(fileFor(playlist.fileName))
-                ?: return@withLock LocalPlaylistOperationResult(false, "歌单不存在")
-            val updated = current.copy(tracks = current.tracks.filterNot { it.uri == uri })
-            writePlaylist(updated)
-            LocalPlaylistOperationResult(true, "已从歌单移除", updated)
-        }
-    }
-
-    override suspend fun importPlaylist(
-        preview: LocalPlaylistImportPreview,
-        mode: LocalPlaylistImportMode,
-        replacePlaylist: LocalPlaylist?,
-    ): LocalPlaylistOperationResult = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            ensureDirectory()
-            val target = when (mode) {
-                LocalPlaylistImportMode.Replace -> {
-                    replacePlaylist ?: return@withLock LocalPlaylistOperationResult(false, "没有可覆盖的歌单")
-                    LocalPlaylist(
-                        id = replacePlaylist.id,
-                        fileName = replacePlaylist.fileName,
-                        title = preview.title,
-                        description = preview.description,
-                        tracks = preview.tracks,
-                    )
+            if (!temp.renameTo(target)) {
+                if (target.exists() && !target.delete()) {
+                    error("无法替换本地歌单文件：${target.name}")
                 }
-                LocalPlaylistImportMode.CreateNew -> {
-                    val fileName = uniqueFileName(preview.title)
-                    LocalPlaylist(
-                        id = fileName,
-                        fileName = fileName,
-                        title = preview.title,
-                        description = preview.description,
-                        tracks = preview.tracks,
-                    )
-                }
+                check(temp.renameTo(target)) { "无法写入本地歌单文件：${target.name}" }
             }
-            writePlaylist(target)
-            val skippedMessage = preview.skippedLineCount.takeIf { it > 0 }
-                ?.let { "，已跳过 $it 行不支持内容" }
-                .orEmpty()
-            LocalPlaylistOperationResult(true, "已导入：${target.title}$skippedMessage", target)
+        } finally {
+            if (temp.exists()) temp.delete()
         }
+        Unit
     }
 
-    override suspend fun export(playlist: LocalPlaylist): LocalPlaylistFile = withContext(Dispatchers.IO) {
-        mutex.withLock {
-            val current = readPlaylist(fileFor(playlist.fileName)) ?: playlist
-            LocalPlaylistFile(current.fileName, LocalPlaylistFileCodec.encode(current))
-        }
+    override suspend fun delete(fileName: String): Boolean = withContext(Dispatchers.IO) {
+        val target = fileFor(fileName)
+        target.exists() && target.delete()
+    }
+
+    override suspend fun exists(fileName: String): Boolean = withContext(Dispatchers.IO) {
+        fileFor(fileName).exists()
     }
 
     private fun ensureDirectory() {
-        check(collectionsDirectory.exists() || collectionsDirectory.mkdirs()) {
+        check(directory.exists() || directory.mkdirs()) {
             "无法创建本地歌单目录"
         }
     }
 
-    private fun fileFor(fileName: String): File {
-        val safeName = File(fileName).name
-        return File(collectionsDirectory, safeName)
-    }
-
-    private fun readPlaylist(file: File): LocalPlaylist? {
-        if (!file.isFile) return null
-        return runCatching {
-            val preview = LocalPlaylistFileCodec.decode(file.name, file.readText(Charsets.UTF_8))
-            LocalPlaylist(
-                id = file.name,
-                fileName = file.name,
-                title = preview.title,
-                description = preview.description,
-                tracks = preview.tracks,
-            )
-        }.getOrNull()
-    }
-
-    private fun writePlaylist(playlist: LocalPlaylist) {
-        ensureDirectory()
-        val target = fileFor(playlist.fileName)
-        val temp = File(collectionsDirectory, ".${target.name}.${System.nanoTime()}.tmp")
-        FileOutputStream(temp).use { output ->
-            output.write(LocalPlaylistFileCodec.encode(playlist).toByteArray(Charsets.UTF_8))
-            output.fd.sync()
-        }
-        if (!temp.renameTo(target)) {
-            // renameTo is atomic on the same filesystem. The fallback is only
-            // for filesystems that refuse replacing an existing target.
-            if (target.exists() && !target.delete()) {
-                temp.delete()
-                error("无法替换本地歌单文件：${target.name}")
-            }
-            check(temp.renameTo(target)) { "无法写入本地歌单文件：${target.name}" }
-        }
-    }
-
-    private fun uniqueFileName(title: String): String {
-        val base = LocalPlaylistFileCodec.sanitizeFileName(title).ifBlank { "playlist" }
-        var candidate = "$base.$FILE_EXTENSION"
-        var index = 2
-        while (fileFor(candidate).exists()) {
-            candidate = "${base}_$index.$FILE_EXTENSION"
-            index += 1
-        }
-        return candidate
-    }
-
-    private companion object {
-        const val COLLECTIONS_DIRECTORY = "collections"
-        const val FILE_EXTENSION = "fuo"
-    }
+    private fun fileFor(fileName: String): File = File(directory, File(fileName).name)
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumePolicy.kt
@@ -1,9 +1,3 @@
 package org.feeluown.mobile
 
-/** Only established playback can become a durable resume point. */
-internal fun PlayerStatus.isDurablePlaybackResumeStatus(): Boolean =
-    this == PlayerStatus.Playing || this == PlayerStatus.Paused
-
-/** Only a new logical selection invalidates the previous durable resume point. */
-internal val PlaybackStartReason.clearsDurablePlaybackResume: Boolean
-    get() = isActiveSelection
+// Playback resume policy is platform-neutral and now lives in :feature:playback.

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.window.rememberWindowState
 import java.awt.Window as AwtWindow
 import javax.swing.SwingUtilities
 import org.feeluown.mobile.DesktopAppHost
+import org.feeluown.mobile.createDesktopPlaybackResumeStore
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
 import org.feeluown.mobile.installDesktopPlaybackEngineFactory
 import org.feeluown.mobile.installDesktopPlaybackSessionIntegrationFactory
@@ -22,7 +23,12 @@ import org.feeluown.mobile.installDesktopProviderCredentialStoreFactory
 import org.feeluown.mobile.installFallbackOAuthDeviceCodeAssistant
 
 fun main() {
-    installDesktopPlaybackEngineFactory { DesktopMpvPlaybackEngine() }
+    installDesktopPlaybackEngineFactory {
+        PersistentDesktopPlaybackEngine(
+            delegate = DesktopMpvPlaybackEngine(),
+            resumeStore = createDesktopPlaybackResumeStore(),
+        )
+    }
     installDesktopProviderCredentialStoreFactory { DesktopSecureProviderCredentialStore() }
     installDesktopLocalMusicRepositoryFactory { DesktopLocalMusicRepository() }
     installFallbackOAuthDeviceCodeAssistant(DesktopOAuthDeviceCodeAssistant())

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngine.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngine.kt
@@ -1,0 +1,217 @@
+package org.feeluown.mobile.desktop
+
+import kotlin.math.abs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackEngine
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.PlaybackPlan
+import org.feeluown.mobile.PlaybackResumeSnapshot
+import org.feeluown.mobile.PlaybackResumeStore
+import org.feeluown.mobile.PlaybackStartReason
+import org.feeluown.mobile.PlaybackStartReasonAwareEngine
+import org.feeluown.mobile.PlaybackState
+import org.feeluown.mobile.PlayerStatus
+import org.feeluown.mobile.ResolvedPlaybackSourceAwareEngine
+import org.feeluown.mobile.clearsDurablePlaybackResume
+import org.feeluown.mobile.isDurablePlaybackResumeStatus
+
+/**
+ * Adds durable session semantics around the native libmpv adapter.
+ *
+ * The wrapper persists only logical track/session state. URLs and provider credentials are resolved
+ * again by the shared playback transaction after restart, keeping the native engine free of stale
+ * network resources and keeping persistence policy outside the libmpv adapter itself.
+ */
+internal class PersistentDesktopPlaybackEngine(
+    private val delegate: PlaybackEngine,
+    private val resumeStore: PlaybackResumeStore,
+) : PlaybackEngine, PlaybackStartReasonAwareEngine, ResolvedPlaybackSourceAwareEngine, AutoCloseable {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var restoredSession: PlaybackResumeSnapshot? = resumeStore.load()
+    private var exposeRestoredState = restoredSession != null
+    private val mutableState = MutableStateFlow(restoredSession?.toPlaybackState() ?: delegate.state.value)
+
+    @Volatile
+    private var pendingResumePositionMs: Long? = null
+    private var lastPersistedIdentity: String? = null
+    private var lastPersistedPositionMs: Long = restoredSession?.positionMs ?: 0L
+
+    override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
+    override val resolvesResourcesInternally: Boolean
+        get() = delegate.resolvesResourcesInternally
+
+    init {
+        scope.launch {
+            delegate.state.collect { next ->
+                if (exposeRestoredState && next.currentTrack == null && next.status == PlayerStatus.Idle) {
+                    return@collect
+                }
+                exposeRestoredState = false
+                mutableState.value = next
+                if (applyPendingResumeSeek(next)) return@collect
+                persist(next)
+            }
+        }
+    }
+
+    override fun prepareLoading(track: MusicTrack) {
+        prepareLoading(track, PlaybackStartReason.RESTORE_SESSION)
+    }
+
+    override fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason) {
+        val restored = if (reason.mayResumePausedSession) {
+            restoredSession ?: resumeStore.load()
+        } else {
+            null
+        }
+        pendingResumePositionMs = restored
+            ?.takeIf { session -> session.currentTrack.id == track.id }
+            ?.positionMs
+            ?.coerceAtLeast(0L)
+
+        if (reason.clearsDurablePlaybackResume) {
+            restoredSession = null
+            pendingResumePositionMs = null
+            lastPersistedIdentity = null
+            lastPersistedPositionMs = 0L
+            resumeStore.clear()
+        }
+        exposeRestoredState = false
+        delegate.prepareLoading(track)
+    }
+
+    override fun play(track: MusicTrack, payload: PlaybackPayload) {
+        delegate.play(track, payload)
+    }
+
+    override fun play(plan: PlaybackPlan) {
+        delegate.play(plan)
+    }
+
+    override fun playResolved(
+        logicalTrack: MusicTrack,
+        resolveTrack: MusicTrack,
+        payload: PlaybackPayload,
+    ) {
+        val sourceAware = delegate as? ResolvedPlaybackSourceAwareEngine
+        if (sourceAware != null) {
+            sourceAware.playResolved(logicalTrack, resolveTrack, payload)
+        } else {
+            delegate.play(logicalTrack, payload)
+        }
+    }
+
+    override fun pause() {
+        delegate.pause()
+        delegate.state.value.takeIf { it.status.isDurablePlaybackResumeStatus() }?.let {
+            resumeStore.saveSession(it)
+            rememberPersisted(it)
+        }
+    }
+
+    override fun resume() {
+        delegate.resume()
+    }
+
+    override fun stop() {
+        pendingResumePositionMs = null
+        restoredSession = null
+        exposeRestoredState = false
+        lastPersistedIdentity = null
+        lastPersistedPositionMs = 0L
+        resumeStore.clear()
+        delegate.stop()
+    }
+
+    override fun seekTo(positionMs: Long) {
+        pendingResumePositionMs = null
+        delegate.seekTo(positionMs)
+        val current = delegate.state.value
+        if (current.currentTrack != null && current.status.isDurablePlaybackResumeStatus()) {
+            resumeStore.savePosition(current.positionMs, current.durationMs)
+            lastPersistedPositionMs = current.positionMs
+        }
+    }
+
+    override fun setStopAfterCurrentTrack(enabled: Boolean) {
+        delegate.setStopAfterCurrentTrack(enabled)
+    }
+
+    override fun close() {
+        val current = delegate.state.value
+        if (current.currentTrack != null && current.status.isDurablePlaybackResumeStatus()) {
+            resumeStore.saveSession(current)
+        }
+        resumeStore.flush()
+        scope.cancel()
+        (delegate as? AutoCloseable)?.close()
+    }
+
+    private fun applyPendingResumeSeek(state: PlaybackState): Boolean {
+        val position = pendingResumePositionMs ?: return false
+        if (state.currentTrack == null || state.status != PlayerStatus.Playing) return false
+        pendingResumePositionMs = null
+        delegate.seekTo(position)
+        return true
+    }
+
+    private fun persist(state: PlaybackState) {
+        val track = state.currentTrack ?: return
+        if (!state.status.isDurablePlaybackResumeStatus()) return
+
+        val identity = buildString {
+            append(track.id)
+            append('|')
+            append(state.currentPartIndex)
+            append('|')
+            state.playbackParts.forEach { part ->
+                append(part.id)
+                append(',')
+            }
+        }
+        if (identity != lastPersistedIdentity) {
+            resumeStore.saveSession(state)
+            rememberPersisted(state)
+            restoredSession = PlaybackResumeSnapshot(
+                currentTrack = track,
+                positionMs = state.positionMs,
+                durationMs = state.durationMs,
+                playbackParts = state.playbackParts,
+                currentPartIndex = state.currentPartIndex,
+            )
+            return
+        }
+
+        if (abs(state.positionMs - lastPersistedPositionMs) >= POSITION_PERSIST_INTERVAL_MS) {
+            resumeStore.savePosition(state.positionMs, state.durationMs)
+            lastPersistedPositionMs = state.positionMs
+        }
+    }
+
+    private fun rememberPersisted(state: PlaybackState) {
+        val track = state.currentTrack ?: return
+        lastPersistedIdentity = buildString {
+            append(track.id)
+            append('|')
+            append(state.currentPartIndex)
+            append('|')
+            state.playbackParts.forEach { part ->
+                append(part.id)
+                append(',')
+            }
+        }
+        lastPersistedPositionMs = state.positionMs
+    }
+
+    private companion object {
+        const val POSITION_PERSIST_INTERVAL_MS = 5_000L
+    }
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngine.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngine.kt
@@ -68,7 +68,7 @@ internal class PersistentDesktopPlaybackEngine(
 
     override fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason) {
         val restored = if (reason.mayResumePausedSession) {
-            restoredSession ?: resumeStore.load()
+            resumeStore.load()?.also { restoredSession = it }
         } else {
             null
         }

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngineTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngineTest.kt
@@ -71,6 +71,35 @@ class PersistentDesktopPlaybackEngineTest {
         engine.close()
     }
 
+    @Test
+    fun resumeUsesLatestPersistedPositionInsteadOfInitialCachedSnapshot() {
+        val restoredTrack = track("a")
+        val store = FakeResumeStore(
+            PlaybackResumeSnapshot(
+                currentTrack = restoredTrack,
+                positionMs = 42_000L,
+                durationMs = 180_000L,
+            ),
+        )
+        val delegate = FakePlaybackEngine()
+        val engine = PersistentDesktopPlaybackEngine(delegate, store)
+
+        store.savePosition(88_000L, 180_000L)
+        engine.prepareLoading(restoredTrack, PlaybackStartReason.RESUME)
+        engine.playResolved(
+            logicalTrack = restoredTrack,
+            resolveTrack = restoredTrack,
+            payload = payload(restoredTrack),
+        )
+
+        repeat(100) {
+            if (delegate.lastSeekPositionMs == 88_000L) return@repeat
+            Thread.sleep(5)
+        }
+        assertEquals(88_000L, delegate.lastSeekPositionMs)
+        engine.close()
+    }
+
     private fun track(id: String) = MusicTrack(
         id = "netease:$id",
         title = "Track $id",

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngineTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/PersistentDesktopPlaybackEngineTest.kt
@@ -1,0 +1,162 @@
+package org.feeluown.mobile.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackEngine
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.PlaybackResumeSnapshot
+import org.feeluown.mobile.PlaybackResumeStore
+import org.feeluown.mobile.PlaybackStartReason
+import org.feeluown.mobile.PlaybackState
+import org.feeluown.mobile.PlayerStatus
+import org.feeluown.mobile.ResolvedPlaybackSourceAwareEngine
+import org.feeluown.mobile.TrackSourceType
+
+class PersistentDesktopPlaybackEngineTest {
+    @Test
+    fun restoredStateIsVisibleUntilUserSelectsAnotherTrack() {
+        val restoredTrack = track("a")
+        val selectedTrack = track("b")
+        val store = FakeResumeStore(
+            PlaybackResumeSnapshot(
+                currentTrack = restoredTrack,
+                positionMs = 42_000L,
+                durationMs = 180_000L,
+            ),
+        )
+        val delegate = FakePlaybackEngine()
+        val engine = PersistentDesktopPlaybackEngine(delegate, store)
+
+        assertEquals(PlayerStatus.Paused, engine.state.value.status)
+        assertEquals(restoredTrack.id, engine.state.value.currentTrack?.id)
+        assertEquals(42_000L, engine.state.value.positionMs)
+
+        engine.prepareLoading(selectedTrack, PlaybackStartReason.USER_SELECTION)
+
+        assertTrue(store.cleared)
+        assertEquals(selectedTrack.id, delegate.preparedTrack?.id)
+        engine.close()
+    }
+
+    @Test
+    fun resumeReResolvesTrackThenSeeksToPersistedPosition() {
+        val restoredTrack = track("a")
+        val store = FakeResumeStore(
+            PlaybackResumeSnapshot(
+                currentTrack = restoredTrack,
+                positionMs = 42_000L,
+                durationMs = 180_000L,
+            ),
+        )
+        val delegate = FakePlaybackEngine()
+        val engine = PersistentDesktopPlaybackEngine(delegate, store)
+
+        engine.prepareLoading(restoredTrack, PlaybackStartReason.RESUME)
+        engine.playResolved(
+            logicalTrack = restoredTrack,
+            resolveTrack = restoredTrack,
+            payload = payload(restoredTrack),
+        )
+
+        repeat(100) {
+            if (delegate.lastSeekPositionMs == 42_000L) return@repeat
+            Thread.sleep(5)
+        }
+        assertEquals(42_000L, delegate.lastSeekPositionMs)
+        engine.close()
+    }
+
+    private fun track(id: String) = MusicTrack(
+        id = "netease:$id",
+        title = "Track $id",
+        artists = "Artist",
+        album = "Album",
+        source = "netease",
+        sourceType = TrackSourceType.Provider,
+        durationMs = 180_000L,
+        providerId = "netease:$id",
+        providerName = "网易云音乐",
+    )
+
+    private fun payload(track: MusicTrack) = PlaybackPayload(
+        url = "https://example.invalid/${track.id}.mp3",
+        title = track.title,
+        artists = track.artists,
+        album = track.album,
+        source = track.source,
+        durationMs = track.durationMs,
+    )
+}
+
+private class FakeResumeStore(
+    private var snapshot: PlaybackResumeSnapshot?,
+) : PlaybackResumeStore {
+    var cleared = false
+    override fun load(): PlaybackResumeSnapshot? = snapshot
+    override fun saveSession(state: PlaybackState) {
+        val track = state.currentTrack ?: return
+        snapshot = PlaybackResumeSnapshot(track, state.positionMs, state.durationMs, state.playbackParts, state.currentPartIndex)
+    }
+    override fun savePosition(positionMs: Long, durationMs: Long) {
+        snapshot = snapshot?.copy(positionMs = positionMs, durationMs = durationMs)
+    }
+    override fun flush() = Unit
+    override fun clear() {
+        cleared = true
+        snapshot = null
+    }
+}
+
+private class FakePlaybackEngine : PlaybackEngine, ResolvedPlaybackSourceAwareEngine {
+    private val mutableState = MutableStateFlow(PlaybackState())
+    override val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
+    var preparedTrack: MusicTrack? = null
+    var lastSeekPositionMs: Long? = null
+
+    override fun prepareLoading(track: MusicTrack) {
+        preparedTrack = track
+        mutableState.value = PlaybackState(
+            status = PlayerStatus.Loading,
+            currentTrack = track,
+            durationMs = track.durationMs ?: 0L,
+        )
+    }
+
+    override fun play(track: MusicTrack, payload: PlaybackPayload) {
+        mutableState.value = PlaybackState(
+            status = PlayerStatus.Playing,
+            currentTrack = track,
+            durationMs = payload.durationMs ?: track.durationMs ?: 0L,
+        )
+    }
+
+    override fun playResolved(
+        logicalTrack: MusicTrack,
+        resolveTrack: MusicTrack,
+        payload: PlaybackPayload,
+    ) {
+        play(logicalTrack, payload)
+    }
+
+    override fun pause() {
+        mutableState.value = mutableState.value.copy(status = PlayerStatus.Paused)
+    }
+
+    override fun resume() {
+        mutableState.value = mutableState.value.copy(status = PlayerStatus.Playing)
+    }
+
+    override fun stop() {
+        mutableState.value = PlaybackState()
+    }
+
+    override fun seekTo(positionMs: Long) {
+        lastSeekPositionMs = positionMs
+        mutableState.value = mutableState.value.copy(positionMs = positionMs)
+    }
+}

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
@@ -502,16 +502,24 @@ private class DefaultPlaybackFeatureOwner(
 
     private fun restorePlaybackQueue(snapshot: PlaybackQueueSnapshot) {
         if (!queueState.restore(snapshot)) return
-        playbackParts = emptyList()
-        currentPartIndex = -1
-        updatePlaybackState { current ->
-            current.copy(
-                currentTrack = queueState.mainQueue.getOrNull(queueState.mainQueueIndex),
+        val restoredTrack = queueState.mainQueue.getOrNull(queueState.mainQueueIndex)
+        val current = playbackState.value
+        val preserveRestoredSession = restoredTrack != null && current.currentTrack?.id == restoredTrack.id
+        if (preserveRestoredSession) {
+            playbackParts = current.playbackParts
+            currentPartIndex = current.currentPartIndex
+        } else {
+            playbackParts = emptyList()
+            currentPartIndex = -1
+        }
+        updatePlaybackState {
+            it.copy(
+                currentTrack = restoredTrack,
                 resolvedSource = null,
                 queue = queueState.displayQueue(),
                 queueIndex = queueState.displayQueueIndex(),
-                playbackParts = emptyList(),
-                currentPartIndex = -1,
+                playbackParts = playbackParts,
+                currentPartIndex = currentPartIndex,
             )
         }
     }

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
@@ -66,7 +66,9 @@ internal class PlaybackQueueCoordinator(
 
     override fun startCurrent() {
         (queueState.currentTrack() ?: fallbackTrack())?.let { track ->
-            startTrack(track, 0, null, PlaybackStartReason.RESUME)
+            val parts = playbackParts()
+            val resumePartIndex = currentPartIndex().takeIf { it in parts.indices }
+            startTrack(track, 0, resumePartIndex, PlaybackStartReason.RESUME)
         }
     }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackResumePersistence.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackResumePersistence.kt
@@ -1,0 +1,154 @@
+package org.feeluown.mobile
+
+/** Only established playback can become a durable resume point. */
+fun PlayerStatus.isDurablePlaybackResumeStatus(): Boolean =
+    this == PlayerStatus.Playing || this == PlayerStatus.Paused
+
+/** Only a new logical selection invalidates the previous durable resume point. */
+val PlaybackStartReason.clearsDurablePlaybackResume: Boolean
+    get() = isActiveSelection
+
+/**
+ * Platform-neutral durable playback resume state.
+ *
+ * Physical media URLs are deliberately excluded. A restored session re-enters the normal provider
+ * resolution transaction, so expired URLs/tokens are never persisted across application launches.
+ */
+data class PlaybackResumeSnapshot(
+    val currentTrack: MusicTrack,
+    val positionMs: Long,
+    val durationMs: Long,
+    val playbackParts: List<PlaybackPart> = emptyList(),
+    val currentPartIndex: Int = -1,
+) {
+    fun toPlaybackState(): PlaybackState {
+        val normalizedDuration = durationMs.takeIf { it > 0L } ?: currentTrack.durationMs ?: 0L
+        val normalizedPosition = positionMs.coerceAtLeast(0L).let { position ->
+            normalizedDuration.takeIf { it > 0L }?.let(position::coerceAtMost) ?: position
+        }
+        return PlaybackState(
+            status = PlayerStatus.Paused,
+            currentTrack = currentTrack,
+            positionMs = normalizedPosition,
+            durationMs = normalizedDuration,
+            playbackParts = playbackParts,
+            currentPartIndex = currentPartIndex.takeIf { it in playbackParts.indices } ?: -1,
+            lyrics = currentTrack.lyrics,
+        )
+    }
+}
+
+/** Blocking store: platform implementations own their IO/threading policy. */
+interface PlaybackResumeStore {
+    fun load(): PlaybackResumeSnapshot?
+    fun saveSession(state: PlaybackState)
+    fun savePosition(positionMs: Long, durationMs: Long)
+    fun flush()
+    fun clear()
+}
+
+object NoOpPlaybackResumeStore : PlaybackResumeStore {
+    override fun load(): PlaybackResumeSnapshot? = null
+    override fun saveSession(state: PlaybackState) = Unit
+    override fun savePosition(positionMs: Long, durationMs: Long) = Unit
+    override fun flush() = Unit
+    override fun clear() = Unit
+}
+
+/** Text codec shared by desktop stores and future platform persistence adapters. */
+object PlaybackResumeCodec {
+    private const val VERSION = "v1"
+    private const val QUEUE_MARKER = "--track--"
+
+    fun encode(snapshot: PlaybackResumeSnapshot): String = buildString {
+        appendLine(VERSION)
+        appendLine(
+            listOf(
+                snapshot.positionMs.coerceAtLeast(0L).toString(),
+                snapshot.durationMs.coerceAtLeast(0L).toString(),
+                snapshot.currentPartIndex.toString(),
+            ).joinToString("\t")
+        )
+        snapshot.playbackParts.forEach { part ->
+            append("part\t")
+            append(escape(part.id))
+            append('\t')
+            append(escape(part.title))
+            append('\t')
+            append(part.durationMs?.toString().orEmpty())
+            appendLine()
+        }
+        appendLine(QUEUE_MARKER)
+        append(
+            PlaybackQueueCodec.encode(
+                PlaybackQueueSnapshot(
+                    mainQueue = listOf(snapshot.currentTrack),
+                    queueIndex = 0,
+                )
+            )
+        )
+    }
+
+    fun decode(raw: String): PlaybackResumeSnapshot? {
+        val normalized = raw.replace("\r\n", "\n").replace('\r', '\n')
+        val marker = normalized.indexOf("\n$QUEUE_MARKER\n")
+        if (marker < 0) return null
+        val headerLines = normalized.substring(0, marker).lineSequence().filter(String::isNotBlank).toList()
+        if (headerLines.firstOrNull() != VERSION) return null
+        val state = headerLines.getOrNull(1)?.split('\t') ?: return null
+        val queueRaw = normalized.substring(marker + QUEUE_MARKER.length + 2)
+        val track = runCatching { PlaybackQueueCodec.decode(queueRaw).mainQueue.firstOrNull() }.getOrNull() ?: return null
+        val parts = headerLines.drop(2).mapNotNull { line ->
+            val fields = line.split('\t')
+            if (fields.firstOrNull() != "part" || fields.size < 3) return@mapNotNull null
+            PlaybackPart(
+                id = unescape(fields[1]),
+                title = unescape(fields[2]),
+                durationMs = fields.getOrNull(3)?.toLongOrNull()?.takeIf { it > 0L },
+            )
+        }
+        return PlaybackResumeSnapshot(
+            currentTrack = track,
+            positionMs = state.getOrNull(0)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+            durationMs = state.getOrNull(1)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+            playbackParts = parts,
+            currentPartIndex = state.getOrNull(2)?.toIntOrNull() ?: -1,
+        )
+    }
+
+    private fun escape(value: String): String = buildString {
+        value.forEach { char ->
+            when (char) {
+                '%' -> append("%25")
+                '\t' -> append("%09")
+                '\n' -> append("%0A")
+                '\r' -> append("%0D")
+                else -> append(char)
+            }
+        }
+    }
+
+    private fun unescape(value: String): String {
+        val result = StringBuilder()
+        var index = 0
+        while (index < value.length) {
+            if (value[index] == '%' && index + 2 < value.length) {
+                val decoded = when (value.substring(index + 1, index + 3)) {
+                    "25" -> '%'
+                    "09" -> '\t'
+                    "0A" -> '\n'
+                    "0D" -> '\r'
+                    else -> null
+                }
+                if (decoded != null) {
+                    result.append(decoded)
+                    index += 3
+                    continue
+                }
+            }
+            result.append(value[index])
+            index += 1
+        }
+        return result.toString()
+    }
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCoordinatorTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueCoordinatorTest.kt
@@ -221,6 +221,30 @@ class PlaybackQueueCoordinatorTest {
     }
 
     @Test
+    fun startCurrentPreservesRestoredPlaybackPart() = runTest {
+        val current = track("main:1")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(current)
+            mainQueueIndex = 0
+        }
+        var started: StartRequest? = null
+        val coordinator = coordinator(
+            queue = queue,
+            parts = listOf(
+                PlaybackPart("part:1", "P1"),
+                PlaybackPart("part:2", "P2"),
+            ),
+            currentPartIndex = 1,
+            onStart = { track, skipped, part -> started = StartRequest(track, skipped, part) },
+        )
+
+        coordinator.startCurrent()
+
+        assertEquals(current, started?.track)
+        assertEquals(1, started?.partIndex)
+    }
+
+    @Test
     fun explicitMainSelectionResetsDirectionAfterPrevious() = runTest {
         val first = track("main:1")
         val second = track("main:2")

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResumePersistenceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResumePersistenceTest.kt
@@ -1,0 +1,44 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PlaybackResumePersistenceTest {
+    @Test
+    fun resumeSnapshotRoundTripsLogicalTrackAndParts() {
+        val track = MusicTrack(
+            id = "bilibili:BV1",
+            title = "Title",
+            artists = "Artist",
+            album = "Album",
+            source = "bilibili",
+            sourceType = TrackSourceType.Provider,
+            coverUrl = "https://example.invalid/cover.jpg",
+            durationMs = 180_000L,
+            providerId = "bilibili:BV1",
+            providerName = "哔哩哔哩",
+        )
+        val snapshot = PlaybackResumeSnapshot(
+            currentTrack = track,
+            positionMs = 42_000L,
+            durationMs = 180_000L,
+            playbackParts = listOf(
+                PlaybackPart("part-1", "第一段", 90_000L),
+                PlaybackPart("part-2", "第二段\tLive", 90_000L),
+            ),
+            currentPartIndex = 1,
+        )
+
+        val decoded = PlaybackResumeCodec.decode(PlaybackResumeCodec.encode(snapshot))
+
+        assertEquals(snapshot, decoded)
+        assertEquals(PlayerStatus.Paused, decoded?.toPlaybackState()?.status)
+        assertEquals(42_000L, decoded?.toPlaybackState()?.positionMs)
+    }
+
+    @Test
+    fun invalidResumePayloadIsIgnored() {
+        assertNull(PlaybackResumeCodec.decode("broken"))
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/FileBackedLocalPlaylistRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/localplaylist/FileBackedLocalPlaylistRepository.kt
@@ -1,0 +1,158 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Minimal persistence boundary for local playlist collection files.
+ *
+ * File naming, directory selection and atomic replacement are platform responsibilities. The
+ * playlist lifecycle and `.fuo` semantics stay in common code so desktop/mobile hosts do not grow
+ * parallel repository implementations.
+ */
+interface LocalPlaylistFileStorage {
+    suspend fun listFileNames(): List<String>
+    suspend fun readText(fileName: String): String?
+    suspend fun writeTextAtomically(fileName: String, content: String)
+    suspend fun delete(fileName: String): Boolean
+    suspend fun exists(fileName: String): Boolean
+}
+
+class FileBackedLocalPlaylistRepository(
+    private val storage: LocalPlaylistFileStorage,
+    private val fileExtension: String = "fuo",
+) : LocalPlaylistRepository {
+    private val mutex = Mutex()
+
+    override suspend fun list(): List<LocalPlaylist> = locked {
+        storage.listFileNames()
+            .filter { it.substringAfterLast('.', missingDelimiterValue = "").equals(fileExtension, ignoreCase = true) }
+            .sorted()
+            .mapNotNull { fileName -> readPlaylist(fileName) }
+    }
+
+    override suspend fun create(title: String): LocalPlaylistOperationResult = locked {
+        val normalizedTitle = title.trim()
+        if (normalizedTitle.isBlank()) {
+            return@locked LocalPlaylistOperationResult(false, "歌单名称不能为空")
+        }
+        val fileName = uniqueFileName(normalizedTitle)
+        val playlist = LocalPlaylist(
+            id = fileName,
+            fileName = fileName,
+            title = normalizedTitle,
+        )
+        writePlaylist(playlist)
+        LocalPlaylistOperationResult(true, "已新建歌单：$normalizedTitle", playlist)
+    }
+
+    override suspend fun delete(playlist: LocalPlaylist): LocalPlaylistOperationResult = locked {
+        if (!storage.delete(playlist.fileName)) {
+            return@locked LocalPlaylistOperationResult(false, "删除歌单失败：${playlist.title}")
+        }
+        LocalPlaylistOperationResult(true, "已删除歌单：${playlist.title}")
+    }
+
+    override suspend fun addTrack(
+        playlist: LocalPlaylist,
+        track: LocalPlaylistTrack,
+    ): LocalPlaylistOperationResult = locked {
+        val current = readPlaylist(playlist.fileName)
+            ?: return@locked LocalPlaylistOperationResult(false, "歌单不存在")
+        if (current.tracks.any { it.uri == track.uri }) {
+            return@locked LocalPlaylistOperationResult(false, "歌曲已在歌单中", current)
+        }
+        val updated = current.copy(tracks = current.tracks + track)
+        writePlaylist(updated)
+        LocalPlaylistOperationResult(true, "已添加到：${current.title}", updated)
+    }
+
+    override suspend fun removeTrack(
+        playlist: LocalPlaylist,
+        uri: String,
+    ): LocalPlaylistOperationResult = locked {
+        val current = readPlaylist(playlist.fileName)
+            ?: return@locked LocalPlaylistOperationResult(false, "歌单不存在")
+        val updated = current.copy(tracks = current.tracks.filterNot { it.uri == uri })
+        writePlaylist(updated)
+        LocalPlaylistOperationResult(true, "已从歌单移除", updated)
+    }
+
+    override suspend fun importPlaylist(
+        preview: LocalPlaylistImportPreview,
+        mode: LocalPlaylistImportMode,
+        replacePlaylist: LocalPlaylist?,
+    ): LocalPlaylistOperationResult = locked {
+        val target = when (mode) {
+            LocalPlaylistImportMode.Replace -> {
+                val existing = replacePlaylist
+                    ?: return@locked LocalPlaylistOperationResult(false, "没有可覆盖的歌单")
+                LocalPlaylist(
+                    id = existing.id,
+                    fileName = existing.fileName,
+                    title = preview.title,
+                    description = preview.description,
+                    tracks = preview.tracks,
+                )
+            }
+
+            LocalPlaylistImportMode.CreateNew -> {
+                val fileName = uniqueFileName(preview.title)
+                LocalPlaylist(
+                    id = fileName,
+                    fileName = fileName,
+                    title = preview.title,
+                    description = preview.description,
+                    tracks = preview.tracks,
+                )
+            }
+        }
+        writePlaylist(target)
+        val skippedMessage = preview.skippedLineCount.takeIf { it > 0 }
+            ?.let { "，已跳过 $it 行不支持内容" }
+            .orEmpty()
+        LocalPlaylistOperationResult(true, "已导入：${target.title}$skippedMessage", target)
+    }
+
+    override suspend fun export(playlist: LocalPlaylist): LocalPlaylistFile = locked {
+        val current = readPlaylist(playlist.fileName) ?: playlist
+        LocalPlaylistFile(current.fileName, LocalPlaylistFileCodec.encode(current))
+    }
+
+    private suspend fun readPlaylist(fileName: String): LocalPlaylist? {
+        val raw = storage.readText(fileName) ?: return null
+        return runCatching {
+            val preview = LocalPlaylistFileCodec.decode(fileName, raw)
+            LocalPlaylist(
+                id = fileName,
+                fileName = fileName,
+                title = preview.title,
+                description = preview.description,
+                tracks = preview.tracks,
+            )
+        }.getOrNull()
+    }
+
+    private suspend fun writePlaylist(playlist: LocalPlaylist) {
+        storage.writeTextAtomically(playlist.fileName, LocalPlaylistFileCodec.encode(playlist))
+    }
+
+    private suspend fun uniqueFileName(title: String): String {
+        val base = LocalPlaylistFileCodec.sanitizeFileName(title).ifBlank { "playlist" }
+        var candidate = "$base.$fileExtension"
+        var index = 2
+        while (storage.exists(candidate)) {
+            candidate = "${base}_$index.$fileExtension"
+            index += 1
+        }
+        return candidate
+    }
+
+    private suspend inline fun <T> locked(crossinline block: suspend () -> T): T {
+        mutex.lock()
+        return try {
+            block()
+        } finally {
+            mutex.unlock()
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/FileBackedLocalPlaylistRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/FileBackedLocalPlaylistRepositoryTest.kt
@@ -1,0 +1,71 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class FileBackedLocalPlaylistRepositoryTest {
+    @Test
+    fun persistsCreateAndTrackMutationAcrossRepositoryInstances() = runTest {
+        val storage = MemoryLocalPlaylistStorage()
+        val first = FileBackedLocalPlaylistRepository(storage)
+
+        val created = first.create("桌面歌单")
+        assertTrue(created.success)
+        val playlist = assertNotNull(created.playlist)
+        val track = LocalPlaylistTrack(
+            uri = "fuo://netease/songs/123",
+            providerId = "netease",
+            identifier = "123",
+            title = "Song",
+            artists = "Artist",
+        )
+        assertTrue(first.addTrack(playlist, track).success)
+
+        val restored = FileBackedLocalPlaylistRepository(storage).list().single()
+        assertEquals("桌面歌单", restored.title)
+        assertEquals(listOf(track), restored.tracks)
+    }
+
+    @Test
+    fun importUsesUniqueNamesAndExportReadsDurableContent() = runTest {
+        val storage = MemoryLocalPlaylistStorage()
+        val repository = FileBackedLocalPlaylistRepository(storage)
+        val preview = LocalPlaylistImportPreview(
+            fileName = "mix.fuo",
+            title = "Mix",
+            tracks = listOf(
+                LocalPlaylistTrack(
+                    uri = "fuo://qqmusic/songs/abc",
+                    providerId = "qqmusic",
+                    identifier = "abc",
+                    title = "Track",
+                ),
+            ),
+        )
+
+        val first = assertNotNull(repository.importPlaylist(preview, LocalPlaylistImportMode.CreateNew).playlist)
+        val second = assertNotNull(repository.importPlaylist(preview, LocalPlaylistImportMode.CreateNew).playlist)
+        assertEquals("Mix.fuo", first.fileName)
+        assertEquals("Mix_2.fuo", second.fileName)
+
+        val exported = repository.export(first)
+        val decoded = LocalPlaylistFileCodec.decode(exported.fileName, exported.content)
+        assertEquals("Mix", decoded.title)
+        assertEquals(1, decoded.tracks.size)
+    }
+}
+
+private class MemoryLocalPlaylistStorage : LocalPlaylistFileStorage {
+    private val files = linkedMapOf<String, String>()
+
+    override suspend fun listFileNames(): List<String> = files.keys.toList()
+    override suspend fun readText(fileName: String): String? = files[fileName]
+    override suspend fun writeTextAtomically(fileName: String, content: String) {
+        files[fileName] = content
+    }
+    override suspend fun delete(fileName: String): Boolean = files.remove(fileName) != null
+    override suspend fun exists(fileName: String): Boolean = fileName in files
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppDirectories.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppDirectories.kt
@@ -1,0 +1,35 @@
+package org.feeluown.mobile
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/** Desktop-only directory policy. Common features receive stores/repositories, never OS paths. */
+internal object DesktopAppDirectories {
+    fun data(): Path {
+        val home = System.getProperty("user.home").orEmpty()
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val base = when {
+            osName.contains("win") -> System.getenv("LOCALAPPDATA")?.takeIf(String::isNotBlank)
+                ?: System.getenv("APPDATA")?.takeIf(String::isNotBlank)
+                ?: "$home/AppData/Local"
+            osName.contains("mac") -> "$home/Library/Application Support"
+            else -> System.getenv("XDG_DATA_HOME")?.takeIf(String::isNotBlank)
+                ?: "$home/.local/share"
+        }
+        return Paths.get(base, "FuoEvolve")
+    }
+
+    fun state(): Path {
+        val home = System.getProperty("user.home").orEmpty()
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val base = when {
+            osName.contains("win") -> System.getenv("LOCALAPPDATA")?.takeIf(String::isNotBlank)
+                ?: System.getenv("APPDATA")?.takeIf(String::isNotBlank)
+                ?: "$home/AppData/Local"
+            osName.contains("mac") -> "$home/Library/Application Support"
+            else -> System.getenv("XDG_STATE_HOME")?.takeIf(String::isNotBlank)
+                ?: "$home/.local/state"
+        }
+        return Paths.get(base, "FuoEvolve")
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
@@ -36,6 +36,8 @@ fun DesktopAppHost() {
                 },
                 onOpenProviderWebLogin = container::openProviderWebLogin,
                 onLogoutProvider = container::logoutProvider,
+                onImportLocalPlaylistFile = container::importLocalPlaylistFile,
+                onExportLocalPlaylistFile = container::exportLocalPlaylistFile,
                 appVersionInfo = "Desktop development build",
             ),
         )
@@ -65,7 +67,7 @@ private class DesktopAppContainer {
         providerPlaybackSource = providerGraph.playbackSource,
     )
     private val localRepository: LocalMusicRepository = DesktopUnsupportedLocalMusicRepository
-    private val localPlaylistRepository: LocalPlaylistRepository = NoOpLocalPlaylistRepository
+    private val localPlaylistRepository: LocalPlaylistRepository = createDesktopLocalPlaylistRepository()
     private val desktopDownloadRepository = DesktopDownloadRepository(
         resolvePayload = { track -> playbackProvider.resolve(track) },
     )
@@ -80,7 +82,8 @@ private class DesktopAppContainer {
     private val navigator = AppNavigator()
     private val trackNavigationPort: TrackNavigationPort = createTrackNavigationPort(navigator)
     private val homeRefreshPort: HomeRefreshPort by lazy { createHomeRefreshPort { homeFeatureController } }
-    private val playbackQueueStore: PlaybackQueueStore = NoOpPlaybackQueueStore
+    private val playbackResumeStore: PlaybackResumeStore = createDesktopPlaybackResumeStore()
+    private val playbackQueueStore = createDesktopPlaybackQueueStore(playbackResumeStore)
     private val listeningHistorySink: ListeningHistorySink = NoOpListeningHistorySink
     private val resourceCacheRepository: ResourceCacheRepository = NoOpResourceCacheRepository
     private val debugLogFeatureController by lazy {
@@ -407,10 +410,38 @@ private class DesktopAppContainer {
         providerAuthFeatureController.logout(provider.providerId)
     }
 
+    fun importLocalPlaylistFile() {
+        val file = openDesktopTextFile(
+            dialogTitle = "导入本地歌单",
+            filterDescription = "FeelUOwn 歌单 (*.fuo)",
+            extensions = listOf("fuo"),
+            onFeedback = appViewModel::showFeedback,
+        ) ?: return
+        if (file.content.isBlank()) {
+            appViewModel.showFeedback("无法读取本地歌单文件")
+            return
+        }
+        runCatching { localPlaylistFeatureController.prepareImport(file.fileName, file.content) }
+            .onFailure { appViewModel.showFeedback(it.message ?: "无法解析本地歌单文件") }
+    }
+
+    fun exportLocalPlaylistFile(fileName: String, content: String) {
+        val saved = saveDesktopTextFile(
+            dialogTitle = "导出本地歌单",
+            suggestedFileName = fileName,
+            filterDescription = "FeelUOwn 歌单 (*.fuo)",
+            extensions = listOf("fuo"),
+            content = content,
+            onFeedback = appViewModel::showFeedback,
+        )
+        if (saved) appViewModel.showFeedback("本地歌单已导出")
+    }
+
     fun close() {
         if (playbackSessionIntegration.isInitialized()) {
             playbackSessionIntegration.value.close()
         }
+        playbackQueueStore.flushLatest()
         webLoginLauncher.close()
         scope.cancel()
         desktopDownloadRepository.close()

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopLocalPlaylistRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopLocalPlaylistRepository.kt
@@ -22,7 +22,7 @@ private class DesktopLocalPlaylistFileStorage(
     override suspend fun listFileNames(): List<String> = withContext(Dispatchers.IO) {
         ensureDirectory()
         Files.list(directory).use { paths ->
-            paths.filter(Files::isRegularFile)
+            paths.filter { Files.isRegularFile(it) }
                 .map { it.fileName.toString() }
                 .toList()
         }
@@ -34,7 +34,7 @@ private class DesktopLocalPlaylistFileStorage(
         Files.readString(target, StandardCharsets.UTF_8)
     }
 
-    override suspend fun writeTextAtomically(fileName: String, content: String) = withContext(Dispatchers.IO) {
+    override suspend fun writeTextAtomically(fileName: String, content: String): Unit = withContext(Dispatchers.IO) {
         ensureDirectory()
         val target = fileFor(fileName)
         val temp = Files.createTempFile(directory, ".${target.fileName}.", ".tmp")
@@ -56,6 +56,7 @@ private class DesktopLocalPlaylistFileStorage(
         } finally {
             Files.deleteIfExists(temp)
         }
+        Unit
     }
 
     override suspend fun delete(fileName: String): Boolean = withContext(Dispatchers.IO) {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopLocalPlaylistRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopLocalPlaylistRepository.kt
@@ -1,0 +1,77 @@
+package org.feeluown.mobile
+
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal fun createDesktopLocalPlaylistRepository(): LocalPlaylistRepository =
+    FileBackedLocalPlaylistRepository(
+        storage = DesktopLocalPlaylistFileStorage(
+            directory = DesktopAppDirectories.data().resolve("collections"),
+        ),
+    )
+
+private class DesktopLocalPlaylistFileStorage(
+    private val directory: Path,
+) : LocalPlaylistFileStorage {
+    override suspend fun listFileNames(): List<String> = withContext(Dispatchers.IO) {
+        ensureDirectory()
+        Files.list(directory).use { paths ->
+            paths.filter(Files::isRegularFile)
+                .map { it.fileName.toString() }
+                .toList()
+        }
+    }
+
+    override suspend fun readText(fileName: String): String? = withContext(Dispatchers.IO) {
+        val target = fileFor(fileName)
+        if (!Files.isRegularFile(target)) return@withContext null
+        Files.readString(target, StandardCharsets.UTF_8)
+    }
+
+    override suspend fun writeTextAtomically(fileName: String, content: String) = withContext(Dispatchers.IO) {
+        ensureDirectory()
+        val target = fileFor(fileName)
+        val temp = Files.createTempFile(directory, ".${target.fileName}.", ".tmp")
+        try {
+            FileOutputStream(temp.toFile()).use { output ->
+                output.write(content.toByteArray(StandardCharsets.UTF_8))
+                output.fd.sync()
+            }
+            try {
+                Files.move(
+                    temp,
+                    target,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING)
+            }
+        } finally {
+            Files.deleteIfExists(temp)
+        }
+    }
+
+    override suspend fun delete(fileName: String): Boolean = withContext(Dispatchers.IO) {
+        Files.deleteIfExists(fileFor(fileName))
+    }
+
+    override suspend fun exists(fileName: String): Boolean = withContext(Dispatchers.IO) {
+        Files.exists(fileFor(fileName))
+    }
+
+    private fun ensureDirectory() {
+        Files.createDirectories(directory)
+    }
+
+    private fun fileFor(fileName: String): Path {
+        val safeName = Path.of(fileName).fileName.toString()
+        return directory.resolve(safeName)
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlatformServices.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlatformServices.kt
@@ -76,6 +76,7 @@ fun installDesktopPlaybackEngineFactory(factory: () -> PlaybackEngine) {
  */
 internal class DesktopUnsupportedPlaybackEngine :
     PlaybackEngine,
+    PlaybackStartReasonAwareEngine,
     ResolvedPlaybackSourceAwareEngine,
     AutoCloseable {
     private val delegate: PlaybackEngine = desktopPlaybackEngineFactory?.invoke()
@@ -88,6 +89,15 @@ internal class DesktopUnsupportedPlaybackEngine :
         get() = delegate.resolvesResourcesInternally
 
     override fun prepareLoading(track: MusicTrack) = delegate.prepareLoading(track)
+
+    override fun prepareLoading(track: MusicTrack, reason: PlaybackStartReason) {
+        val reasonAware = delegate as? PlaybackStartReasonAwareEngine
+        if (reasonAware != null) {
+            reasonAware.prepareLoading(track, reason)
+        } else {
+            delegate.prepareLoading(track)
+        }
+    }
 
     override fun play(track: MusicTrack, payload: PlaybackPayload) = delegate.play(track, payload)
 

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -1,0 +1,144 @@
+package org.feeluown.mobile
+
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal fun createDesktopPlaybackResumeStore(): PlaybackResumeStore =
+    DesktopPlaybackResumeStore(DesktopAppDirectories.state().resolve("playback-resume.txt"))
+
+internal fun createDesktopPlaybackQueueStore(
+    resumeStore: PlaybackResumeStore,
+): DesktopPlaybackQueueStore = DesktopPlaybackQueueStore(
+    file = DesktopAppDirectories.state().resolve("playback-queue.txt"),
+    resumeStore = resumeStore,
+)
+
+internal class DesktopPlaybackQueueStore(
+    private val file: Path,
+    private val resumeStore: PlaybackResumeStore,
+) : PlaybackQueueStore {
+    @Volatile
+    private var latestSnapshot: PlaybackQueueSnapshot? = null
+
+    @Volatile
+    private var loadCompleted = false
+
+    override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
+        val persisted = readTextIfExists(file)
+            ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
+            ?: PlaybackQueueSnapshot()
+        val restoredSession = resumeStore.load()
+        val snapshot = persisted.reconcileRestoredPlayback(
+            plan = null,
+            currentTrack = restoredSession?.currentTrack,
+        )
+        latestSnapshot = snapshot
+        loadCompleted = true
+        snapshot
+    }
+
+    override suspend fun save(snapshot: PlaybackQueueSnapshot) {
+        if (!loadCompleted) return
+        latestSnapshot = snapshot
+        withContext(Dispatchers.IO) {
+            writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+        }
+    }
+
+    fun flushLatest() {
+        if (!loadCompleted) return
+        latestSnapshot?.let { snapshot ->
+            writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+        }
+    }
+}
+
+private class DesktopPlaybackResumeStore(
+    private val file: Path,
+) : PlaybackResumeStore {
+    private val lock = Any()
+    private var latest: PlaybackResumeSnapshot? = null
+    private var loaded = false
+
+    override fun load(): PlaybackResumeSnapshot? = synchronized(lock) {
+        if (!loaded) {
+            latest = readTextIfExists(file)
+                ?.let { raw -> runCatching { PlaybackResumeCodec.decode(raw) }.getOrNull() }
+            loaded = true
+        }
+        latest
+    }
+
+    override fun saveSession(state: PlaybackState) = synchronized(lock) {
+        val currentTrack = state.currentTrack ?: return@synchronized
+        val snapshot = PlaybackResumeSnapshot(
+            currentTrack = currentTrack.logicalPlaybackTrack(),
+            positionMs = state.positionMs.coerceAtLeast(0L),
+            durationMs = state.durationMs.coerceAtLeast(0L),
+            playbackParts = state.playbackParts,
+            currentPartIndex = state.currentPartIndex,
+        )
+        latest = snapshot
+        loaded = true
+        writeSnapshot(snapshot)
+    }
+
+    override fun savePosition(positionMs: Long, durationMs: Long) = synchronized(lock) {
+        val current = load() ?: return@synchronized
+        val updated = current.copy(
+            positionMs = positionMs.coerceAtLeast(0L),
+            durationMs = durationMs.coerceAtLeast(0L),
+        )
+        latest = updated
+        writeSnapshot(updated)
+    }
+
+    override fun flush() = synchronized(lock) {
+        latest?.let(::writeSnapshot)
+    }
+
+    override fun clear() = synchronized(lock) {
+        latest = null
+        loaded = true
+        runCatching { Files.deleteIfExists(file) }
+    }
+
+    private fun writeSnapshot(snapshot: PlaybackResumeSnapshot) {
+        writeAtomicText(file, PlaybackResumeCodec.encode(snapshot))
+    }
+}
+
+private fun readTextIfExists(file: Path): String? {
+    if (!Files.isRegularFile(file)) return null
+    return Files.readString(file, StandardCharsets.UTF_8)
+}
+
+private fun writeAtomicText(file: Path, content: String) {
+    val directory = requireNotNull(file.parent) { "Desktop persistence file must have a parent directory" }
+    Files.createDirectories(directory)
+    val temp = Files.createTempFile(directory, ".${file.fileName}.", ".tmp")
+    try {
+        FileOutputStream(temp.toFile()).use { output ->
+            output.write(content.toByteArray(StandardCharsets.UTF_8))
+            output.fd.sync()
+        }
+        try {
+            Files.move(
+                temp,
+                file,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING)
+        }
+    } finally {
+        Files.deleteIfExists(temp)
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -23,11 +23,17 @@ internal class DesktopPlaybackQueueStore(
     private val file: Path,
     private val resumeStore: PlaybackResumeStore,
 ) : PlaybackQueueStore {
+    private val writeVersionLock = Any()
+    private val fileWriteLock = Any()
+
     @Volatile
     private var latestSnapshot: PlaybackQueueSnapshot? = null
 
     @Volatile
     private var loadCompleted = false
+
+    private var nextWriteVersion = 0L
+    private var lastWrittenVersion = 0L
 
     override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
         val persisted = readTextIfExists(file)
@@ -38,23 +44,39 @@ internal class DesktopPlaybackQueueStore(
             plan = null,
             currentTrack = restoredSession?.currentTrack,
         )
-        latestSnapshot = snapshot
+        synchronized(writeVersionLock) {
+            latestSnapshot = snapshot
+        }
         loadCompleted = true
         snapshot
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
         if (!loadCompleted) return
-        latestSnapshot = snapshot
+        val version = synchronized(writeVersionLock) {
+            latestSnapshot = snapshot
+            ++nextWriteVersion
+        }
         withContext(Dispatchers.IO) {
-            writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+            synchronized(fileWriteLock) {
+                if (version <= lastWrittenVersion) return@synchronized
+                writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+                lastWrittenVersion = version
+            }
         }
     }
 
     fun flushLatest() {
         if (!loadCompleted) return
-        latestSnapshot?.let { snapshot ->
-            writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+        val pending = synchronized(writeVersionLock) {
+            val snapshot = latestSnapshot ?: return
+            val version = ++nextWriteVersion
+            version to snapshot
+        }
+        synchronized(fileWriteLock) {
+            if (pending.first <= lastWrittenVersion) return
+            writeAtomicText(file, PlaybackQueueCodec.encode(pending.second))
+            lastWrittenVersion = pending.first
         }
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -99,14 +99,16 @@ private class DesktopPlaybackResumeStore(
         writeSnapshot(updated)
     }
 
-    override fun flush() = synchronized(lock) {
+    override fun flush(): Unit = synchronized(lock) {
         latest?.let(::writeSnapshot)
+        Unit
     }
 
-    override fun clear() = synchronized(lock) {
+    override fun clear(): Unit = synchronized(lock) {
         latest = null
         loaded = true
         runCatching { Files.deleteIfExists(file) }
+        Unit
     }
 
     private fun writeSnapshot(snapshot: PlaybackResumeSnapshot) {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -9,7 +9,7 @@ import java.nio.file.StandardCopyOption
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-internal fun createDesktopPlaybackResumeStore(): PlaybackResumeStore =
+fun createDesktopPlaybackResumeStore(): PlaybackResumeStore =
     DesktopPlaybackResumeStore(DesktopAppDirectories.state().resolve("playback-resume.txt"))
 
 internal fun createDesktopPlaybackQueueStore(

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCredentialBackupHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCredentialBackupHost.kt
@@ -6,10 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import java.io.File
-import javax.swing.JFileChooser
-import javax.swing.JOptionPane
-import javax.swing.filechooser.FileNameExtensionFilter
 
 @Composable
 internal fun DesktopProviderCredentialBackupHost(
@@ -58,18 +54,14 @@ private fun openCredentialBackupFile(
     backup: ProviderCredentialBackup,
     onFeedback: (String) -> Unit,
 ) {
-    val chooser = credentialFileChooser().apply {
-        dialogTitle = "导入登录凭证"
-        fileSelectionMode = JFileChooser.FILES_ONLY
-    }
-    if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) return
-
-    runCatching { chooser.selectedFile.readText(Charsets.UTF_8) }
-        .onSuccess { content ->
-            if (content.isBlank()) onFeedback("无法读取登录凭证备份文件")
-            else backup.stageImport(content)
-        }
-        .onFailure { onFeedback(it.message ?: "无法读取登录凭证备份文件") }
+    val file = openDesktopTextFile(
+        dialogTitle = "导入登录凭证",
+        filterDescription = "FuoEvolve 登录凭证备份 (*.json)",
+        extensions = listOf("json"),
+        onFeedback = onFeedback,
+    ) ?: return
+    if (file.content.isBlank()) onFeedback("无法读取登录凭证备份文件")
+    else backup.stageImport(file.content)
 }
 
 private fun saveCredentialBackupFile(
@@ -78,29 +70,13 @@ private fun saveCredentialBackupFile(
     onFeedback: (String) -> Unit,
 ) {
     val pending = backup.consumePendingExport() ?: return
-    val chooser = credentialFileChooser().apply {
-        dialogTitle = "导出登录凭证"
-        selectedFile = File(fileName)
-    }
-    if (chooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) return
-
-    val target = chooser.selectedFile
-    if (target.exists()) {
-        val overwrite = JOptionPane.showConfirmDialog(
-            null,
-            "${target.name} 已存在，是否覆盖？",
-            "导出登录凭证",
-            JOptionPane.YES_NO_OPTION,
-            JOptionPane.WARNING_MESSAGE,
-        )
-        if (overwrite != JOptionPane.YES_OPTION) return
-    }
-
-    runCatching { target.writeText(pending.content, Charsets.UTF_8) }
-        .onSuccess { onFeedback("登录凭证备份已导出") }
-        .onFailure { onFeedback(it.message ?: "导出登录凭证失败") }
-}
-
-private fun credentialFileChooser(): JFileChooser = JFileChooser().apply {
-    fileFilter = FileNameExtensionFilter("FuoEvolve 登录凭证备份 (*.json)", "json")
+    val saved = saveDesktopTextFile(
+        dialogTitle = "导出登录凭证",
+        suggestedFileName = fileName,
+        filterDescription = "FuoEvolve 登录凭证备份 (*.json)",
+        extensions = listOf("json"),
+        content = pending.content,
+        onFeedback = onFeedback,
+    )
+    if (saved) onFeedback("登录凭证备份已导出")
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopTextFileDialogs.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopTextFileDialogs.kt
@@ -1,0 +1,81 @@
+package org.feeluown.mobile
+
+import java.io.File
+import javax.swing.JFileChooser
+import javax.swing.JOptionPane
+import javax.swing.filechooser.FileNameExtensionFilter
+
+internal data class DesktopTextFile(
+    val fileName: String,
+    val content: String,
+)
+
+/**
+ * Desktop-only file picker boundary. Common features deal only in names/content; Swing remains at
+ * the platform edge and therefore cannot leak into shared feature contracts.
+ */
+internal fun openDesktopTextFile(
+    dialogTitle: String,
+    filterDescription: String,
+    extensions: List<String>,
+    onFeedback: (String) -> Unit,
+): DesktopTextFile? {
+    val chooser = desktopTextFileChooser(filterDescription, extensions).apply {
+        this.dialogTitle = dialogTitle
+        fileSelectionMode = JFileChooser.FILES_ONLY
+    }
+    if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) return null
+
+    return runCatching {
+        val file = chooser.selectedFile
+        DesktopTextFile(file.name, file.readText(Charsets.UTF_8))
+    }.onFailure { onFeedback(it.message ?: "无法读取文件") }
+        .getOrNull()
+}
+
+internal fun saveDesktopTextFile(
+    dialogTitle: String,
+    suggestedFileName: String,
+    filterDescription: String,
+    extensions: List<String>,
+    content: String,
+    onFeedback: (String) -> Unit,
+): Boolean {
+    val chooser = desktopTextFileChooser(filterDescription, extensions).apply {
+        this.dialogTitle = dialogTitle
+        selectedFile = File(suggestedFileName)
+    }
+    if (chooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) return false
+
+    val target = chooser.selectedFile.withDefaultExtension(extensions.firstOrNull())
+    if (target.exists()) {
+        val overwrite = JOptionPane.showConfirmDialog(
+            null,
+            "${target.name} 已存在，是否覆盖？",
+            dialogTitle,
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE,
+        )
+        if (overwrite != JOptionPane.YES_OPTION) return false
+    }
+
+    return runCatching { target.writeText(content, Charsets.UTF_8) }
+        .onFailure { onFeedback(it.message ?: "写入文件失败") }
+        .isSuccess
+}
+
+private fun desktopTextFileChooser(
+    filterDescription: String,
+    extensions: List<String>,
+): JFileChooser = JFileChooser().apply {
+    val normalized = extensions.map { it.trim().removePrefix(".") }.filter(String::isNotBlank)
+    if (normalized.isNotEmpty()) {
+        fileFilter = FileNameExtensionFilter(filterDescription, *normalized.toTypedArray())
+    }
+}
+
+private fun File.withDefaultExtension(extension: String?): File {
+    val normalized = extension?.trim()?.removePrefix(".").orEmpty()
+    if (normalized.isBlank() || this.extension.isNotBlank()) return this
+    return File(parentFile, "$name.$normalized")
+}


### PR DESCRIPTION
## Summary

Complete the desktop P0 persistence work, intentionally excluding application update/version support for now.

### Playback persistence
- persist desktop playback queue, shuffle/repeat state and current queue position
- persist a platform-neutral logical playback resume snapshot (track, position, duration and part metadata)
- expose the restored session as paused state on startup
- re-enter the normal provider resolution path when resuming so expired media URLs/credentials are never persisted
- clear stale durable resume state for active user selections, preserving the existing playback-start transaction semantics
- flush the latest queue/session state at desktop shutdown boundaries

### Local playlists
- extract a common `FileBackedLocalPlaylistRepository` and narrow `LocalPlaylistFileStorage` boundary
- move create/delete/add/remove/import/export and filename semantics into common code
- reuse the same common repository from Android and Desktop
- keep actual directory selection, atomic/fsync file IO and Swing file pickers platform-specific
- wire desktop `.fuo` import/export into the existing common UI callbacks

### Platform-boundary cleanup
- add a desktop application data/state directory policy only in `desktopMain`
- centralize desktop text-file dialogs so Swing does not leak into common features
- move durable playback-resume policy/model/codec into `:feature:playback`; native playback remains in `desktopApp`

### Tests
- common file-backed local playlist persistence/import/export tests
- common playback resume codec/state tests
- desktop restored-session vs active-selection and resume-position tests

Update/version support is deliberately not included in this PR.