### PR TITLE
docs: refresh README for desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,153 +2,89 @@
 
 [![Stable release](https://img.shields.io/github/v/release/feeluown/FuoEvolve?label=stable)](https://github.com/feeluown/FuoEvolve/releases/latest)
 [![Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml/badge.svg?branch=master)](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster)
-[![PR Tests](https://github.com/feeluown/FuoEvolve/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/feeluown/FuoEvolve/actions/workflows/pr-tests.yml)
-[![Release](https://github.com/feeluown/FuoEvolve/actions/workflows/release.yml/badge.svg)](https://github.com/feeluown/FuoEvolve/actions/workflows/release.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)
-![Compose Multiplatform](https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white)
-![Android](https://img.shields.io/badge/Android-Available-3DDC84?logo=android&logoColor=white)
-![iOS](https://img.shields.io/badge/iOS-Experimental-FF9500?logo=apple&logoColor=white)
+[![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/docs/multiplatform.html)
 
 [中文](README.zh-CN.md) | English
 
-FuoEvolve is an open-source music player built around the [FeelUOwn](https://github.com/feeluown/FeelUOwn) ecosystem. It brings multiple online music services, local music, playlists, downloads, lyrics, and video into one app with a modern Material 3 experience.
-
-Android is the primary supported platform. iOS builds are available for experimentation and development, but are not currently released for end users.
+FuoEvolve is an open-source, cross-platform music player built around the [FeelUOwn](https://github.com/feeluown/FeelUOwn) ecosystem. It brings online music services, local music, lyrics, downloads, and video into one modern app.
 
 ## Download
 
-| Channel | Link | Notes |
+| Platform | Stable | Canary / Preview |
 | --- | --- | --- |
-| Stable | [Latest GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | Signed multi-ABI Android APK for `arm64-v8a` and `x86_64`. |
-| F-Droid | [Official self-hosted repository](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | Keeps the latest stable releases and updates automatically after GitHub Releases. |
-| Canary | [Latest master Android build](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) | Signed release APK built from the latest successful `master` workflow. |
+| **Android** | [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) · [F-Droid repository](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | [Latest master build](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **Windows x64** | — | MSI / EXE from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **macOS arm64 / x64** | — | DMG / PKG from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **Linux x64** | — | AppImage / DEB / RPM / Arch package from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **iOS** | — | Experimental development builds only |
 
-## Highlights
+> Desktop Canary packages are preview builds. Windows and macOS packages are not yet production-signed/notarized.
 
-- 🎵 **Multiple music sources in one app** — use NetEase Cloud Music, QQ Music, Bilibili, and YouTube Music side by side, and choose which sources are enabled and preferred.
-- 🧭 **Rich discovery** — browse daily recommendations, private radio, charts, playlist and artist collections, new releases, MV collections, music styles, and other source-specific content.
-- 🔎 **Unified search** — search enabled online sources and local music, with dedicated result types where available and persistent recent-search history for quick reuse.
-- ▶️ **Resilient playback** — manage the queue, shuffle/repeat, Up Next, seeking, multipart content, audio and video playback, use a sleep timer, and resume the active queue and playback state after an Android process restart.
-- 🎤 **Rich and flexible lyrics** — synchronized, translated, romanized, and word-level lyrics where providers support them; manually associate and remember lyrics for tracks whose source does not provide lyrics.
-- 📱 **System and device lyric output** — publish timed lyrics to supported ColorOS lock screens, Lyricon status-bar lyrics, and supported BYD instrument clusters on Android.
-- 🔁 **Smarter source replacement** — when a track is unavailable, automatically find a close match from another enabled source with recording-aware scoring while preserving the original song context and lyrics.
-- ❤️ **Manage online libraries** — where the provider allows it, favorite or unfavorite playlists, artists, and albums, and manage owned NetEase/QQ Music playlists from inside FuoEvolve.
-- 💽 **Local music and offline listening** — browse and edit local music, create portable local playlists, download supported online tracks, resume interrupted downloads, and keep downloaded content indexed in the local library.
-- 🔐 **Portable provider credentials** — Android can export encrypted credential backups for all or individual providers and restore them later without replacing normal on-device secure storage.
-- 🎙️ **Audio recognition** — identify a song from the microphone and jump directly to search or song details.
-- 🔗 **Share into FuoEvolve** — on Android, share supported NetEase, QQ Music, Bilibili, YouTube, or YouTube Music links to the app to open the matching content; unsupported share text can fall back to search.
-- 🎨 **Material 3 Expressive UI** — light/dark themes, dynamic color, cover-inspired player colors, smooth transitions, and layouts that adapt across phone and larger screens.
+## Features
+
+- 🎵 **Multiple music sources** — use NetEase Cloud Music, QQ Music, Bilibili, and YouTube Music in one app.
+- 🧭 **Discover and search** — browse recommendations, charts, playlists, artists, albums, videos, and search across enabled sources.
+- ▶️ **Music and video playback** — queue management, shuffle/repeat, seeking, sleep timer, MV/video playback, and multipart Bilibili content.
+- 🎤 **Rich lyrics** — synchronized lyrics, translations, romanization, word-level timing where available, plus manual lyric matching.
+- 🔁 **Smart source replacement** — automatically look for a suitable alternative when the current track cannot be played.
+- 💽 **Local and offline music** — scan local files, edit metadata, create local playlists, download supported tracks, and resume interrupted downloads.
+- ❤️ **Library management** — manage favorites, playlists, albums, and artists where the music service supports it.
+- 🎙️ **Audio recognition** — identify nearby music and jump directly to search or song details.
+- 🔐 **Portable account credentials** — securely store provider logins and move supported credentials between devices when needed.
+- 🎨 **Material 3 Expressive UI** — adaptive layouts, light/dark themes, dynamic color, and cover-inspired player colors.
+
+## Desktop
+
+The desktop app uses the same shared interface and core experience as mobile instead of maintaining a reduced desktop-only UI.
+
+- **Windows:** system media controls through SMTC.
+- **macOS:** Now Playing / Remote Command Center integration.
+- **Linux:** MPRIS media controls and native Wayland runtime support.
+- **Tray lifecycle:** closing the window keeps playback and downloads running; the tray/status item can restore or exit the app.
+- **Secure login storage:** Windows Credential Manager, macOS Keychain, and Linux Secret Service/Libsecret.
+
+Desktop packages currently ship through the Canary workflow while release signing and final distribution are still being completed.
 
 ## Music Sources
 
-FuoEvolve currently includes four online sources. Available content can vary by source, region, account state, and upstream service behavior.
-
-| Source | What you can explore |
+| Source | Main content |
 | --- | --- |
-| **NetEase Cloud Music** | Daily songs, recommended and new songs, private FM, charts, playlist square, artist square, MV square, music styles, favorite songs, cloud songs, playlists, artists, and albums, with supported playlist and favorite mutations. |
-| **QQ Music** | Daily songs, recommendations, private FM, charts, playlist square, artist square, new albums, MV square, multi-type search, owned/favorite playlists, favorite albums, followed artists, and supported playlist/favorite mutations. |
-| **Bilibili** | Music/video search and playback, personalized recommendations, dynamic videos, weekly must-watch, watch later, viewing history, followed creators and uploads, favorites, collected bangumi/films, and multipart playback. |
-| **YouTube Music** | Song/video search, recommendations and library content, playlists, artists, albums, charts, lyrics, similar-track radio, and video playback where available. |
+| **NetEase Cloud Music** | Recommendations, private FM, charts, playlists, artists, albums, MV, favorites, and cloud music |
+| **QQ Music** | Recommendations, private FM, charts, playlists, artists, albums, MV, favorites, and library content |
+| **Bilibili** | Music/video search, recommendations, followed creators, favorites, history, watch later, and multipart video |
+| **YouTube Music** | Search, recommendations, library, playlists, artists, albums, radio, lyrics, and video |
 
-Sources can be enabled, disabled, reordered, and signed in from Settings. NetEase, QQ Music, and Bilibili use account cookies. YouTube Music supports Google authorization as well as imported account headers/cookies.
+Available content depends on the source, region, login state, and upstream service behavior. Sources can be enabled, disabled, reordered, and signed in from Settings.
 
-## Playback and Lyrics
+## Platform Status
 
-FuoEvolve is designed for both everyday listening and mixed music/video libraries. You can manage the play queue, use shuffle or repeat, add tracks to Up Next, seek through playback, open artist or album details directly from the player, and start a sleep timer that stops playback after a chosen duration or at the end of the current track.
-
-On Android, the playback session and durable queue cooperate so a process restart can restore the active track, queue, shuffle/repeat state, multipart position, and playback progress. Explicit user selections remain separate from resume behavior, so choosing a new song or playlist does not accidentally revive an older paused session.
-
-MV and video playback has a dedicated viewing experience with transport controls, full-screen playback, orientation handling, and support for multipart Bilibili videos. Smart replacement treats multipart replacement candidates as a single replacement track instead of unexpectedly advancing through their parts.
-
-Lyrics support includes synchronized lyrics, translations, romanized lines, and rich word-level timing from NetEase and QQ Music where available. For sources without usable lyrics, you can manually search for another track's lyrics, associate them with the current track, and keep that choice for future playback. Bilibili uses the video's BGM title as the preferred lyric search keyword when the upstream metadata provides one, falling back to the video title.
-
-Android can also publish timed lyrics outside the player: supported ColorOS devices can show lock-screen live lyrics, Lyricon can provide status-bar lyrics, and supported BYD vehicles can receive instrument-cluster lyrics.
-
-## Discovery and Personal Library
-
-The home and library experience follows the content each source actually provides instead of forcing every source into the same shape. Provider sections load incrementally, keeping large discovery and library views responsive while additional content is fetched.
-
-NetEase and QQ Music expose broader discovery areas such as charts, playlist collections, artist browsing, MV browsing, categories, and filters. NetEase also includes music-style browsing, while QQ Music includes new album discovery and expanded Mine content such as favorite playlists, favorite albums, and followed artists.
-
-Where supported, provider detail pages expose the resource's current favorite state and let you favorite or unfavorite playlists, artists, and albums. Owned NetEase and QQ Music playlists expose only the mutations they actually allow; QQ Music supports creating and deleting owned playlists, and supported playlists can add or remove tracks.
-
-Bilibili focuses on its own content model: personalized and dynamic videos, weekly recommendations, Watch Later, viewing history, followed creators, creator uploads, favorites, and collected bangumi/films.
-
-Your library also surfaces frequently played playlists so commonly used collections are easier to return to. Search keeps recent queries newest-first for quick reuse and lets you remove individual history entries.
-
-## Local Music, Playlists, and Downloads
-
-Local music can be scanned into the app and browsed by all tracks, artist, album, or directory. Scan rules can be adjusted to include specific folders or ignore very short audio files. The local index tracks media changes and stored lyrics so large libraries can refresh without rebuilding unchanged entries unnecessarily.
-
-Track title, artist, and album information can be edited locally. FuoEvolve can also use enabled online sources to help find better metadata and lyrics, and manually associated lyrics remain available across later playback.
-
-Local playlists can contain local, downloaded, and supported online tracks. They can be created and managed in the app, imported from files, and shared as playlist files.
-
-Supported online tracks can be downloaded for offline listening. Download state and resume metadata are persisted so interrupted transfers can continue, and completed downloads are integrated into the offline/local library for normal playback and browsing.
-
-## Audio Recognition
-
-Open audio recognition from the microphone action in Search. The app records only what is needed to generate an audio fingerprint, keeps the captured audio in memory, and sends the fingerprint to the recognition service rather than uploading the original recording.
-
-Recognized songs can be searched immediately or opened in their NetEase details. The latest recognition result remains available when navigating between Search and detail pages, and unsuccessful recognition can be retried.
-
-## Personalization and Settings
-
-FuoEvolve lets you tune the experience without requiring deep configuration. Common options include:
-
-- online source enablement, priority, and login management;
-- encrypted provider credential backup and restore on Android, including per-provider export;
-- separate Wi-Fi and cellular audio-quality preferences;
-- smart replacement providers, behavior, and matching strictness for unavailable tracks;
-- playback behavior, including whether another app starting audio should pause FuoEvolve;
-- system, light, or dark appearance, dynamic color, preset colors, and cover-inspired player colors on a dedicated appearance settings page;
-- lyric font size and external lyric output such as supported ColorOS, Lyricon, and BYD integrations;
-- local music scan folders and minimum track duration;
-- audio and image cache limits.
-
-## iOS Status
-
-iOS support is experimental. The project includes an iOS app and CI builds for development, and a growing set of shared features such as browsing, playback, MV controls, and audio recognition are available there.
-
-iOS is not currently published as a GitHub Release or App Store build, so it should not yet be considered an end-user supported platform.
+| Platform | Status | Notes |
+| --- | --- | --- |
+| Android | **Stable** | Primary release platform |
+| Windows | **Canary** | Installable x64 desktop packages |
+| macOS | **Canary** | Apple Silicon and Intel packages |
+| Linux | **Canary** | Native Wayland target; AppImage and distribution packages |
+| iOS | **Experimental** | Development and CI validation only |
 
 ## Development
 
-FuoEvolve uses Kotlin Multiplatform and Compose Multiplatform to share most application code across platforms. Android uses AndroidX Media3 for playback. The codebase is split into explicit feature, playback, provider, persistence, and platform boundaries so shared UI does not own provider or playback runtime responsibilities.
-
-Requirements:
-
-- JDK 17 or newer;
-- Android Studio or Android command-line tools for Android builds;
-- Xcode on macOS for experimental iOS builds.
-
-Build and install the Android debug app:
+FuoEvolve is built with Kotlin Multiplatform and Compose Multiplatform.
 
 ```bash
+# Android debug build
 ./gradlew :androidApp:assembleDebug
-./gradlew :androidApp:installDebug
+
+# Run the desktop app
+./gradlew :desktopApp:run
 ```
 
-Run shared tests and Android lint:
+Desktop architecture and packaging details are documented in [docs/desktop-foundation.md](docs/desktop-foundation.md) and [docs/desktop-packaging.md](docs/desktop-packaging.md).
 
-```bash
-./gradlew :shared:allTests
-./gradlew :androidApp:lint :shared:lint
-```
+## Contributing
 
-Main Gradle module groups:
-
-- `core:model` — shared application/domain models;
-- `feature:*` — feature ownership for search, recognition, local/offline libraries, provider browsing/auth/details, settings, onboarding, and home;
-- `playback:api` / `playback:runtime` — playback contracts, session orchestration, queue/lyrics/timer behavior, and platform integration boundaries;
-- `provider:api` / `provider:runtime` plus `provider:netease`, `provider:qqmusic`, `provider:bilibili`, and `provider:ytmusic` — provider contracts, runtime plumbing, and source-specific implementations;
-- `persistence:settings` — persisted shared settings and user choices;
-- `shared` — shared Compose application/UI integration;
-- `androidApp` — Android application and platform services;
-- `iosApp/FuoEvolve` — experimental iOS application;
-- `.github/workflows` — PR tests, master Canary builds, release automation, and reusable platform validation/packaging workflows.
+Bug reports, feature discussions, and pull requests are welcome. See [Issues](https://github.com/feeluown/FuoEvolve/issues) and [Pull Requests](https://github.com/feeluown/FuoEvolve/pulls).
 
 ## License
 
-FuoEvolve is licensed under the GNU General Public License v3.0. See [LICENSE](LICENSE) for details.
+FuoEvolve is licensed under the [GNU General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The desktop app uses the same shared interface and core experience as mobile ins
 
 - **Windows:** system media controls through SMTC.
 - **macOS:** Now Playing / Remote Command Center integration.
-- **Linux:** MPRIS media controls and native Wayland runtime support.
+- **Linux:** MPRIS media controls; native Wayland is the target, with packaging validation still in progress.
 - **Tray lifecycle:** closing the window keeps playback and downloads running; the tray/status item can restore or exit the app.
 - **Secure login storage:** Windows Credential Manager, macOS Keychain, and Linux Secret Service/Libsecret.
 
@@ -79,7 +79,7 @@ FuoEvolve is built with Kotlin Multiplatform and Compose Multiplatform.
 ./gradlew :desktopApp:run
 ```
 
-Desktop architecture and packaging details are documented in [docs/desktop-foundation.md](docs/desktop-foundation.md) and [docs/desktop-packaging.md](docs/desktop-packaging.md).
+Desktop development also requires a Rust/Cargo toolchain and the native dependencies for the target platform. See [docs/desktop-foundation.md](docs/desktop-foundation.md) and [docs/desktop-packaging.md](docs/desktop-packaging.md) for architecture, runtime, and packaging prerequisites.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Stable release](https://img.shields.io/github/v/release/feeluown/FuoEvolve?label=stable)](https://github.com/feeluown/FuoEvolve/releases/latest)
 [![Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml/badge.svg?branch=master)](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster)
+[![Downloads](https://img.shields.io/github/downloads/feeluown/FuoEvolve/total?label=downloads)](https://github.com/feeluown/FuoEvolve/releases)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/docs/multiplatform.html)
+[![Compose Multiplatform](https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white)](https://www.jetbrains.com/compose-multiplatform/)
 
 [中文](README.zh-CN.md) | English
 
@@ -36,7 +37,7 @@ FuoEvolve is an open-source, cross-platform music player built around the [FeelU
 
 ## Desktop
 
-The desktop app uses the same shared interface and core experience as mobile instead of maintaining a reduced desktop-only UI.
+The desktop app shares the same experience as mobile and is available for Windows, macOS, and Linux.
 
 - **Windows:** system media controls through SMTC.
 - **macOS:** Now Playing / Remote Command Center integration.
@@ -69,7 +70,7 @@ Available content depends on the source, region, login state, and upstream servi
 
 ## Development
 
-FuoEvolve is built with Kotlin Multiplatform and Compose Multiplatform.
+FuoEvolve uses [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/) across supported platforms.
 
 ```bash
 # Android debug build
@@ -79,7 +80,7 @@ FuoEvolve is built with Kotlin Multiplatform and Compose Multiplatform.
 ./gradlew :desktopApp:run
 ```
 
-Desktop development also requires a Rust/Cargo toolchain and the native dependencies for the target platform. See [docs/desktop-foundation.md](docs/desktop-foundation.md) and [docs/desktop-packaging.md](docs/desktop-packaging.md) for architecture, runtime, and packaging prerequisites.
+Desktop development also requires a Rust/Cargo toolchain and the native dependencies for the target platform. See [docs/desktop-foundation.md](docs/desktop-foundation.md) and [docs/desktop-packaging.md](docs/desktop-packaging.md) for setup and packaging prerequisites.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 
 - **Windows**：支持 SMTC 系统媒体控制。
 - **macOS**：支持 Now Playing / Remote Command Center。
-- **Linux**：支持 MPRIS 媒体控制，并以原生 Wayland 运行作为目标。
+- **Linux**：支持 MPRIS 媒体控制；原生 Wayland 运行是目标，目前仍在完善打包验证。
 - **托盘生命周期**：关闭窗口后继续播放和下载，可从托盘 / 状态栏图标恢复窗口或退出应用。
 - **安全登录存储**：使用 Windows Credential Manager、macOS Keychain 和 Linux Secret Service / Libsecret。
 
@@ -79,7 +79,7 @@ FuoEvolve 基于 Kotlin Multiplatform 和 Compose Multiplatform。
 ./gradlew :desktopApp:run
 ```
 
-桌面端架构和打包说明见 [docs/desktop-foundation.md](docs/desktop-foundation.md) 与 [docs/desktop-packaging.md](docs/desktop-packaging.md)。
+桌面端开发还需要 Rust/Cargo 工具链以及目标平台所需的原生依赖。架构、运行时与打包前置条件见 [docs/desktop-foundation.md](docs/desktop-foundation.md) 与 [docs/desktop-packaging.md](docs/desktop-packaging.md)。
 
 ## 参与贡献
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,153 +2,89 @@
 
 [![正式版](https://img.shields.io/github/v/release/feeluown/FuoEvolve?label=stable)](https://github.com/feeluown/FuoEvolve/releases/latest)
 [![Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml/badge.svg?branch=master)](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster)
-[![PR Tests](https://github.com/feeluown/FuoEvolve/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/feeluown/FuoEvolve/actions/workflows/pr-tests.yml)
-[![Release](https://github.com/feeluown/FuoEvolve/actions/workflows/release.yml/badge.svg)](https://github.com/feeluown/FuoEvolve/actions/workflows/release.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)
-![Compose Multiplatform](https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white)
-![Android](https://img.shields.io/badge/Android-Available-3DDC84?logo=android&logoColor=white)
-![iOS](https://img.shields.io/badge/iOS-Experimental-FF9500?logo=apple&logoColor=white)
+[![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/docs/multiplatform.html)
 
 中文 | [English](README.md)
 
-FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生态构建的开源音乐播放器。它把多个在线音乐平台、本地音乐、歌单、下载、歌词和视频内容整合到同一个应用中，并提供现代化的 Material 3 使用体验。
-
-目前 Android 是主要支持的平台；iOS 已有实验性构建，可用于体验和开发验证，但暂未面向普通用户正式发布。
+FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生态构建的开源跨平台音乐播放器，将在线音乐、本地音乐、歌词、下载和视频整合到一个现代化应用中。
 
 ## 下载
 
-| 渠道 | 地址 | 说明 |
+| 平台 | 正式版 | Canary / 预览版 |
 | --- | --- | --- |
-| 正式版 | [GitHub 最新 Release](https://github.com/feeluown/FuoEvolve/releases/latest) | 签名的 Android multi-ABI APK，包含 `arm64-v8a` 和 `x86_64`。 |
-| F-Droid | [官方自托管仓库](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | 保留近期稳定版本，并在 GitHub Release 发布后自动更新。 |
-| Canary | [master 最新 Android 构建](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) | 从最新成功的 `master` workflow 下载签名 release APK。 |
+| **Android** | [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) · [F-Droid 仓库](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | [最新 master 构建](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **Windows x64** | — | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 MSI / EXE |
+| **macOS arm64 / x64** | — | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 DMG / PKG |
+| **Linux x64** | — | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 AppImage / DEB / RPM / Arch 包 |
+| **iOS** | — | 仅提供实验性开发构建 |
 
-## 项目亮点
+> 桌面端 Canary 目前属于预览版本，Windows 和 macOS 安装包尚未完成正式签名 / 公证。
 
-- 🎵 **多音乐源整合**：在一个应用中使用网易云音乐、QQ 音乐、哔哩哔哩和 YouTube Music，并可自由启用、关闭和调整优先级。
-- 🧭 **丰富的发现内容**：浏览每日推荐、私人 FM、排行榜、歌单广场、歌手广场、新歌新碟、MV、音乐风格以及各平台自己的特色内容。
-- 🔎 **统一搜索**：同时搜索已启用的在线音乐源和本地音乐，在支持时按不同资源类型查看结果，并保留最近搜索历史以便快速再次搜索。
-- ▶️ **更可靠的播放体验**：支持播放队列、随机/循环、稍后播放、进度跳转、多分 P、音频和视频播放、睡眠定时，以及 Android 进程重启后的队列与播放状态恢复。
-- 🎤 **丰富且可补全的歌词体验**：在音乐源支持时显示同步歌词、翻译、罗马音和逐字歌词；对于没有可用歌词的来源，可以手动搜索并关联其他歌曲的歌词，并记住选择。
-- 📱 **系统与设备歌词输出**：Android 可向支持的 ColorOS 锁屏、Lyricon 状态栏歌词以及支持的比亚迪仪表歌词能力发布实时歌词。
-- 🔁 **更准确的智能换源**：当前资源不可用时，可自动在其他已启用音乐源中寻找更匹配的版本，并结合录音版本等信息提高匹配准确度，同时保留原歌曲上下文和歌词。
-- ❤️ **管理在线媒体库**：在音乐源允许时，可收藏/取消收藏歌单、歌手和专辑，并直接管理网易云音乐和 QQ 音乐中的自建歌单。
-- 💽 **本地音乐与离线播放**：可浏览和修改本地音乐、创建可导入导出的本地歌单、下载在线歌曲、断点续传未完成下载，并将已下载内容纳入本地媒体库管理。
-- 🔐 **可迁移的登录凭证**：Android 支持导出加密的音乐源登录凭证备份，可整体或按单个音乐源导出并在之后恢复，同时不改变应用正常的本机安全存储方式。
-- 🎙️ **听歌识曲**：通过麦克风识别正在播放的歌曲，并快速跳转到搜索或歌曲详情。
-- 🔗 **分享直达**：Android 上可直接把网易云、QQ 音乐、哔哩哔哩、YouTube 或 YouTube Music 的分享链接发送给 FuoEvolve，自动打开对应内容；无法识别的分享文本也可以回退到应用内搜索。
-- 🎨 **Material 3 Expressive 界面**：支持亮色/暗色、动态颜色、根据封面生成的播放器配色、流畅页面过渡，以及适配手机和更大屏幕的布局。
+## 功能
+
+- 🎵 **多音乐源**：在一个应用中使用网易云音乐、QQ 音乐、哔哩哔哩和 YouTube Music。
+- 🧭 **发现与搜索**：浏览推荐、排行榜、歌单、歌手、专辑和视频，并统一搜索已启用的音乐源。
+- ▶️ **音乐与视频播放**：支持播放队列、随机/循环、进度跳转、睡眠定时、MV / 视频和哔哩哔哩多分 P。
+- 🎤 **丰富歌词**：支持同步歌词、翻译、罗马音、可用时的逐字歌词，以及手动匹配其他歌曲歌词。
+- 🔁 **智能换源**：当前歌曲无法播放时，自动从其他已启用来源寻找合适的替代资源。
+- 💽 **本地与离线音乐**：扫描本地音乐、编辑信息、创建本地歌单、下载在线歌曲并支持断点续传。
+- ❤️ **音乐库管理**：在音乐源支持时管理收藏、歌单、专辑和歌手。
+- 🎙️ **听歌识曲**：识别周围正在播放的音乐，并快速进入搜索或歌曲详情。
+- 🔐 **可迁移登录凭证**：安全保存音乐源登录信息，并在需要时迁移受支持的登录凭证。
+- 🎨 **Material 3 Expressive 界面**：自适应布局、亮色 / 暗色、动态颜色和封面跟随配色。
+
+## 桌面端
+
+桌面端直接复用移动端的共享界面和核心体验，不维护一套功能缩水的独立桌面 UI。
+
+- **Windows**：支持 SMTC 系统媒体控制。
+- **macOS**：支持 Now Playing / Remote Command Center。
+- **Linux**：支持 MPRIS 媒体控制，并以原生 Wayland 运行作为目标。
+- **托盘生命周期**：关闭窗口后继续播放和下载，可从托盘 / 状态栏图标恢复窗口或退出应用。
+- **安全登录存储**：使用 Windows Credential Manager、macOS Keychain 和 Linux Secret Service / Libsecret。
+
+桌面端安装包目前通过 Canary 工作流提供，正式签名和稳定版发布流程仍在完善中。
 
 ## 音乐源
 
-FuoEvolve 目前内置四个在线音乐源。具体可用内容可能会受到平台能力、地区、登录状态和上游服务变化的影响。
-
-| 音乐源 | 可以浏览的内容 |
+| 音乐源 | 主要内容 |
 | --- | --- |
-| **网易云音乐** | 每日推荐歌曲、推荐新歌、私人 FM、排行榜、歌单广场、歌手广场、MV 广场、音乐风格、我喜欢、云盘歌曲、用户歌单、收藏歌手和专辑等，并支持可用的歌单和收藏写操作。 |
-| **QQ 音乐** | 每日推荐、推荐内容、私人 FM、排行榜、歌单广场、歌手广场、新碟、MV 广场、多类型搜索、自建/收藏歌单、收藏专辑、关注歌手，以及可用的歌单和收藏写操作。 |
-| **哔哩哔哩** | 音乐/视频搜索与播放、个性化推荐、动态视频、每周必看、稍后再看、观看历史、关注的 UP 主及投稿、收藏夹、追番和影视收藏，以及多分 P 播放。 |
-| **YouTube Music** | 歌曲/视频搜索、推荐与媒体库内容、歌单、歌手、专辑、排行榜、歌词、相似歌曲电台，以及可用的视频播放能力。 |
+| **网易云音乐** | 推荐、私人 FM、排行榜、歌单、歌手、专辑、MV、收藏和云盘音乐 |
+| **QQ 音乐** | 推荐、私人 FM、排行榜、歌单、歌手、专辑、MV、收藏和个人音乐库 |
+| **哔哩哔哩** | 音乐 / 视频搜索、推荐、关注 UP 主、收藏、历史、稍后再看和多分 P 视频 |
+| **YouTube Music** | 搜索、推荐、音乐库、歌单、歌手、专辑、电台、歌词和视频 |
 
-所有音乐源都可以在设置中启用、关闭、排序和管理登录。网易云音乐、QQ 音乐和哔哩哔哩主要通过账号 Cookie 登录；YouTube Music 支持 Google 授权，也可以导入账号 Headers/Cookie。
+具体可用内容会受到音乐源能力、地区、登录状态和上游服务变化影响。所有音乐源都可以在设置中启用、关闭、排序和管理登录。
 
-## 播放与歌词
+## 平台状态
 
-FuoEvolve 同时面向普通音乐播放和音乐/视频混合内容使用。可以管理播放队列，使用随机或循环模式，把歌曲加入“稍后播放”，拖动进度，从播放器直接进入歌手或专辑详情，并设置按时长或当前歌曲结束后停止播放的睡眠定时。
-
-Android 上的播放会话和持久化队列会协同工作，因此在应用进程被系统回收并重新启动后，可以恢复当前歌曲、队列、随机/循环状态、多分 P 位置和播放进度。用户主动点击新歌曲或新歌单与“恢复上次播放”是分离的，不会因为旧暂停会话而覆盖新的播放选择。
-
-MV 和视频拥有独立播放页面，支持播放控制、全屏显示、横竖屏切换，以及哔哩哔哩多分 P 内容。智能换源遇到多分 P 的替代结果时会把它作为单个替代资源处理，避免错误地把分 P 当成后续队列继续播放。
-
-歌词支持普通时间轴歌词、翻译、罗马音，以及网易云和 QQ 音乐在可用时提供的富歌词/逐字时间信息。对于来源本身没有可用歌词的歌曲，可以手动搜索其他歌曲的歌词进行关联，并保存选择以供之后继续使用。哔哩哔哩会优先使用接口提供的 BGM 标题作为歌词搜索词，没有 BGM 信息时再回退到视频标题。
-
-Android 还可以把实时歌词发布到播放器之外：支持的 ColorOS 设备可显示锁屏实时歌词，Lyricon 可提供状态栏歌词，支持对应能力的比亚迪车型可接收仪表歌词。
-
-## 发现与个人媒体库
-
-FuoEvolve 会尽量按照每个平台原本的内容特点来组织首页和“我的”，而不是把所有音乐源强行做成完全一致的结构。各音乐源内容支持增量加载，大型发现页和媒体库可以在继续加载后续内容时保持可操作。
-
-网易云音乐和 QQ 音乐提供更完整的发现入口，例如排行榜、歌单广场、歌手浏览、MV 浏览，以及分类和筛选。网易云音乐额外支持音乐风格内容；QQ 音乐支持新碟浏览，并扩展了“我的”内容，包括收藏歌单、收藏专辑和关注歌手等。
-
-在音乐源支持时，资源详情页会显示当前收藏状态，并允许直接收藏或取消收藏歌单、歌手和专辑。网易云和 QQ 音乐的自建歌单只暴露实际允许的操作；QQ 音乐支持创建和删除自建歌单，支持写操作的歌单可以添加或移除歌曲。
-
-哔哩哔哩更贴近自身内容生态，可查看个性化推荐、动态视频、每周必看、稍后再看、观看历史、关注的 UP 主及投稿，以及收藏的番剧和影视内容。
-
-“我的”还会根据播放记录展示常听歌单，让经常使用的内容更容易再次找到。搜索页会按最新优先保留最近搜索词，也支持删除单条历史记录。
-
-## 本地音乐、歌单与下载
-
-本地音乐可以扫描进入应用，并按全部歌曲、歌手、专辑或目录浏览。扫描时可以指定目录，也可以过滤时长过短的音频文件。本地索引会跟踪媒体变化和已保存歌词，因此大型媒体库刷新时不需要重复重建未变化的条目。
-
-本地歌曲的标题、歌手和专辑信息可以直接修改，也可以借助已启用的在线音乐源查找更合适的元信息和歌词。手动关联的歌词也会在后续播放中继续生效。
-
-本地歌单可以同时容纳本地歌曲、已下载歌曲以及受支持的在线歌曲。歌单可在应用内创建和管理，也可以从文件导入或分享为歌单文件。
-
-支持的在线歌曲可以下载用于离线播放。下载状态和断点续传信息会被持久化，未完成的下载可以继续；完成后的资源会纳入离线/本地媒体库，按普通本地内容进行播放和浏览。
-
-## 听歌识曲
-
-在搜索页点击麦克风入口即可开始听歌识曲。应用只会录制生成音频指纹所需的声音，原始录音保留在内存中，并向识别服务发送音频指纹，而不是上传整段录音。
-
-识别成功后可以直接搜索歌曲或打开网易云详情；在搜索页和详情页之间切换时，最近一次识别结果会保留，识别失败也可以直接重试。
-
-## 个性化与设置
-
-FuoEvolve 提供常用的个性化设置，同时尽量避免复杂配置。主要包括：
-
-- 音乐源启用状态、优先级和登录管理；
-- Android 上的加密登录凭证备份与恢复，并支持按单个音乐源导出；
-- Wi-Fi 与蜂窝网络分别设置音质偏好；
-- 资源不可用时的智能换源来源、行为和匹配严格度；
-- 播放行为，例如其他应用开始播放音频时是否暂停 FuoEvolve；
-- 独立外观设置页中的跟随系统、亮色或暗色主题、动态颜色、预设配色和封面衍生的播放器配色；
-- 歌词字号，以及支持的 ColorOS、Lyricon、比亚迪等外部歌词输出；
-- 本地音乐扫描目录和最短歌曲时长；
-- 音频缓存和图片缓存上限。
-
-## iOS 状态
-
-iOS 目前仍处于实验阶段。项目已经包含 iOS 应用和持续集成构建，浏览、播放、MV 控制、听歌识曲等越来越多的共享功能也已经可以在 iOS 上运行。
-
-但 iOS 暂未作为 GitHub Release 或 App Store 版本正式发布，因此目前还不属于面向普通用户支持的平台。
+| 平台 | 状态 | 说明 |
+| --- | --- | --- |
+| Android | **稳定版** | 主要正式发布平台 |
+| Windows | **Canary** | 提供 x64 可安装桌面包 |
+| macOS | **Canary** | 支持 Apple Silicon 和 Intel |
+| Linux | **Canary** | 以原生 Wayland 为目标，提供 AppImage 和发行版安装包 |
+| iOS | **实验性** | 仅用于开发与 CI 验证 |
 
 ## 开发
 
-FuoEvolve 使用 Kotlin Multiplatform 和 Compose Multiplatform 共享大部分应用代码，Android 端使用 AndroidX Media3 提供播放能力。当前代码已经拆分为明确的 feature、playback、provider、persistence 和平台边界，使共享 UI 不再直接承担音乐源实现或播放运行时职责。
-
-环境要求：
-
-- JDK 17 或更新版本；
-- Android Studio 或 Android 命令行工具，用于 Android 构建；
-- macOS + Xcode，用于 iOS 实验性构建。
-
-构建并安装 Android Debug 版本：
+FuoEvolve 基于 Kotlin Multiplatform 和 Compose Multiplatform。
 
 ```bash
+# 构建 Android Debug 包
 ./gradlew :androidApp:assembleDebug
-./gradlew :androidApp:installDebug
+
+# 运行桌面端
+./gradlew :desktopApp:run
 ```
 
-运行共享测试和 Android lint：
+桌面端架构和打包说明见 [docs/desktop-foundation.md](docs/desktop-foundation.md) 与 [docs/desktop-packaging.md](docs/desktop-packaging.md)。
 
-```bash
-./gradlew :shared:allTests
-./gradlew :androidApp:lint :shared:lint
-```
+## 参与贡献
 
-主要 Gradle 模块：
-
-- `core:model`：共享应用/领域模型；
-- `feature:*`：搜索、听歌识曲、本地/离线媒体库、音乐源浏览/登录/详情、设置、新手引导和首页等 feature owner；
-- `playback:api` / `playback:runtime`：播放契约、会话编排、队列/歌词/定时逻辑和平台集成边界；
-- `provider:api` / `provider:runtime` 以及 `provider:netease`、`provider:qqmusic`、`provider:bilibili`、`provider:ytmusic`：音乐源契约、运行时基础设施和各来源实现；
-- `persistence:settings`：共享设置和用户选择的持久化；
-- `shared`：共享 Compose 应用/UI 集成；
-- `androidApp`：Android 应用和平台服务；
-- `iosApp/FuoEvolve`：实验性的 iOS 应用；
-- `.github/workflows`：PR 测试、master Canary 构建、正式发布，以及可复用的平台测试/打包流程。
+欢迎提交问题、功能建议和 Pull Request。可前往 [Issues](https://github.com/feeluown/FuoEvolve/issues) 和 [Pull Requests](https://github.com/feeluown/FuoEvolve/pulls)。
 
 ## 许可证
 
-FuoEvolve 使用 GNU General Public License v3.0 开源许可证，详情见 [LICENSE](LICENSE)。
+FuoEvolve 使用 [GNU General Public License v3.0](LICENSE)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,8 +2,9 @@
 
 [![正式版](https://img.shields.io/github/v/release/feeluown/FuoEvolve?label=stable)](https://github.com/feeluown/FuoEvolve/releases/latest)
 [![Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml/badge.svg?branch=master)](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster)
+[![Downloads](https://img.shields.io/github/downloads/feeluown/FuoEvolve/total?label=downloads)](https://github.com/feeluown/FuoEvolve/releases)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/docs/multiplatform.html)
+[![Compose Multiplatform](https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white)](https://www.jetbrains.com/compose-multiplatform/)
 
 中文 | [English](README.md)
 
@@ -36,7 +37,7 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 
 ## 桌面端
 
-桌面端直接复用移动端的共享界面和核心体验，不维护一套功能缩水的独立桌面 UI。
+桌面端与移动端共享一致的使用体验，并提供 Windows、macOS 和 Linux 版本。
 
 - **Windows**：支持 SMTC 系统媒体控制。
 - **macOS**：支持 Now Playing / Remote Command Center。
@@ -69,7 +70,7 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 
 ## 开发
 
-FuoEvolve 基于 Kotlin Multiplatform 和 Compose Multiplatform。
+FuoEvolve 使用 [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/) 支持多个平台。
 
 ```bash
 # 构建 Android Debug 包
@@ -79,7 +80,7 @@ FuoEvolve 基于 Kotlin Multiplatform 和 Compose Multiplatform。
 ./gradlew :desktopApp:run
 ```
 
-桌面端开发还需要 Rust/Cargo 工具链以及目标平台所需的原生依赖。架构、运行时与打包前置条件见 [docs/desktop-foundation.md](docs/desktop-foundation.md) 与 [docs/desktop-packaging.md](docs/desktop-packaging.md)。
+桌面端开发还需要 Rust/Cargo 工具链以及目标平台所需的原生依赖。具体环境与打包前置条件见 [docs/desktop-foundation.md](docs/desktop-foundation.md) 与 [docs/desktop-packaging.md](docs/desktop-packaging.md)。
 
 ## 参与贡献
 


### PR DESCRIPTION
## Summary

- simplify the English and Chinese READMEs into a more conventional open-source project overview
- remove stale/no-status PR and release workflow badges and keep only durable project/build badges
- add Windows, macOS, and Linux Canary download/status information
- add a concise desktop section covering native media controls, tray lifecycle, Wayland target, and secure credential storage
- rewrite the feature list from an end-user perspective and remove implementation-heavy detail
- keep development information short and link to the dedicated desktop architecture/packaging docs

## Notes

- Android remains the stable release platform
- desktop artifacts are explicitly described as Canary/preview builds
- Windows/macOS preview packages are called out as not yet production-signed/notarized

Documentation-only change; no runtime code is modified.