### PR TITLE
test: await desktop download state publication

### DIFF
--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopDownloadRepositoryTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopDownloadRepositoryTest.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -30,10 +31,10 @@ class DesktopDownloadRepositoryTest {
             durationMs = track.durationMs,
             lyrics = "[00:00.00]Desktop lyrics",
         )
-        var resolverCalls = 0
+        val resolverCalls = AtomicInteger(0)
         val repository = DesktopDownloadRepository(
             resolvePayload = {
-                resolverCalls += 1
+                resolverCalls.incrementAndGet()
                 payload
             },
             storageRoot = root,
@@ -48,7 +49,7 @@ class DesktopDownloadRepositoryTest {
                 }.first { it.id == track.id }
             }
 
-            assertEquals(1, resolverCalls)
+            assertEquals(1, resolverCalls.get())
             assertEquals(bytes.size.toLong(), completed.downloadedBytes)
             val completedUri = requireNotNull(completed.completedUri)
             val completedPath = Path.of(URI(completedUri))

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopDownloadRepositoryTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopDownloadRepositoryTest.kt
@@ -3,7 +3,6 @@ package org.feeluown.mobile
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -31,10 +30,10 @@ class DesktopDownloadRepositoryTest {
             durationMs = track.durationMs,
             lyrics = "[00:00.00]Desktop lyrics",
         )
-        val resolverCalls = AtomicInteger(0)
+        var resolverCalls = 0
         val repository = DesktopDownloadRepository(
             resolvePayload = {
-                resolverCalls.incrementAndGet()
+                resolverCalls += 1
                 payload
             },
             storageRoot = root,
@@ -49,7 +48,7 @@ class DesktopDownloadRepositoryTest {
                 }.first { it.id == track.id }
             }
 
-            assertEquals(1, resolverCalls.get())
+            assertEquals(1, resolverCalls)
             assertEquals(bytes.size.toLong(), completed.downloadedBytes)
             val completedUri = requireNotNull(completed.completedUri)
             val completedPath = Path.of(URI(completedUri))
@@ -59,8 +58,10 @@ class DesktopDownloadRepositoryTest {
                 "[00:00.00]Desktop lyrics",
                 Files.readString(completedPath.resolveSibling("${completedPath.fileName}.lrc")),
             )
-            val downloadedState = assertIs<DownloadState.Downloaded>(repository.states.value.getValue(track.id))
-            assertEquals(completedUri, downloadedState.uri)
+            val downloadedState = withTimeout(5_000) {
+                repository.states.first { states -> states[track.id] is DownloadState.Downloaded }
+            }.getValue(track.id)
+            assertEquals(completedUri, assertIs<DownloadState.Downloaded>(downloadedState).uri)
 
             repository.close()
 


### PR DESCRIPTION
## Summary
- make `DesktopDownloadRepositoryTest` wait for the `Downloaded` state before asserting it
- remove the race between observing `tasks=Completed` and the subsequent `states=Downloaded` publication
- leave production desktop download behavior unchanged

## Root cause
`DesktopDownloadRepository.publishLocked()` updates the two StateFlows sequentially: `mutableTasks` first, then `mutableStates`. The test waited only for the completed task and immediately read `states.value`. On a fast scheduler it could resume in the small window between those two publications and still observe `DownloadState.Downloading`, producing the intermittent assertion failure seen on macOS.

The original failed macOS job passes when rerun on the exact same master commit, confirming this is a flaky timing issue rather than a deterministic regression from #174.

## Validation
- original failed macOS job rerun: passed
- PR Desktop Tests: running against the corrected synchronization point