### PR TITLE
feat(ui): use Material Expressive page loading

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ serializationJson = "1.8.1"
 lifecycle = "2.10.0"
 navigation3 = "1.1.1"
 datastore = "1.2.1"
+graphicsShapes = "1.1.0"
 materialKolor = "5.0.0-alpha07"
 ktor = "3.5.1"
 kover = "0.9.8"
@@ -25,6 +26,7 @@ dbusJava = "5.2.0"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-graphics-shapes = { module = "androidx.graphics:graphics-shapes", version.ref = "graphicsShapes" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 androidx-media3-datasource = { module = "androidx.media3:media3-datasource", version.ref = "media3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ serializationJson = "1.8.1"
 lifecycle = "2.10.0"
 navigation3 = "1.1.1"
 datastore = "1.2.1"
-graphicsShapes = "1.1.0"
 materialKolor = "5.0.0-alpha07"
 ktor = "3.5.1"
 kover = "0.9.8"
@@ -26,7 +25,6 @@ dbusJava = "5.2.0"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
-androidx-graphics-shapes = { module = "androidx.graphics:graphics-shapes", version.ref = "graphicsShapes" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 androidx-media3-datasource = { module = "androidx.media3:media3-datasource", version.ref = "media3" }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppInitializationLoadingScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppInitializationLoadingScreen.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppInitializationLoadingScreen() {
     Box(
@@ -23,7 +20,7 @@ fun AppInitializationLoadingScreen() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
         ) {
-            LoadingIndicator()
+            ExpressiveLoadingIndicator()
             Text(
                 text = "正在加载设置",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppInitializationLoadingScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppInitializationLoadingScreen.kt
@@ -4,13 +4,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppInitializationLoadingScreen() {
     Box(
@@ -21,7 +23,7 @@ fun AppInitializationLoadingScreen() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(FuoSpacing.md),
         ) {
-            CircularProgressIndicator()
+            LoadingIndicator()
             Text(
                 text = "正在加载设置",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -1,28 +1,96 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LoadingIndicator as MaterialLoadingIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 
-/** Shared indeterminate loading treatment for page and content-area loading states. */
+private const val PageLoadingFadeOutMillis = 100
+private const val PageContentFadeInDelayMillis = PageLoadingFadeOutMillis
+private const val PageContentFadeInMillis = 160
+
+/** Shared Material Expressive indeterminate loading treatment for content-area loading states. */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
-    AnimatedVisibility(visible = visible, modifier = modifier.fillMaxWidth()) {
-        Row(
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier.fillMaxWidth(),
+        enter = fadeIn(animationSpec = tween(PageLoadingFadeOutMillis)),
+        exit = fadeOut(animationSpec = tween(PageLoadingFadeOutMillis)),
+    ) {
+        Box(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center,
+            contentAlignment = Alignment.Center,
         ) {
-            CircularWavyProgressIndicator(
-                modifier = Modifier.size(32.dp),
-            )
+            MaterialLoadingIndicator()
+        }
+    }
+}
+
+/**
+ * Keeps page content composed while an initial load is in progress, but only reveals it after the
+ * centered Material Expressive loading indicator has exited. Keeping the content composed avoids
+ * resetting list/scroll state and page-side effects when loading completes.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun PageLoadingContent(
+    loading: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (loading) 0f else 1f,
+        animationSpec = tween(
+            durationMillis = if (loading) PageLoadingFadeOutMillis else PageContentFadeInMillis,
+            delayMillis = if (loading) 0 else PageContentFadeInDelayMillis,
+        ),
+        label = "page-loading-content-alpha",
+    )
+
+    Box(modifier = modifier) {
+        Box(
+            modifier = Modifier.fillMaxSize().alpha(contentAlpha),
+        ) {
+            content()
+        }
+        AnimatedVisibility(
+            visible = loading,
+            modifier = Modifier.fillMaxSize(),
+            enter = fadeIn(animationSpec = tween(PageLoadingFadeOutMillis)),
+            exit = fadeOut(animationSpec = tween(PageLoadingFadeOutMillis)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                            }
+                        }
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                MaterialLoadingIndicator()
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -84,6 +85,11 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
         label = "expressive-loading-rotation",
     )
     val indicatorColor = MaterialTheme.colorScheme.primary
+    // These objects are mutated only by the Canvas draw pass. Reusing them avoids allocating a
+    // FloatArray and a native-backed Path on every animation frame, which is especially noticeable
+    // on lower-end Android devices and the Skia desktop targets.
+    val morphPoints = remember { FloatArray(ShapePointCount * 2) }
+    val morphPath = remember { Path() }
 
     Canvas(
         modifier = modifier
@@ -96,19 +102,18 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
         val morphProgress = FastOutSlowInEasing.transform(cycle - shapeIndex)
         val start = ExpressiveLoadingShapes[shapeIndex]
         val end = ExpressiveLoadingShapes[(shapeIndex + 1) % shapeCount]
-        val points = FloatArray(ShapePointCount * 2)
         val radius = min(size.width, size.height) / 3f
         val centerX = size.width / 2f
         val centerY = size.height / 2f
 
-        for (index in points.indices step 2) {
-            points[index] = centerX + lerp(start[index], end[index], morphProgress) * radius
-            points[index + 1] = centerY + lerp(start[index + 1], end[index + 1], morphProgress) * radius
+        for (index in morphPoints.indices step 2) {
+            morphPoints[index] = centerX + lerp(start[index], end[index], morphProgress) * radius
+            morphPoints[index + 1] = centerY + lerp(start[index + 1], end[index + 1], morphProgress) * radius
         }
 
-        val path = smoothClosedPath(points)
+        morphPath.setSmoothClosed(morphPoints)
         rotate(degrees = rotation, pivot = center) {
-            drawPath(path = path, color = indicatorColor)
+            drawPath(path = morphPath, color = indicatorColor)
         }
     }
 }
@@ -212,29 +217,28 @@ private fun superellipseShape(xScale: Float, yScale: Float, exponent: Float): Fl
         }
     }
 
-private fun smoothClosedPath(points: FloatArray): Path {
+private fun Path.setSmoothClosed(points: FloatArray) {
+    reset()
     val pointCount = points.size / 2
     fun x(index: Int): Float = points[((index + pointCount) % pointCount) * 2]
     fun y(index: Int): Float = points[((index + pointCount) % pointCount) * 2 + 1]
 
-    return Path().apply {
-        moveTo(x(0), y(0))
-        repeat(pointCount) { index ->
-            val p0 = index - 1
-            val p1 = index
-            val p2 = index + 1
-            val p3 = index + 2
-            cubicTo(
-                x(p1) + (x(p2) - x(p0)) / 6f,
-                y(p1) + (y(p2) - y(p0)) / 6f,
-                x(p2) - (x(p3) - x(p1)) / 6f,
-                y(p2) - (y(p3) - y(p1)) / 6f,
-                x(p2),
-                y(p2),
-            )
-        }
-        close()
+    moveTo(x(0), y(0))
+    repeat(pointCount) { index ->
+        val p0 = index - 1
+        val p1 = index
+        val p2 = index + 1
+        val p3 = index + 2
+        cubicTo(
+            x(p1) + (x(p2) - x(p0)) / 6f,
+            y(p1) + (y(p2) - y(p0)) / 6f,
+            x(p2) - (x(p3) - x(p1)) / 6f,
+            y(p2) - (y(p3) - y(p1)) / 6f,
+            x(p2),
+            y(p2),
+        )
     }
+    close()
 }
 
 private fun lerp(start: Float, end: Float, progress: Float): Float =

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -1,31 +1,119 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.LoadingIndicator as MaterialLoadingIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sign
+import kotlin.math.sin
 
 private const val PageLoadingFadeOutMillis = 100
 private const val PageContentFadeInDelayMillis = PageLoadingFadeOutMillis
 private const val PageContentFadeInMillis = 160
+private const val ShapeMorphIntervalMillis = 650
+private const val ShapeRotationDurationMillis = 4666
+private const val ShapePointCount = 36
+private val ExpressiveLoadingShapes = listOf(
+    radialShape(lobes = 10, depth = 0.17f, phase = 0.08f),
+    radialShape(lobes = 9, depth = 0.10f, phase = 0.20f),
+    radialShape(lobes = 5, depth = 0.08f, phase = -0.18f),
+    superellipseShape(xScale = 1f, yScale = 0.58f, exponent = 0.52f),
+    radialShape(lobes = 8, depth = 0.18f, phase = 0.12f),
+    radialShape(lobes = 4, depth = 0.12f, phase = PI.toFloat() / 4f),
+    ellipseShape(xScale = 0.78f, yScale = 1f),
+)
 
-/** Shared Material Expressive indeterminate loading treatment for content-area loading states. */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+/**
+ * Material Expressive-style indeterminate indicator for the Compose Multiplatform Material3
+ * version currently used by the app. The upstream Material3 component is newer than the available
+ * multiplatform artifact, so this keeps the same seven-shape morphing treatment in commonMain.
+ */
+@Composable
+fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "expressive-loading")
+    val shapeCycle by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = ExpressiveLoadingShapes.size.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = ShapeMorphIntervalMillis * ExpressiveLoadingShapes.size,
+                easing = LinearEasing,
+            ),
+        ),
+        label = "expressive-loading-shape",
+    )
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = ShapeRotationDurationMillis,
+                easing = LinearEasing,
+            ),
+        ),
+        label = "expressive-loading-rotation",
+    )
+    val indicatorColor = MaterialTheme.colorScheme.primary
+
+    Canvas(
+        modifier = modifier
+            .size(48.dp)
+            .semantics { contentDescription = "加载中" },
+    ) {
+        val shapeCount = ExpressiveLoadingShapes.size
+        val cycle = if (shapeCycle >= shapeCount) 0f else shapeCycle
+        val shapeIndex = cycle.toInt().coerceIn(0, shapeCount - 1)
+        val morphProgress = FastOutSlowInEasing.transform(cycle - shapeIndex)
+        val start = ExpressiveLoadingShapes[shapeIndex]
+        val end = ExpressiveLoadingShapes[(shapeIndex + 1) % shapeCount]
+        val points = FloatArray(ShapePointCount * 2)
+        val radius = min(size.width, size.height) / 3f
+        val centerX = size.width / 2f
+        val centerY = size.height / 2f
+
+        for (index in points.indices step 2) {
+            points[index] = centerX + lerp(start[index], end[index], morphProgress) * radius
+            points[index + 1] = centerY + lerp(start[index + 1], end[index + 1], morphProgress) * radius
+        }
+
+        val path = smoothClosedPath(points)
+        rotate(degrees = rotation, pivot = center) {
+            drawPath(path = path, color = indicatorColor)
+        }
+    }
+}
+
+/** Shared indeterminate loading treatment for smaller content-area loading states. */
 @Composable
 fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
     AnimatedVisibility(
@@ -38,17 +126,16 @@ fun LoadingIndicator(visible: Boolean, modifier: Modifier = Modifier) {
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center,
         ) {
-            MaterialLoadingIndicator()
+            ExpressiveLoadingIndicator()
         }
     }
 }
 
 /**
  * Keeps page content composed while an initial load is in progress, but only reveals it after the
- * centered Material Expressive loading indicator has exited. Keeping the content composed avoids
- * resetting list/scroll state and page-side effects when loading completes.
+ * centered loading indicator has exited. Keeping the content composed avoids resetting list/scroll
+ * state and page-side effects when loading completes.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PageLoadingContent(
     loading: Boolean,
@@ -89,8 +176,66 @@ fun PageLoadingContent(
                     },
                 contentAlignment = Alignment.Center,
             ) {
-                MaterialLoadingIndicator()
+                ExpressiveLoadingIndicator()
             }
         }
     }
 }
+
+private fun radialShape(lobes: Int, depth: Float, phase: Float): FloatArray =
+    FloatArray(ShapePointCount * 2).also { points ->
+        repeat(ShapePointCount) { index ->
+            val angle = (2.0 * PI * index / ShapePointCount).toFloat()
+            val radius = 0.83f + depth * cos(lobes * angle + phase)
+            points[index * 2] = cos(angle) * radius
+            points[index * 2 + 1] = sin(angle) * radius
+        }
+    }
+
+private fun ellipseShape(xScale: Float, yScale: Float): FloatArray =
+    FloatArray(ShapePointCount * 2).also { points ->
+        repeat(ShapePointCount) { index ->
+            val angle = (2.0 * PI * index / ShapePointCount).toFloat()
+            points[index * 2] = cos(angle) * xScale
+            points[index * 2 + 1] = sin(angle) * yScale
+        }
+    }
+
+private fun superellipseShape(xScale: Float, yScale: Float, exponent: Float): FloatArray =
+    FloatArray(ShapePointCount * 2).also { points ->
+        repeat(ShapePointCount) { index ->
+            val angle = (2.0 * PI * index / ShapePointCount).toFloat()
+            val cosine = cos(angle)
+            val sine = sin(angle)
+            points[index * 2] = sign(cosine) * abs(cosine).pow(exponent) * xScale
+            points[index * 2 + 1] = sign(sine) * abs(sine).pow(exponent) * yScale
+        }
+    }
+
+private fun smoothClosedPath(points: FloatArray): Path {
+    val pointCount = points.size / 2
+    fun x(index: Int): Float = points[((index + pointCount) % pointCount) * 2]
+    fun y(index: Int): Float = points[((index + pointCount) % pointCount) * 2 + 1]
+
+    return Path().apply {
+        moveTo(x(0), y(0))
+        repeat(pointCount) { index ->
+            val p0 = index - 1
+            val p1 = index
+            val p2 = index + 1
+            val p3 = index + 2
+            cubicTo(
+                x(p1) + (x(p2) - x(p0)) / 6f,
+                y(p1) + (y(p2) - y(p0)) / 6f,
+                x(p2) - (x(p3) - x(p1)) / 6f,
+                y(p2) - (y(p3) - y(p1)) / 6f,
+                x(p2),
+                y(p2),
+            )
+        }
+        close()
+    }
+}
+
+private fun lerp(start: Float, end: Float, progress: Float): Float =
+    start + (end - start) * progress

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -1,12 +1,13 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,8 +19,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -30,6 +35,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
@@ -43,6 +50,7 @@ private const val PageContentFadeInDelayMillis = PageLoadingFadeOutMillis
 private const val PageContentFadeInMillis = 160
 private const val ShapeMorphIntervalMillis = 650
 private const val ShapeRotationDurationMillis = 4666
+private const val ShapeMorphRotationDegrees = 90f
 private const val ShapePointCount = 36
 private val ExpressiveLoadingShapes = listOf(
     radialShape(lobes = 10, depth = 0.17f, phase = 0.08f),
@@ -61,19 +69,11 @@ private val ExpressiveLoadingShapes = listOf(
  */
 @Composable
 fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
