### PR TITLE
ci: rebuild desktop packages for source changes

### DIFF
--- a/.github/workflows/desktop-packaging-source-trigger.yml
+++ b/.github/workflows/desktop-packaging-source-trigger.yml
@@ -1,0 +1,36 @@
+name: Desktop Packaging Source Trigger
+
+"on":
+  push:
+    branches:
+      - master
+    paths:
+      - "desktopApp/src/**"
+      - "shared/**"
+      - "core/**"
+      - "feature/**"
+      - "playback/**"
+      - "provider/**"
+      - "persistence/**"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle.properties"
+      - "gradlew"
+      - "gradlew.bat"
+      - ".github/workflows/desktop-packaging-source-trigger.yml"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch desktop packaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Build installable packages from current master
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run desktop-packaging.yml --repo "$GITHUB_REPOSITORY" --ref master


### PR DESCRIPTION
## Summary
- trigger desktop installable-package builds after source changes that affect the desktop runtime
- keep the existing expensive packaging PR checks narrow; only master pushes dispatch the full cross-platform packaging workflow
- cover desktop host, shared/core/feature/playback/provider/persistence modules and root build configuration

## Why
PR #174 changed `desktopApp/src/**`, but `.github/workflows/desktop-packaging.yml` only watches packaging/native/build files. As a result, the latest Arch artifact was still built from `f3d29c6` and did not contain the merged secure-store diagnostics from `3f1a7886`. This is why the app still displayed the old generic credential-store error.

Merging this PR also triggers a fresh desktop packaging run for current `master`, so the next Arch artifact will contain #174.