### PR TITLE
feat: add desktop video playback and audio recognition

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAudioRecognitionRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAudioRecognitionRepository.kt
@@ -16,122 +16,42 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.ContextCompat
-import java.net.HttpURLConnection
-import java.net.URI
-import java.net.URLEncoder
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import org.json.JSONArray
 import org.json.JSONObject
 
 class AndroidAudioRecognitionRepository(
-    private val context: Context,
+    context: Context,
 ) : AudioRecognitionRepository {
-    private val cancelled = AtomicBoolean(false)
-    private val matching = AtomicBoolean(false)
-    private val recognitionMutex = Mutex()
-    private val activeConnection = AtomicReference<HttpURLConnection?>()
-    private val fingerprintRuntime = AndroidFingerprintRuntime(context.applicationContext)
-
-    @Volatile
-    private var audioRecord: AudioRecord? = null
+    private val delegate = DefaultAudioRecognitionRepository(
+        captureDevice = AndroidAudioRecognitionCaptureDevice(context.applicationContext),
+        fingerprintRuntime = AndroidFingerprintRuntime(context.applicationContext),
+        matcher = NeteaseAudioRecognitionMatcher(),
+    )
 
     override suspend fun recognize(onEvent: (AudioRecognitionEvent) -> Unit): List<RecognizedSong> =
-        recognitionMutex.withLock {
-            coroutineScope recognition@{
-                checkMicrophonePermission()
-                cancelled.set(false)
-                val sessionId = UUID.randomUUID().toString()
-                val windows = Channel<FloatArray>(Channel.CONFLATED)
-                val captureJob = launch(Dispatchers.IO) {
-                    captureWindows(windows, onEvent)
-                }
-                var attempt = 1
-                try {
-                    while (isActive && !cancelled.get()) {
-                        val window = windows.receive()
-                        matching.set(true)
-                        withContext(Dispatchers.Main.immediate) {
-                            onEvent(AudioRecognitionEvent.Matching(attempt))
-                        }
-                        val fingerprint = fingerprintRuntime.generate(
-                            downsampleRecognitionWindow(window),
-                        )
-                        val matches = withContext(Dispatchers.IO) {
-                            requestMatches(sessionId, fingerprint)
-                        }
-                        if (matches.isNotEmpty()) {
-                            withContext(Dispatchers.Main.immediate) {
-                                onEvent(AudioRecognitionEvent.Success(matches))
-                            }
-                            return@recognition matches
-                        }
-                        matching.set(false)
-                        withContext(Dispatchers.Main.immediate) {
-                            onEvent(AudioRecognitionEvent.NoMatch(attempt))
-                        }
-                        attempt += 1
-                    }
-                    emptyList()
-                } catch (throwable: Throwable) {
-                    if (throwable !is CancellationException && !cancelled.get()) {
-                        withContext(Dispatchers.Main.immediate) {
-                            onEvent(
-                                AudioRecognitionEvent.Error(
-                                    throwable.message ?: "听歌识曲失败",
-                                ),
-                            )
-                        }
-                    }
-                    throw throwable
-                } finally {
-                    cancelled.set(true)
-                    matching.set(false)
-                    releaseAudioRecord()
-                    activeConnection.getAndSet(null)?.disconnect()
-                    captureJob.cancel()
-                    windows.close()
-                }
-            }
-        }
+        delegate.recognize(onEvent)
 
-    override fun cancel() {
-        cancelled.set(true)
-        matching.set(false)
-        releaseAudioRecord()
-        activeConnection.getAndSet(null)?.disconnect()
-    }
+    override fun cancel() = delegate.cancel()
+}
 
