### PR TITLE
fix: restore video controls auto hide

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderVideoDetailRoute.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/provider/ProviderVideoDetailRoute.kt
@@ -1,5 +1,8 @@
 package org.feeluown.mobile
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -46,6 +49,26 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.delay
+
+private const val PROVIDER_VIDEO_CONTROLS_AUTO_HIDE_MS = 3_000L
+
+internal data class ProviderVideoControlsVisibilityState(
+    val visible: Boolean = true,
+    val interactionEpoch: Long = 0L,
+) {
+    fun afterPlaybackChanged(isPlaying: Boolean): ProviderVideoControlsVisibilityState =
+        if (isPlaying) this else copy(visible = true)
+
+    fun afterSurfaceTap(): ProviderVideoControlsVisibilityState =
+        if (visible) copy(visible = false) else afterInteraction()
+
+    fun afterInteraction(): ProviderVideoControlsVisibilityState =
+        copy(visible = true, interactionEpoch = interactionEpoch + 1L)
+
+    fun afterAutoHide(isPlaying: Boolean): ProviderVideoControlsVisibilityState =
+        if (visible && isPlaying) copy(visible = false) else this
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -157,22 +180,48 @@ private fun ProviderOwnedVideoFrame(
     onToggleFullscreen: () -> Unit,
     modifier: Modifier,
 ) {
+    var controlsState by remember { mutableStateOf(ProviderVideoControlsVisibilityState()) }
     val interactionSource = remember { MutableInteractionSource() }
+
+    fun showControlsForInteraction() {
+        controlsState = controlsState.afterInteraction()
+    }
+
+    LaunchedEffect(playbackState.isPlaying) {
+        controlsState = controlsState.afterPlaybackChanged(playbackState.isPlaying)
+    }
+    LaunchedEffect(controlsState.visible, playbackState.isPlaying, controlsState.interactionEpoch) {
+        if (controlsState.visible && playbackState.isPlaying) {
+            delay(PROVIDER_VIDEO_CONTROLS_AUTO_HIDE_MS)
+            controlsState = controlsState.afterAutoHide(playbackState.isPlaying)
+        }
+    }
+
     Box(modifier = modifier.background(Color.Black), contentAlignment = Alignment.Center) {
         PlatformVideoPlayer(payload = payload, controller = controller, modifier = Modifier.fillMaxSize())
         Box(
             modifier = Modifier.fillMaxSize().clickable(
                 interactionSource = interactionSource,
                 indication = null,
-            ) {},
+            ) {
+                controlsState = controlsState.afterSurfaceTap()
+            },
         )
-        ProviderOwnedVideoControls(
-            controller = controller,
-            state = playbackState,
-            fullscreen = fullscreen,
-            onToggleFullscreen = onToggleFullscreen,
-            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
-        )
+        AnimatedVisibility(
+            visible = controlsState.visible,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.BottomCenter),
+        ) {
+            ProviderOwnedVideoControls(
+                controller = controller,
+                state = playbackState,
+                fullscreen = fullscreen,
+                onInteraction = ::showControlsForInteraction,
+                onToggleFullscreen = onToggleFullscreen,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 
@@ -181,6 +230,7 @@ private fun ProviderOwnedVideoControls(
     controller: PlatformVideoController,
     state: PlatformVideoPlaybackState,
     fullscreen: Boolean,
+    onInteraction: () -> Unit,
     onToggleFullscreen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -195,25 +245,36 @@ private fun ProviderOwnedVideoControls(
         Column(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
             Slider(
                 value = shownFraction,
-                onValueChange = { scrub = it },
+                onValueChange = {
+                    onInteraction()
+                    scrub = it
+                },
                 onValueChangeFinished = {
                     if (scrub >= 0f && duration > 0) controller.seekTo((scrub * duration).toLong())
                     scrub = -1f
+                    onInteraction()
                 },
                 enabled = duration > 0,
                 modifier = Modifier.fillMaxWidth(),
             )
             Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = { if (state.isPlaying) controller.pause() else controller.play() }) {
+                IconButton(onClick = {
+                    onInteraction()
+                    if (state.isPlaying) controller.pause() else controller.play()
+                }) {
                     Icon(
                         if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
                         contentDescription = if (state.isPlaying) "暂停" else "播放",
                     )
                 }
-                IconButton(onClick = { controller.seekTo((state.positionMs - 10_000L).coerceAtLeast(0L)) }) {
+                IconButton(onClick = {
+                    onInteraction()
+                    controller.seekTo((state.positionMs - 10_000L).coerceAtLeast(0L))
+                }) {
                     Icon(Icons.Filled.Replay10, contentDescription = "后退 10 秒")
                 }
                 IconButton(onClick = {
+                    onInteraction()
                     val target = state.positionMs + 10_000L
                     controller.seekTo(if (duration > 0) target.coerceAtMost(duration) else target)
                 }) {
@@ -221,7 +282,10 @@ private fun ProviderOwnedVideoControls(
                 }
                 Text("${formatProviderVideoTime(state.positionMs)} / ${formatProviderVideoTime(duration)}")
                 Spacer(Modifier.weight(1f))
-                IconButton(onClick = onToggleFullscreen) {
+                IconButton(onClick = {
+                    onInteraction()
+                    onToggleFullscreen()
+                }) {
                     Icon(
                         if (fullscreen) Icons.Filled.FullscreenExit else Icons.Filled.Fullscreen,
                         contentDescription = if (fullscreen) "退出全屏" else "全屏",

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderVideoControlsVisibilityStateTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/ProviderVideoControlsVisibilityStateTest.kt
@@ -1,0 +1,42 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProviderVideoControlsVisibilityStateTest {
+    @Test
+    fun playingControlsCanAutoHideAndSurfaceTapRestoresThem() {
+        var state = ProviderVideoControlsVisibilityState()
+
+        state = state.afterAutoHide(isPlaying = true)
+        assertFalse(state.visible)
+
+        val previousEpoch = state.interactionEpoch
+        state = state.afterSurfaceTap()
+        assertTrue(state.visible)
+        assertEquals(previousEpoch + 1L, state.interactionEpoch)
+    }
+
+    @Test
+    fun pausedPlaybackKeepsControlsVisible() {
+        var state = ProviderVideoControlsVisibilityState(visible = false)
+
+        state = state.afterPlaybackChanged(isPlaying = false)
+        assertTrue(state.visible)
+        assertEquals(state, state.afterAutoHide(isPlaying = false))
+    }
+
+    @Test
+    fun controlInteractionRestartsAutoHideEpoch() {
+        var state = ProviderVideoControlsVisibilityState()
+
+        state = state.afterInteraction()
+        val firstEpoch = state.interactionEpoch
+        state = state.afterInteraction()
+
+        assertTrue(state.visible)
+        assertEquals(firstEpoch + 1L, state.interactionEpoch)
+    }
+}


### PR DESCRIPTION
## Summary
- restore the provider video control bar auto-hide behavior lost during the P2 ownership migration
- hide controls after 3 seconds of inactivity while video is playing
- restore tap-to-toggle controls and fade in/out transitions
- keep controls visible while paused and restart the hide timeout after slider/button interactions
- add shared regression coverage for the visibility state transitions

## Root cause
PR #104 replaced the legacy `EnhancedProviderVideoScreen` with the owner-driven `ProviderVideoDetailRoute`. The player controls were migrated, but the previous visibility/auto-hide interaction state was not, leaving the control bar permanently visible and the video surface tap handler empty.

## Validation
- added `ProviderVideoControlsVisibilityStateTest` covering auto-hide, paused visibility, tap restore, and interaction epoch reset behavior
- change remains entirely in shared UI/state code; Android/iOS native player implementations are unchanged

Closes #181