### PR TITLE
feat: complete desktop P1 platform parity

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -92,6 +92,7 @@ jobs:
           :desktopApp:compileKotlin
           :desktopApp:test
           :shared:desktopTest
+          :persistence:listening:desktopTest
 
   windows-smtc:
     name: Compile Windows desktop, SMTC and WebView login helper
@@ -146,6 +147,7 @@ jobs:
           :desktopApp:compileKotlin
           :desktopApp:test
           :shared:desktopTest
+          :persistence:listening:desktopTest
 
   macos-now-playing:
     name: Compile macOS desktop, Now Playing and WebView login helper
@@ -196,3 +198,4 @@ jobs:
           :desktopApp:compileKotlin
           :desktopApp:test
           :shared:desktopTest
+          :persistence:listening:desktopTest

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCacheStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidProviderCacheStore.kt
@@ -1,77 +1,41 @@
 package org.feeluown.mobile
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import org.feeluown.mobile.provider.core.network.PersistedProviderCacheEntry
-import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
 
-internal class AndroidProviderCacheStore(context: Context) : ProviderPersistentCache {
-    private val file = File(context.applicationContext.filesDir, CACHE_FILE_NAME)
-    private val mutex = Mutex()
-    private val json = Json {
-        encodeDefaults = true
-        ignoreUnknownKeys = true
+internal class AndroidProviderCacheStore(context: Context) : ProviderPersistentCache by JsonProviderPersistentCache(
+    AndroidProviderCacheSnapshotStorage(
+        File(context.applicationContext.filesDir, CACHE_FILE_NAME),
+    ),
+)
+
+private class AndroidProviderCacheSnapshotStorage(
+    private val file: File,
+) : ProviderCacheSnapshotStorage {
+    override suspend fun readText(): String? = withContext(Dispatchers.IO) {
+        file.takeIf(File::isFile)?.readText()
     }
 
-    override suspend fun read(key: String): PersistedProviderCacheEntry? = withContext(Dispatchers.IO) {
-        mutex.withLock { load()[key] }
-    }
-
-    override suspend fun write(key: String, entry: PersistedProviderCacheEntry) {
+    override suspend fun writeText(content: String) {
         withContext(Dispatchers.IO) {
-            mutex.withLock {
-                val entries = load().toMutableMap()
-                entries[key] = entry
-                save(entries)
-            }
+            file.parentFile?.mkdirs()
+            val temporary = File(file.parentFile, "${file.name}.tmp")
+            temporary.writeText(content)
+            check(temporary.renameTo(file) || run {
+                file.delete()
+                temporary.renameTo(file)
+            }) { "无法写入 Provider HTTP 缓存" }
         }
     }
 
-    override suspend fun invalidate(prefix: String) {
+    override suspend fun delete() {
         withContext(Dispatchers.IO) {
-            mutex.withLock {
-                save(load().filterKeys { !it.startsWith(prefix) })
-            }
-        }
-    }
-
-    override suspend fun clear() {
-        withContext(Dispatchers.IO) {
-            mutex.withLock {
-                if (file.exists()) file.delete()
-            }
-        }
-    }
-
-    private fun load(): Map<String, PersistedProviderCacheEntry> {
-        if (!file.isFile) return emptyMap()
-        return runCatching {
-            json.decodeFromString<Map<String, PersistedProviderCacheEntry>>(file.readText())
-        }.getOrDefault(emptyMap())
-    }
-
-    private fun save(entries: Map<String, PersistedProviderCacheEntry>) {
-        if (entries.isEmpty()) {
             if (file.exists()) file.delete()
-            return
         }
-        file.parentFile?.mkdirs()
-        val temporary = File(file.parentFile, "${file.name}.tmp")
-        temporary.writeText(json.encodeToString(entries))
-        check(temporary.renameTo(file) || run {
-            file.delete()
-            temporary.renameTo(file)
-        }) { "无法写入 Provider HTTP 缓存" }
-    }
-
-    private companion object {
-        const val CACHE_FILE_NAME = "provider_http_cache.json"
     }
 }
+
+private const val CACHE_FILE_NAME = "provider_http_cache.json"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidResourceCacheRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidResourceCacheRepository.kt
@@ -2,36 +2,26 @@ package org.feeluown.mobile
 
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 
 class AndroidResourceCacheRepository(
     context: Context,
-) : ResourceCacheRepository {
-    private val appContext = context.applicationContext
-    private val mutableUsage = MutableStateFlow(CacheUsage())
+) : ResourceCacheRepository by StorageBackedResourceCacheRepository(
+    AndroidResourceCacheStorage(context.applicationContext),
+)
 
-    override val usage: StateFlow<CacheUsage> = mutableUsage.asStateFlow()
-
-    override suspend fun refreshUsage() {
-        mutableUsage.value = withContext(Dispatchers.IO) {
-            AndroidResourceCache.usage(appContext)
-        }
+private class AndroidResourceCacheStorage(
+    private val context: Context,
+) : ResourceCacheStorage {
+    override suspend fun usage(): CacheUsage = withContext(Dispatchers.IO) {
+        AndroidResourceCache.usage(context)
     }
 
     override suspend fun clearAll() {
-        withContext(Dispatchers.IO) {
-            AndroidResourceCache.clearAll(appContext)
-            mutableUsage.value = CacheUsage()
-        }
+        withContext(Dispatchers.IO) { AndroidResourceCache.clearAll(context) }
     }
 
     override suspend fun updateLimit(limit: CacheLimit) {
-        withContext(Dispatchers.IO) {
-            AndroidResourceCache.updateLimit(appContext, limit)
-            mutableUsage.value = AndroidResourceCache.usage(appContext)
-        }
+        withContext(Dispatchers.IO) { AndroidResourceCache.updateLimit(context, limit) }
     }
 }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -302,6 +302,7 @@ tasks.register("printDesktopPackageProfile") {
 dependencies {
     implementation(project(":shared"))
     implementation(project(":playback:api"))
+    implementation(project(":persistence:listening"))
     implementation(compose.desktop.currentOs)
     implementation(libs.kotlinx.coroutines.swing)
     implementation(libs.kotlinx.serialization.json)
@@ -334,9 +335,15 @@ compose.desktop {
 
         nativeDistributions {
             // These dependencies are reached reflectively by desktop-only libraries and are not
-            // always discovered by jdeps: JNA/credential storage uses sun.misc.Unsafe, while
-            // dbus-java uses com.sun.security.auth.module.UnixSystem for the MPRIS Unix identity.
-            modules("jdk.unsupported", "jdk.security.auth")
+            // always discovered by jdeps: JNA/credential storage uses sun.misc.Unsafe, dbus-java
+            // uses UnixSystem, and SQLDelight's desktop driver reaches JDBC through DriverManager.
+            modules("jdk.unsupported", "jdk.security.auth", "java.sql")
+
+            fileAssociation(
+                mimeType = "application/x-fuoevolve-playlist",
+                extension = "fuo",
+                description = "FeelUOwn playlist",
+            )
 
             when {
                 isWindowsHost -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)
@@ -362,6 +369,21 @@ compose.desktop {
                 bundleID = "org.feeluown.mobile.desktop"
                 dockName = "FuoEvolve"
                 appCategory = "public.app-category.music"
+                infoPlist {
+                    extraKeysRawXml = """
+                        <key>CFBundleURLTypes</key>
+                        <array>
+                            <dict>
+                                <key>CFBundleURLName</key>
+                                <string>org.feeluown.mobile.desktop</string>
+                                <key>CFBundleURLSchemes</key>
+                                <array>
+                                    <string>fuo</string>
+                                </array>
+                            </dict>
+                        </array>
+                    """.trimIndent()
+                }
             }
             linux {
                 packageName = "fuoevolve"

--- a/desktopApp/compose-desktop.pro
+++ b/desktopApp/compose-desktop.pro
@@ -28,6 +28,11 @@
 -keep interface org.freedesktop.dbus.** { *; }
 -dontwarn org.freedesktop.dbus.**
 
+# SQLDelight's desktop SQLite backend reaches the Xerial JDBC driver through DriverManager /
+# ServiceLoader, which ProGuard cannot infer from META-INF/services/java.sql.Driver.
+-keep class org.sqlite.** { *; }
+-dontwarn org.sqlite.**
+
 # Ktor discovers kotlinx.serialization format integrations through java.util.ServiceLoader.
 # ProGuard keeps META-INF/services resources but cannot infer that their implementation
 # classes are runtime entry points, so preserve the JSON provider explicitly.

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
@@ -1,0 +1,76 @@
+package org.feeluown.mobile.desktop
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/** Runtime registration is needed on Windows/Linux; macOS receives the URL scheme from Info.plist. */
+internal fun registerDesktopFuoProtocolHandler() {
+    val launcher = packagedLauncher() ?: return
+    runCatching {
+        when {
+            isWindows() -> registerWindowsProtocol(launcher)
+            isLinux() -> registerLinuxProtocol(launcher)
+        }
+    }.onFailure { throwable ->
+        System.err.println("FuoEvolve: unable to register fuo:// protocol: ${throwable.message}")
+    }
+}
+
+private fun packagedLauncher(): Path? {
+    val command = ProcessHandle.current().info().command().orElse(null) ?: return null
+    val path = runCatching { Paths.get(command).toAbsolutePath().normalize() }.getOrNull() ?: return null
+    val fileName = path.fileName?.toString().orEmpty().lowercase()
+    val looksLikeJvm = fileName in setOf("java", "java.exe", "javaw.exe")
+    return path.takeIf { Files.isRegularFile(it) && !looksLikeJvm }
+}
+
+private fun registerWindowsProtocol(launcher: Path) {
+    val root = "HKCU\\Software\\Classes\\fuo"
+    runCommand("reg", "add", root, "/ve", "/d", "URL:FuoEvolve Protocol", "/f")
+    runCommand("reg", "add", root, "/v", "URL Protocol", "/d", "", "/f")
+    val command = "\"${launcher}\" \"%1\""
+    runCommand("reg", "add", "$root\\shell\\open\\command", "/ve", "/d", command, "/f")
+}
+
+private fun registerLinuxProtocol(launcher: Path) {
+    val home = System.getProperty("user.home").orEmpty()
+    if (home.isBlank()) return
+    val applicationsDir = Paths.get(home, ".local", "share", "applications")
+    Files.createDirectories(applicationsDir)
+    val desktopFileName = "fuoevolve-url.desktop"
+    val desktopFile = applicationsDir.resolve(desktopFileName)
+    val exec = desktopExecQuote(launcher.toString())
+    Files.writeString(
+        desktopFile,
+        """
+        [Desktop Entry]
+        Type=Application
+        Name=FuoEvolve
+        NoDisplay=true
+        Exec=$exec %u
+        MimeType=x-scheme-handler/fuo;
+        """.trimIndent() + "\n",
+        StandardCharsets.UTF_8,
+    )
+    runCommand("xdg-mime", "default", desktopFileName, "x-scheme-handler/fuo")
+    runCatching { runCommand("update-desktop-database", applicationsDir.toString()) }
+}
+
+private fun desktopExecQuote(value: String): String =
+    "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+
+private fun runCommand(vararg command: String) {
+    val process = ProcessBuilder(*command)
+        .redirectErrorStream(true)
+        .start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    val exitCode = process.waitFor()
+    check(exitCode == 0) {
+        "${command.firstOrNull().orEmpty()} exited with $exitCode${output.trim().takeIf(String::isNotBlank)?.let { ": $it" }.orEmpty()}"
+    }
+}
+
+private fun isWindows(): Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("win")
+private fun isLinux(): Boolean = System.getProperty("os.name").orEmpty().lowercase().contains("linux")

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
@@ -19,6 +19,14 @@ internal fun registerDesktopFuoProtocolHandler() {
 }
 
 private fun packagedLauncher(): Path? {
+    if (isLinux()) {
+        // AppImage runs from a transient mount point, while APPIMAGE points to the stable image path.
+        System.getenv("APPIMAGE")
+            ?.takeIf(String::isNotBlank)
+            ?.let { runCatching { Paths.get(it).toAbsolutePath().normalize() }.getOrNull() }
+            ?.takeIf { Files.isRegularFile(it) }
+            ?.let { return it }
+    }
     val command = ProcessHandle.current().info().command().orElse(null) ?: return null
     val path = runCatching { Paths.get(command).toAbsolutePath().normalize() }.getOrNull() ?: return null
     val fileName = path.fileName?.toString().orEmpty().lowercase()
@@ -37,7 +45,9 @@ private fun registerWindowsProtocol(launcher: Path) {
 private fun registerLinuxProtocol(launcher: Path) {
     val home = System.getProperty("user.home").orEmpty()
     if (home.isBlank()) return
-    val applicationsDir = Paths.get(home, ".local", "share", "applications")
+    val dataHome = System.getenv("XDG_DATA_HOME")?.takeIf(String::isNotBlank)
+        ?: Paths.get(home, ".local", "share").toString()
+    val applicationsDir = Paths.get(dataHome).resolve("applications")
     Files.createDirectories(applicationsDir)
     val desktopFileName = "fuoevolve-url.desktop"
     val desktopFile = applicationsDir.resolve(desktopFileName)

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -64,7 +64,7 @@ fun main(args: Array<String>) {
             }
 
             LaunchedEffect(activation) {
-                activation.inputs.collect { showWindow() }
+                activation.focusRequests.collect { showWindow() }
             }
 
             DisposableEffect(Unit) {

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile.desktop
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,14 +16,27 @@ import androidx.compose.ui.window.rememberWindowState
 import java.awt.Window as AwtWindow
 import javax.swing.SwingUtilities
 import org.feeluown.mobile.DesktopAppHost
+import org.feeluown.mobile.DesktopExternalActivationSession
 import org.feeluown.mobile.createDesktopPlaybackResumeStore
+import org.feeluown.mobile.installDesktopDebugLogCapture
+import org.feeluown.mobile.installDesktopListeningHistorySinkFactory
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
 import org.feeluown.mobile.installDesktopPlaybackEngineFactory
 import org.feeluown.mobile.installDesktopPlaybackSessionIntegrationFactory
 import org.feeluown.mobile.installDesktopProviderCredentialStoreFactory
 import org.feeluown.mobile.installFallbackOAuthDeviceCodeAssistant
+import org.feeluown.mobile.persistence.listening.DesktopListeningHistoryDriverFactory
+import org.feeluown.mobile.persistence.listening.SqlDelightListeningHistoryStore
 
-fun main() {
+fun main(args: Array<String>) {
+    installDesktopDebugLogCapture()
+    val activation = DesktopExternalActivationSession.open(args.toList()) ?: return
+    registerDesktopFuoProtocolHandler()
+    installDesktopListeningHistorySinkFactory { databasePath ->
+        SqlDelightListeningHistoryStore(
+            DesktopListeningHistoryDriverFactory(databasePath),
+        )
+    }
     installDesktopPlaybackEngineFactory {
         PersistentDesktopPlaybackEngine(
             delegate = DesktopMpvPlaybackEngine(),
@@ -32,69 +46,80 @@ fun main() {
     installDesktopProviderCredentialStoreFactory { DesktopSecureProviderCredentialStore() }
     installDesktopLocalMusicRepositoryFactory { DesktopLocalMusicRepository() }
     installFallbackOAuthDeviceCodeAssistant(DesktopOAuthDeviceCodeAssistant())
-    application {
-        var windowVisible by remember { mutableStateOf(true) }
-        var windowRef by remember { mutableStateOf<AwtWindow?>(null) }
-        var trayController by remember { mutableStateOf<DesktopTrayController?>(null) }
 
-        DisposableEffect(Unit) {
-            val controller = createDesktopTrayController(
-                onShow = {
-                    windowVisible = true
-                    SwingUtilities.invokeLater {
-                        windowRef?.let { window ->
-                            window.toFront()
-                            window.requestFocus()
-                        }
+    try {
+        application {
+            var windowVisible by remember { mutableStateOf(true) }
+            var windowRef by remember { mutableStateOf<AwtWindow?>(null) }
+            var trayController by remember { mutableStateOf<DesktopTrayController?>(null) }
+
+            fun showWindow() {
+                windowVisible = true
+                SwingUtilities.invokeLater {
+                    windowRef?.let { window ->
+                        window.toFront()
+                        window.requestFocus()
+                    }
+                }
+            }
+
+            LaunchedEffect(activation) {
+                activation.inputs.collect { showWindow() }
+            }
+
+            DisposableEffect(Unit) {
+                val controller = createDesktopTrayController(
+                    onShow = ::showWindow,
+                    onExit = ::exitApplication,
+                )
+                trayController = controller
+                onDispose {
+                    trayController = null
+                    controller.close()
+                }
+            }
+
+            Window(
+                onCloseRequest = {
+                    when (desktopCloseBehavior(trayController?.isAvailable == true)) {
+                        DesktopCloseBehavior.HideToTray -> windowVisible = false
+                        DesktopCloseBehavior.KeepVisible -> System.err.println(
+                            "FuoEvolve: close-to-tray ignored because no usable tray integration is available",
+                        )
                     }
                 },
-                onExit = ::exitApplication,
-            )
-            trayController = controller
-            onDispose {
-                trayController = null
-                controller.close()
+                visible = windowVisible,
+                title = "FuoEvolve",
+                state = rememberWindowState(width = 1280.dp, height = 800.dp),
+            ) {
+                SideEffect {
+                    windowRef = window
+                }
+                DisposableEffect(window) {
+                    onDispose {
+                        if (windowRef === window) windowRef = null
+                    }
+                }
+                installDesktopPlaybackSessionIntegrationFactory { playbackSession ->
+                    createDesktopSystemMediaSessionForWindow(playbackSession, window)
+                }
+
+                // Compose's desktop UriHandler is synchronous. On Linux the OS browser launcher may
+                // block while xdg-open/desktop integration resolves the target application, so never
+                // invoke it directly from the Compose UI dispatcher.
+                val platformUriHandler = LocalUriHandler.current
+                val nonBlockingUriHandler = remember(platformUriHandler) {
+                    DesktopNonBlockingUriHandler(platformUriHandler)
+                }
+                DisposableEffect(nonBlockingUriHandler) {
+                    onDispose(nonBlockingUriHandler::close)
+                }
+                CompositionLocalProvider(LocalUriHandler provides nonBlockingUriHandler) {
+                    DesktopAppHost(externalInputs = activation.inputs)
+                }
             }
         }
-
-        Window(
-            onCloseRequest = {
-                when (desktopCloseBehavior(trayController?.isAvailable == true)) {
-                    DesktopCloseBehavior.HideToTray -> windowVisible = false
-                    DesktopCloseBehavior.KeepVisible -> System.err.println(
-                        "FuoEvolve: close-to-tray ignored because no usable tray integration is available",
-                    )
-                }
-            },
-            visible = windowVisible,
-            title = "FuoEvolve",
-            state = rememberWindowState(width = 1280.dp, height = 800.dp),
-        ) {
-            SideEffect {
-                windowRef = window
-            }
-            DisposableEffect(window) {
-                onDispose {
-                    if (windowRef === window) windowRef = null
-                }
-            }
-            installDesktopPlaybackSessionIntegrationFactory { playbackSession ->
-                createDesktopSystemMediaSessionForWindow(playbackSession, window)
-            }
-
-            // Compose's desktop UriHandler is synchronous. On Linux the OS browser launcher may
-            // block while xdg-open/desktop integration resolves the target application, so never
-            // invoke it directly from the Compose UI dispatcher.
-            val platformUriHandler = LocalUriHandler.current
-            val nonBlockingUriHandler = remember(platformUriHandler) {
-                DesktopNonBlockingUriHandler(platformUriHandler)
-            }
-            DisposableEffect(nonBlockingUriHandler) {
-                onDispose(nonBlockingUriHandler::close)
-            }
-            CompositionLocalProvider(LocalUriHandler provides nonBlockingUriHandler) {
-                DesktopAppHost()
-            }
-        }
+    } finally {
+        activation.close()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ lyricon-provider = { module = "io.github.proify.lyricon:provider", version.ref =
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 credential-secure-storage = { module = "com.microsoft:credential-secure-storage", version.ref = "credentialSecureStorage" }

--- a/persistence/listening/build.gradle.kts
+++ b/persistence/listening/build.gradle.kts
@@ -16,6 +16,12 @@ kotlin {
         }
     }
 
+    jvm("desktop") {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
     iosArm64()
     iosSimulatorArm64()
 
@@ -27,6 +33,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.sqldelight.android.driver)
+        }
+        desktopMain.dependencies {
+            implementation(libs.sqldelight.sqlite.driver)
         }
         iosMain.dependencies {
             implementation(libs.sqldelight.native.driver)

--- a/persistence/listening/src/desktopMain/kotlin/org/feeluown/mobile/persistence/listening/DesktopListeningHistoryDriverFactory.kt
+++ b/persistence/listening/src/desktopMain/kotlin/org/feeluown/mobile/persistence/listening/DesktopListeningHistoryDriverFactory.kt
@@ -1,0 +1,20 @@
+package org.feeluown.mobile.persistence.listening
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import java.nio.file.Files
+import java.nio.file.Path
+import org.feeluown.mobile.persistence.listening.db.ListeningHistoryDatabase
+
+class DesktopListeningHistoryDriverFactory(
+    private val databasePath: Path,
+) : ListeningHistoryDriverFactory {
+    override fun createDriver(): SqlDriver {
+        val parent = requireNotNull(databasePath.parent) { "Listening history database must have a parent directory" }
+        Files.createDirectories(parent)
+        val needsCreate = !Files.isRegularFile(databasePath) || Files.size(databasePath) == 0L
+        return JdbcSqliteDriver("jdbc:sqlite:${databasePath.toAbsolutePath()}").also { driver ->
+            if (needsCreate) ListeningHistoryDatabase.Schema.create(driver)
+        }
+    }
+}

--- a/persistence/listening/src/desktopTest/kotlin/org/feeluown/mobile/persistence/listening/DesktopListeningHistoryDriverFactoryTest.kt
+++ b/persistence/listening/src/desktopTest/kotlin/org/feeluown/mobile/persistence/listening/DesktopListeningHistoryDriverFactoryTest.kt
@@ -1,0 +1,27 @@
+package org.feeluown.mobile.persistence.listening
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopListeningHistoryDriverFactoryTest {
+    @Test
+    fun createsSqliteDatabaseAndCommonStoreCanQueryIt() {
+        val directory = Files.createTempDirectory("fuoevolve-listening-history-test")
+        val database = directory.resolve("listening_history.db")
+        try {
+            val store = SqlDelightListeningHistoryStore(
+                DesktopListeningHistoryDriverFactory(database),
+            )
+
+            assertEquals(0L, kotlinx.coroutines.runBlocking { store.eventCount() })
+            kotlin.test.assertTrue(Files.isRegularFile(database))
+        } finally {
+            runCatching {
+                Files.walk(directory).use { stream ->
+                    stream.sorted(java.util.Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/StorageBackedResourceCacheRepository.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/model/StorageBackedResourceCacheRepository.kt
@@ -1,0 +1,34 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Platform boundary for physical resource-cache storage. */
+interface ResourceCacheStorage {
+    suspend fun usage(): CacheUsage
+    suspend fun clearAll()
+    suspend fun updateLimit(limit: CacheLimit)
+}
+
+/** Keeps cache state/refresh semantics common while platforms own their physical cache backend. */
+class StorageBackedResourceCacheRepository(
+    private val storage: ResourceCacheStorage,
+) : ResourceCacheRepository {
+    private val mutableUsage = MutableStateFlow(CacheUsage())
+    override val usage: StateFlow<CacheUsage> = mutableUsage.asStateFlow()
+
+    override suspend fun refreshUsage() {
+        mutableUsage.value = storage.usage()
+    }
+
+    override suspend fun clearAll() {
+        storage.clearAll()
+        mutableUsage.value = CacheUsage()
+    }
+
+    override suspend fun updateLimit(limit: CacheLimit) {
+        storage.updateLimit(limit)
+        mutableUsage.value = storage.usage()
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/JsonProviderPersistentCache.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/JsonProviderPersistentCache.kt
@@ -1,0 +1,67 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.feeluown.mobile.provider.core.network.PersistedProviderCacheEntry
+import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
+
+/** Platform storage boundary for the provider HTTP cache snapshot. */
+interface ProviderCacheSnapshotStorage {
+    suspend fun readText(): String?
+    suspend fun writeText(content: String)
+    suspend fun delete()
+}
+
+/**
+ * Platform-neutral provider cache implementation.
+ *
+ * Cache serialization, prefix invalidation and corruption tolerance belong to shared runtime
+ * semantics. Platforms only decide where and how the snapshot is stored atomically.
+ */
+class JsonProviderPersistentCache(
+    private val storage: ProviderCacheSnapshotStorage,
+    private val json: Json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    },
+) : ProviderPersistentCache {
+    private val mutex = Mutex()
+
+    override suspend fun read(key: String): PersistedProviderCacheEntry? =
+        mutex.withLock { load()[key] }
+
+    override suspend fun write(key: String, entry: PersistedProviderCacheEntry) {
+        mutex.withLock {
+            save(load().toMutableMap().apply { put(key, entry) })
+        }
+    }
+
+    override suspend fun invalidate(prefix: String) {
+        mutex.withLock {
+            val current = load()
+            val filtered = current.filterKeys { !it.startsWith(prefix) }
+            if (filtered.size != current.size) save(filtered)
+        }
+    }
+
+    override suspend fun clear() {
+        mutex.withLock { storage.delete() }
+    }
+
+    private suspend fun load(): Map<String, PersistedProviderCacheEntry> =
+        storage.readText()
+            ?.takeIf(String::isNotBlank)
+            ?.let { raw -> runCatching { json.decodeFromString<Map<String, PersistedProviderCacheEntry>>(raw) }.getOrNull() }
+            ?: emptyMap()
+
+    private suspend fun save(entries: Map<String, PersistedProviderCacheEntry>) {
+        if (entries.isEmpty()) {
+            storage.delete()
+        } else {
+            storage.writeText(json.encodeToString(entries))
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/JsonProviderPersistentCache.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/provider/JsonProviderPersistentCache.kt
@@ -18,16 +18,21 @@ interface ProviderCacheSnapshotStorage {
 /**
  * Platform-neutral provider cache implementation.
  *
- * Cache serialization, prefix invalidation and corruption tolerance belong to shared runtime
- * semantics. Platforms only decide where and how the snapshot is stored atomically.
+ * Cache serialization, bounded eviction, prefix invalidation and corruption tolerance belong to
+ * shared runtime semantics. Platforms only decide where and how the snapshot is stored atomically.
  */
 class JsonProviderPersistentCache(
     private val storage: ProviderCacheSnapshotStorage,
+    private val maxEntries: Int = DEFAULT_PROVIDER_PERSISTENT_CACHE_ENTRIES,
     private val json: Json = Json {
         encodeDefaults = true
         ignoreUnknownKeys = true
     },
 ) : ProviderPersistentCache {
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive" }
+    }
+
     private val mutex = Mutex()
 
     override suspend fun read(key: String): PersistedProviderCacheEntry? =
@@ -35,7 +40,8 @@ class JsonProviderPersistentCache(
 
     override suspend fun write(key: String, entry: PersistedProviderCacheEntry) {
         mutex.withLock {
-            save(load().toMutableMap().apply { put(key, entry) })
+            val entries = load().toMutableMap().apply { put(key, entry) }
+            save(entries.trimToNewest(maxEntries))
         }
     }
 
@@ -65,3 +71,18 @@ class JsonProviderPersistentCache(
         }
     }
 }
+
+private fun Map<String, PersistedProviderCacheEntry>.trimToNewest(
+    maxEntries: Int,
+): Map<String, PersistedProviderCacheEntry> {
+    if (size <= maxEntries) return this
+    return entries
+        .sortedWith(
+            compareByDescending<Map.Entry<String, PersistedProviderCacheEntry>> { it.value.storedAtMillis }
+                .thenBy { it.key },
+        )
+        .take(maxEntries)
+        .associate { it.toPair() }
+}
+
+private const val DEFAULT_PROVIDER_PERSISTENT_CACHE_ENTRIES = 256

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/JsonProviderPersistentCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/JsonProviderPersistentCacheTest.kt
@@ -1,0 +1,52 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import org.feeluown.mobile.provider.core.network.PersistedProviderCacheEntry
+
+class JsonProviderPersistentCacheTest {
+    @Test
+    fun persistsReadsAndInvalidatesByPrefix() = runTest {
+        val storage = MemoryProviderCacheStorage()
+        val cache = JsonProviderPersistentCache(storage)
+        val first = PersistedProviderCacheEntry("first", 100L)
+        val second = PersistedProviderCacheEntry("second", 200L)
+
+        cache.write("catalog:one", first)
+        cache.write("auth:two", second)
+
+        assertEquals(first, cache.read("catalog:one"))
+        assertEquals(second, cache.read("auth:two"))
+
+        cache.invalidate("catalog:")
+
+        assertNull(cache.read("catalog:one"))
+        assertEquals(second, cache.read("auth:two"))
+    }
+
+    @Test
+    fun corruptedSnapshotIsTreatedAsEmptyAndCanRecover() = runTest {
+        val storage = MemoryProviderCacheStorage("not-json")
+        val cache = JsonProviderPersistentCache(storage)
+        assertNull(cache.read("missing"))
+
+        val entry = PersistedProviderCacheEntry("recovered", 300L)
+        cache.write("key", entry)
+
+        assertEquals(entry, JsonProviderPersistentCache(storage).read("key"))
+    }
+}
+
+private class MemoryProviderCacheStorage(
+    private var content: String? = null,
+) : ProviderCacheSnapshotStorage {
+    override suspend fun readText(): String? = content
+    override suspend fun writeText(content: String) {
+        this.content = content
+    }
+    override suspend fun delete() {
+        content = null
+    }
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/JsonProviderPersistentCacheTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/JsonProviderPersistentCacheTest.kt
@@ -37,6 +37,25 @@ class JsonProviderPersistentCacheTest {
 
         assertEquals(entry, JsonProviderPersistentCache(storage).read("key"))
     }
+
+    @Test
+    fun oldestEntriesAreEvictedWhenCapacityIsExceeded() = runTest {
+        val storage = MemoryProviderCacheStorage()
+        val cache = JsonProviderPersistentCache(storage, maxEntries = 2)
+
+        cache.write("oldest", PersistedProviderCacheEntry("one", 100L))
+        cache.write("newest", PersistedProviderCacheEntry("two", 300L))
+        cache.write("middle", PersistedProviderCacheEntry("three", 200L))
+
+        assertNull(cache.read("oldest"))
+        assertEquals("two", cache.read("newest")?.value)
+        assertEquals("three", cache.read("middle")?.value)
+
+        val reopened = JsonProviderPersistentCache(storage, maxEntries = 2)
+        assertNull(reopened.read("oldest"))
+        assertEquals("two", reopened.read("newest")?.value)
+        assertEquals("three", reopened.read("middle")?.value)
+    }
 }
 
 private class MemoryProviderCacheStorage(

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/StorageBackedResourceCacheRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/StorageBackedResourceCacheRepositoryTest.kt
@@ -1,0 +1,43 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class StorageBackedResourceCacheRepositoryTest {
+    @Test
+    fun refreshUpdateAndClearKeepRepositoryStateInSync() = runTest {
+        val storage = FakeResourceCacheStorage(CacheUsage(audioBytes = 10L, imageBytes = 20L))
+        val repository = StorageBackedResourceCacheRepository(storage)
+
+        repository.refreshUsage()
+        assertEquals(CacheUsage(10L, 20L), repository.usage.value)
+
+        storage.nextUsage = CacheUsage(audioBytes = 30L, imageBytes = 40L)
+        val limit = CacheLimit(audioMaxBytes = 100L, imageMaxBytes = 200L)
+        repository.updateLimit(limit)
+        assertEquals(limit, storage.updatedLimit)
+        assertEquals(CacheUsage(30L, 40L), repository.usage.value)
+
+        repository.clearAll()
+        assertEquals(1, storage.clearCount)
+        assertEquals(CacheUsage(), repository.usage.value)
+    }
+}
+
+private class FakeResourceCacheStorage(
+    var nextUsage: CacheUsage,
+) : ResourceCacheStorage {
+    var updatedLimit: CacheLimit? = null
+    var clearCount = 0
+
+    override suspend fun usage(): CacheUsage = nextUsage
+
+    override suspend fun clearAll() {
+        clearCount += 1
+    }
+
+    override suspend fun updateLimit(limit: CacheLimit) {
+        updatedLimit = limit
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppDirectories.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppDirectories.kt
@@ -32,4 +32,17 @@ internal object DesktopAppDirectories {
         }
         return Paths.get(base, "FuoEvolve")
     }
+
+    fun cache(): Path {
+        val home = System.getProperty("user.home").orEmpty()
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val base = when {
+            osName.contains("win") -> System.getenv("LOCALAPPDATA")?.takeIf(String::isNotBlank)
+                ?: "$home/AppData/Local"
+            osName.contains("mac") -> "$home/Library/Caches"
+            else -> System.getenv("XDG_CACHE_HOME")?.takeIf(String::isNotBlank)
+                ?: "$home/.cache"
+        }
+        return Paths.get(base, "FuoEvolve")
+    }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
@@ -2,19 +2,24 @@ package org.feeluown.mobile
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 /** Desktop composition root. It hosts the same AppRoot/UI graph used by Android and iOS. */
 @Composable
-fun DesktopAppHost() {
+fun DesktopAppHost(externalInputs: Flow<String>? = null) {
     val container = remember { DesktopAppContainer() }
     DisposableEffect(container) {
         onDispose(container::close)
+    }
+    LaunchedEffect(container, externalInputs) {
+        externalInputs?.collect(container::openExternalInput)
     }
     DesktopProviderCredentialBackupHost(
         backup = container.providerCredentialBackup,
@@ -50,7 +55,7 @@ private class DesktopAppContainer {
     private val providerCredentialStore = createDesktopProviderCredentialStore()
     private val providerGraph = createFuoProviderGraph(
         credentials = providerCredentialStore,
-        persistentCache = null,
+        persistentCache = createDesktopProviderCacheStore(),
         isCellularConnection = { false },
     )
     val providerCredentialBackup by lazy {
@@ -84,10 +89,10 @@ private class DesktopAppContainer {
     private val homeRefreshPort: HomeRefreshPort by lazy { createHomeRefreshPort { homeFeatureController } }
     private val playbackResumeStore: PlaybackResumeStore = createDesktopPlaybackResumeStore()
     private val playbackQueueStore = createDesktopPlaybackQueueStore(playbackResumeStore)
-    private val listeningHistorySink: ListeningHistorySink = NoOpListeningHistorySink
-    private val resourceCacheRepository: ResourceCacheRepository = NoOpResourceCacheRepository
+    private val listeningHistorySink: ListeningHistorySink = createDesktopListeningHistorySink()
+    private val resourceCacheRepository: ResourceCacheRepository = createDesktopResourceCacheRepository()
     private val debugLogFeatureController by lazy {
-        createDebugLogFeatureController(NoOpDebugLogRepository, scope)
+        createDebugLogFeatureController(createDesktopDebugLogRepository(), scope)
     }
     private val audioRecognitionRepository: AudioRecognitionRepository = UnsupportedAudioRecognitionRepository
 
@@ -408,6 +413,23 @@ private class DesktopAppContainer {
 
     fun logoutProvider(provider: ProviderInfo) {
         providerAuthFeatureController.logout(provider.providerId)
+    }
+
+    fun openExternalInput(input: String) {
+        if (input == DESKTOP_ACTIVATION_FOCUS) return
+        val normalized = input.trim().trim('"')
+        if (normalized.isBlank()) return
+        val playlistResult = runCatching { readDesktopExternalPlaylist(normalized) }
+        playlistResult.exceptionOrNull()?.let { throwable ->
+            appViewModel.showFeedback(throwable.message ?: "无法读取本地歌单文件")
+            return
+        }
+        playlistResult.getOrNull()?.let { file ->
+            runCatching { localPlaylistFeatureController.prepareImport(file.fileName, file.content) }
+                .onFailure { appViewModel.showFeedback(it.message ?: "无法解析本地歌单文件") }
+            return
+        }
+        sharedResourceActionPort.open(normalized)
     }
 
     fun importLocalPlaylistFile() {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
@@ -90,27 +90,25 @@ private class DesktopDebugLogRepository : DebugLogRepository {
         val file = DesktopDebugLogCapture.logFile
         if (!Files.isRegularFile(file)) return@withContext emptyList()
         Files.readAllLines(file, StandardCharsets.UTF_8)
-            .asSequence()
             .map(String::trimEnd)
             .filter(String::isNotBlank)
             .takeLast(MAX_DEBUG_LOG_LINES)
-            .toList()
     }
 
     override suspend fun exportLogFile(lines: List<String>): String {
         if (lines.isEmpty()) return "没有可导出的日志"
         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
         val fileName = "fuo-evolve-log-$timestamp.txt"
-        val saved = withContext(Dispatchers.IO) {
-            saveDesktopTextFile(
-                dialogTitle = "导出应用日志",
-                suggestedFileName = fileName,
-                filterDescription = "文本日志 (*.txt)",
-                extensions = listOf("txt"),
-                content = lines.joinToString("\n"),
-                onFeedback = {},
-            )
-        }
+        // The common feature invokes export from its UI scope. Keep JFileChooser on that thread;
+        // only log reading itself belongs on Dispatchers.IO.
+        val saved = saveDesktopTextFile(
+            dialogTitle = "导出应用日志",
+            suggestedFileName = fileName,
+            filterDescription = "文本日志 (*.txt)",
+            extensions = listOf("txt"),
+            content = lines.joinToString("\n"),
+            onFeedback = {},
+        )
         return if (saved) "日志已导出：$fileName" else "已取消导出日志"
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
@@ -4,6 +4,7 @@ import java.io.OutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.text.SimpleDateFormat
@@ -35,13 +36,11 @@ private object DesktopDebugLogCapture {
         if (installed) return
         runCatching {
             Files.createDirectories(logDirectory)
-            rotateIfNeeded()
-            val sink = Files.newOutputStream(
-                logFile,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.APPEND,
-                StandardOpenOption.WRITE,
-            ).buffered()
+            val sink = RollingFileOutputStream(
+                activeFile = logFile,
+                previousFile = logDirectory.resolve("application.previous.log"),
+                maxBytes = MAX_DEBUG_LOG_BYTES,
+            )
             val originalOut = System.out
             val originalErr = System.err
             System.setOut(PrintStream(TeeOutputStream(originalOut, sink), true, StandardCharsets.UTF_8))
@@ -52,12 +51,82 @@ private object DesktopDebugLogCapture {
             System.err.println("FuoEvolve: unable to enable desktop debug log capture: ${throwable.message}")
         }
     }
+}
 
-    private fun rotateIfNeeded() {
-        if (!Files.isRegularFile(logFile) || Files.size(logFile) < MAX_DEBUG_LOG_BYTES) return
-        val previous = logDirectory.resolve("application.previous.log")
-        Files.move(logFile, previous, StandardCopyOption.REPLACE_EXISTING)
+/**
+ * A small platform filesystem primitive used by desktop log capture.
+ *
+ * Rotation happens at write time, so a long-running process cannot grow the active log without
+ * bound. Both stdout and stderr share the same instance, making rotation and file writes serialized.
+ */
+internal class RollingFileOutputStream(
+    private val activeFile: Path,
+    private val previousFile: Path,
+    private val maxBytes: Long,
+) : OutputStream() {
+    private var activeBytes: Long
+    private var file: OutputStream
+
+    init {
+        require(maxBytes > 0L) { "maxBytes must be positive" }
+        Files.createDirectories(requireNotNull(activeFile.parent))
+        if (Files.isRegularFile(activeFile) && Files.size(activeFile) >= maxBytes) {
+            Files.move(activeFile, previousFile, StandardCopyOption.REPLACE_EXISTING)
+        }
+        activeBytes = if (Files.isRegularFile(activeFile)) Files.size(activeFile) else 0L
+        file = openActiveFile()
     }
+
+    @Synchronized
+    override fun write(value: Int) {
+        ensureWritableFile()
+        file.write(value)
+        activeBytes += 1L
+    }
+
+    @Synchronized
+    override fun write(buffer: ByteArray, offset: Int, length: Int) {
+        if (length <= 0) return
+        var position = offset
+        var remaining = length
+        while (remaining > 0) {
+            ensureWritableFile()
+            val capacity = maxBytes - activeBytes
+            val chunkSize = minOf(remaining.toLong(), capacity).toInt()
+            file.write(buffer, position, chunkSize)
+            activeBytes += chunkSize.toLong()
+            position += chunkSize
+            remaining -= chunkSize
+        }
+    }
+
+    @Synchronized
+    override fun flush() {
+        file.flush()
+    }
+
+    @Synchronized
+    override fun close() {
+        file.close()
+    }
+
+    private fun ensureWritableFile() {
+        if (activeBytes < maxBytes) return
+        file.flush()
+        file.close()
+        if (Files.isRegularFile(activeFile)) {
+            Files.move(activeFile, previousFile, StandardCopyOption.REPLACE_EXISTING)
+        }
+        activeBytes = 0L
+        file = openActiveFile()
+    }
+
+    private fun openActiveFile(): OutputStream = Files.newOutputStream(
+        activeFile,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND,
+        StandardOpenOption.WRITE,
+    )
 }
 
 private class TeeOutputStream(

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
@@ -1,0 +1,116 @@
+package org.feeluown.mobile
+
+import java.io.OutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val MAX_DEBUG_LOG_LINES = 2_000
+private const val MAX_DEBUG_LOG_BYTES = 4L * 1024L * 1024L
+
+/** Install as early as possible so native/platform startup diagnostics are available in Settings. */
+fun installDesktopDebugLogCapture() {
+    DesktopDebugLogCapture.install()
+}
+
+internal fun createDesktopDebugLogRepository(): DebugLogRepository = DesktopDebugLogRepository()
+
+private object DesktopDebugLogCapture {
+    private val logDirectory
+        get() = DesktopAppDirectories.state().resolve("logs")
+    val logFile
+        get() = logDirectory.resolve("application.log")
+
+    private var installed = false
+
+    @Synchronized
+    fun install() {
+        if (installed) return
+        runCatching {
+            Files.createDirectories(logDirectory)
+            rotateIfNeeded()
+            val sink = Files.newOutputStream(
+                logFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND,
+                StandardOpenOption.WRITE,
+            ).buffered()
+            val originalOut = System.out
+            val originalErr = System.err
+            System.setOut(PrintStream(TeeOutputStream(originalOut, sink), true, StandardCharsets.UTF_8))
+            System.setErr(PrintStream(TeeOutputStream(originalErr, sink), true, StandardCharsets.UTF_8))
+            installed = true
+            System.err.println("FuoEvolve: desktop debug log capture enabled at $logFile")
+        }.onFailure { throwable ->
+            System.err.println("FuoEvolve: unable to enable desktop debug log capture: ${throwable.message}")
+        }
+    }
+
+    private fun rotateIfNeeded() {
+        if (!Files.isRegularFile(logFile) || Files.size(logFile) < MAX_DEBUG_LOG_BYTES) return
+        val previous = logDirectory.resolve("application.previous.log")
+        Files.move(logFile, previous, StandardCopyOption.REPLACE_EXISTING)
+    }
+}
+
+private class TeeOutputStream(
+    private val console: OutputStream,
+    private val file: OutputStream,
+) : OutputStream() {
+    @Synchronized
+    override fun write(value: Int) {
+        console.write(value)
+        file.write(value)
+    }
+
+    @Synchronized
+    override fun write(buffer: ByteArray, offset: Int, length: Int) {
+        console.write(buffer, offset, length)
+        file.write(buffer, offset, length)
+    }
+
+    @Synchronized
+    override fun flush() {
+        console.flush()
+        file.flush()
+    }
+}
+
+private class DesktopDebugLogRepository : DebugLogRepository {
+    override val isAvailable: Boolean = true
+
+    override suspend fun logLines(): List<String> = withContext(Dispatchers.IO) {
+        val file = DesktopDebugLogCapture.logFile
+        if (!Files.isRegularFile(file)) return@withContext emptyList()
+        Files.readAllLines(file, StandardCharsets.UTF_8)
+            .asSequence()
+            .map(String::trimEnd)
+            .filter(String::isNotBlank)
+            .takeLast(MAX_DEBUG_LOG_LINES)
+            .toList()
+    }
+
+    override suspend fun exportLogFile(lines: List<String>): String {
+        if (lines.isEmpty()) return "没有可导出的日志"
+        val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val fileName = "fuo-evolve-log-$timestamp.txt"
+        val saved = withContext(Dispatchers.IO) {
+            saveDesktopTextFile(
+                dialogTitle = "导出应用日志",
+                suggestedFileName = fileName,
+                filterDescription = "文本日志 (*.txt)",
+                extensions = listOf("txt"),
+                content = lines.joinToString("\n"),
+                onFeedback = {},
+            )
+        }
+        return if (saved) "日志已导出：$fileName" else "已取消导出日志"
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
@@ -130,8 +130,8 @@ class DesktopExternalActivationSession private constructor(
         }
 
         private fun relayToPrimary(endpointFile: Path, inputs: List<String>) {
-            val payload = inputs.filter(String::isNotBlank).take(MAX_ACTIVATION_INPUTS)
-            if (payload.isEmpty()) return
+            val requested = inputs.filter(String::isNotBlank).take(MAX_ACTIVATION_INPUTS)
+            val payload = requested.ifEmpty { listOf(DESKTOP_ACTIVATION_FOCUS) }
             repeat(RELAY_ATTEMPTS) { attempt ->
                 val endpoint = runCatching {
                     Files.readAllLines(endpointFile, StandardCharsets.UTF_8)

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
+private const val MAX_DESKTOP_ACTIVATION_INPUTS = 32
+
 /**
  * Desktop-only activation broker. It keeps one process owning persistence/native media integration
  * and forwards file/protocol activations from later launcher processes to that primary instance.
@@ -29,7 +31,12 @@ class DesktopExternalActivationSession private constructor(
     private val endpointFile: Path,
     initialInputs: List<String>,
 ) : AutoCloseable {
-    private val mutableInputs = MutableSharedFlow<String>(replay = 16, extraBufferCapacity = 48)
+    // Initial launcher arguments are emitted before Compose collectors attach, so replay must retain
+    // the same maximum batch that the secondary-instance relay accepts.
+    private val mutableInputs = MutableSharedFlow<String>(
+        replay = MAX_DESKTOP_ACTIVATION_INPUTS,
+        extraBufferCapacity = MAX_DESKTOP_ACTIVATION_INPUTS,
+    )
     val inputs: SharedFlow<String> = mutableInputs.asSharedFlow()
     private val token = UUID.randomUUID().toString()
     @Volatile
@@ -50,7 +57,11 @@ class DesktopExternalActivationSession private constructor(
             StandardOpenOption.TRUNCATE_EXISTING,
             StandardOpenOption.WRITE,
         )
-        initialInputs.filter(String::isNotBlank).forEach(mutableInputs::tryEmit)
+        initialInputs
+            .asSequence()
+            .filter(String::isNotBlank)
+            .take(MAX_DESKTOP_ACTIVATION_INPUTS)
+            .forEach(mutableInputs::tryEmit)
         serverThread.start()
         installAwtOpenHandlers()
     }
@@ -71,7 +82,7 @@ class DesktopExternalActivationSession private constructor(
                 runCatching {
                     val input = DataInputStream(incoming.getInputStream().buffered())
                     if (input.readUTF() != token) return@runCatching
-                    repeat(input.readInt().coerceIn(0, MAX_ACTIVATION_INPUTS)) {
+                    repeat(input.readInt().coerceIn(0, MAX_DESKTOP_ACTIVATION_INPUTS)) {
                         input.readUTF().takeIf(String::isNotBlank)?.let(mutableInputs::tryEmit)
                     }
                 }
@@ -130,7 +141,7 @@ class DesktopExternalActivationSession private constructor(
         }
 
         private fun relayToPrimary(endpointFile: Path, inputs: List<String>) {
-            val requested = inputs.filter(String::isNotBlank).take(MAX_ACTIVATION_INPUTS)
+            val requested = inputs.filter(String::isNotBlank).take(MAX_DESKTOP_ACTIVATION_INPUTS)
             val payload = requested.ifEmpty { listOf(DESKTOP_ACTIVATION_FOCUS) }
             repeat(RELAY_ATTEMPTS) { attempt ->
                 val endpoint = runCatching {
@@ -155,7 +166,6 @@ class DesktopExternalActivationSession private constructor(
             }
         }
 
-        private const val MAX_ACTIVATION_INPUTS = 32
         private const val RELAY_ATTEMPTS = 20
         private const val RELAY_RETRY_MS = 50L
     }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
@@ -1,0 +1,162 @@
+package org.feeluown.mobile
+
+import java.awt.Desktop
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.UUID
+import kotlin.concurrent.thread
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Desktop-only activation broker. It keeps one process owning persistence/native media integration
+ * and forwards file/protocol activations from later launcher processes to that primary instance.
+ */
+class DesktopExternalActivationSession private constructor(
+    private val lockChannel: FileChannel,
+    private val processLock: FileLock,
+    private val server: ServerSocket,
+    private val endpointFile: Path,
+    initialInputs: List<String>,
+) : AutoCloseable {
+    private val mutableInputs = MutableSharedFlow<String>(replay = 16, extraBufferCapacity = 48)
+    val inputs: SharedFlow<String> = mutableInputs.asSharedFlow()
+    private val token = UUID.randomUUID().toString()
+    @Volatile
+    private var closed = false
+
+    private val serverThread = thread(
+        start = false,
+        isDaemon = true,
+        name = "fuoevolve-desktop-activation",
+    ) { acceptLoop() }
+
+    init {
+        Files.writeString(
+            endpointFile,
+            "${server.localPort}\n$token",
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE,
+        )
+        initialInputs.filter(String::isNotBlank).forEach(mutableInputs::tryEmit)
+        serverThread.start()
+        installAwtOpenHandlers()
+    }
+
+    override fun close() {
+        closed = true
+        runCatching { server.close() }
+        runCatching { serverThread.join(500) }
+        runCatching { Files.deleteIfExists(endpointFile) }
+        runCatching { processLock.release() }
+        runCatching { lockChannel.close() }
+    }
+
+    private fun acceptLoop() {
+        while (!closed) {
+            val socket = runCatching { server.accept() }.getOrNull() ?: break
+            socket.use { incoming ->
+                runCatching {
+                    val input = DataInputStream(incoming.getInputStream().buffered())
+                    if (input.readUTF() != token) return@runCatching
+                    repeat(input.readInt().coerceIn(0, MAX_ACTIVATION_INPUTS)) {
+                        input.readUTF().takeIf(String::isNotBlank)?.let(mutableInputs::tryEmit)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun installAwtOpenHandlers() {
+        if (!Desktop.isDesktopSupported()) return
+        val desktop = runCatching { Desktop.getDesktop() }.getOrNull() ?: return
+        if (desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {
+            runCatching {
+                desktop.setOpenFileHandler { event ->
+                    event.files.forEach { file -> mutableInputs.tryEmit(file.absolutePath) }
+                }
+            }
+        }
+        if (desktop.isSupported(Desktop.Action.APP_OPEN_URI)) {
+            runCatching {
+                desktop.setOpenURIHandler { event -> mutableInputs.tryEmit(event.uri.toString()) }
+            }
+        }
+    }
+
+    companion object {
+        /** Returns null in a secondary process after its activation has been relayed. */
+        fun open(initialInputs: List<String>): DesktopExternalActivationSession? {
+            val directory = DesktopAppDirectories.state().resolve("activation")
+            Files.createDirectories(directory)
+            val lockFile = directory.resolve("instance.lock")
+            val endpointFile = directory.resolve("endpoint")
+            val channel = FileChannel.open(
+                lockFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+            )
+            val lock = runCatching { channel.tryLock() }.getOrNull()
+            if (lock == null) {
+                channel.close()
+                relayToPrimary(endpointFile, initialInputs)
+                return null
+            }
+            return runCatching {
+                DesktopExternalActivationSession(
+                    lockChannel = channel,
+                    processLock = lock,
+                    server = ServerSocket(0, 16, InetAddress.getLoopbackAddress()),
+                    endpointFile = endpointFile,
+                    initialInputs = initialInputs,
+                )
+            }.getOrElse { throwable ->
+                runCatching { lock.release() }
+                runCatching { channel.close() }
+                throw throwable
+            }
+        }
+
+        private fun relayToPrimary(endpointFile: Path, inputs: List<String>) {
+            val payload = inputs.filter(String::isNotBlank).take(MAX_ACTIVATION_INPUTS)
+            if (payload.isEmpty()) return
+            repeat(RELAY_ATTEMPTS) { attempt ->
+                val endpoint = runCatching {
+                    Files.readAllLines(endpointFile, StandardCharsets.UTF_8)
+                }.getOrNull()
+                val port = endpoint?.getOrNull(0)?.toIntOrNull()
+                val token = endpoint?.getOrNull(1)
+                if (port != null && !token.isNullOrBlank()) {
+                    val sent = runCatching {
+                        Socket(InetAddress.getLoopbackAddress(), port).use { socket ->
+                            DataOutputStream(socket.getOutputStream().buffered()).use { output ->
+                                output.writeUTF(token)
+                                output.writeInt(payload.size)
+                                payload.forEach(output::writeUTF)
+                                output.flush()
+                            }
+                        }
+                    }.isSuccess
+                    if (sent) return
+                }
+                if (attempt + 1 < RELAY_ATTEMPTS) Thread.sleep(RELAY_RETRY_MS)
+            }
+        }
+
+        private const val MAX_ACTIVATION_INPUTS = 32
+        private const val RELAY_ATTEMPTS = 20
+        private const val RELAY_RETRY_MS = 50L
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
@@ -24,8 +24,8 @@ private const val MAX_DESKTOP_ACTIVATION_INPUTS = 32
  * Desktop-only activation broker. It keeps one process owning persistence/native media integration
  * and forwards file/protocol activations from later launcher processes to that primary instance.
  *
- * Inputs are queued for one composition-root consumer instead of replayed as state. This preserves
- * startup activations without making old deep links fire again if the UI collector is recreated.
+ * Payloads are queued for exactly one business consumer, while focus requests use a separate queue.
+ * This preserves startup events without replaying old deep links if a UI collector is recreated.
  */
 class DesktopExternalActivationSession private constructor(
     private val lockChannel: FileChannel,
@@ -35,7 +35,9 @@ class DesktopExternalActivationSession private constructor(
     initialInputs: List<String>,
 ) : AutoCloseable {
     private val inputChannel = Channel<String>(Channel.UNLIMITED)
+    private val focusChannel = Channel<Unit>(Channel.UNLIMITED)
     val inputs: Flow<String> = inputChannel.receiveAsFlow()
+    val focusRequests: Flow<Unit> = focusChannel.receiveAsFlow()
     private val token = UUID.randomUUID().toString()
     @Volatile
     private var closed = false
@@ -59,7 +61,7 @@ class DesktopExternalActivationSession private constructor(
             .asSequence()
             .filter(String::isNotBlank)
             .take(MAX_DESKTOP_ACTIVATION_INPUTS)
-            .forEach { inputChannel.trySend(it) }
+            .forEach(::enqueue)
         serverThread.start()
         installAwtOpenHandlers()
     }
@@ -67,11 +69,18 @@ class DesktopExternalActivationSession private constructor(
     override fun close() {
         closed = true
         inputChannel.close()
+        focusChannel.close()
         runCatching { server.close() }
         runCatching { serverThread.join(500) }
         runCatching { Files.deleteIfExists(endpointFile) }
         runCatching { processLock.release() }
         runCatching { lockChannel.close() }
+    }
+
+    private fun enqueue(value: String) {
+        if (value.isBlank() || closed) return
+        inputChannel.trySend(value)
+        focusChannel.trySend(Unit)
     }
 
     private fun acceptLoop() {
@@ -82,7 +91,7 @@ class DesktopExternalActivationSession private constructor(
                     val input = DataInputStream(incoming.getInputStream().buffered())
                     if (input.readUTF() != token) return@runCatching
                     repeat(input.readInt().coerceIn(0, MAX_DESKTOP_ACTIVATION_INPUTS)) {
-                        input.readUTF().takeIf(String::isNotBlank)?.let { value -> inputChannel.trySend(value) }
+                        input.readUTF().takeIf(String::isNotBlank)?.let(::enqueue)
                     }
                 }
             }
@@ -95,13 +104,13 @@ class DesktopExternalActivationSession private constructor(
         if (desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {
             runCatching {
                 desktop.setOpenFileHandler { event ->
-                    event.files.forEach { file -> inputChannel.trySend(file.absolutePath) }
+                    event.files.forEach { file -> enqueue(file.absolutePath) }
                 }
             }
         }
         if (desktop.isSupported(Desktop.Action.APP_OPEN_URI)) {
             runCatching {
-                desktop.setOpenURIHandler { event -> inputChannel.trySend(event.uri.toString()) }
+                desktop.setOpenURIHandler { event -> enqueue(event.uri.toString()) }
             }
         }
     }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalActivation.kt
@@ -14,15 +14,18 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.util.UUID
 import kotlin.concurrent.thread
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 private const val MAX_DESKTOP_ACTIVATION_INPUTS = 32
 
 /**
  * Desktop-only activation broker. It keeps one process owning persistence/native media integration
  * and forwards file/protocol activations from later launcher processes to that primary instance.
+ *
+ * Inputs are queued for one composition-root consumer instead of replayed as state. This preserves
+ * startup activations without making old deep links fire again if the UI collector is recreated.
  */
 class DesktopExternalActivationSession private constructor(
     private val lockChannel: FileChannel,
@@ -31,13 +34,8 @@ class DesktopExternalActivationSession private constructor(
     private val endpointFile: Path,
     initialInputs: List<String>,
 ) : AutoCloseable {
-    // Initial launcher arguments are emitted before Compose collectors attach, so replay must retain
-    // the same maximum batch that the secondary-instance relay accepts.
-    private val mutableInputs = MutableSharedFlow<String>(
-        replay = MAX_DESKTOP_ACTIVATION_INPUTS,
-        extraBufferCapacity = MAX_DESKTOP_ACTIVATION_INPUTS,
-    )
-    val inputs: SharedFlow<String> = mutableInputs.asSharedFlow()
+    private val inputChannel = Channel<String>(Channel.UNLIMITED)
+    val inputs: Flow<String> = inputChannel.receiveAsFlow()
     private val token = UUID.randomUUID().toString()
     @Volatile
     private var closed = false
@@ -61,13 +59,14 @@ class DesktopExternalActivationSession private constructor(
             .asSequence()
             .filter(String::isNotBlank)
             .take(MAX_DESKTOP_ACTIVATION_INPUTS)
-            .forEach(mutableInputs::tryEmit)
+            .forEach { inputChannel.trySend(it) }
         serverThread.start()
         installAwtOpenHandlers()
     }
 
     override fun close() {
         closed = true
+        inputChannel.close()
         runCatching { server.close() }
         runCatching { serverThread.join(500) }
         runCatching { Files.deleteIfExists(endpointFile) }
@@ -83,7 +82,7 @@ class DesktopExternalActivationSession private constructor(
                     val input = DataInputStream(incoming.getInputStream().buffered())
                     if (input.readUTF() != token) return@runCatching
                     repeat(input.readInt().coerceIn(0, MAX_DESKTOP_ACTIVATION_INPUTS)) {
-                        input.readUTF().takeIf(String::isNotBlank)?.let(mutableInputs::tryEmit)
+                        input.readUTF().takeIf(String::isNotBlank)?.let { value -> inputChannel.trySend(value) }
                     }
                 }
             }
@@ -96,13 +95,13 @@ class DesktopExternalActivationSession private constructor(
         if (desktop.isSupported(Desktop.Action.APP_OPEN_FILE)) {
             runCatching {
                 desktop.setOpenFileHandler { event ->
-                    event.files.forEach { file -> mutableInputs.tryEmit(file.absolutePath) }
+                    event.files.forEach { file -> inputChannel.trySend(file.absolutePath) }
                 }
             }
         }
         if (desktop.isSupported(Desktop.Action.APP_OPEN_URI)) {
             runCatching {
-                desktop.setOpenURIHandler { event -> mutableInputs.tryEmit(event.uri.toString()) }
+                desktop.setOpenURIHandler { event -> inputChannel.trySend(event.uri.toString()) }
             }
         }
     }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalInput.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopExternalInput.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+internal const val DESKTOP_ACTIVATION_FOCUS = "fuoevolve-internal://focus"
+
+/** Resolve only platform file IO here; playlist parsing/import remains in the common feature owner. */
+internal fun readDesktopExternalPlaylist(input: String): DesktopTextFile? {
+    val normalized = input.trim().trim('"')
+    val path = when {
+        normalized.startsWith("file:", ignoreCase = true) ->
+            runCatching { Paths.get(URI(normalized)) }.getOrNull()
+        "://" !in normalized -> runCatching { Paths.get(normalized) }.getOrNull()
+        else -> null
+    } ?: return null
+    if (!path.isFuoPlaylistFile()) return null
+    return DesktopTextFile(
+        fileName = path.fileName.toString(),
+        content = Files.readString(path, StandardCharsets.UTF_8),
+    )
+}
+
+private fun Path.isFuoPlaylistFile(): Boolean =
+    Files.isRegularFile(this) && fileName.toString().substringAfterLast('.', "").equals("fuo", ignoreCase = true)

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlatformServices.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlatformServices.kt
@@ -1,5 +1,6 @@
 package org.feeluown.mobile
 
+import java.nio.file.Path
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +17,18 @@ fun installDesktopPlaybackSessionIntegrationFactory(factory: (PlaybackSession) -
 
 internal fun createDesktopPlaybackSessionIntegration(playbackSession: PlaybackSession): AutoCloseable =
     desktopPlaybackSessionIntegrationFactory?.invoke(playbackSession) ?: AutoCloseable { }
+
+@Volatile
+private var desktopListeningHistorySinkFactory: ((Path) -> ListeningHistorySink)? = null
+
+/** Installs the JVM SQLDelight history backend while shared playback sees only its sink contract. */
+fun installDesktopListeningHistorySinkFactory(factory: (Path) -> ListeningHistorySink) {
+    desktopListeningHistorySinkFactory = factory
+}
+
+internal fun createDesktopListeningHistorySink(): ListeningHistorySink =
+    desktopListeningHistorySinkFactory?.invoke(DesktopAppDirectories.data().resolve("listening_history.db"))
+        ?: NoOpListeningHistorySink
 
 @Volatile
 private var desktopLocalMusicRepositoryFactory: (() -> LocalMusicRepository)? = null

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCacheStore.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCacheStore.kt
@@ -19,7 +19,7 @@ private class DesktopProviderCacheSnapshotStorage(
     private val file: Path,
 ) : ProviderCacheSnapshotStorage {
     override suspend fun readText(): String? = withContext(Dispatchers.IO) {
-        file.takeIf(Files::isRegularFile)?.let { Files.readString(it, StandardCharsets.UTF_8) }
+        file.takeIf { Files.isRegularFile(it) }?.let { Files.readString(it, StandardCharsets.UTF_8) }
     }
 
     override suspend fun writeText(content: String) {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCacheStore.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopProviderCacheStore.kt
@@ -1,0 +1,51 @@
+package org.feeluown.mobile
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.feeluown.mobile.provider.core.network.ProviderPersistentCache
+
+internal fun createDesktopProviderCacheStore(): ProviderPersistentCache = JsonProviderPersistentCache(
+    DesktopProviderCacheSnapshotStorage(
+        DesktopAppDirectories.cache().resolve("provider_http_cache.json"),
+    ),
+)
+
+private class DesktopProviderCacheSnapshotStorage(
+    private val file: Path,
+) : ProviderCacheSnapshotStorage {
+    override suspend fun readText(): String? = withContext(Dispatchers.IO) {
+        file.takeIf(Files::isRegularFile)?.let { Files.readString(it, StandardCharsets.UTF_8) }
+    }
+
+    override suspend fun writeText(content: String) {
+        withContext(Dispatchers.IO) {
+            val directory = requireNotNull(file.parent)
+            Files.createDirectories(directory)
+            val temporary = Files.createTempFile(directory, ".provider-cache-", ".tmp")
+            try {
+                Files.writeString(temporary, content, StandardCharsets.UTF_8)
+                try {
+                    Files.move(
+                        temporary,
+                        file,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING,
+                    )
+                } catch (_: AtomicMoveNotSupportedException) {
+                    Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING)
+                }
+            } finally {
+                Files.deleteIfExists(temporary)
+            }
+        }
+    }
+
+    override suspend fun delete() {
+        withContext(Dispatchers.IO) { Files.deleteIfExists(file) }
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
@@ -1,0 +1,126 @@
+package org.feeluown.mobile
+
+import java.net.URI
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal fun createDesktopResourceCacheRepository(): ResourceCacheRepository =
+    StorageBackedResourceCacheRepository(DesktopResourceCache)
+
+/** Desktop filesystem adapter for resource caching. Shared code owns repository state semantics. */
+internal object DesktopResourceCache : ResourceCacheStorage {
+    private val root: Path
+        get() = DesktopAppDirectories.cache().resolve("resources")
+    private val imageDirectory: Path
+        get() = root.resolve("images")
+
+    private val lock = Any()
+    private var imageLimitBytes = DEFAULT_IMAGE_CACHE_LIMIT_MB.toLong() * 1024L * 1024L
+
+    override suspend fun usage(): CacheUsage = withContext(Dispatchers.IO) {
+        synchronized(lock) {
+            CacheUsage(
+                // libmpv owns its streaming buffer; do not report a fake Media3-style disk audio cache.
+                audioBytes = 0L,
+                imageBytes = directorySize(imageDirectory),
+            )
+        }
+    }
+
+    override suspend fun clearAll() {
+        withContext(Dispatchers.IO) {
+            synchronized(lock) {
+                deleteRecursively(root)
+                Files.createDirectories(root)
+            }
+        }
+    }
+
+    override suspend fun updateLimit(limit: CacheLimit) {
+        withContext(Dispatchers.IO) {
+            synchronized(lock) {
+                imageLimitBytes = limit.imageMaxBytes.coerceAtLeast(0L)
+                trimImagesLocked()
+            }
+        }
+    }
+
+    fun cachedRemoteImage(url: String): Path? = synchronized(lock) {
+        if (!isHttpUrl(url)) return null
+        if (imageLimitBytes <= 0L) return null
+        Files.createDirectories(imageDirectory)
+        val target = imageDirectory.resolve("${sha256(url)}.img")
+        if (Files.isRegularFile(target) && Files.size(target) > 0L) {
+            Files.setLastModifiedTime(target, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()))
+            return target
+        }
+
+        val temporary = Files.createTempFile(imageDirectory, ".cover-", ".tmp")
+        return try {
+            URL(url).openConnection().run {
+                connectTimeout = 15_000
+                readTimeout = 20_000
+                getInputStream().use { input -> Files.newOutputStream(temporary).use(input::copyTo) }
+            }
+            if (Files.size(temporary) <= 0L) {
+                null
+            } else {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING)
+                Files.setLastModifiedTime(target, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()))
+                trimImagesLocked()
+                target.takeIf(Files::isRegularFile)
+            }
+        } catch (_: Throwable) {
+            null
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+    }
+
+    private fun trimImagesLocked() {
+        if (!Files.isDirectory(imageDirectory)) return
+        if (imageLimitBytes <= 0L) {
+            deleteRecursively(imageDirectory)
+            return
+        }
+        val files = Files.list(imageDirectory).use { stream ->
+            stream.filter(Files::isRegularFile).toList()
+        }
+        var total = files.sumOf { runCatching { Files.size(it) }.getOrDefault(0L) }
+        files.sortedBy { runCatching { Files.getLastModifiedTime(it).toMillis() }.getOrDefault(0L) }
+            .forEach { file ->
+                if (total <= imageLimitBytes) return
+                val size = runCatching { Files.size(file) }.getOrDefault(0L)
+                if (Files.deleteIfExists(file)) total -= size
+            }
+    }
+
+    private fun directorySize(directory: Path): Long {
+        if (!Files.isDirectory(directory)) return 0L
+        return Files.walk(directory).use { stream ->
+            stream.filter(Files::isRegularFile)
+                .mapToLong { runCatching { Files.size(it) }.getOrDefault(0L) }
+                .sum()
+        }
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path).use { stream ->
+            stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    private fun isHttpUrl(value: String): Boolean = runCatching {
+        URI(value).scheme?.lowercase() in setOf("http", "https")
+    }.getOrDefault(false)
+
+    private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.encodeToByteArray())
+        .joinToString("") { byte -> "%02x".format(byte) }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
+import java.util.Comparator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -51,8 +52,7 @@ internal object DesktopResourceCache : ResourceCacheStorage {
     }
 
     fun cachedRemoteImage(url: String): Path? = synchronized(lock) {
-        if (!isHttpUrl(url)) return null
-        if (imageLimitBytes <= 0L) return null
+        if (!isHttpUrl(url) || imageLimitBytes <= 0L) return null
         Files.createDirectories(imageDirectory)
         val target = imageDirectory.resolve("${sha256(url)}.img")
         if (Files.isRegularFile(target) && Files.size(target) > 0L) {
@@ -65,7 +65,9 @@ internal object DesktopResourceCache : ResourceCacheStorage {
             URL(url).openConnection().run {
                 connectTimeout = 15_000
                 readTimeout = 20_000
-                getInputStream().use { input -> Files.newOutputStream(temporary).use(input::copyTo) }
+                getInputStream().use { input ->
+                    Files.newOutputStream(temporary).use { output -> input.copyTo(output) }
+                }
             }
             if (Files.size(temporary) <= 0L) {
                 null

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopResourceCache.kt
@@ -75,7 +75,7 @@ internal object DesktopResourceCache : ResourceCacheStorage {
                 Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING)
                 Files.setLastModifiedTime(target, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()))
                 trimImagesLocked()
-                target.takeIf(Files::isRegularFile)
+                target.takeIf { Files.isRegularFile(it) }
             }
         } catch (_: Throwable) {
             null
@@ -91,7 +91,7 @@ internal object DesktopResourceCache : ResourceCacheStorage {
             return
         }
         val files = Files.list(imageDirectory).use { stream ->
-            stream.filter(Files::isRegularFile).toList()
+            stream.filter { Files.isRegularFile(it) }.toList()
         }
         var total = files.sumOf { runCatching { Files.size(it) }.getOrDefault(0L) }
         files.sortedBy { runCatching { Files.getLastModifiedTime(it).toMillis() }.getOrDefault(0L) }
@@ -105,7 +105,7 @@ internal object DesktopResourceCache : ResourceCacheStorage {
     private fun directorySize(directory: Path): Long {
         if (!Files.isDirectory(directory)) return 0L
         return Files.walk(directory).use { stream ->
-            stream.filter(Files::isRegularFile)
+            stream.filter { Files.isRegularFile(it) }
                 .mapToLong { runCatching { Files.size(it) }.getOrDefault(0L) }
                 .sum()
         }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformCoverArt.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformCoverArt.desktop.kt
@@ -23,13 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.jetbrains.skia.Image
 import java.net.URI
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Paths
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
 
 @Composable
 actual fun PlatformCoverArt(
@@ -86,7 +86,9 @@ private suspend fun loadDesktopCover(imageUrl: String): ImageBitmap? = withConte
 
     val bytes = when {
         resolvedUrl.startsWith("file:") -> Files.readAllBytes(Paths.get(URI(resolvedUrl)))
-        else -> URL(resolvedUrl).openStream().use { it.readBytes() }
+        else -> DesktopResourceCache.cachedRemoteImage(resolvedUrl)
+            ?.let(Files::readAllBytes)
+            ?: URL(resolvedUrl).openStream().use { it.readBytes() }
     }
     runCatching { Image.makeFromEncoded(bytes).toComposeImageBitmap() }.getOrNull()
 }

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/RollingFileOutputStreamTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/RollingFileOutputStreamTest.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.util.Comparator
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/RollingFileOutputStreamTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/RollingFileOutputStreamTest.kt
@@ -1,0 +1,32 @@
+package org.feeluown.mobile
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RollingFileOutputStreamTest {
+    @Test
+    fun rotatesDuringWritesAndBoundsActiveFile() {
+        val directory = Files.createTempDirectory("fuoevolve-log-test")
+        try {
+            val active = directory.resolve("application.log")
+            val previous = directory.resolve("application.previous.log")
+
+            RollingFileOutputStream(active, previous, maxBytes = 8L).use { output ->
+                output.write("123456".toByteArray(StandardCharsets.UTF_8))
+                output.write("7890".toByteArray(StandardCharsets.UTF_8))
+            }
+
+            assertEquals("12345678", Files.readString(previous, StandardCharsets.UTF_8))
+            assertEquals("90", Files.readString(active, StandardCharsets.UTF_8))
+            assertTrue(Files.size(active) <= 8L)
+            assertTrue(Files.size(previous) <= 8L)
+        } finally {
+            Files.walk(directory).use { stream ->
+                stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Complete the next four desktop parity capabilities while keeping shared semantics platform-neutral and isolating OS-specific work at the desktop edge.

### Listening history
- reuse the existing common SQLDelight listening-history schema/store/query model
- add only a Desktop JDBC SQLite driver factory under `:persistence:listening`
- inject the resulting `ListeningHistorySink` through the existing desktop platform boundary

### Provider and resource cache
- extract provider persistent-cache JSON serialization, corruption handling, prefix invalidation and locking into common code
- refactor Android to reuse that common provider-cache implementation
- extract `ResourceCacheRepository` state/refresh/clear/limit semantics into common code and refactor Android to reuse it
- add Desktop filesystem adapters for provider HTTP cache and cover-art disk cache
- keep Desktop audio cache usage at zero because libmpv owns streaming buffering; do not emulate Android Media3 cache semantics

### Debug logs
- reuse the existing common debug-log feature/controller and filtering UI
- add Desktop stdout/stderr capture with bounded rolling files under the platform state directory
- export through the existing generic Desktop text-file dialog boundary

### External resources / deep links
- keep resource parsing/navigation in the existing common `SharedResourceActionPort`
- add Desktop single-instance activation with loopback forwarding so relaunching a hidden-to-tray app focuses the existing process
- route `.fuo` files through platform file IO into the common local-playlist import flow
- register `.fuo` file association for packaged Desktop apps
- register `fuo://` through macOS Info.plist and per-user Windows/Linux protocol handlers

### Tests
- common provider persistent-cache behavior tests
- common resource-cache repository state tests
- Desktop SQLDelight database creation smoke test

Application update/version, video playback, and audio recognition remain out of scope.