-    private fun checkMicrophonePermission() {
-        if (
-            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) !=
-            PackageManager.PERMISSION_GRANTED
-        ) {
-            throw SecurityException("需要麦克风权限")
-        }
-    }
+private class AndroidAudioRecognitionCaptureDevice(
+    private val context: Context,
+) : AudioRecognitionCaptureDevice {
+    private val activeRecorder = AtomicReference<AudioRecord?>()
 
-    @SuppressLint("MissingPermission")
-    private suspend fun captureWindows(
-        windows: Channel<FloatArray>,
-        onEvent: (AudioRecognitionEvent) -> Unit,
-    ) {
+    override suspend fun capture(onSamples: (FloatArray) -> Unit) = withContext(Dispatchers.IO) {
+        checkMicrophonePermission()
         val minBufferSize = AudioRecord.getMinBufferSize(
             AUDIO_RECOGNITION_SAMPLE_RATE,
             AudioFormat.CHANNEL_IN_MONO,
@@ -141,89 +61,35 @@ class AndroidAudioRecognitionRepository(
         val recorder = createAudioRecord(MediaRecorder.AudioSource.UNPROCESSED, minBufferSize)
             ?: createAudioRecord(MediaRecorder.AudioSource.MIC, minBufferSize)
             ?: throw IllegalStateException("麦克风初始化失败")
-        audioRecord = recorder
+        check(activeRecorder.compareAndSet(null, recorder)) { "麦克风录音已经在进行中" }
         val readBuffer = ShortArray(2_048)
-        var window = FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES)
-        var windowOffset = 0
-        var captureAttempt = 1
-        var lastProgressMs = -1L
         try {
             recorder.startRecording()
-            while (!cancelled.get()) {
+            while (activeRecorder.get() === recorder) {
                 val read = recorder.read(readBuffer, 0, readBuffer.size, AudioRecord.READ_BLOCKING)
                 if (read < 0) {
-                    if (cancelled.get()) break
+                    if (activeRecorder.get() !== recorder) break
                     throw IllegalStateException("麦克风读取失败：$read")
                 }
-                var sourceOffset = 0
-                while (sourceOffset < read) {
-                    val copied = minOf(read - sourceOffset, window.size - windowOffset)
-                    for (index in 0 until copied) {
-                        window[windowOffset + index] = readBuffer[sourceOffset + index] / 32768f
-                    }
-                    sourceOffset += copied
-                    windowOffset += copied
-                    val capturedMs = windowOffset * 1_000L / AUDIO_RECOGNITION_SAMPLE_RATE
-                    if (!matching.get() && capturedMs - lastProgressMs >= 250L) {
-                        lastProgressMs = capturedMs
-                        withContext(Dispatchers.Main.immediate) {
-                            onEvent(
-                                AudioRecognitionEvent.Capturing(
-                                    attempt = captureAttempt,
-                                    capturedMs = capturedMs,
-                                ),
-                            )
-                        }
-                    }
-                    if (windowOffset == window.size) {
-                        windows.trySend(window)
-                        window = FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES)
-                        windowOffset = 0
-                        captureAttempt += 1
-                        lastProgressMs = -1
-                    }
+                if (read > 0) {
+                    onSamples(FloatArray(read) { index -> readBuffer[index] / 32768f })
                 }
             }
         } finally {
-            releaseAudioRecord(recorder)
+            releaseRecorder(recorder)
         }
     }
 
-    private fun requestMatches(sessionId: String, fingerprint: String): List<RecognizedSong> {
-        val body = formBody(
-            "sessionId" to sessionId,
-            "algorithmCode" to "shazam_v2",
-            "duration" to "6",
-            "rawdata" to fingerprint,
-            "times" to "2",
-            "decrypt" to "1",
-        )
-        val connection = URI(RECOGNITION_ENDPOINT).toURL().openConnection() as HttpURLConnection
-        activeConnection.set(connection)
-        return try {
-            connection.requestMethod = "POST"
-            connection.connectTimeout = 15_000
-            connection.readTimeout = 15_000
-            connection.doOutput = true
-            connection.setRequestProperty(
-                "Content-Type",
-                "application/x-www-form-urlencoded; charset=UTF-8",
-            )
-            connection.setRequestProperty(
-                "Origin",
-                "chrome-extension://pgphbbekcgpfaekhcbjamjjkegcclhhd",
-            )
-            connection.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
-            val status = connection.responseCode
-            val response = (if (status in 200..299) connection.inputStream else connection.errorStream)
-                ?.bufferedReader()
-                ?.use { it.readText() }
-                .orEmpty()
-            check(status in 200..299) { "识别接口请求失败：HTTP $status" }
-            parseMatches(response)
-        } finally {
-            activeConnection.compareAndSet(connection, null)
-            connection.disconnect()
+    override fun cancel() {
+        activeRecorder.getAndSet(null)?.let(::stopAndRelease)
+    }
+
+    private fun checkMicrophonePermission() {
+        if (
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            throw SecurityException("需要麦克风权限")
         }
     }
 
@@ -247,80 +113,28 @@ class AndroidAudioRecognitionRepository(
         return null
     }
 
-    private fun parseMatches(response: String): List<RecognizedSong> {
-        val root = JSONObject(response)
-        check(root.optInt("code") == 200) {
-            root.optString("message").ifBlank { "识别接口返回错误" }
-        }
-        val data = root.optJSONObject("data")
-            ?: throw IllegalStateException("识别接口响应缺少 data")
-        val resultValue = data.opt("result")
-        if (resultValue == null || resultValue == JSONObject.NULL) return emptyList()
-        val results = resultValue as? JSONArray
-            ?: throw IllegalStateException("识别接口 result 格式错误")
-        return buildList {
-            for (index in 0 until results.length()) {
-                val match = results.optJSONObject(index) ?: continue
-                val song = match.optJSONObject("song") ?: continue
-                val title = song.optString("name")
-                if (title.isBlank()) continue
-                val artists = song.optJSONArray("artists") ?: song.optJSONArray("ar")
-                val album = song.optJSONObject("album") ?: song.optJSONObject("al")
-                add(
-                    RecognizedSong(
-                        neteaseSongId = song.opt("id")?.toString()?.takeIf { it.isNotBlank() },
-                        title = title,
-                        artists = artists.artistNames(),
-                        album = album?.optString("name").orEmpty(),
-                        coverUrl = album?.optString("picUrl")?.takeIf { it.isNotBlank() },
-                        matchStartTimeMs = match.optLong("startTime")
-                            .takeIf { match.has("startTime") },
-                    ),
-                )
-            }
-        }
+    private fun releaseRecorder(recorder: AudioRecord) {
+        activeRecorder.compareAndSet(recorder, null)
+        stopAndRelease(recorder)
     }
 
-    private fun JSONArray?.artistNames(): List<String> {
-        if (this == null) return emptyList()
-        return buildList {
-            for (index in 0 until length()) {
-                optJSONObject(index)?.optString("name")?.takeIf { it.isNotBlank() }?.let(::add)
-            }
-        }
-    }
-
-    private fun formBody(vararg fields: Pair<String, String>): String =
-        fields.joinToString("&") { (key, value) ->
-            "${URLEncoder.encode(key, Charsets.UTF_8.name())}=" +
-                URLEncoder.encode(value, Charsets.UTF_8.name())
-        }
-
-    private fun releaseAudioRecord(expected: AudioRecord? = null) {
-        val recorder = audioRecord
-        if (expected != null && recorder !== expected) return
-        audioRecord = null
-        recorder ?: return
+    private fun stopAndRelease(recorder: AudioRecord) {
         runCatching { recorder.stop() }
         runCatching { recorder.release() }
-    }
-
-    private companion object {
-        const val RECOGNITION_ENDPOINT = "https://interface.music.163.com/api/music/audio/match"
     }
 }
 
 private class AndroidFingerprintRuntime(
     private val context: Context,
-) {
+) : AudioFingerprintRuntime {
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val pending = ConcurrentHashMap<String, kotlin.coroutines.Continuation<String>>()
+    private val pending = ConcurrentHashMap<String, Continuation<String>>()
     private var webView: WebView? = null
     private var ready = false
     private val waiting = mutableListOf<() -> Unit>()
     private val bridge = FingerprintBridge()
 
-    suspend fun generate(samples: FloatArray): String = suspendCancellableCoroutine { continuation ->
+    override suspend fun generate(samples: FloatArray): String = suspendCancellableCoroutine { continuation ->
         val requestId = UUID.randomUUID().toString()
         pending[requestId] = continuation
         continuation.invokeOnCancellation { pending.remove(requestId) }
@@ -335,6 +149,18 @@ private class AndroidFingerprintRuntime(
                 )
             }
             if (ready) action() else waiting.add(action)
+        }
+    }
+
+    override fun cancel() {
+        mainHandler.post {
+            waiting.clear()
+            val cancellation = CancellationException("听歌识曲已取消")
+            pending.entries.toList().forEach { (requestId, continuation) ->
+                if (pending.remove(requestId, continuation)) {
+                    continuation.resumeWithException(cancellation)
+                }
+            }
         }
     }
 
@@ -367,10 +193,7 @@ private class AndroidFingerprintRuntime(
                 }
 
                 override fun onPageFinished(view: WebView, url: String) {
-                    view.evaluateJavascript(
-                        "void globalThis.fuoFingerprint.verifyRuntime()",
-                        null,
-                    )
+                    view.evaluateJavascript("void globalThis.fuoFingerprint.verifyRuntime()", null)
                 }
             }
             val runtimeHtml = context.assets.open("audio_recognition/runtime.html")
@@ -395,7 +218,7 @@ private class AndroidFingerprintRuntime(
                     waiting.toList().forEach { it() }
                     waiting.clear()
                 } else {
-                    failWaiting(IllegalStateException("音频指纹运行时初始化失败：$error"))
+                    failPending(IllegalStateException("音频指纹运行时初始化失败：$error"))
                 }
             }
         }
@@ -415,7 +238,7 @@ private class AndroidFingerprintRuntime(
         }
     }
 
-    private fun failWaiting(error: Throwable) {
+    private fun failPending(error: Throwable) {
         waiting.clear()
         pending.entries.toList().forEach { (requestId, continuation) ->
             if (pending.remove(requestId, continuation)) {

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -371,6 +371,8 @@ compose.desktop {
                 appCategory = "public.app-category.music"
                 infoPlist {
                     extraKeysRawXml = """
+                        <key>NSMicrophoneUsageDescription</key>
+                        <string>FuoEvolve 使用麦克风进行听歌识曲。</string>
                         <key>CFBundleURLTypes</key>
                         <array>
                             <dict>

--- a/desktopApp/native/web-login/src/main.rs
+++ b/desktopApp/native/web-login/src/main.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::io::{self, Read, Write};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use tao::{
     dpi::LogicalSize,
@@ -9,9 +11,36 @@ use tao::{
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
 };
-use wry::{NewWindowResponse, WebViewBuilder};
+use wry::{
+    http::{header::CONTENT_TYPE, Response},
+    NewWindowResponse, WebViewBuilder,
+};
 
 const COOKIE_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const FINGERPRINT_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const FINGERPRINT_TIMEOUT: Duration = Duration::from_secs(20);
+const RUNTIME_HTML: &[u8] = include_bytes!(
+    "../../../../shared/src/commonMain/resources/audio_recognition/runtime.html"
+);
+const FINGERPRINT_JS: &[u8] = include_bytes!(
+    "../../../../shared/src/commonMain/resources/audio_recognition/fingerprint.js"
+);
+const AFP_WASM: &[u8] = include_bytes!(
+    "../../../../shared/src/commonMain/resources/audio_recognition/afp.wasm"
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum HelperRequest {
+    Fingerprint(FingerprintRequest),
+    Login(LoginRequest),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FingerprintRequest {
+    samples_base64: String,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -31,35 +60,56 @@ enum LoginResponse {
     Error { message: String },
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum FingerprintResponse {
+    Success { fingerprint: String },
+    Error { message: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FingerprintBridgeMessage {
+    #[serde(default)]
+    runtime_ready: bool,
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    fingerprint: String,
+    #[serde(default)]
+    error: String,
+}
+
 fn main() {
-    match read_request().and_then(run) {
-        Ok(()) => {}
-        Err(error) => {
-            emit_response(&LoginResponse::Error {
-                message: error.to_string(),
-            });
-            std::process::exit(1);
-        }
+    let result = read_request().and_then(|request| match request {
+        HelperRequest::Login(request) => run_login(request),
+        HelperRequest::Fingerprint(request) => run_fingerprint(request),
+    });
+    if let Err(error) = result {
+        emit_json(&FingerprintResponse::Error {
+            message: error.to_string(),
+        });
+        std::process::exit(1);
     }
 }
 
-fn read_request() -> Result<LoginRequest, Box<dyn Error>> {
+fn read_request() -> Result<HelperRequest, Box<dyn Error>> {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
     if input.trim().is_empty() {
-        return Err("missing login request on stdin".into());
+        return Err("missing helper request on stdin".into());
     }
-    let request: LoginRequest = serde_json::from_str(&input)?;
+    Ok(serde_json::from_str(&input)?)
+}
+
+fn run_login(request: LoginRequest) -> Result<(), Box<dyn Error>> {
     if request.provider_id.trim().is_empty() {
         return Err("providerId is required".into());
     }
     if request.login_url.trim().is_empty() {
         return Err("loginUrl is required".into());
     }
-    Ok(request)
-}
 
-fn run(request: LoginRequest) -> Result<(), Box<dyn Error>> {
     let event_loop = EventLoop::new();
     let title = if request.provider_name.trim().is_empty() {
         format!("FuoEvolve 登录 - {}", request.provider_id)
@@ -112,7 +162,7 @@ fn run(request: LoginRequest) -> Result<(), Box<dyn Error>> {
                             .map(|cookie| (cookie.name().to_owned(), cookie.value().to_owned()))
                             .collect::<BTreeMap<_, _>>();
                         if has_required_cookies(&cookies, &cookie_key_groups) {
-                            emit_response(&LoginResponse::Success { cookies });
+                            emit_json(&LoginResponse::Success { cookies });
                             finished = true;
                             *control_flow = ControlFlow::Exit;
                         }
@@ -128,7 +178,7 @@ fn run(request: LoginRequest) -> Result<(), Box<dyn Error>> {
                 ..
             } => {
                 if !finished {
-                    emit_response(&LoginResponse::Cancelled);
+                    emit_json(&LoginResponse::Cancelled);
                     finished = true;
                 }
                 *control_flow = ControlFlow::Exit;
@@ -136,6 +186,144 @@ fn run(request: LoginRequest) -> Result<(), Box<dyn Error>> {
             _ => {}
         }
     });
+}
+
+fn run_fingerprint(request: FingerprintRequest) -> Result<(), Box<dyn Error>> {
+    if request.samples_base64.trim().is_empty() {
+        return Err("samplesBase64 is required".into());
+    }
+
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new()
+        .with_title("FuoEvolve Audio Fingerprint")
+        .with_visible(false)
+        .with_inner_size(LogicalSize::new(1.0, 1.0))
+        .build(&event_loop)?;
+    let (bridge_sender, bridge_receiver) = mpsc::channel::<FingerprintBridgeMessage>();
+
+    let builder = WebViewBuilder::new()
+        .with_visible(false)
+        .with_incognito(true)
+        .with_custom_protocol("fuofingerprint".into(), |_webview_id, request| {
+            fingerprint_resource_response(request.uri().path())
+        })
+        .with_ipc_handler(move |request| {
+            if let Ok(message) = serde_json::from_str::<FingerprintBridgeMessage>(request.body()) {
+                let _ = bridge_sender.send(message);
+            }
+        })
+        .with_initialization_script(
+            "window.addEventListener('load', () => { void globalThis.fuoFingerprint.verifyRuntime(); });",
+        )
+        .with_url("fuofingerprint://localhost/runtime.html");
+
+    #[cfg(target_os = "linux")]
+    let webview = {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+        builder.build_gtk(window.gtk_window())?
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let webview = builder.build(&window)?;
+
+    let samples_base64 = request.samples_base64;
+    let started_at = Instant::now();
+    let mut next_poll = Instant::now();
+    let mut generate_started = false;
+    let mut finished = false;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::WaitUntil(next_poll);
+        match event {
+            Event::NewEvents(StartCause::ResumeTimeReached { .. }) | Event::MainEventsCleared => {
+                if finished || Instant::now() < next_poll {
+                    return;
+                }
+                next_poll = Instant::now() + FINGERPRINT_POLL_INTERVAL;
+
+                if started_at.elapsed() >= FINGERPRINT_TIMEOUT {
+                    emit_json(&FingerprintResponse::Error {
+                        message: "音频指纹运行时初始化超时".to_string(),
+                    });
+                    finished = true;
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
+
+                while let Ok(message) = bridge_receiver.try_recv() {
+                    if message.runtime_ready {
+                        if !message.error.is_empty() {
+                            emit_json(&FingerprintResponse::Error {
+                                message: format!("音频指纹运行时初始化失败：{}", message.error),
+                            });
+                            finished = true;
+                            *control_flow = ControlFlow::Exit;
+                            return;
+                        }
+                        if !generate_started {
+                            generate_started = true;
+                            let script = format!(
+                                "void globalThis.fuoFingerprint.generate('desktop', {});",
+                                serde_json::to_string(&samples_base64).unwrap_or_else(|_| "\"\"".into()),
+                            );
+                            if let Err(error) = webview.evaluate_script(&script) {
+                                emit_json(&FingerprintResponse::Error {
+                                    message: format!("无法执行音频指纹运行时：{error}"),
+                                });
+                                finished = true;
+                                *control_flow = ControlFlow::Exit;
+                                return;
+                            }
+                        }
+                    } else if message.request_id == "desktop" {
+                        if message.error.is_empty() && !message.fingerprint.is_empty() {
+                            emit_json(&FingerprintResponse::Success {
+                                fingerprint: message.fingerprint,
+                            });
+                        } else {
+                            emit_json(&FingerprintResponse::Error {
+                                message: if message.error.is_empty() {
+                                    "音频指纹结果为空".to_string()
+                                } else {
+                                    format!("音频指纹生成失败：{}", message.error)
+                                },
+                            });
+                        }
+                        finished = true;
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
+                }
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                if !finished {
+                    emit_json(&FingerprintResponse::Error {
+                        message: "音频指纹窗口意外关闭".to_string(),
+                    });
+                    finished = true;
+                }
+                *control_flow = ControlFlow::Exit;
+            }
+            _ => {}
+        }
+    });
+}
+
+fn fingerprint_resource_response(path: &str) -> Response<Cow<'static, [u8]>> {
+    let (body, content_type): (&'static [u8], &'static str) = match path {
+        "/runtime.html" | "/" => (RUNTIME_HTML, "text/html; charset=utf-8"),
+        "/fingerprint.js" => (FINGERPRINT_JS, "application/javascript; charset=utf-8"),
+        "/afp.wasm" => (AFP_WASM, "application/wasm"),
+        _ => (b"not found", "text/plain; charset=utf-8"),
+    };
+    Response::builder()
+        .header(CONTENT_TYPE, content_type)
+        .body(Cow::Borrowed(body))
+        .expect("valid embedded recognition response")
 }
 
 fn has_required_cookies(
@@ -151,7 +339,7 @@ fn has_required_cookies(
         })
 }
 
-fn emit_response(response: &LoginResponse) {
+fn emit_json<T: Serialize>(response: &T) {
     let stdout = io::stdout();
     let mut output = stdout.lock();
     if serde_json::to_writer(&mut output, response).is_ok() {
@@ -183,5 +371,34 @@ mod tests {
             &cookies,
             &[vec!["a".to_string(), "b".to_string()]],
         ));
+    }
+
+    #[test]
+    fn helper_request_keeps_legacy_login_shape() {
+        let request: HelperRequest = serde_json::from_str(
+            r#"{"providerId":"netease","providerName":"NetEase","loginUrl":"https://example.test","cookieKeyGroups":[["MUSIC_U"]]}"#,
+        )
+        .unwrap();
+        assert!(matches!(request, HelperRequest::Login(_)));
+    }
+
+    #[test]
+    fn helper_request_accepts_fingerprint_shape() {
+        let request: HelperRequest = serde_json::from_str(r#"{"samplesBase64":"AQID"}"#).unwrap();
+        assert!(matches!(request, HelperRequest::Fingerprint(_)));
+    }
+
+    #[test]
+    fn embedded_fingerprint_resources_have_expected_mime_types() {
+        assert_eq!(
+            fingerprint_resource_response("/afp.wasm")
+                .headers()
+                .get(CONTENT_TYPE)
+                .unwrap(),
+            "application/wasm",
+        );
+        assert!(!RUNTIME_HTML.is_empty());
+        assert!(!FINGERPRINT_JS.is_empty());
+        assert!(!AFP_WASM.is_empty());
     }
 }

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopMpvVideoController.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopMpvVideoController.kt
@@ -1,0 +1,470 @@
+package org.feeluown.mobile.desktop
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import com.sun.jna.Library
+import com.sun.jna.Memory
+import com.sun.jna.Native
+import com.sun.jna.Platform
+import com.sun.jna.Pointer
+import com.sun.jna.StringArray
+import com.sun.jna.Structure
+import com.sun.jna.ptr.PointerByReference
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.math.sqrt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.feeluown.mobile.DesktopPlatformVideoController
+import org.feeluown.mobile.PlatformVideoPlaybackState
+import org.feeluown.mobile.VideoPlaybackPayload
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+
+internal class DesktopMpvVideoController(
+    private val library: MpvVideoNative = loadMpvVideoLibrary(),
+) : DesktopPlatformVideoController {
+    private val closed = AtomicBoolean(false)
+    private val mutableState = MutableStateFlow(PlatformVideoPlaybackState())
+    override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
+    private val mutableFrame = MutableStateFlow<ImageBitmap?>(null)
+    override val frame: StateFlow<ImageBitmap?> = mutableFrame.asStateFlow()
+
+    private val handle: Pointer
+    private val renderContext: Pointer
+    private val eventThread: Thread
+    private val renderThread: Thread
+
+    @Volatile private var viewportWidth = 0
+    @Volatile private var viewportHeight = 0
+    @Volatile private var playbackActive = false
+
+    init {
+        handle = library.mpv_create()
+            ?: throw IllegalStateException("libmpv mpv_create() returned null for video")
+        var createdRenderContext: Pointer? = null
+        try {
+            setOption("config", "no")
+            setOption("terminal", "no")
+            setOption("input-default-bindings", "no")
+            setOption("ytdl", "no")
+            setOption("vo", "libmpv")
+            setOption("hwdec", "no")
+            setOption("audio-display", "no")
+            checkMpv(library.mpv_initialize(handle), "mpv_initialize video")
+            createdRenderContext = createSoftwareRenderContext()
+            VIDEO_OBSERVED_PROPERTIES.forEach { property ->
+                checkMpv(
+                    library.mpv_observe_property(handle, 0L, property, MPV_FORMAT_STRING),
+                    "observe video $property",
+                )
+            }
+        } catch (throwable: Throwable) {
+            createdRenderContext?.let(library::mpv_render_context_free)
+            library.mpv_terminate_destroy(handle)
+            throw throwable
+        }
+        renderContext = checkNotNull(createdRenderContext)
+        eventThread = thread(
+            start = true,
+            isDaemon = true,
+            name = "fuoevolve-libmpv-video-events",
+            block = ::eventLoop,
+        )
+        renderThread = thread(
+            start = true,
+            isDaemon = true,
+            name = "fuoevolve-libmpv-video-render",
+            block = ::renderLoop,
+        )
+    }
+
+    override fun setPayload(payload: VideoPlaybackPayload?) {
+        ensureOpen()
+        mutableFrame.value = null
+        if (payload == null) {
+            playbackActive = false
+            command("stop")
+            mutableState.value = PlatformVideoPlaybackState()
+            return
+        }
+        val mainUrl = payload.url.takeIf(String::isNotBlank)
+            ?: payload.videoUrl.takeIf(String::isNotBlank)
+        if (mainUrl == null) {
+            playbackActive = false
+            mutableState.value = PlatformVideoPlaybackState(errorMessage = "当前视频没有可播放地址")
+            return
+        }
+        val externalAudio = if (payload.url.isBlank()) payload.audioUrl.takeIf(String::isNotBlank) else null
+        val options = encodeVideoLoadfileOptions(payload.headers, externalAudio)
+        mutableState.value = PlatformVideoPlaybackState()
+        playbackActive = true
+        if (options.isBlank()) {
+            command("loadfile", mainUrl, "replace")
+        } else {
+            command("loadfile", mainUrl, "replace", "-1", options)
+        }
+    }
+
+    override fun setViewportSize(width: Int, height: Int) {
+        viewportWidth = width.coerceAtLeast(0)
+        viewportHeight = height.coerceAtLeast(0)
+    }
+
+    override fun play() {
+        ensureOpen()
+        setProperty("pause", "no")
+    }
+
+    override fun pause() {
+        ensureOpen()
+        setProperty("pause", "yes")
+    }
+
+    override fun seekTo(positionMs: Long) {
+        ensureOpen()
+        command("seek", (positionMs.coerceAtLeast(0L) / 1000.0).toString(), "absolute")
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        playbackActive = false
+        library.mpv_wakeup(handle)
+        if (Thread.currentThread() !== eventThread) runCatching { eventThread.join(2_000) }
+        if (Thread.currentThread() !== renderThread) runCatching { renderThread.join(2_000) }
+        library.mpv_render_context_free(renderContext)
+        library.mpv_terminate_destroy(handle)
+        mutableFrame.value = null
+    }
+
+    private fun createSoftwareRenderContext(): Pointer {
+        val apiType = Memory(3).apply { setString(0, MPV_RENDER_API_TYPE_SW) }
+        val params = renderParams(2)
+        params[0].type = MPV_RENDER_PARAM_API_TYPE
+        params[0].data = apiType
+        params[1].type = MPV_RENDER_PARAM_INVALID
+        writeParams(params)
+        val result = PointerByReference()
+        checkMpv(
+            library.mpv_render_context_create(result, handle, params.first().pointer),
+            "create software video render context",
+        )
+        return result.value ?: throw IllegalStateException("libmpv returned null video render context")
+    }
+
+    private fun eventLoop() {
+        try {
+            while (!closed.get()) {
+                val pointer = library.mpv_wait_event(handle, -1.0)
+                val event = VideoMpvEvent(pointer)
+                when (event.eventId) {
+                    MPV_EVENT_NONE -> Unit
+                    MPV_EVENT_SHUTDOWN -> break
+                    MPV_EVENT_PLAYBACK_RESTART -> {
+                        playbackActive = true
+                        mutableState.value = mutableState.value.copy(isPlaying = true, errorMessage = null)
+                    }
+                    MPV_EVENT_PROPERTY_CHANGE -> {
+                        val data = event.data ?: continue
+                        val property = VideoMpvEventProperty(data)
+                        handleProperty(
+                            property.name?.getString(0, StandardCharsets.UTF_8.name()).orEmpty(),
+                            property.stringValue(),
+                        )
+                    }
+                    MPV_EVENT_END_FILE -> {
+                        val data = event.data ?: continue
+                        val endFile = VideoMpvEndFile(data)
+                        playbackActive = false
+                        if (endFile.reason == MPV_END_FILE_REASON_ERROR && endFile.error < 0) {
+                            mutableState.value = mutableState.value.copy(
+                                isPlaying = false,
+                                errorMessage = library.mpv_error_string(endFile.error)
+                                    ?.let { "视频播放失败：$it" }
+                                    ?: "视频播放失败",
+                            )
+                        } else {
+                            mutableState.value = mutableState.value.copy(isPlaying = false)
+                        }
+                    }
+                }
+            }
+        } catch (throwable: Throwable) {
+            if (!closed.get()) {
+                mutableState.value = mutableState.value.copy(
+                    isPlaying = false,
+                    errorMessage = throwable.message ?: "libmpv 视频事件处理失败",
+                )
+            }
+        }
+    }
+
+    private fun handleProperty(name: String, value: String?) {
+        when (name) {
+            "pause" -> mutableState.value = mutableState.value.copy(
+                isPlaying = playbackActive && value != "yes" && value != "true",
+            )
+            "time-pos" -> value.secondsToMsOrNull()?.let { position ->
+                mutableState.value = mutableState.value.copy(positionMs = position.coerceAtLeast(0L))
+            }
+            "duration" -> value.secondsToMsOrNull()?.let { duration ->
+                mutableState.value = mutableState.value.copy(durationMs = duration.coerceAtLeast(0L))
+            }
+            "demuxer-cache-time" -> value.secondsToMsOrNull()?.let { buffered ->
+                val duration = mutableState.value.durationMs
+                mutableState.value = mutableState.value.copy(
+                    bufferedMs = if (duration > 0) buffered.coerceIn(0, duration) else buffered.coerceAtLeast(0),
+                )
+            }
+            "video-params/w" -> value?.toIntOrNull()?.let { width ->
+                mutableState.value = mutableState.value.copy(videoWidth = width.coerceAtLeast(0))
+            }
+            "video-params/h" -> value?.toIntOrNull()?.let { height ->
+                mutableState.value = mutableState.value.copy(videoHeight = height.coerceAtLeast(0))
+            }
+        }
+    }
+
+    private fun renderLoop() {
+        var surface: SoftwareRenderSurface? = null
+        while (!closed.get()) {
+            val target = boundedVideoRenderSize(viewportWidth, viewportHeight)
+            if (!playbackActive || target.first <= 0 || target.second <= 0) {
+                Thread.sleep(if (playbackActive) 30L else 80L)
+                continue
+            }
+            try {
+                if (surface == null || surface.width != target.first || surface.height != target.second) {
+                    surface = SoftwareRenderSurface(target.first, target.second)
+                }
+                val currentSurface = surface
+                renderTo(currentSurface)
+                val bytes = currentSurface.pixels.getByteArray(0, currentSurface.byteSize)
+                val imageInfo = ImageInfo.makeN32(
+                    currentSurface.width,
+                    currentSurface.height,
+                    ColorAlphaType.OPAQUE,
+                )
+                mutableFrame.value = Image.makeRaster(
+                    imageInfo,
+                    bytes,
+                    currentSurface.stride,
+                ).toComposeImageBitmap()
+            } catch (throwable: Throwable) {
+                if (!closed.get()) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = throwable.message ?: "视频画面渲染失败",
+                    )
+                }
+                Thread.sleep(100L)
+            }
+            Thread.sleep(VIDEO_RENDER_INTERVAL_MS)
+        }
+    }
+
+    private fun renderTo(surface: SoftwareRenderSurface) {
+        val size = Memory(8).apply {
+            setInt(0, surface.width)
+            setInt(4, surface.height)
+        }
+        val format = Memory(5).apply { setString(0, MPV_SW_PIXEL_FORMAT) }
+        val stride = Memory(Native.SIZE_T_SIZE.toLong()).apply {
+            if (Native.SIZE_T_SIZE == Long.SIZE_BYTES) setLong(0, surface.stride.toLong())
+            else setInt(0, surface.stride)
+        }
+        val params = renderParams(5)
+        params[0].type = MPV_RENDER_PARAM_SW_SIZE
+        params[0].data = size
+        params[1].type = MPV_RENDER_PARAM_SW_FORMAT
+        params[1].data = format
+        params[2].type = MPV_RENDER_PARAM_SW_STRIDE
+        params[2].data = stride
+        params[3].type = MPV_RENDER_PARAM_SW_POINTER
+        params[3].data = surface.pixels
+        params[4].type = MPV_RENDER_PARAM_INVALID
+        writeParams(params)
+        checkMpv(
+            library.mpv_render_context_render(renderContext, params.first().pointer),
+            "render software video frame",
+        )
+    }
+
+    private fun setOption(name: String, value: String) {
+        checkMpv(library.mpv_set_option_string(handle, name, value), "set video option $name")
+    }
+
+    private fun setProperty(name: String, value: String) {
+        checkMpv(library.mpv_set_property_string(handle, name, value), "set video property $name")
+    }
+
+    private fun command(vararg args: String) {
+        checkMpv(library.mpv_command(handle, StringArray(args)), "video command ${args.firstOrNull().orEmpty()}")
+    }
+
+    private fun checkMpv(result: Int, operation: String) {
+        if (result >= 0) return
+        val detail = library.mpv_error_string(result) ?: "error $result"
+        throw IllegalStateException("libmpv $operation failed: $detail")
+    }
+
+    private fun ensureOpen() {
+        check(!closed.get()) { "libmpv video controller is closed" }
+    }
+}
+
+internal fun boundedVideoRenderSize(width: Int, height: Int): Pair<Int, Int> {
+    if (width <= 0 || height <= 0) return 0 to 0
+    val pixels = width.toLong() * height.toLong()
+    if (pixels <= MAX_SOFTWARE_RENDER_PIXELS) return width to height
+    val scale = sqrt(MAX_SOFTWARE_RENDER_PIXELS.toDouble() / pixels.toDouble())
+    return (width * scale).toInt().coerceAtLeast(1) to (height * scale).toInt().coerceAtLeast(1)
+}
+
+private class SoftwareRenderSurface(
+    val width: Int,
+    val height: Int,
+) {
+    val stride: Int = alignTo64(width * BYTES_PER_PIXEL)
+    val byteSize: Long = stride.toLong() * height
+    val pixels = Memory(byteSize)
+}
+
+internal fun encodeVideoLoadfileOptions(
+    headers: Map<String, String>,
+    externalAudioUrl: String?,
+): String = buildList {
+    encodeMpvLoadfileOptions(headers).takeIf(String::isNotBlank)?.let(::add)
+    externalAudioUrl?.takeIf(String::isNotBlank)?.let { url ->
+        add("audio-files-append=${mpvVideoFixedLength(url)}")
+    }
+}.joinToString(",")
+
+private fun mpvVideoFixedLength(value: String): String {
+    val byteLength = value.toByteArray(StandardCharsets.UTF_8).size
+    return "%$byteLength%$value"
+}
+
+private fun alignTo64(value: Int): Int = ((value + 63) / 64) * 64
+
+private fun renderParams(count: Int): List<MpvRenderParam> =
+    MpvRenderParam().toArray(count).map { it as MpvRenderParam }
+
+private fun writeParams(params: List<MpvRenderParam>) = params.forEach(Structure::write)
+
+internal interface MpvVideoNative : Library {
+    fun mpv_create(): Pointer?
+    fun mpv_initialize(ctx: Pointer): Int
+    fun mpv_terminate_destroy(ctx: Pointer)
+    fun mpv_set_option_string(ctx: Pointer, name: String, data: String): Int
+    fun mpv_set_property_string(ctx: Pointer, name: String, data: String): Int
+    fun mpv_command(ctx: Pointer, args: Pointer): Int
+    fun mpv_observe_property(ctx: Pointer, replyUserdata: Long, name: String, format: Int): Int
+    fun mpv_wait_event(ctx: Pointer, timeout: Double): Pointer
+    fun mpv_wakeup(ctx: Pointer)
+    fun mpv_error_string(error: Int): String?
+    fun mpv_render_context_create(result: PointerByReference, mpv: Pointer, params: Pointer): Int
+    fun mpv_render_context_render(context: Pointer, params: Pointer): Int
+    fun mpv_render_context_free(context: Pointer)
+}
+
+private class MpvRenderParam : Structure() {
+    @JvmField var type: Int = 0
+    @JvmField var data: Pointer? = null
+    override fun getFieldOrder(): List<String> = listOf("type", "data")
+}
+
+private class VideoMpvEvent(pointer: Pointer) : Structure(pointer) {
+    @JvmField var eventId: Int = 0
+    @JvmField var error: Int = 0
+    @JvmField var replyUserdata: Long = 0L
+    @JvmField var data: Pointer? = null
+    override fun getFieldOrder(): List<String> = listOf("eventId", "error", "replyUserdata", "data")
+    init { read() }
+}
+
+private class VideoMpvEventProperty(pointer: Pointer) : Structure(pointer) {
+    @JvmField var name: Pointer? = null
+    @JvmField var format: Int = 0
+    @JvmField var data: Pointer? = null
+    override fun getFieldOrder(): List<String> = listOf("name", "format", "data")
+    init { read() }
+    fun stringValue(): String? {
+        if (format != MPV_FORMAT_STRING) return null
+        val stringPointer = data?.getPointer(0L) ?: return null
+        return stringPointer.getString(0L, StandardCharsets.UTF_8.name())
+    }
+}
+
+private class VideoMpvEndFile(pointer: Pointer) : Structure(pointer) {
+    @JvmField var reason: Int = 0
+    @JvmField var error: Int = 0
+    @JvmField var playlistEntryId: Long = 0L
+    @JvmField var playlistInsertId: Long = 0L
+    @JvmField var playlistInsertNumEntries: Int = 0
+    override fun getFieldOrder(): List<String> = listOf(
+        "reason", "error", "playlistEntryId", "playlistInsertId", "playlistInsertNumEntries",
+    )
+    init { read() }
+}
+
+private fun loadMpvVideoLibrary(): MpvVideoNative {
+    val explicit = System.getProperty("fuoevolve.libmpv.path")
+        ?.takeIf(String::isNotBlank)
+        ?: System.getenv("FUOEVOLVE_LIBMPV_PATH")?.takeIf(String::isNotBlank)
+    val candidates = buildList {
+        explicit?.let(::add)
+        when {
+            Platform.isWindows() -> addAll(listOf("mpv-2", "mpv"))
+            Platform.isMac() -> addAll(listOf("mpv", "libmpv.dylib"))
+            else -> addAll(listOf("mpv", "libmpv.so.2", "libmpv.so"))
+        }
+    }.distinct()
+    var lastFailure: Throwable? = null
+    candidates.forEach { candidate ->
+        try {
+            return Native.load(candidate, MpvVideoNative::class.java)
+        } catch (throwable: Throwable) {
+            lastFailure = throwable
+        }
+    }
+    throw IllegalStateException(
+        "Unable to load libmpv video renderer from ${candidates.joinToString()}",
+        lastFailure,
+    )
+}
+
+private fun String?.secondsToMsOrNull(): Long? = this
+    ?.toDoubleOrNull()
+    ?.takeIf(Double::isFinite)
+    ?.let { seconds -> (seconds * 1000.0).toLong() }
+
+private const val MPV_FORMAT_STRING = 1
+private const val MPV_EVENT_NONE = 0
+private const val MPV_EVENT_SHUTDOWN = 1
+private const val MPV_EVENT_END_FILE = 7
+private const val MPV_EVENT_PLAYBACK_RESTART = 21
+private const val MPV_EVENT_PROPERTY_CHANGE = 22
+private const val MPV_END_FILE_REASON_ERROR = 4
+private const val MPV_RENDER_PARAM_INVALID = 0
+private const val MPV_RENDER_PARAM_API_TYPE = 1
+private const val MPV_RENDER_PARAM_SW_SIZE = 17
+private const val MPV_RENDER_PARAM_SW_FORMAT = 18
+private const val MPV_RENDER_PARAM_SW_STRIDE = 19
+private const val MPV_RENDER_PARAM_SW_POINTER = 20
+private const val MPV_RENDER_API_TYPE_SW = "sw"
+private const val MPV_SW_PIXEL_FORMAT = "bgr0"
+private const val BYTES_PER_PIXEL = 4
+private const val VIDEO_RENDER_INTERVAL_MS = 33L
+private const val MAX_SOFTWARE_RENDER_PIXELS = 1920L * 1080L
+
+private val VIDEO_OBSERVED_PROPERTIES = listOf(
+    "pause",
+    "time-pos",
+    "duration",
+    "demuxer-cache-time",
+    "video-params/w",
+    "video-params/h",
+)

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/JnaPointerExtensions.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/JnaPointerExtensions.kt
@@ -1,0 +1,9 @@
+package org.feeluown.mobile.desktop
+
+import com.sun.jna.Pointer
+
+/** Keep large native buffers bounds-checked before passing their length to JNA's Int-sized array API. */
+internal fun Pointer.getByteArray(offset: Long, arraySize: Long): ByteArray {
+    require(arraySize in 0..Int.MAX_VALUE.toLong()) { "native buffer too large: $arraySize bytes" }
+    return getByteArray(offset, arraySize.toInt())
+}

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -21,6 +21,7 @@ import org.feeluown.mobile.createDesktopPlaybackResumeStore
 import org.feeluown.mobile.installDesktopDebugLogCapture
 import org.feeluown.mobile.installDesktopListeningHistorySinkFactory
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
+import org.feeluown.mobile.installDesktopPlatformVideoControllerFactory
 import org.feeluown.mobile.installDesktopPlaybackEngineFactory
 import org.feeluown.mobile.installDesktopPlaybackSessionIntegrationFactory
 import org.feeluown.mobile.installDesktopProviderCredentialStoreFactory
@@ -43,6 +44,7 @@ fun main(args: Array<String>) {
             resumeStore = createDesktopPlaybackResumeStore(),
         )
     }
+    installDesktopPlatformVideoControllerFactory { DesktopMpvVideoController() }
     installDesktopProviderCredentialStoreFactory { DesktopSecureProviderCredentialStore() }
     installDesktopLocalMusicRepositoryFactory { DesktopLocalMusicRepository() }
     installFallbackOAuthDeviceCodeAssistant(DesktopOAuthDeviceCodeAssistant())
@@ -104,9 +106,6 @@ fun main(args: Array<String>) {
                     createDesktopSystemMediaSessionForWindow(playbackSession, window)
                 }
 
-                // Compose's desktop UriHandler is synchronous. On Linux the OS browser launcher may
-                // block while xdg-open/desktop integration resolves the target application, so never
-                // invoke it directly from the Compose UI dispatcher.
                 val platformUriHandler = LocalUriHandler.current
                 val nonBlockingUriHandler = remember(platformUriHandler) {
                     DesktopNonBlockingUriHandler(platformUriHandler)

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopMpvVideoControllerTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopMpvVideoControllerTest.kt
@@ -1,0 +1,32 @@
+package org.feeluown.mobile.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopMpvVideoControllerTest {
+    @Test
+    fun softwareRenderSizeCapsLargeViewportsWithoutChangingAspect() {
+        val (width, height) = boundedVideoRenderSize(3840, 2160)
+
+        assertTrue(width.toLong() * height <= 1920L * 1080L)
+        assertTrue(kotlin.math.abs(width.toDouble() / height - 16.0 / 9.0) < 0.01)
+    }
+
+    @Test
+    fun splitDashPayloadAddsExternalAudioAsFileLocalOption() {
+        val options = encodeVideoLoadfileOptions(
+            headers = mapOf("Referer" to "https://www.bilibili.com/"),
+            externalAudioUrl = "https://cdn.example/audio.m4s?x=1,2",
+        )
+
+        assertTrue(options.contains("http-header-fields="))
+        assertTrue(options.contains("audio-files-append="))
+        assertTrue(options.contains("audio.m4s?x=1,2"))
+    }
+
+    @Test
+    fun smallViewportKeepsNativeRenderSize() {
+        assertEquals(1280 to 720, boundedVideoRenderSize(1280, 720))
+    }
+}

--- a/feature/recognition/src/commonMain/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepository.kt
+++ b/feature/recognition/src/commonMain/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepository.kt
@@ -4,6 +4,7 @@ import kotlin.random.Random
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -40,14 +41,12 @@ class DefaultAudioRecognitionRepository(
     private val sessionIdFactory: () -> String = ::newRecognitionSessionId,
 ) : AudioRecognitionRepository {
     private val recognitionMutex = Mutex()
-
-    @Volatile
-    private var cancelled = false
+    private val cancelled = MutableStateFlow(false)
 
     override suspend fun recognize(onEvent: (AudioRecognitionEvent) -> Unit): List<RecognizedSong> =
         recognitionMutex.withLock {
             coroutineScope recognition@{
-                cancelled = false
+                cancelled.value = false
                 val windows = Channel<FloatArray>(Channel.CONFLATED)
                 var matching = false
                 var captureAttempt = 1
@@ -57,9 +56,9 @@ class DefaultAudioRecognitionRepository(
 
                 val captureJob = launch {
                     captureDevice.capture { chunk ->
-                        if (cancelled || chunk.isEmpty()) return@capture
+                        if (cancelled.value || chunk.isEmpty()) return@capture
                         var sourceOffset = 0
-                        while (sourceOffset < chunk.size && !cancelled) {
+                        while (sourceOffset < chunk.size && !cancelled.value) {
                             val copied = minOf(chunk.size - sourceOffset, window.size - windowOffset)
                             chunk.copyInto(
                                 destination = window,
@@ -95,7 +94,7 @@ class DefaultAudioRecognitionRepository(
                 val sessionId = sessionIdFactory()
                 var attempt = 1
                 try {
-                    while (isActive && !cancelled) {
+                    while (isActive && !cancelled.value) {
                         val capturedWindow = windows.receive()
                         matching = true
                         onEvent(AudioRecognitionEvent.Matching(attempt))
@@ -117,12 +116,12 @@ class DefaultAudioRecognitionRepository(
                     }
                     emptyList()
                 } catch (throwable: Throwable) {
-                    if (throwable !is CancellationException && !cancelled) {
+                    if (throwable !is CancellationException && !cancelled.value) {
                         onEvent(AudioRecognitionEvent.Error(throwable.message ?: "听歌识曲失败"))
                     }
                     throw throwable
                 } finally {
-                    cancelled = true
+                    cancelled.value = true
                     captureDevice.cancel()
                     fingerprintRuntime.cancel()
                     matcher.cancel()
@@ -133,7 +132,7 @@ class DefaultAudioRecognitionRepository(
         }
 
     override fun cancel() {
-        cancelled = true
+        cancelled.value = true
         captureDevice.cancel()
         fingerprintRuntime.cancel()
         matcher.cancel()

--- a/feature/recognition/src/commonMain/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepository.kt
+++ b/feature/recognition/src/commonMain/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepository.kt
@@ -1,0 +1,150 @@
+package org.feeluown.mobile
+
+import kotlin.random.Random
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Platform microphone boundary. Implementations emit normalized mono PCM chunks at 48 kHz. */
+interface AudioRecognitionCaptureDevice {
+    suspend fun capture(onSamples: (FloatArray) -> Unit)
+    fun cancel()
+}
+
+/** Platform host for the shared NetEase fingerprint JavaScript/WASM runtime. */
+interface AudioFingerprintRuntime {
+    suspend fun generate(samples: FloatArray): String
+    fun cancel() = Unit
+}
+
+/** Network matching boundary kept independent from microphone and fingerprint runtimes. */
+interface AudioRecognitionMatcher {
+    suspend fun match(sessionId: String, fingerprint: String): List<RecognizedSong>
+    fun cancel() = Unit
+}
+
+/**
+ * Shared recognition transaction.
+ *
+ * Platform code only captures PCM and hosts the fingerprint runtime. Windowing, progress,
+ * matching attempts, cancellation and result semantics stay identical on every platform.
+ */
+class DefaultAudioRecognitionRepository(
+    private val captureDevice: AudioRecognitionCaptureDevice,
+    private val fingerprintRuntime: AudioFingerprintRuntime,
+    private val matcher: AudioRecognitionMatcher,
+    private val sessionIdFactory: () -> String = ::newRecognitionSessionId,
+) : AudioRecognitionRepository {
+    private val recognitionMutex = Mutex()
+
+    @Volatile
+    private var cancelled = false
+
+    override suspend fun recognize(onEvent: (AudioRecognitionEvent) -> Unit): List<RecognizedSong> =
+        recognitionMutex.withLock {
+            coroutineScope recognition@{
+                cancelled = false
+                val windows = Channel<FloatArray>(Channel.CONFLATED)
+                var matching = false
+                var captureAttempt = 1
+                var window = FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES)
+                var windowOffset = 0
+                var lastProgressMs = -1L
+
+                val captureJob = launch {
+                    captureDevice.capture { chunk ->
+                        if (cancelled || chunk.isEmpty()) return@capture
+                        var sourceOffset = 0
+                        while (sourceOffset < chunk.size && !cancelled) {
+                            val copied = minOf(chunk.size - sourceOffset, window.size - windowOffset)
+                            chunk.copyInto(
+                                destination = window,
+                                destinationOffset = windowOffset,
+                                startIndex = sourceOffset,
+                                endIndex = sourceOffset + copied,
+                            )
+                            sourceOffset += copied
+                            windowOffset += copied
+
+                            val capturedMs = windowOffset * 1_000L / AUDIO_RECOGNITION_SAMPLE_RATE
+                            if (!matching && capturedMs - lastProgressMs >= RECOGNITION_PROGRESS_INTERVAL_MS) {
+                                lastProgressMs = capturedMs
+                                onEvent(
+                                    AudioRecognitionEvent.Capturing(
+                                        attempt = captureAttempt,
+                                        capturedMs = capturedMs,
+                                    ),
+                                )
+                            }
+
+                            if (windowOffset == window.size) {
+                                windows.trySend(window)
+                                window = FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES)
+                                windowOffset = 0
+                                captureAttempt += 1
+                                lastProgressMs = -1L
+                            }
+                        }
+                    }
+                }
+
+                val sessionId = sessionIdFactory()
+                var attempt = 1
+                try {
+                    while (isActive && !cancelled) {
+                        val capturedWindow = windows.receive()
+                        matching = true
+                        onEvent(AudioRecognitionEvent.Matching(attempt))
+                        val fingerprint = fingerprintRuntime.generate(
+                            downsampleRecognitionWindow(capturedWindow),
+                        )
+                        val matches = matcher.match(sessionId, fingerprint)
+                        if (matches.isNotEmpty()) {
+                            onEvent(AudioRecognitionEvent.Success(matches))
+                            return@recognition matches
+                        }
+
+                        matching = false
+                        onEvent(AudioRecognitionEvent.NoMatch(attempt))
+                        if (attempt >= AUDIO_RECOGNITION_MAX_ATTEMPTS) {
+                            return@recognition emptyList()
+                        }
+                        attempt += 1
+                    }
+                    emptyList()
+                } catch (throwable: Throwable) {
+                    if (throwable !is CancellationException && !cancelled) {
+                        onEvent(AudioRecognitionEvent.Error(throwable.message ?: "听歌识曲失败"))
+                    }
+                    throw throwable
+                } finally {
+                    cancelled = true
+                    captureDevice.cancel()
+                    fingerprintRuntime.cancel()
+                    matcher.cancel()
+                    captureJob.cancel()
+                    windows.close()
+                }
+            }
+        }
+
+    override fun cancel() {
+        cancelled = true
+        captureDevice.cancel()
+        fingerprintRuntime.cancel()
+        matcher.cancel()
+    }
+}
+
+private fun newRecognitionSessionId(): String = buildString {
+    repeat(4) { index ->
+        if (index > 0) append('-')
+        append(Random.nextLong().toULong().toString(16))
+    }
+}
+
+private const val RECOGNITION_PROGRESS_INTERVAL_MS = 250L

--- a/feature/recognition/src/commonTest/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepositoryTest.kt
+++ b/feature/recognition/src/commonTest/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepositoryTest.kt
@@ -29,6 +29,7 @@ class DefaultAudioRecognitionRepositoryTest {
             neteaseSongId = "42",
             title = "Song",
             artists = listOf("Artist"),
+            album = "Album",
         )
         var matcherSession = ""
         val matcher = object : AudioRecognitionMatcher {

--- a/feature/recognition/src/commonTest/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepositoryTest.kt
+++ b/feature/recognition/src/commonTest/kotlin/org/feeluown/mobile/DefaultAudioRecognitionRepositoryTest.kt
@@ -1,0 +1,57 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.test.runTest
+
+class DefaultAudioRecognitionRepositoryTest {
+    @Test
+    fun captureWindowFingerprintAndMatchAreSharedAcrossPlatforms() = runTest {
+        val chunks = listOf(
+            FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES / 2) { 0.25f },
+            FloatArray(AUDIO_RECOGNITION_WINDOW_SAMPLES - AUDIO_RECOGNITION_WINDOW_SAMPLES / 2) { -0.25f },
+        )
+        val capture = object : AudioRecognitionCaptureDevice {
+            override suspend fun capture(onSamples: (FloatArray) -> Unit) {
+                chunks.forEach(onSamples)
+            }
+            override fun cancel() = Unit
+        }
+        var fingerprintSamples = 0
+        val fingerprint = object : AudioFingerprintRuntime {
+            override suspend fun generate(samples: FloatArray): String {
+                fingerprintSamples = samples.size
+                return "fingerprint"
+            }
+        }
+        val expected = RecognizedSong(
+            neteaseSongId = "42",
+            title = "Song",
+            artists = listOf("Artist"),
+        )
+        var matcherSession = ""
+        val matcher = object : AudioRecognitionMatcher {
+            override suspend fun match(sessionId: String, fingerprint: String): List<RecognizedSong> {
+                matcherSession = sessionId
+                assertEquals("fingerprint", fingerprint)
+                return listOf(expected)
+            }
+        }
+        val repository = DefaultAudioRecognitionRepository(
+            captureDevice = capture,
+            fingerprintRuntime = fingerprint,
+            matcher = matcher,
+            sessionIdFactory = { "session" },
+        )
+        val events = mutableListOf<AudioRecognitionEvent>()
+
+        val result = repository.recognize(events::add)
+
+        assertEquals(listOf(expected), result)
+        assertEquals(AUDIO_RECOGNITION_FINGERPRINT_SAMPLES, fingerprintSamples)
+        assertEquals("session", matcherSession)
+        assertIs<AudioRecognitionEvent.Matching>(events.first { it is AudioRecognitionEvent.Matching })
+        assertIs<AudioRecognitionEvent.Success>(events.last())
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseAudioRecognitionMatcher.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/NeteaseAudioRecognitionMatcher.kt
@@ -1,0 +1,80 @@
+package org.feeluown.mobile
+
+import io.ktor.http.Parameters
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
+
+class NeteaseAudioRecognitionMatcher(
+    private val httpClient: ProviderHttpClient = ProviderHttpClient(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : AudioRecognitionMatcher {
+    override suspend fun match(sessionId: String, fingerprint: String): List<RecognizedSong> {
+        val response = httpClient.postForm(
+            providerId = "netease",
+            url = RECOGNITION_ENDPOINT,
+            form = Parameters.build {
+                append("sessionId", sessionId)
+                append("algorithmCode", "shazam_v2")
+                append("duration", "6")
+                append("rawdata", fingerprint)
+                append("times", "2")
+                append("decrypt", "1")
+            },
+            headers = mapOf("Origin" to RECOGNITION_ORIGIN),
+            kind = ProviderRequestKind.Media,
+        ).value
+        return parseNeteaseRecognitionMatches(response, json)
+    }
+}
+
+internal fun parseNeteaseRecognitionMatches(
+    response: String,
+    json: Json = Json { ignoreUnknownKeys = true },
+): List<RecognizedSong> {
+    val root = json.parseToJsonElement(response).jsonObject
+    val code = root["code"]?.jsonPrimitive?.longOrNull
+    check(code == 200L) {
+        root["message"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)
+            ?: "识别接口返回错误"
+    }
+    val data = root["data"] as? JsonObject
+        ?: throw IllegalStateException("识别接口响应缺少 data")
+    val results = data["result"] as? JsonArray ?: return emptyList()
+    return results.mapNotNull { element ->
+        val match = element as? JsonObject ?: return@mapNotNull null
+        val song = match["song"] as? JsonObject ?: return@mapNotNull null
+        val title = song["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        if (title.isBlank()) return@mapNotNull null
+        val artists = (song["artists"] ?: song["ar"]) as? JsonArray
+        val album = (song["album"] ?: song["al"]) as? JsonObject
+        RecognizedSong(
+            neteaseSongId = song["id"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank),
+            title = title,
+            artists = artists.artistNames(),
+            album = album?.get("name")?.jsonPrimitive?.contentOrNull.orEmpty(),
+            coverUrl = album?.get("picUrl")?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank),
+            matchStartTimeMs = match["startTime"]?.jsonPrimitive?.longOrNull,
+        )
+    }
+}
+
+private fun JsonArray?.artistNames(): List<String> = this
+    ?.mapNotNull { element ->
+        (element as? JsonObject)
+            ?.get("name")
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.takeIf(String::isNotBlank)
+    }
+    .orEmpty()
+
+private const val RECOGNITION_ENDPOINT = "https://interface.music.163.com/api/music/audio/match"
+private const val RECOGNITION_ORIGIN = "chrome-extension://pgphbbekcgpfaekhcbjamjjkegcclhhd"

--- a/shared/src/commonMain/resources/audio_recognition/runtime.html
+++ b/shared/src/commonMain/resources/audio_recognition/runtime.html
@@ -61,6 +61,14 @@
         }
     };
 
+    function postDesktopMessage(message) {
+        if (globalThis.ipc && typeof globalThis.ipc.postMessage === "function") {
+            globalThis.ipc.postMessage(JSON.stringify(message));
+            return true;
+        }
+        return false;
+    }
+
     function deliverFingerprint(requestId, fingerprint, error) {
         if (globalThis.FuoFingerprintBridge) {
             globalThis.FuoFingerprintBridge.onFingerprint(requestId, fingerprint, error);
@@ -72,7 +80,13 @@
                 fingerprint: fingerprint,
                 error: error
             });
+            return;
         }
+        postDesktopMessage({
+            requestId: requestId,
+            fingerprint: fingerprint,
+            error: error
+        });
     }
 
     function deliverRuntimeReady(error) {
@@ -85,7 +99,12 @@
                 runtimeReady: true,
                 error: error
             });
+            return;
         }
+        postDesktopMessage({
+            runtimeReady: true,
+            error: error
+        });
     }
 </script>
 </body>

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppHost.kt
@@ -35,10 +35,8 @@ fun DesktopAppHost(externalInputs: Flow<String>? = null) {
             platform = AppPlatformBindings(
                 hasAudioPermission = true,
                 onRequestAudioPermission = {},
-                hasMicrophonePermission = false,
-                onRequestMicrophonePermission = {
-                    container.appViewModel.showFeedback("桌面端听歌识曲将在后续开发阶段接入")
-                },
+                hasMicrophonePermission = true,
+                onRequestMicrophonePermission = {},
                 onOpenProviderWebLogin = container::openProviderWebLogin,
                 onLogoutProvider = container::logoutProvider,
                 onImportLocalPlaylistFile = container::importLocalPlaylistFile,
@@ -94,7 +92,7 @@ private class DesktopAppContainer {
     private val debugLogFeatureController by lazy {
         createDebugLogFeatureController(createDesktopDebugLogRepository(), scope)
     }
-    private val audioRecognitionRepository: AudioRecognitionRepository = UnsupportedAudioRecognitionRepository
+    private val audioRecognitionRepository: AudioRecognitionRepository = DesktopAudioRecognitionRepository()
 
     private val searchController: SearchFeatureController by lazy {
         val initialSettings = settingsRepository.state.value.settings

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAudioRecognitionRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAudioRecognitionRepository.kt
@@ -1,0 +1,179 @@
+package org.feeluown.mobile
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicReference
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.DataLine
+import javax.sound.sampled.TargetDataLine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class DesktopAudioRecognitionRepository : AudioRecognitionRepository {
+    private val delegate = DefaultAudioRecognitionRepository(
+        captureDevice = DesktopAudioRecognitionCaptureDevice(),
+        fingerprintRuntime = DesktopAudioFingerprintRuntime(),
+        matcher = NeteaseAudioRecognitionMatcher(),
+    )
+
+    override suspend fun recognize(onEvent: (AudioRecognitionEvent) -> Unit): List<RecognizedSong> =
+        delegate.recognize(onEvent)
+
+    override fun cancel() = delegate.cancel()
+}
+
+internal class DesktopAudioRecognitionCaptureDevice : AudioRecognitionCaptureDevice {
+    private val activeLine = AtomicReference<TargetDataLine?>()
+
+    override suspend fun capture(onSamples: (FloatArray) -> Unit) = withContext(Dispatchers.IO) {
+        val format = AudioFormat(
+            AUDIO_RECOGNITION_SAMPLE_RATE.toFloat(),
+            PCM_BITS_PER_SAMPLE,
+            PCM_CHANNELS,
+            true,
+            false,
+        )
+        val lineInfo = DataLine.Info(TargetDataLine::class.java, format)
+        val line = runCatching { AudioSystem.getLine(lineInfo) as TargetDataLine }
+            .getOrElse { throw IllegalStateException("系统没有可用的麦克风输入设备", it) }
+        try {
+            line.open(format, DESKTOP_AUDIO_BUFFER_BYTES)
+        } catch (throwable: Throwable) {
+            runCatching { line.close() }
+            throw IllegalStateException("麦克风不支持 48 kHz 单声道 PCM 录音", throwable)
+        }
+        check(activeLine.compareAndSet(null, line)) { "麦克风录音已经在进行中" }
+
+        val bytes = ByteArray(DESKTOP_AUDIO_READ_BYTES)
+        try {
+            line.start()
+            while (activeLine.get() === line) {
+                val read = line.read(bytes, 0, bytes.size)
+                if (read < 0) {
+                    if (activeLine.get() !== line) break
+                    throw IllegalStateException("麦克风读取失败")
+                }
+                if (read >= PCM_BYTES_PER_SAMPLE) {
+                    onSamples(decodePcm16Le(bytes, read))
+                }
+            }
+        } finally {
+            releaseLine(line)
+        }
+    }
+
+    override fun cancel() {
+        activeLine.getAndSet(null)?.let(::stopAndClose)
+    }
+
+    private fun releaseLine(line: TargetDataLine) {
+        activeLine.compareAndSet(line, null)
+        stopAndClose(line)
+    }
+
+    private fun stopAndClose(line: TargetDataLine) {
+        runCatching { line.stop() }
+        runCatching { line.flush() }
+        runCatching { line.close() }
+    }
+}
+
+internal fun decodePcm16Le(bytes: ByteArray, length: Int): FloatArray {
+    val sampleCount = length.coerceAtMost(bytes.size) / PCM_BYTES_PER_SAMPLE
+    return FloatArray(sampleCount) { index ->
+        val byteOffset = index * PCM_BYTES_PER_SAMPLE
+        val low = bytes[byteOffset].toInt() and 0xff
+        val high = bytes[byteOffset + 1].toInt()
+        val sample = ((high shl 8) or low).toShort()
+        sample / 32768f
+    }
+}
+
+private class DesktopAudioFingerprintRuntime : AudioFingerprintRuntime {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val activeProcess = AtomicReference<Process?>()
+
+    override suspend fun generate(samples: FloatArray): String = withContext(Dispatchers.IO) {
+        val helper = resolveDesktopWebViewHelper()
+            ?: throw IllegalStateException("桌面音频指纹组件未找到，请重新安装应用")
+        val process = ProcessBuilder(helper.absolutePath).start()
+        check(activeProcess.compareAndSet(null, process)) {
+            process.destroyForcibly()
+            "音频指纹任务已经在进行中"
+        }
+        try {
+            coroutineScope {
+                val diagnosticsDeferred = async(Dispatchers.IO) {
+                    runCatching {
+                        process.errorStream.bufferedReader(Charsets.UTF_8)
+                            .use(::readDesktopWebViewHelperDiagnosticTail)
+                    }.getOrDefault("")
+                }
+                try {
+                    val request = DesktopFingerprintRequest(samples.toBase64FloatBytes())
+                    process.outputStream.bufferedWriter(Charsets.UTF_8).use { writer ->
+                        writer.write(json.encodeToString(request))
+                        writer.newLine()
+                    }
+                    val responseLine = process.inputStream.bufferedReader(Charsets.UTF_8).readLine().orEmpty()
+                    val exitCode = process.waitFor()
+                    val diagnostics = diagnosticsDeferred.await().trim()
+                    if (responseLine.isBlank()) {
+                        val detail = diagnostics.takeLast(240).ifBlank { "退出码 $exitCode" }
+                        throw IllegalStateException("音频指纹组件启动失败：$detail")
+                    }
+                    val response = json.decodeFromString<DesktopFingerprintResponse>(responseLine)
+                    if (response.status != "success" || response.fingerprint.isBlank()) {
+                        throw IllegalStateException(
+                            response.message?.takeIf(String::isNotBlank) ?: "音频指纹生成失败",
+                        )
+                    }
+                    response.fingerprint
+                } finally {
+                    diagnosticsDeferred.cancel()
+                }
+            }
+        } finally {
+            activeProcess.compareAndSet(process, null)
+            if (process.isAlive) process.destroyForcibly()
+        }
+    }
+
+    override fun cancel() {
+        activeProcess.getAndSet(null)?.let { process ->
+            if (process.isAlive) process.destroyForcibly()
+        }
+    }
+
+    private fun FloatArray.toBase64FloatBytes(): String {
+        val buffer = ByteBuffer.allocate(size * Float.SIZE_BYTES).order(ByteOrder.nativeOrder())
+        forEach(buffer::putFloat)
+        return Base64.getEncoder().encodeToString(buffer.array())
+    }
+}
+
+@Serializable
+private data class DesktopFingerprintRequest(
+    val samplesBase64: String,
+)
+
+@Serializable
+private data class DesktopFingerprintResponse(
+    val status: String,
+    val fingerprint: String = "",
+    val message: String? = null,
+)
+
+private const val PCM_BITS_PER_SAMPLE = 16
+private const val PCM_CHANNELS = 1
+private const val PCM_BYTES_PER_SAMPLE = PCM_BITS_PER_SAMPLE / 8
+private const val DESKTOP_AUDIO_READ_BYTES = 4_096
+private const val DESKTOP_AUDIO_BUFFER_BYTES = 16_384

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -1,7 +1,5 @@
 package org.feeluown.mobile
 
-import java.io.File
-import java.io.Reader
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -45,9 +43,8 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
         if (config.cookieKeyGroups.isEmpty()) {
             return@withContext DesktopWebLoginResult.Failure("${provider.providerName} 未配置登录 Cookie 判定规则")
         }
-        val helper = resolveHelper()
+        val helper = resolveDesktopWebViewHelper()
             ?: return@withContext DesktopWebLoginResult.Failure("桌面网页登录组件未找到，请重新安装应用")
-
         if (!activeProviderIds.add(provider.providerId)) {
             return@withContext DesktopWebLoginResult.Failure("${provider.providerName} 网页登录正在进行中")
         }
@@ -60,14 +57,14 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
                 cookieKeyGroups = config.cookieKeyGroups,
                 userAgent = loginUserAgent(provider.providerId),
             )
-
             runCatching {
                 val process = ProcessBuilder(helper.absolutePath).start()
                 activeProcesses += process
                 coroutineScope {
                     val diagnosticsDeferred = async(Dispatchers.IO) {
                         runCatching {
-                            process.errorStream.bufferedReader(Charsets.UTF_8).use(::readDiagnosticTail)
+                            process.errorStream.bufferedReader(Charsets.UTF_8)
+                                .use(::readDesktopWebViewHelperDiagnosticTail)
                         }.getOrDefault("")
                     }
                     try {
@@ -75,25 +72,19 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
                             writer.write(json.encodeToString(request))
                             writer.newLine()
                         }
-
-                        // Drain stderr concurrently so native WebView diagnostics cannot fill the
-                        // process pipe and block the helper while the user is still logging in.
                         val responseLine = process.inputStream.bufferedReader(Charsets.UTF_8).readLine().orEmpty()
                         val exitCode = process.waitFor()
                         val diagnostics = diagnosticsDeferred.await().trim()
-
                         if (responseLine.isBlank()) {
                             val detail = diagnostics.takeLast(240).ifBlank { "退出码 $exitCode" }
                             return@coroutineScope DesktopWebLoginResult.Failure("网页登录组件启动失败：$detail")
                         }
                         val response = json.decodeFromString<DesktopWebLoginResponse>(responseLine)
                         when (response.status) {
-                            "success" -> {
-                                if (response.cookies.isEmpty()) {
-                                    DesktopWebLoginResult.Failure("网页登录完成，但未获取到 Cookie")
-                                } else {
-                                    DesktopWebLoginResult.Success(json.encodeToString(response.cookies))
-                                }
+                            "success" -> if (response.cookies.isEmpty()) {
+                                DesktopWebLoginResult.Failure("网页登录完成，但未获取到 Cookie")
+                            } else {
+                                DesktopWebLoginResult.Success(json.encodeToString(response.cookies))
                             }
                             "cancelled" -> DesktopWebLoginResult.Cancelled
                             "error" -> DesktopWebLoginResult.Failure(
@@ -116,76 +107,20 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
     }
 
     override fun close() {
-        activeProcesses.toList().forEach { process ->
-            if (process.isAlive) process.destroyForcibly()
-        }
+        activeProcesses.toList().forEach { process -> if (process.isAlive) process.destroyForcibly() }
         activeProcesses.clear()
         activeProviderIds.clear()
     }
-
-    private fun resolveHelper(): File? {
-        val executableName = if (isWindows()) "fuoevolve-web-login.exe" else "fuoevolve-web-login"
-        val appDir = System.getProperty("fuoevolve.appdir")
-            ?.takeIf { it.isNotBlank() && !it.contains("\$APPDIR") }
-            ?.let(::File)
-        val userDir = File(System.getProperty("user.dir").orEmpty().ifBlank { "." })
-
-        val directCandidates = buildList {
-            if (appDir != null) {
-                // Current Compose layout. Keep this fast path, but do not make runtime correctness
-                // depend on the exact resource nesting used by a particular Compose plugin version.
-                add(File(appDir, "resources/native/helpers/$executableName"))
-            }
-            // Development fallbacks for `./gradlew :desktopApp:run` from either repository root
-            // or the desktopApp project directory.
-            add(File(userDir, "desktopApp/native/web-login/target/release/$executableName"))
-            add(File(userDir, "native/web-login/target/release/$executableName"))
-        }
-        directCandidates.firstOrNull(::isUsableHelper)?.let { return it }
-
-        // Native distributions may relocate app resources while preserving their contents. Search
-        // only below the installed app root and only when the direct path did not match.
-        return appDir
-            ?.takeIf { it.isDirectory }
-            ?.walkTopDown()
-            ?.maxDepth(6)
-            ?.firstOrNull { candidate ->
-                candidate.name == executableName && isUsableHelper(candidate)
-            }
-    }
-
-    private fun isUsableHelper(candidate: File): Boolean =
-        candidate.isFile && (isWindows() || candidate.canExecute())
-
-    private fun isWindows(): Boolean =
-        System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true)
 
     private fun loginUserAgent(providerId: String): String =
         if (providerId == "bilibili") MOBILE_USER_AGENT else DESKTOP_USER_AGENT
 
     private companion object {
-        const val MAX_DIAGNOSTIC_CHARS = 8 * 1024
-        const val DIAGNOSTIC_BUFFER_CHARS = 1024
-
         const val DESKTOP_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
         const val MOBILE_USER_AGENT =
             "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
-
-        fun readDiagnosticTail(reader: Reader): String {
-            val tail = StringBuilder()
-            val buffer = CharArray(DIAGNOSTIC_BUFFER_CHARS)
-            while (true) {
-                val count = reader.read(buffer)
-                if (count < 0) break
-                tail.append(buffer, 0, count)
-                if (tail.length > MAX_DIAGNOSTIC_CHARS) {
-                    tail.delete(0, tail.length - MAX_DIAGNOSTIC_CHARS)
-                }
-            }
-            return tail.toString()
-        }
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebViewHelper.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebViewHelper.kt
@@ -1,0 +1,55 @@
+package org.feeluown.mobile
+
+import java.io.File
+import java.io.Reader
+
+internal fun resolveDesktopWebViewHelper(): File? {
+    val executableName = desktopWebViewHelperExecutableName()
+    val appDir = System.getProperty("fuoevolve.appdir")
+        ?.takeIf { it.isNotBlank() && !it.contains("\$APPDIR") }
+        ?.let(::File)
+    val userDir = File(System.getProperty("user.dir").orEmpty().ifBlank { "." })
+
+    val directCandidates = buildList {
+        if (appDir != null) {
+            add(File(appDir, "resources/native/helpers/$executableName"))
+        }
+        add(File(userDir, "desktopApp/native/web-login/target/release/$executableName"))
+        add(File(userDir, "native/web-login/target/release/$executableName"))
+    }
+    directCandidates.firstOrNull(::isUsableDesktopWebViewHelper)?.let { return it }
+
+    return appDir
+        ?.takeIf { it.isDirectory }
+        ?.walkTopDown()
+        ?.maxDepth(6)
+        ?.firstOrNull { candidate ->
+            candidate.name == executableName && isUsableDesktopWebViewHelper(candidate)
+        }
+}
+
+internal fun readDesktopWebViewHelperDiagnosticTail(reader: Reader): String {
+    val tail = StringBuilder()
+    val buffer = CharArray(DIAGNOSTIC_BUFFER_CHARS)
+    while (true) {
+        val count = reader.read(buffer)
+        if (count < 0) break
+        tail.append(buffer, 0, count)
+        if (tail.length > MAX_DIAGNOSTIC_CHARS) {
+            tail.delete(0, tail.length - MAX_DIAGNOSTIC_CHARS)
+        }
+    }
+    return tail.toString()
+}
+
+private fun desktopWebViewHelperExecutableName(): String =
+    if (isDesktopWindows()) "fuoevolve-web-login.exe" else "fuoevolve-web-login"
+
+private fun isUsableDesktopWebViewHelper(candidate: File): Boolean =
+    candidate.isFile && (isDesktopWindows() || candidate.canExecute())
+
+internal fun isDesktopWindows(): Boolean =
+    System.getProperty("os.name").orEmpty().contains("windows", ignoreCase = true)
+
+private const val MAX_DIAGNOSTIC_CHARS = 8 * 1024
+private const val DIAGNOSTIC_BUFFER_CHARS = 1024

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -1,25 +1,59 @@
 package org.feeluown.mobile
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-private class DesktopUnsupportedVideoController : PlatformVideoController {
-    private val mutableState = MutableStateFlow(PlatformVideoPlaybackState())
-    override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
+/** Desktop-only bridge implemented by the host module that owns libmpv/JNA. */
+interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseable {
+    val frame: StateFlow<ImageBitmap?>
+    fun setPayload(payload: VideoPlaybackPayload?)
+    fun setViewportSize(width: Int, height: Int)
+}
 
+private var desktopPlatformVideoControllerFactory: () -> DesktopPlatformVideoController = {
+    UnsupportedDesktopPlatformVideoController()
+}
+
+fun installDesktopPlatformVideoControllerFactory(factory: () -> DesktopPlatformVideoController) {
+    desktopPlatformVideoControllerFactory = factory
+}
+
+private class UnsupportedDesktopPlatformVideoController : DesktopPlatformVideoController {
+    private val mutableState = MutableStateFlow(
+        PlatformVideoPlaybackState(errorMessage = "桌面视频播放组件未初始化"),
+    )
+    override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
+    private val mutableFrame = MutableStateFlow<ImageBitmap?>(null)
+    override val frame: StateFlow<ImageBitmap?> = mutableFrame.asStateFlow()
     override fun play() = Unit
     override fun pause() = Unit
     override fun seekTo(positionMs: Long) = Unit
+    override fun setPayload(payload: VideoPlaybackPayload?) = Unit
+    override fun setViewportSize(width: Int, height: Int) = Unit
+    override fun close() = Unit
 }
 
 @Composable
-actual fun rememberPlatformVideoController(): PlatformVideoController = remember {
-    DesktopUnsupportedVideoController()
+actual fun rememberPlatformVideoController(): PlatformVideoController {
+    val controller = remember { desktopPlatformVideoControllerFactory() }
+    DisposableEffect(controller) {
+        onDispose(controller::close)
+    }
+    return controller
 }
 
 @Composable
@@ -28,7 +62,29 @@ actual fun PlatformVideoPlayer(
     controller: PlatformVideoController,
     modifier: Modifier,
 ) {
-    Box(modifier)
+    val desktopController = controller as? DesktopPlatformVideoController
+    LaunchedEffect(desktopController, payload) {
+        desktopController?.setPayload(payload)
+    }
+    val frame by desktopController?.frame?.collectAsState() ?: remember {
+        MutableStateFlow<ImageBitmap?>(null)
+    }.collectAsState()
+
+    Box(
+        modifier = modifier.onSizeChanged { size ->
+            desktopController?.setViewportSize(size.width, size.height)
+        },
+        contentAlignment = Alignment.Center,
+    ) {
+        frame?.let { bitmap ->
+            Image(
+                bitmap = bitmap,
+                contentDescription = payload?.video?.title,
+                modifier = Modifier.matchParentSize(),
+                contentScale = ContentScale.Fit,
+            )
+        }
+    }
 }
 
 @Composable

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -66,9 +67,12 @@ actual fun PlatformVideoPlayer(
     LaunchedEffect(desktopController, payload) {
         desktopController?.setPayload(payload)
     }
-    val frame by desktopController?.frame?.collectAsState() ?: remember {
-        MutableStateFlow<ImageBitmap?>(null)
-    }.collectAsState()
+    val frame = if (desktopController != null) {
+        val value by desktopController.frame.collectAsState()
+        value
+    } else {
+        null
+    }
 
     Box(
         modifier = modifier.onSizeChanged { size ->
@@ -80,7 +84,7 @@ actual fun PlatformVideoPlayer(
             Image(
                 bitmap = bitmap,
                 contentDescription = payload?.video?.title,
-                modifier = Modifier.matchParentSize(),
+                modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Fit,
             )
         }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -26,17 +26,17 @@ interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseabl
 }
 
 private var desktopPlatformVideoControllerFactory: () -> DesktopPlatformVideoController = {
-    UnsupportedDesktopPlatformVideoController()
+    UnsupportedDesktopPlatformVideoController("桌面视频播放组件未初始化")
 }
 
 fun installDesktopPlatformVideoControllerFactory(factory: () -> DesktopPlatformVideoController) {
     desktopPlatformVideoControllerFactory = factory
 }
 
-private class UnsupportedDesktopPlatformVideoController : DesktopPlatformVideoController {
-    private val mutableState = MutableStateFlow(
-        PlatformVideoPlaybackState(errorMessage = "桌面视频播放组件未初始化"),
-    )
+private class UnsupportedDesktopPlatformVideoController(
+    message: String,
+) : DesktopPlatformVideoController {
+    private val mutableState = MutableStateFlow(PlatformVideoPlaybackState(errorMessage = message))
     override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
     private val mutableFrame = MutableStateFlow<ImageBitmap?>(null)
     override val frame: StateFlow<ImageBitmap?> = mutableFrame.asStateFlow()
@@ -50,7 +50,13 @@ private class UnsupportedDesktopPlatformVideoController : DesktopPlatformVideoCo
 
 @Composable
 actual fun rememberPlatformVideoController(): PlatformVideoController {
-    val controller = remember { desktopPlatformVideoControllerFactory() }
+    val controller = remember {
+        runCatching(desktopPlatformVideoControllerFactory).getOrElse { throwable ->
+            UnsupportedDesktopPlatformVideoController(
+                throwable.message?.takeIf(String::isNotBlank) ?: "桌面视频播放组件初始化失败",
+            )
+        }
+    }
     DisposableEffect(controller) {
         onDispose(controller::close)
     }

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopAudioRecognitionRepositoryTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopAudioRecognitionRepositoryTest.kt
@@ -1,0 +1,24 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopAudioRecognitionRepositoryTest {
+    @Test
+    fun pcm16LittleEndianIsNormalizedForSharedRecognition() {
+        val samples = decodePcm16Le(
+            byteArrayOf(
+                0x00, 0x00,
+                0xff.toByte(), 0x7f,
+                0x00, 0x80.toByte(),
+            ),
+            6,
+        )
+
+        assertEquals(3, samples.size)
+        assertEquals(0f, samples[0])
+        assertTrue(samples[1] > 0.999f)
+        assertEquals(-1f, samples[2])
+    }
+}


### PR DESCRIPTION
## Summary
- add desktop provider video playback using an isolated libmpv software-render context rendered into Compose/Skia, without X11 window embedding
- add desktop listening recognition with JavaSound microphone capture and the shared fingerprint runtime hosted by the existing Wry helper
- move recognition windowing/retry/cancellation semantics into `feature:recognition` common code
- reuse one NetEase recognition matcher and one shared fingerprint resource bundle across Android/Desktop
- keep the existing desktop music playback engine isolated from video playback state

## Architecture
- `feature:recognition`: shared capture/fingerprint/matcher ports and recognition transaction
- `shared`: shared NetEase matcher plus desktop adapters/composition wiring
- `desktopApp`: native libmpv video renderer and Wry fingerprint host
- Android recognition now supplies only platform capture/WebView fingerprint adapters

## Validation focus
- Android regression checks after recognition refactor
- desktop JVM compilation/tests
- Rust Wry helper compilation on Windows/macOS/Linux
- desktop packaging with embedded recognition resources
- Wayland remains native because video does not use X11 `wid` embedding