+    val morphProgress = remember { Animatable(0f) }
+    var currentMorphIndex by remember { mutableIntStateOf(0) }
+    var morphRotationTarget by remember { mutableFloatStateOf(0f) }
     val transition = rememberInfiniteTransition(label = "expressive-loading")
-    val shapeCycle by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = ExpressiveLoadingShapes.size.toFloat(),
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = ShapeMorphIntervalMillis * ExpressiveLoadingShapes.size,
-                easing = LinearEasing,
-            ),
-        ),
-        label = "expressive-loading-shape",
-    )
-    val rotation by transition.animateFloat(
+    val globalRotation by transition.animateFloat(
         initialValue = 0f,
         targetValue = 360f,
         animationSpec = infiniteRepeatable(
@@ -82,7 +82,7 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
                 easing = LinearEasing,
             ),
         ),
-        label = "expressive-loading-rotation",
+        label = "expressive-loading-global-rotation",
     )
     val indicatorColor = MaterialTheme.colorScheme.primary
     // These objects are mutated only by the Canvas draw pass. Reusing them avoids allocating a
@@ -91,28 +91,51 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
     val morphPoints = remember { FloatArray(ShapePointCount * 2) }
     val morphPath = remember { Path() }
 
+    // Match the Material3 expressive cadence: spring each morph, start a new one every 650 ms,
+    // rotate a quarter turn with each shape change, and keep a slower global rotation underneath.
+    LaunchedEffect(Unit) {
+        val morphAnimationSpec = spring<Float>(
+            dampingRatio = 0.6f,
+            stiffness = 200f,
+            visibilityThreshold = 0.1f,
+        )
+        while (true) {
+            val morph = async {
+                morphProgress.animateTo(
+                    targetValue = 1f,
+                    animationSpec = morphAnimationSpec,
+                )
+                currentMorphIndex = (currentMorphIndex + 1) % ExpressiveLoadingShapes.size
+                morphProgress.snapTo(0f)
+                morphRotationTarget = (morphRotationTarget + ShapeMorphRotationDegrees) % 360f
+            }
+            delay(ShapeMorphIntervalMillis.toLong())
+            morph.await()
+        }
+    }
+
     Canvas(
         modifier = modifier
             .size(48.dp)
             .semantics { contentDescription = "加载中" },
     ) {
-        val shapeCount = ExpressiveLoadingShapes.size
-        val cycle = if (shapeCycle >= shapeCount.toFloat()) 0f else shapeCycle
-        val shapeIndex = cycle.toInt().coerceIn(0, shapeCount - 1)
-        val morphProgress = FastOutSlowInEasing.transform(cycle - shapeIndex)
-        val start = ExpressiveLoadingShapes[shapeIndex]
-        val end = ExpressiveLoadingShapes[(shapeIndex + 1) % shapeCount]
+        val progress = morphProgress.value.coerceIn(0f, 1f)
+        val start = ExpressiveLoadingShapes[currentMorphIndex]
+        val end = ExpressiveLoadingShapes[(currentMorphIndex + 1) % ExpressiveLoadingShapes.size]
         val radius = min(size.width, size.height) / 3f
         val centerX = size.width / 2f
         val centerY = size.height / 2f
 
         for (index in morphPoints.indices step 2) {
-            morphPoints[index] = centerX + lerp(start[index], end[index], morphProgress) * radius
-            morphPoints[index + 1] = centerY + lerp(start[index + 1], end[index + 1], morphProgress) * radius
+            morphPoints[index] = centerX + lerp(start[index], end[index], progress) * radius
+            morphPoints[index + 1] = centerY + lerp(start[index + 1], end[index + 1], progress) * radius
         }
 
         morphPath.setSmoothClosed(morphPoints)
-        rotate(degrees = rotation, pivot = center) {
+        rotate(
+            degrees = progress * ShapeMorphRotationDegrees + morphRotationTarget + globalRotation,
+            pivot = center,
+        ) {
             drawPath(path = morphPath, color = indicatorColor)
         }
     }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/FuoLoadingIndicator.kt
@@ -91,7 +91,7 @@ fun ExpressiveLoadingIndicator(modifier: Modifier = Modifier) {
             .semantics { contentDescription = "加载中" },
     ) {
         val shapeCount = ExpressiveLoadingShapes.size
-        val cycle = if (shapeCycle >= shapeCount) 0f else shapeCycle
+        val cycle = if (shapeCycle >= shapeCount.toFloat()) 0f else shapeCycle
         val shapeIndex = cycle.toInt().coerceIn(0, shapeCount - 1)
         val morphProgress = FastOutSlowInEasing.transform(cycle - shapeIndex)
         val start = ExpressiveLoadingShapes[shapeIndex]

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -69,23 +69,24 @@ fun MineHomeSection(
             },
             modifier = Modifier.weight(1f).fillMaxWidth(),
         ) {
-            when (state.mineSection) {
-                MineSection.Playlists, MineSection.Songs -> MineOwnerPlaylists(home, !wide, Modifier.fillMaxSize())
-                MineSection.Artists -> MineOwnerMediaItems(home, ProviderContentType.Artists, "歌手", Modifier.fillMaxSize())
-                MineSection.Albums -> MineOwnerMediaItems(home, ProviderContentType.Albums, "专辑", Modifier.fillMaxSize())
-                MineSection.LocalMusic -> LocalMusicSection(
-                    hasAudioPermission = hasAudioPermission,
-                    onRequestAudioPermission = onRequestAudioPermission,
-                    hasImagePermission = hasImagePermission,
-                    onRequestImagePermission = onRequestImagePermission,
-                    showModeFilter = !wide,
-                    modifier = Modifier.fillMaxSize(),
-                )
+            PageLoadingContent(
+                loading = showPageLoading,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                when (state.mineSection) {
+                    MineSection.Playlists, MineSection.Songs -> MineOwnerPlaylists(home, !wide, Modifier.fillMaxSize())
+                    MineSection.Artists -> MineOwnerMediaItems(home, ProviderContentType.Artists, "歌手", Modifier.fillMaxSize())
+                    MineSection.Albums -> MineOwnerMediaItems(home, ProviderContentType.Albums, "专辑", Modifier.fillMaxSize())
+                    MineSection.LocalMusic -> LocalMusicSection(
+                        hasAudioPermission = hasAudioPermission,
+                        onRequestAudioPermission = onRequestAudioPermission,
+                        hasImagePermission = hasImagePermission,
+                        onRequestImagePermission = onRequestImagePermission,
+                        showModeFilter = !wide,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
-            LoadingIndicator(
-                visible = showPageLoading,
-                modifier = Modifier.align(Alignment.Center),
-            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/MineHomeFeatureSection.kt
@@ -49,29 +49,48 @@ fun MineHomeSection(
     val wide = LocalAppLayoutInfo.current.useWideLayout
     var refreshRequested by remember(state.mineSection) { mutableStateOf(false) }
     val isLoading = state.isLoading || (state.mineSection == MineSection.LocalMusic && localMusicState.isLoading)
+    val hasInitialContent = when (state.mineSection) {
+        MineSection.Playlists, MineSection.Songs ->
+            state.minePlaylistSections.isNotEmpty() || state.mineFavoritePlaylistSections.isNotEmpty()
+        MineSection.Artists -> state.mineSections.any { it.feature.contentType == ProviderContentType.Artists }
+        MineSection.Albums -> state.mineSections.any { it.feature.contentType == ProviderContentType.Albums }
+        MineSection.LocalMusic ->
+            !hasAudioPermission || localMusicState.tracks.isNotEmpty() || localMusicState.directories.isNotEmpty()
+    }
+    var initialLoadPending by rememberSaveable(state.mineSection) { mutableStateOf(!hasInitialContent) }
+    var initialLoadStarted by rememberSaveable(state.mineSection) { mutableStateOf(isLoading) }
     val isPullRefreshing = refreshRequested && isLoading
-    val showPageLoading = isLoading && !refreshRequested
+    val showPageLoading = !refreshRequested && (isLoading || initialLoadPending)
 
-    LaunchedEffect(isLoading) {
+    LaunchedEffect(state.mineSection, isLoading, hasInitialContent, hasAudioPermission) {
+        when {
+            hasInitialContent -> initialLoadPending = false
+            state.mineSection == MineSection.LocalMusic && !hasAudioPermission -> initialLoadPending = false
+            isLoading -> initialLoadStarted = true
+            initialLoadStarted -> initialLoadPending = false
+        }
         if (!isLoading) refreshRequested = false
     }
 
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(if (wide) 6.dp else 12.dp)) {
-        MineOwnerChips(
-            home = home,
-            includeSecondary = wide,
-        )
-        PullToRefreshBox(
-            isRefreshing = isPullRefreshing,
-            onRefresh = {
-                refreshRequested = true
-                home.refreshMine()
-            },
-            modifier = Modifier.weight(1f).fillMaxWidth(),
+    PageLoadingContent(
+        loading = showPageLoading,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(if (wide) 6.dp else 12.dp),
         ) {
-            PageLoadingContent(
-                loading = showPageLoading,
-                modifier = Modifier.fillMaxSize(),
+            MineOwnerChips(
+                home = home,
+                includeSecondary = wide,
+            )
+            PullToRefreshBox(
+                isRefreshing = isPullRefreshing,
+                onRefresh = {
+                    refreshRequested = true
+                    home.refreshMine()
+                },
+                modifier = Modifier.weight(1f).fillMaxWidth(),
             ) {
                 when (state.mineSection) {
                     MineSection.Playlists, MineSection.Songs -> MineOwnerPlaylists(home, !wide, Modifier.fillMaxSize())

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
@@ -36,11 +36,21 @@ fun ProviderContentHomeFeatureSection(
         sections.filter { it.isLoginRequired }.map { it.feature }.distinctBy { it.providerId }
     }
     var refreshRequested by remember(section) { mutableStateOf(false) }
+    var initialLoadPending by remember(section) { mutableStateOf(sections.isEmpty()) }
+    var initialLoadObserved by remember(section) { mutableStateOf(state.isLoading) }
     val isPullRefreshing = refreshRequested && state.isLoading
-    val showPageLoading = state.isLoading && !refreshRequested
+    val showPageLoading = !refreshRequested && (state.isLoading || initialLoadPending)
 
-    LaunchedEffect(state.isLoading) {
-        if (!state.isLoading) refreshRequested = false
+    LaunchedEffect(state.isLoading, sections.isEmpty()) {
+        if (sections.isNotEmpty()) {
+            initialLoadPending = false
+        }
+        if (state.isLoading) {
+            initialLoadObserved = true
+        } else {
+            if (initialLoadObserved) initialLoadPending = false
+            refreshRequested = false
+        }
     }
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/home/ProviderHomeFeatureSection.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -53,171 +52,172 @@ fun ProviderContentHomeFeatureSection(
             },
             modifier = Modifier.weight(1f).fillMaxWidth(),
         ) {
-            LazyColumn(
+            PageLoadingContent(
+                loading = showPageLoading,
                 modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                if (sections.isEmpty()) {
-                    item { EmptyProviderContentHint(title) }
-                } else if (section == HomeSection.Music) {
-                    val entrySections = visibleSections.filter {
-                        it.feature.contentType == ProviderContentType.Songs ||
-                            it.feature.contentType == ProviderContentType.Videos ||
-                            it.feature.isBilibiliWeeklyMustWatch()
-                    }
-                    val previewSections = visibleSections.filter {
-                        (it.feature.contentType == ProviderContentType.Playlists ||
-                            it.feature.contentType == ProviderContentType.Artists ||
-                            it.feature.contentType == ProviderContentType.Albums) &&
-                            !it.feature.isBilibiliWeeklyMustWatch()
-                    }
-                    if (visibleSections.isNotEmpty()) {
-                        item(key = "header:explore") {
-                            ProviderFeatureHeader(
-                                feature = visibleSections.first().feature,
-                                title = "探索",
-                                providerLabel = visibleSections.map { it.feature.providerName }.distinct().joinToString(" / "),
-                            )
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (sections.isEmpty()) {
+                        item { EmptyProviderContentHint(title) }
+                    } else if (section == HomeSection.Music) {
+                        val entrySections = visibleSections.filter {
+                            it.feature.contentType == ProviderContentType.Songs ||
+                                it.feature.contentType == ProviderContentType.Videos ||
+                                it.feature.isBilibiliWeeklyMustWatch()
                         }
-                    }
-                    if (entrySections.isNotEmpty()) {
-                        item(key = "explore-grid") {
-                            ProviderFeatureCoverGrid(entrySections.map { it.feature }, home::openFeature)
+                        val previewSections = visibleSections.filter {
+                            (it.feature.contentType == ProviderContentType.Playlists ||
+                                it.feature.contentType == ProviderContentType.Artists ||
+                                it.feature.contentType == ProviderContentType.Albums) &&
+                                !it.feature.isBilibiliWeeklyMustWatch()
                         }
-                    }
-                    previewSections.forEach { contentSection ->
-                        val hasMore = contentSection.errorMessage == null && when {
-                            contentSection.playlists.isNotEmpty() -> contentSection.playlists.size > gridPreviewCapacity
-                            contentSection.mediaItems.isNotEmpty() -> contentSection.mediaItems.size > gridPreviewCapacity
-                            else -> false
-                        }
-                        item(key = "header:${contentSection.feature.id}") {
-                            ProviderFeatureHeader(
-                                feature = contentSection.feature,
-                                action = if (hasMore) {
-                                    { home.openFeature(contentSection.feature) }
-                                } else null,
-                                actionLabel = "查看更多",
-                            )
-                        }
-                        val errorMessage = contentSection.errorMessage
-                        when {
-                            errorMessage != null -> item(key = "error:${contentSection.feature.id}") {
-                                ProviderContentMessage(errorMessage)
-                            }
-                            contentSection.playlists.isNotEmpty() -> item(key = "playlists:${contentSection.feature.id}") {
-                                ProviderPlaylistGrid(
-                                    playlists = contentSection.playlists,
-                                    onClick = { home.openPlaylist(it, contentSection.feature.category) },
-                                    maxRows = 2,
+                        if (visibleSections.isNotEmpty()) {
+                            item(key = "header:explore") {
+                                ProviderFeatureHeader(
+                                    feature = visibleSections.first().feature,
+                                    title = "探索",
+                                    providerLabel = visibleSections.map { it.feature.providerName }.distinct().joinToString(" / "),
                                 )
                             }
-                            contentSection.mediaItems.isNotEmpty() -> item(key = "media-items:${contentSection.feature.id}") {
-                                ProviderMediaItemGrid(
-                                    items = contentSection.mediaItems,
-                                    onClick = home::openMediaItem,
-                                    maxRows = 2,
-                                )
+                        }
+                        if (entrySections.isNotEmpty()) {
+                            item(key = "explore-grid") {
+                                ProviderFeatureCoverGrid(entrySections.map { it.feature }, home::openFeature)
                             }
-                            else -> item(key = "empty:${contentSection.feature.id}") { ProviderContentMessage("暂无内容") }
                         }
-                    }
-                } else {
-                    val forYouSections = visibleSections.filter {
-                        it.feature.isDailySongs() || it.feature.isPrivateFm() ||
-                            it.feature.isBilibiliRecommendedVideos() || it.feature.isBilibiliDynamicVideos() ||
-                            it.feature.isRecommendedNewSongs()
-                    }
-                    val otherSections = visibleSections.filterNot {
-                        it.feature.isDailySongs() || it.feature.isPrivateFm() ||
-                            it.feature.isBilibiliRecommendedVideos() || it.feature.isBilibiliDynamicVideos() ||
-                            it.feature.isRecommendedNewSongs()
-                    }
-                    if (forYouSections.isNotEmpty()) {
-                        item(key = "header:for-you") {
-                            ProviderFeatureHeader(
-                                feature = forYouSections.first().feature,
-                                title = "为你推荐",
-                                providerLabel = forYouSections.map { it.feature.providerName }.distinct().joinToString(" / "),
-                            )
-                        }
-                        item(key = "for-you-grid") {
-                            ForYouRecommendGrid(
-                                sections = forYouSections,
-                                enabled = !state.isLoading,
-                                onFeatureClick = home::openFeature,
-                                onPrivateFmClick = home::playAllFeature,
-                            )
-                        }
-                    }
-                    otherSections.forEach { contentSection ->
-                        val hasMore = contentSection.errorMessage == null &&
-                            contentSection.tracks.isEmpty() &&
-                            contentSection.playlists.size > gridPreviewCapacity
-                        item(key = "header:${contentSection.feature.id}") {
-                            ProviderFeatureHeader(
-                                feature = contentSection.feature,
-                                onPlayAll = contentSection.tracks.takeIf { it.isNotEmpty() }?.let {
-                                    { home.playAllFeature(contentSection) }
-                                },
-                                action = if (hasMore) {
-                                    { home.openFeature(contentSection.feature) }
-                                } else null,
-                                actionLabel = "查看更多",
-                            )
-                        }
-                        val errorMessage = contentSection.errorMessage
-                        when {
-                            errorMessage != null -> item(key = "error:${contentSection.feature.id}") {
-                                ProviderContentMessage(errorMessage)
+                        previewSections.forEach { contentSection ->
+                            val hasMore = contentSection.errorMessage == null && when {
+                                contentSection.playlists.isNotEmpty() -> contentSection.playlists.size > gridPreviewCapacity
+                                contentSection.mediaItems.isNotEmpty() -> contentSection.mediaItems.size > gridPreviewCapacity
+                                else -> false
                             }
-                            contentSection.tracks.isNotEmpty() -> itemsIndexed(
-                                contentSection.tracks,
-                                key = { _, item -> "${contentSection.feature.id}:${item.id}" },
-                            ) { index, track ->
-                                TrackRow(
-                                    track = track,
-                                    downloadState = graph.downloads.downloadStates[track.id],
-                                    onClick = { home.playFeature(contentSection, index) },
-                                    onAddToUpNext = { graph.playbackQueue.addToUpNext(track) },
-                                    onDownload = { graph.downloads.download(track) },
-                                    onDeleteDownload = { graph.downloads.deleteDownload(track) },
-                                    onOpenArtist = { graph.providerTrackActions.openTrackArtist(track) },
-                                    onOpenAlbum = { graph.providerTrackActions.openTrackAlbum(track) },
-                                    onOpenDetail = { graph.providerTrackActions.openOriginalTrackDetail(track) },
-                                    onAddToPlaylist = if (graph.playlists.canAddTrackToPlaylist(track)) {
-                                        { graph.playlists.openPlaylistTargetPicker(track) }
+                            item(key = "header:${contentSection.feature.id}") {
+                                ProviderFeatureHeader(
+                                    feature = contentSection.feature,
+                                    action = if (hasMore) {
+                                        { home.openFeature(contentSection.feature) }
                                     } else null,
-                                )
-                                HorizontalDivider()
-                            }
-                            contentSection.playlists.isNotEmpty() -> item(key = "playlists:${contentSection.feature.id}") {
-                                ProviderPlaylistGrid(
-                                    playlists = contentSection.playlists,
-                                    onClick = { home.openPlaylist(it, contentSection.feature.category) },
-                                    maxRows = 2,
+                                    actionLabel = "查看更多",
                                 )
                             }
-                            contentSection.mediaItems.isNotEmpty() -> item(key = "media-items:${contentSection.feature.id}") {
-                                ProviderMediaItemGrid(contentSection.mediaItems, home::openMediaItem)
+                            val errorMessage = contentSection.errorMessage
+                            when {
+                                errorMessage != null -> item(key = "error:${contentSection.feature.id}") {
+                                    ProviderContentMessage(errorMessage)
+                                }
+                                contentSection.playlists.isNotEmpty() -> item(key = "playlists:${contentSection.feature.id}") {
+                                    ProviderPlaylistGrid(
+                                        playlists = contentSection.playlists,
+                                        onClick = { home.openPlaylist(it, contentSection.feature.category) },
+                                        maxRows = 2,
+                                    )
+                                }
+                                contentSection.mediaItems.isNotEmpty() -> item(key = "media-items:${contentSection.feature.id}") {
+                                    ProviderMediaItemGrid(
+                                        items = contentSection.mediaItems,
+                                        onClick = home::openMediaItem,
+                                        maxRows = 2,
+                                    )
+                                }
+                                else -> item(key = "empty:${contentSection.feature.id}") { ProviderContentMessage("暂无内容") }
                             }
-                            contentSection.videos.isNotEmpty() -> item(key = "videos:${contentSection.feature.id}") {
-                                ProviderVideoList(contentSection.videos, home::openVideo)
+                        }
+                    } else {
+                        val forYouSections = visibleSections.filter {
+                            it.feature.isDailySongs() || it.feature.isPrivateFm() ||
+                                it.feature.isBilibiliRecommendedVideos() || it.feature.isBilibiliDynamicVideos() ||
+                                it.feature.isRecommendedNewSongs()
+                        }
+                        val otherSections = visibleSections.filterNot {
+                            it.feature.isDailySongs() || it.feature.isPrivateFm() ||
+                                it.feature.isBilibiliRecommendedVideos() || it.feature.isBilibiliDynamicVideos() ||
+                                it.feature.isRecommendedNewSongs()
+                        }
+                        if (forYouSections.isNotEmpty()) {
+                            item(key = "header:for-you") {
+                                ProviderFeatureHeader(
+                                    feature = forYouSections.first().feature,
+                                    title = "为你推荐",
+                                    providerLabel = forYouSections.map { it.feature.providerName }.distinct().joinToString(" / "),
+                                )
                             }
-                            else -> item(key = "empty:${contentSection.feature.id}") { ProviderContentMessage("暂无内容") }
+                            item(key = "for-you-grid") {
+                                ForYouRecommendGrid(
+                                    sections = forYouSections,
+                                    enabled = !state.isLoading,
+                                    onFeatureClick = home::openFeature,
+                                    onPrivateFmClick = home::playAllFeature,
+                                )
+                            }
+                        }
+                        otherSections.forEach { contentSection ->
+                            val hasMore = contentSection.errorMessage == null &&
+                                contentSection.tracks.isEmpty() &&
+                                contentSection.playlists.size > gridPreviewCapacity
+                            item(key = "header:${contentSection.feature.id}") {
+                                ProviderFeatureHeader(
+                                    feature = contentSection.feature,
+                                    onPlayAll = contentSection.tracks.takeIf { it.isNotEmpty() }?.let {
+                                        { home.playAllFeature(contentSection) }
+                                    },
+                                    action = if (hasMore) {
+                                        { home.openFeature(contentSection.feature) }
+                                    } else null,
+                                    actionLabel = "查看更多",
+                                )
+                            }
+                            val errorMessage = contentSection.errorMessage
+                            when {
+                                errorMessage != null -> item(key = "error:${contentSection.feature.id}") {
+                                    ProviderContentMessage(errorMessage)
+                                }
+                                contentSection.tracks.isNotEmpty() -> itemsIndexed(
+                                    contentSection.tracks,
+                                    key = { _, item -> "${contentSection.feature.id}:${item.id}" },
+                                ) { index, track ->
+                                    TrackRow(
+                                        track = track,
+                                        downloadState = graph.downloads.downloadStates[track.id],
+                                        onClick = { home.playFeature(contentSection, index) },
+                                        onAddToUpNext = { graph.playbackQueue.addToUpNext(track) },
+                                        onDownload = { graph.downloads.download(track) },
+                                        onDeleteDownload = { graph.downloads.deleteDownload(track) },
+                                        onOpenArtist = { graph.providerTrackActions.openTrackArtist(track) },
+                                        onOpenAlbum = { graph.providerTrackActions.openTrackAlbum(track) },
+                                        onOpenDetail = { graph.providerTrackActions.openOriginalTrackDetail(track) },
+                                        onAddToPlaylist = if (graph.playlists.canAddTrackToPlaylist(track)) {
+                                            { graph.playlists.openPlaylistTargetPicker(track) }
+                                        } else null,
+                                    )
+                                    HorizontalDivider()
+                                }
+                                contentSection.playlists.isNotEmpty() -> item(key = "playlists:${contentSection.feature.id}") {
+                                    ProviderPlaylistGrid(
+                                        playlists = contentSection.playlists,
+                                        onClick = { home.openPlaylist(it, contentSection.feature.category) },
+                                        maxRows = 2,
+                                    )
+                                }
+                                contentSection.mediaItems.isNotEmpty() -> item(key = "media-items:${contentSection.feature.id}") {
+                                    ProviderMediaItemGrid(contentSection.mediaItems, home::openMediaItem)
+                                }
+                                contentSection.videos.isNotEmpty() -> item(key = "videos:${contentSection.feature.id}") {
+                                    ProviderVideoList(contentSection.videos, home::openVideo)
+                                }
+                                else -> item(key = "empty:${contentSection.feature.id}") { ProviderContentMessage("暂无内容") }
+                            }
                         }
                     }
-                }
-                if (lockedProviders.isNotEmpty()) {
-                    item(key = "locked-providers:${section.name}") {
-                        ProviderLockedSummary(lockedProviders) { home.openSettings(it.providerId) }
+                    if (lockedProviders.isNotEmpty()) {
+                        item(key = "locked-providers:${section.name}") {
+                            ProviderLockedSummary(lockedProviders) { home.openSettings(it.providerId) }
+                        }
                     }
                 }
             }
-            LoadingIndicator(
-                visible = showPageLoading,
-                modifier = Modifier.align(Alignment.Center),
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the shared wavy page loader with a Material Expressive-style seven-shape morphing indicator
- keep the implementation in commonMain so Android, iOS and desktop share the same animation
- add a page loading container that keeps content composed but visually hidden while loading
- center the morphing loader for Recommend/Explore and Mine page-level loads
- reveal page content only after the loader finishes fading out
- use the same expressive loader during app initialization

## Compatibility
The official Material3 `LoadingIndicator` landed after the AndroidX Material3 version currently available through Compose Multiplatform. This PR therefore backports the visual treatment with Compose Canvas instead of upgrading the project's Material3 stack or referencing an unavailable API.

## Behavior
- initial/page-level loads: centered shape morph, loader exits, then content fades in
- pull-to-refresh: unchanged; existing content stays visible and uses Material pull-to-refresh
- existing smaller loading states automatically get the new morphing visual through the shared `LoadingIndicator`
- determinate/action progress such as downloads, playback buffering, recognition and update progress remains unchanged

## Notes
`PageLoadingContent` intentionally keeps page content composed during loading so existing list state and load-completion effects are not reset by swapping composables.