### PR TITLE
fix: set LC_NUMERIC before creating libmpv

### DIFF
--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Platform
 import java.awt.Window as AwtWindow
 import javax.swing.SwingUtilities
 import org.feeluown.mobile.DesktopAppHost
@@ -29,6 +32,25 @@ import org.feeluown.mobile.installFallbackOAuthDeviceCodeAssistant
 import org.feeluown.mobile.persistence.listening.DesktopListeningHistoryDriverFactory
 import org.feeluown.mobile.persistence.listening.SqlDelightListeningHistoryStore
 
+private interface CLocaleNative : Library {
+    fun setlocale(category: Int, locale: String): String?
+}
+
+private val cLocaleNative: CLocaleNative by lazy {
+    Native.load(Platform.C_LIBRARY_NAME, CLocaleNative::class.java)
+}
+
+private fun configureLibMpvNumericLocale() {
+    val lcNumeric = when {
+        Platform.isLinux() -> 1
+        Platform.isMac() || Platform.isWindows() -> 4
+        else -> return
+    }
+    check(cLocaleNative.setlocale(lcNumeric, "C") != null) {
+        "Failed to set LC_NUMERIC=C for libmpv"
+    }
+}
+
 fun main(args: Array<String>) {
     installDesktopDebugLogCapture()
     val activation = DesktopExternalActivationSession.open(args.toList()) ?: return
@@ -39,12 +61,16 @@ fun main(args: Array<String>) {
         )
     }
     installDesktopPlaybackEngineFactory {
+        configureLibMpvNumericLocale()
         PersistentDesktopPlaybackEngine(
             delegate = DesktopMpvPlaybackEngine(),
             resumeStore = createDesktopPlaybackResumeStore(),
         )
     }
-    installDesktopPlatformVideoControllerFactory { DesktopMpvVideoController() }
+    installDesktopPlatformVideoControllerFactory {
+        configureLibMpvNumericLocale()
+        DesktopMpvVideoController()
+    }
     installDesktopProviderCredentialStoreFactory { DesktopSecureProviderCredentialStore() }
     installDesktopLocalMusicRepositoryFactory { DesktopLocalMusicRepository() }
     installFallbackOAuthDeviceCodeAssistant(DesktopOAuthDeviceCodeAssistant())


### PR DESCRIPTION
## Summary
- set the native C runtime `LC_NUMERIC` category to `C` before creating desktop libmpv instances
- apply the guard to both audio playback and desktop video controller factories
- handle Linux/macOS/Windows locale category constants explicitly

## Why
libmpv requires `LC_NUMERIC` to be `C`. On desktop environments such as Linux, GUI/runtime initialization can leave the process with a non-C numeric locale, causing `mpv_create()` to fail with:

`Non-C locale detected. This is not supported.`

## Validation
- code path is limited to desktop libmpv construction
- PR CI should validate desktop compilation/tests
