### PR TITLE
refactor: give playback queue entries stable occurrence identity

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -179,6 +179,7 @@ class AndroidNativeAudioEngine(
             playbackParts = emptyList(),
             currentPartIndex = -1,
             playbackGeneration = 0L,
+            playbackQueueEntryId = null,
             errorMessage = null,
         )
         if (reason.shouldDiscardLiveSession) {
@@ -231,6 +232,7 @@ class AndroidNativeAudioEngine(
             playbackParts = emptyList(),
             currentPartIndex = -1,
             playbackGeneration = plan.generation,
+            playbackQueueEntryId = first.queueEntryId,
             errorMessage = null,
         )
         persistPlaybackState(forceSession = true)
@@ -463,6 +465,8 @@ class AndroidNativeAudioEngine(
             append(plan.generation)
             append('|')
             append(track.id)
+            append('|')
+            append(state.playbackQueueEntryId ?: 0L)
             append('|')
             append(state.currentPartIndex)
             append('|')

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackPlanCodec.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackPlanCodec.kt
@@ -26,6 +26,7 @@ internal fun String.toPlaybackPlan(): PlaybackPlan {
 private fun PlaybackRequest.toJsonObject(): JSONObject = JSONObject()
     .put("track", track.toJsonObject())
     .put("resolve_track", resolveTrack.toJsonObject())
+    .put("queue_entry_id", queueEntryId)
     .put("requested_part_index", requestedPartIndex)
     .put("unavailable_policy", unavailablePolicy.name)
     .put("replacement_provider_ids", JSONArray(smartReplacementProviderIds.toList()))
@@ -37,6 +38,7 @@ private fun PlaybackRequest.toJsonObject(): JSONObject = JSONObject()
 private fun JSONObject.toPlaybackRequest(): PlaybackRequest = PlaybackRequest(
     track = getJSONObject("track").toMusicTrack(),
     resolveTrack = getJSONObject("resolve_track").toMusicTrack(),
+    queueEntryId = optLong("queue_entry_id", 0L).takeIf { it > 0L },
     requestedPartIndex = optInt("requested_part_index", -1).takeIf { it >= 0 },
     unavailablePolicy = optString("unavailable_policy")
         .let { value -> runCatching { UnavailablePlaybackPolicy.valueOf(value) }.getOrDefault(DEFAULT_UNAVAILABLE_PLAYBACK_POLICY) },

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -28,6 +28,7 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
             .reconcileRestoredPlayback(
                 plan = restoredSession?.plan,
                 currentTrack = restoredSession?.currentTrack,
+                currentQueueEntryId = restoredSession?.currentQueueEntryId,
             )
         latestSnapshot = snapshot
         loadCompleted = true

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -19,11 +19,15 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
         val persistedSnapshot = preferences.getString(KEY_QUEUE_SNAPSHOT, null)
             ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
             ?: PlaybackQueueSnapshot()
+        val identity = preferences.getString(KEY_QUEUE_IDENTITY, null)
+            ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
         val restoredSession = playbackResumeStore.load()
-        val snapshot = persistedSnapshot.reconcileRestoredPlayback(
-            plan = restoredSession?.plan,
-            currentTrack = restoredSession?.currentTrack,
-        )
+        val snapshot = persistedSnapshot
+            .withIdentitySnapshot(identity)
+            .reconcileRestoredPlayback(
+                plan = restoredSession?.plan,
+                currentTrack = restoredSession?.currentTrack,
+            )
         latestSnapshot = snapshot
         loadCompleted = true
         snapshot
@@ -44,12 +48,7 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
         }
     }
 
-    /**
-     * Durably writes the most recent complete controller queue snapshot. This is intentionally
-     * synchronous and is only used at important playback lifecycle boundaries (playing/paused),
-     * where surviving an abrupt process kill is more important than deferring a small preference
-     * write.
-     */
+    /** Durably writes the most recent complete controller queue snapshot. */
     fun flushLatest() {
         if (!loadCompleted) return
         latestSnapshot?.let(::writeSnapshot)
@@ -58,11 +57,13 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
     private fun writeSnapshot(snapshot: PlaybackQueueSnapshot) {
         preferences.edit()
             .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
+            .putString(KEY_QUEUE_IDENTITY, PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()))
             .commit()
     }
 
     private companion object {
         private const val PREFS_NAME = "fuo_playback_queue"
         private const val KEY_QUEUE_SNAPSHOT = "queue_snapshot"
+        private const val KEY_QUEUE_IDENTITY = "queue_identity"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackQueueStore.kt
@@ -21,9 +21,10 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
             ?: PlaybackQueueSnapshot()
         val identity = preferences.getString(KEY_QUEUE_IDENTITY, null)
             ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
+        val identityFingerprint = preferences.getString(KEY_QUEUE_IDENTITY_FINGERPRINT, null)
         val restoredSession = playbackResumeStore.load()
         val snapshot = persistedSnapshot
-            .withIdentitySnapshot(identity)
+            .withMatchingIdentitySnapshot(identity, identityFingerprint)
             .reconcileRestoredPlayback(
                 plan = restoredSession?.plan,
                 currentTrack = restoredSession?.currentTrack,
@@ -34,21 +35,13 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
-        // The Android playback engine can publish its restored session before the controller has
-        // loaded the durable queue. Ignore those bootstrap writes: otherwise an empty/default
-        // controller queue can overwrite the real queue (including shuffle/repeat) during startup.
         if (!loadCompleted) return
-
-        // FuoPlayerController launches save from its main-immediate scope. Capture the complete
-        // snapshot before the first suspension so a later pause can synchronously flush exactly
-        // this queue even if the asynchronous IO write has not finished yet.
         latestSnapshot = snapshot
         withContext(Dispatchers.IO) {
             writeSnapshot(snapshot)
         }
     }
 
-    /** Durably writes the most recent complete controller queue snapshot. */
     fun flushLatest() {
         if (!loadCompleted) return
         latestSnapshot?.let(::writeSnapshot)
@@ -58,6 +51,7 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
         preferences.edit()
             .putString(KEY_QUEUE_SNAPSHOT, PlaybackQueueCodec.encode(snapshot))
             .putString(KEY_QUEUE_IDENTITY, PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()))
+            .putString(KEY_QUEUE_IDENTITY_FINGERPRINT, snapshot.queueIdentityFingerprint())
             .commit()
     }
 
@@ -65,5 +59,6 @@ class AndroidPlaybackQueueStore(context: Context) : PlaybackQueueStore {
         private const val PREFS_NAME = "fuo_playback_queue"
         private const val KEY_QUEUE_SNAPSHOT = "queue_snapshot"
         private const val KEY_QUEUE_IDENTITY = "queue_identity"
+        private const val KEY_QUEUE_IDENTITY_FINGERPRINT = "queue_identity_fingerprint"
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidPlaybackResumeStore.kt
@@ -7,6 +7,7 @@ import org.json.JSONObject
 internal data class AndroidPlaybackResumeSnapshot(
     val plan: PlaybackPlan,
     val currentTrack: MusicTrack,
+    val currentQueueEntryId: Long?,
     val positionMs: Long,
     val durationMs: Long,
     val playbackParts: List<PlaybackPart>,
@@ -26,14 +27,16 @@ internal data class AndroidPlaybackResumeSnapshot(
             playbackParts = playbackParts,
             currentPartIndex = normalizedPartIndex,
             playbackGeneration = plan.generation,
+            playbackQueueEntryId = currentQueueEntryId,
             lyrics = currentTrack.lyrics,
         )
     }
 
     fun resumePlan(generation: Long = plan.generation): PlaybackPlan? {
-        val requestIndex = plan.requests.indexOfFirst { request ->
-            request.track.id == currentTrack.id
-        }
+        val requestIndex = currentQueueEntryId
+            ?.let { entryId -> plan.requests.indexOfFirst { request -> request.queueEntryId == entryId } }
+            ?.takeIf { it >= 0 }
+            ?: plan.requests.indexOfFirst { request -> request.track.id == currentTrack.id }
         if (requestIndex < 0) return null
 
         val remainingRequests = plan.requests.drop(requestIndex).toMutableList()
@@ -72,6 +75,7 @@ internal class AndroidPlaybackResumeStore(context: Context) {
             AndroidPlaybackResumeSnapshot(
                 plan = plan,
                 currentTrack = currentTrack,
+                currentQueueEntryId = preferences.getLong(KEY_QUEUE_ENTRY_ID, 0L).takeIf { it > 0L },
                 positionMs = preferences.getLong(KEY_POSITION_MS, 0L),
                 durationMs = preferences.getLong(KEY_DURATION_MS, 0L),
                 playbackParts = playbackParts,
@@ -86,6 +90,7 @@ internal class AndroidPlaybackResumeStore(context: Context) {
             .putInt(KEY_VERSION, CURRENT_VERSION)
             .putString(KEY_PLAN, plan.toJson())
             .putString(KEY_TRACK, currentTrack.toJsonObject().toString())
+            .putLong(KEY_QUEUE_ENTRY_ID, state.playbackQueueEntryId ?: 0L)
             .putString(KEY_PARTS, encodeParts(state.playbackParts))
             .putInt(KEY_PART_INDEX, state.currentPartIndex)
             .putLong(KEY_POSITION_MS, state.positionMs.coerceAtLeast(0L))
@@ -152,6 +157,7 @@ internal class AndroidPlaybackResumeStore(context: Context) {
         private const val KEY_VERSION = "version"
         private const val KEY_PLAN = "plan"
         private const val KEY_TRACK = "track"
+        private const val KEY_QUEUE_ENTRY_ID = "queue_entry_id"
         private const val KEY_POSITION_MS = "position_ms"
         private const val KEY_DURATION_MS = "duration_ms"
         private const val KEY_PARTS = "parts"

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -287,6 +287,7 @@ class FuoPlaybackService : MediaSessionService() {
             durationMs = first.track.durationMs ?: 0L,
             lyrics = first.track.lyrics,
             playbackGeneration = plan.generation,
+            playbackQueueEntryId = first.queueEntryId,
         )
         loadJob = serviceScope.launch {
             try {
@@ -313,6 +314,7 @@ class FuoPlaybackService : MediaSessionService() {
                     status = PlayerStatus.Error,
                     currentTrack = first.track,
                     playbackGeneration = plan.generation,
+                    playbackQueueEntryId = first.queueEntryId,
                     errorMessage = throwable.message ?: "音频资源加载失败",
                 )
             }
@@ -612,6 +614,7 @@ class FuoPlaybackService : MediaSessionService() {
                 playbackParts = prepared.payload.parts,
                 currentPartIndex = prepared.payload.currentPartIndex,
                 playbackGeneration = activeGeneration,
+                playbackQueueEntryId = prepared.request.queueEntryId,
                 errorMessage = pendingPreloadError,
             )
             return
@@ -640,6 +643,7 @@ class FuoPlaybackService : MediaSessionService() {
             playbackParts = prepared.payload.parts,
             currentPartIndex = prepared.payload.currentPartIndex,
             playbackGeneration = activeGeneration,
+            playbackQueueEntryId = prepared.request.queueEntryId,
         )
     }
 
@@ -943,5 +947,4 @@ class FuoPlaybackService : MediaSessionService() {
         fun previous()
         fun next()
     }
-
 }

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
@@ -80,6 +80,32 @@ data class PlaybackQueueSnapshot(
     val queueEntrySequence: Long = 0L,
 )
 
+data class PlaybackQueueIdentitySnapshot(
+    val mainQueueEntryIds: List<Long> = emptyList(),
+    val originalMainQueueEntryIds: List<Long> = emptyList(),
+    val upNextQueueEntryIds: List<Long> = emptyList(),
+    val queueEntrySequence: Long = 0L,
+)
+
+fun PlaybackQueueSnapshot.toIdentitySnapshot(): PlaybackQueueIdentitySnapshot =
+    PlaybackQueueIdentitySnapshot(
+        mainQueueEntryIds = mainQueueEntryIds,
+        originalMainQueueEntryIds = originalMainQueueEntryIds,
+        upNextQueueEntryIds = upNextQueueEntryIds,
+        queueEntrySequence = queueEntrySequence,
+    )
+
+fun PlaybackQueueSnapshot.withIdentitySnapshot(
+    identity: PlaybackQueueIdentitySnapshot?,
+): PlaybackQueueSnapshot = identity?.let { value ->
+    copy(
+        mainQueueEntryIds = value.mainQueueEntryIds,
+        originalMainQueueEntryIds = value.originalMainQueueEntryIds,
+        upNextQueueEntryIds = value.upNextQueueEntryIds,
+        queueEntrySequence = value.queueEntrySequence,
+    )
+} ?: this
+
 interface PlaybackQueueStore {
     suspend fun load(): PlaybackQueueSnapshot
     suspend fun save(snapshot: PlaybackQueueSnapshot)
@@ -91,9 +117,9 @@ object NoOpPlaybackQueueStore : PlaybackQueueStore {
     override suspend fun save(snapshot: PlaybackQueueSnapshot) = Unit
 }
 
+/** Durable queue payload. Keep this format at v2 for backward compatibility. */
 object PlaybackQueueCodec {
-    private const val CURRENT_VERSION = "v3"
-    private const val PREVIOUS_VERSION = "v2"
+    private const val CURRENT_VERSION = "v2"
 
     fun encode(snapshot: PlaybackQueueSnapshot): String {
         return buildList {
@@ -105,12 +131,11 @@ object PlaybackQueueCodec {
                     snapshot.repeatMode.name,
                     snapshot.isFmQueue.toString(),
                     snapshot.shuffleBeforeFm?.toString().orEmpty(),
-                    snapshot.queueEntrySequence.toString(),
                 ).joinToString("\t")
             )
-            addTracks("main", snapshot.mainQueue, snapshot.mainQueueEntryIds)
-            addTracks("original", snapshot.originalMainQueue, snapshot.originalMainQueueEntryIds)
-            addTracks("upNext", snapshot.upNextQueue, snapshot.upNextQueueEntryIds)
+            addTracks("main", snapshot.mainQueue)
+            addTracks("original", snapshot.originalMainQueue)
+            addTracks("upNext", snapshot.upNextQueue)
         }.joinToString("\n")
     }
 
@@ -126,77 +151,35 @@ object PlaybackQueueCodec {
                 val boolValue = flags.getOrNull(2)?.toBooleanStrictOrNull() ?: true
                 if (boolValue) RepeatMode.QUEUE else RepeatMode.OFF
             }
-            PREVIOUS_VERSION, CURRENT_VERSION -> {
+            CURRENT_VERSION -> {
                 runCatching { RepeatMode.valueOf(flags.getOrNull(2) ?: "QUEUE") }
                     .getOrDefault(RepeatMode.QUEUE)
             }
             else -> RepeatMode.QUEUE
         }
 
-        val entriesBySection = lines.drop(2)
+        val tracksBySection = lines.drop(2)
             .mapNotNull { line ->
                 val fields = line.split("\t")
                 if (fields.size < 2 || fields[0] != "track") return@mapNotNull null
-                if (version == CURRENT_VERSION) {
-                    if (fields.size < 3) return@mapNotNull null
-                    decodeTrack(fields.drop(3))?.let { track ->
-                        DecodedQueueEntry(
-                            section = fields[1],
-                            entryId = fields[2].toLongOrNull()?.takeIf { it > 0L },
-                            track = track,
-                        )
-                    }
-                } else {
-                    decodeTrack(fields.drop(2))?.let { track ->
-                        DecodedQueueEntry(section = fields[1], entryId = null, track = track)
-                    }
-                }
+                decodeTrack(fields.drop(2))?.let { track -> fields[1] to track }
             }
-            .groupBy(DecodedQueueEntry::section)
-
-        fun tracks(section: String): List<MusicTrack> =
-            entriesBySection[section].orEmpty().map(DecodedQueueEntry::track)
-
-        fun entryIds(section: String): List<Long> {
-            val entries = entriesBySection[section].orEmpty()
-            val ids = entries.mapNotNull(DecodedQueueEntry::entryId)
-            return ids.takeIf { it.size == entries.size } ?: emptyList()
-        }
-
-        val mainEntryIds = entryIds("main")
-        val originalEntryIds = entryIds("original")
-        val upNextEntryIds = entryIds("upNext")
-        val maxEntryId = (mainEntryIds + originalEntryIds + upNextEntryIds).maxOrNull() ?: 0L
+            .groupBy({ it.first }, { it.second })
         return PlaybackQueueSnapshot(
-            mainQueue = tracks("main"),
-            originalMainQueue = tracks("original"),
-            upNextQueue = tracks("upNext"),
+            mainQueue = tracksBySection["main"].orEmpty(),
+            originalMainQueue = tracksBySection["original"].orEmpty(),
+            upNextQueue = tracksBySection["upNext"].orEmpty(),
             queueIndex = flags.getOrNull(0)?.toIntOrNull() ?: -1,
             shuffleEnabled = flags.getOrNull(1)?.toBooleanStrictOrNull() ?: false,
             repeatMode = repeatMode,
             isFmQueue = flags.getOrNull(3)?.toBooleanStrictOrNull() ?: false,
             shuffleBeforeFm = flags.getOrNull(4)?.takeIf { it.isNotBlank() }?.toBooleanStrictOrNull(),
-            mainQueueEntryIds = mainEntryIds,
-            originalMainQueueEntryIds = originalEntryIds,
-            upNextQueueEntryIds = upNextEntryIds,
-            queueEntrySequence = maxOf(flags.getOrNull(5)?.toLongOrNull() ?: 0L, maxEntryId),
         )
     }
 
-    private data class DecodedQueueEntry(
-        val section: String,
-        val entryId: Long?,
-        val track: MusicTrack,
-    )
-
-    private fun MutableList<String>.addTracks(
-        section: String,
-        tracks: List<MusicTrack>,
-        entryIds: List<Long>,
-    ) {
-        tracks.forEachIndexed { index, track ->
-            val entryId = entryIds.getOrNull(index)?.takeIf { it > 0L }?.toString().orEmpty()
-            add((listOf("track", section, entryId) + encodeTrack(track)).joinToString("\t"))
+    private fun MutableList<String>.addTracks(section: String, tracks: List<MusicTrack>) {
+        tracks.forEach { track ->
+            add((listOf("track", section) + encodeTrack(track)).joinToString("\t"))
         }
     }
 
@@ -326,6 +309,43 @@ object PlaybackQueueCodec {
             }
         }
         return result.toString()
+    }
+}
+
+/** Separate sidecar for occurrence identity; the queue payload above remains byte-compatible v2. */
+object PlaybackQueueIdentityCodec {
+    private const val CURRENT_VERSION = "i1"
+
+    fun encode(snapshot: PlaybackQueueIdentitySnapshot): String = buildList {
+        add(CURRENT_VERSION)
+        add(snapshot.queueEntrySequence.toString())
+        addIds("main", snapshot.mainQueueEntryIds)
+        addIds("original", snapshot.originalMainQueueEntryIds)
+        addIds("upNext", snapshot.upNextQueueEntryIds)
+    }.joinToString("\n")
+
+    fun decode(raw: String): PlaybackQueueIdentitySnapshot? {
+        val lines = raw.lineSequence().filter { it.isNotBlank() }.toList()
+        if (lines.firstOrNull() != CURRENT_VERSION) return null
+        val sequence = lines.getOrNull(1)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+        val sections = lines.drop(2).mapNotNull { line ->
+            val parts = line.split("\t", limit = 2)
+            if (parts.size != 2) return@mapNotNull null
+            parts[0] to parts[1]
+                .split(',')
+                .mapNotNull(String::toLongOrNull)
+                .filter { it > 0L }
+        }.toMap()
+        return PlaybackQueueIdentitySnapshot(
+            mainQueueEntryIds = sections["main"].orEmpty(),
+            originalMainQueueEntryIds = sections["original"].orEmpty(),
+            upNextQueueEntryIds = sections["upNext"].orEmpty(),
+            queueEntrySequence = sequence,
+        )
+    }
+
+    private fun MutableList<String>.addIds(section: String, ids: List<Long>) {
+        add("$section\t${ids.joinToString(",")}")
     }
 }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
@@ -78,6 +78,8 @@ data class PlaybackQueueSnapshot(
     val originalMainQueueEntryIds: List<Long> = emptyList(),
     val upNextQueueEntryIds: List<Long> = emptyList(),
     val queueEntrySequence: Long = 0L,
+    /** Ephemeral hydration hint; never encoded into the durable v2 queue payload. */
+    val restoredActiveQueueEntryId: Long? = null,
 )
 
 data class PlaybackQueueIdentitySnapshot(

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackApplicationContracts.kt
@@ -17,10 +17,14 @@ data class ReplacementCandidateState(
 /**
  * A logical request for the platform playback runtime. The runtime, rather
  * than the UI controller, resolves provider media into a playable URL.
+ *
+ * [queueEntryId] identifies the concrete occurrence in the live queue. Multiple requests may
+ * reference the same logical track id, so platform runtimes must not use `track.id` as queue identity.
  */
 data class PlaybackRequest(
     val track: MusicTrack,
     val resolveTrack: MusicTrack = track,
+    val queueEntryId: Long? = null,
     val requestedPartIndex: Int? = null,
     val unavailablePolicy: UnavailablePlaybackPolicy = DEFAULT_UNAVAILABLE_PLAYBACK_POLICY,
     val smartReplacementProviderIds: Set<String> = emptySet(),
@@ -57,6 +61,7 @@ data class PlaybackState(
     val playbackParts: List<PlaybackPart> = emptyList(),
     val currentPartIndex: Int = -1,
     val playbackGeneration: Long = 0,
+    val playbackQueueEntryId: Long? = null,
     val errorMessage: String? = null,
 )
 
@@ -69,6 +74,10 @@ data class PlaybackQueueSnapshot(
     val repeatMode: RepeatMode = RepeatMode.QUEUE,
     val isFmQueue: Boolean = false,
     val shuffleBeforeFm: Boolean? = null,
+    val mainQueueEntryIds: List<Long> = emptyList(),
+    val originalMainQueueEntryIds: List<Long> = emptyList(),
+    val upNextQueueEntryIds: List<Long> = emptyList(),
+    val queueEntrySequence: Long = 0L,
 )
 
 interface PlaybackQueueStore {
@@ -83,7 +92,8 @@ object NoOpPlaybackQueueStore : PlaybackQueueStore {
 }
 
 object PlaybackQueueCodec {
-    private const val CURRENT_VERSION = "v2"
+    private const val CURRENT_VERSION = "v3"
+    private const val PREVIOUS_VERSION = "v2"
 
     fun encode(snapshot: PlaybackQueueSnapshot): String {
         return buildList {
@@ -95,11 +105,12 @@ object PlaybackQueueCodec {
                     snapshot.repeatMode.name,
                     snapshot.isFmQueue.toString(),
                     snapshot.shuffleBeforeFm?.toString().orEmpty(),
+                    snapshot.queueEntrySequence.toString(),
                 ).joinToString("\t")
             )
-            addTracks("main", snapshot.mainQueue)
-            addTracks("original", snapshot.originalMainQueue)
-            addTracks("upNext", snapshot.upNextQueue)
+            addTracks("main", snapshot.mainQueue, snapshot.mainQueueEntryIds)
+            addTracks("original", snapshot.originalMainQueue, snapshot.originalMainQueueEntryIds)
+            addTracks("upNext", snapshot.upNextQueue, snapshot.upNextQueueEntryIds)
         }.joinToString("\n")
     }
 
@@ -115,35 +126,77 @@ object PlaybackQueueCodec {
                 val boolValue = flags.getOrNull(2)?.toBooleanStrictOrNull() ?: true
                 if (boolValue) RepeatMode.QUEUE else RepeatMode.OFF
             }
-            CURRENT_VERSION -> {
+            PREVIOUS_VERSION, CURRENT_VERSION -> {
                 runCatching { RepeatMode.valueOf(flags.getOrNull(2) ?: "QUEUE") }
                     .getOrDefault(RepeatMode.QUEUE)
             }
             else -> RepeatMode.QUEUE
         }
 
-        val tracksBySection = lines.drop(2)
+        val entriesBySection = lines.drop(2)
             .mapNotNull { line ->
                 val fields = line.split("\t")
                 if (fields.size < 2 || fields[0] != "track") return@mapNotNull null
-                decodeTrack(fields.drop(2))?.let { track -> fields[1] to track }
+                if (version == CURRENT_VERSION) {
+                    if (fields.size < 3) return@mapNotNull null
+                    decodeTrack(fields.drop(3))?.let { track ->
+                        DecodedQueueEntry(
+                            section = fields[1],
+                            entryId = fields[2].toLongOrNull()?.takeIf { it > 0L },
+                            track = track,
+                        )
+                    }
+                } else {
+                    decodeTrack(fields.drop(2))?.let { track ->
+                        DecodedQueueEntry(section = fields[1], entryId = null, track = track)
+                    }
+                }
             }
-            .groupBy({ it.first }, { it.second })
+            .groupBy(DecodedQueueEntry::section)
+
+        fun tracks(section: String): List<MusicTrack> =
+            entriesBySection[section].orEmpty().map(DecodedQueueEntry::track)
+
+        fun entryIds(section: String): List<Long> {
+            val entries = entriesBySection[section].orEmpty()
+            val ids = entries.mapNotNull(DecodedQueueEntry::entryId)
+            return ids.takeIf { it.size == entries.size } ?: emptyList()
+        }
+
+        val mainEntryIds = entryIds("main")
+        val originalEntryIds = entryIds("original")
+        val upNextEntryIds = entryIds("upNext")
+        val maxEntryId = (mainEntryIds + originalEntryIds + upNextEntryIds).maxOrNull() ?: 0L
         return PlaybackQueueSnapshot(
-            mainQueue = tracksBySection["main"].orEmpty(),
-            originalMainQueue = tracksBySection["original"].orEmpty(),
-            upNextQueue = tracksBySection["upNext"].orEmpty(),
+            mainQueue = tracks("main"),
+            originalMainQueue = tracks("original"),
+            upNextQueue = tracks("upNext"),
             queueIndex = flags.getOrNull(0)?.toIntOrNull() ?: -1,
             shuffleEnabled = flags.getOrNull(1)?.toBooleanStrictOrNull() ?: false,
             repeatMode = repeatMode,
             isFmQueue = flags.getOrNull(3)?.toBooleanStrictOrNull() ?: false,
             shuffleBeforeFm = flags.getOrNull(4)?.takeIf { it.isNotBlank() }?.toBooleanStrictOrNull(),
+            mainQueueEntryIds = mainEntryIds,
+            originalMainQueueEntryIds = originalEntryIds,
+            upNextQueueEntryIds = upNextEntryIds,
+            queueEntrySequence = maxOf(flags.getOrNull(5)?.toLongOrNull() ?: 0L, maxEntryId),
         )
     }
 
-    private fun MutableList<String>.addTracks(section: String, tracks: List<MusicTrack>) {
-        tracks.forEach { track ->
-            add((listOf("track", section) + encodeTrack(track)).joinToString("\t"))
+    private data class DecodedQueueEntry(
+        val section: String,
+        val entryId: Long?,
+        val track: MusicTrack,
+    )
+
+    private fun MutableList<String>.addTracks(
+        section: String,
+        tracks: List<MusicTrack>,
+        entryIds: List<Long>,
+    ) {
+        tracks.forEachIndexed { index, track ->
+            val entryId = entryIds.getOrNull(index)?.takeIf { it > 0L }?.toString().orEmpty()
+            add((listOf("track", section, entryId) + encodeTrack(track)).joinToString("\t"))
         }
     }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackFeatureOwner.kt
@@ -260,7 +260,9 @@ private class DefaultPlaybackFeatureOwner(
     private fun onEngineState(engineState: PlaybackState) {
         val engineTrack = engineState.currentTrack
         val logicalEngineTrack = engineTrack?.logicalPlaybackTrack()
-        logicalEngineTrack?.let(::synchronizePlaybackTrack)
+        logicalEngineTrack?.let { track ->
+            synchronizePlaybackTrack(track, engineState.playbackQueueEntryId)
+        }
         val currentQueueTrackId = queueState.currentTrack()?.id
         val endAction = lifecycleOwner.evaluate(
             engineState.copy(currentTrack = logicalEngineTrack),
@@ -464,8 +466,17 @@ private class DefaultPlaybackFeatureOwner(
         }
     }
 
-    private fun synchronizePlaybackTrack(track: MusicTrack) {
+    private fun synchronizePlaybackTrack(track: MusicTrack, queueEntryId: Long?) {
         val logicalTrack = track.logicalPlaybackTrack()
+        val entryChanged = queueEntryId?.let { entryId ->
+            queueState.synchronizePlaybackEntry(entryId, logicalTrack)
+        }
+        if (entryChanged != null) {
+            if (entryChanged) persistPlaybackQueue()
+            return
+        }
+
+        // Compatibility path for engines/restored sessions that do not yet expose queue-entry identity.
         val current = queueState.currentTrack()
         var changed = current != logicalTrack
         if (current?.id != logicalTrack.id) {

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueController.kt
@@ -26,11 +26,20 @@ data class PlaybackQueueState(
     val playbackStartSequence: Long = 0L,
 )
 
+/** Stable occurrence identity for one item in the live playback queue. */
+internal data class PlaybackQueueEntry(
+    val id: Long,
+    val track: MusicTrack,
+)
+
 /**
  * Owns the durable playback-queue state independently from the app controller.
  *
  * Queue transition policy is coordinated by [PlaybackQueueCoordinator]; this
  * type remains the single source of truth for queue state and persistence.
+ *
+ * Queue-entry ids intentionally live beside the queue rather than inside [MusicTrack]. A logical
+ * track may appear multiple times in one queue, so track identity cannot identify an occurrence.
  */
 internal class PlaybackQueueController {
     private var applyingStartupSnapshot = false
@@ -38,24 +47,62 @@ internal class PlaybackQueueController {
     private val mutableState = MutableStateFlow(PlaybackQueueState())
     val state: StateFlow<PlaybackQueueState> = mutableState.asStateFlow()
 
+    private var queueEntrySequence = 0L
+    private var mainQueueEntryIds: List<Long> = emptyList()
+    private var originalMainQueueEntryIds: List<Long> = emptyList()
+    private var upNextQueueEntryIds: List<Long> = emptyList()
+    private var currentUpNextEntryId: Long? = null
+
     var mainQueue: List<MusicTrack>
         get() = mutableState.value.mainQueue
-        set(value) = update { it.copy(mainQueue = value.logicalTracks()) }
+        set(value) {
+            val logicalTracks = value.logicalTracks()
+            mainQueueEntryIds = reconcileEntryIds(
+                oldTracks = mutableState.value.mainQueue,
+                oldEntryIds = mainQueueEntryIds,
+                newTracks = logicalTracks,
+            )
+            update { it.copy(mainQueue = logicalTracks) }
+        }
     var originalMainQueue: List<MusicTrack>
         get() = mutableState.value.originalMainQueue
-        set(value) = update { it.copy(originalMainQueue = value.logicalTracks()) }
+        set(value) {
+            val logicalTracks = value.logicalTracks()
+            originalMainQueueEntryIds = reconcileOriginalEntryIds(logicalTracks)
+            update { it.copy(originalMainQueue = logicalTracks) }
+        }
     var upNextQueue: List<MusicTrack>
         get() = mutableState.value.upNextQueue
-        set(value) = update { it.copy(upNextQueue = value.logicalTracks()) }
+        set(value) {
+            val logicalTracks = value.logicalTracks()
+            upNextQueueEntryIds = reconcileEntryIds(
+                oldTracks = mutableState.value.upNextQueue,
+                oldEntryIds = upNextQueueEntryIds,
+                newTracks = logicalTracks,
+            )
+            update { it.copy(upNextQueue = logicalTracks) }
+        }
     var mainQueueIndex: Int
         get() = mutableState.value.mainQueueIndex
         set(value) = update { it.copy(mainQueueIndex = value) }
     var currentUpNextTrack: MusicTrack?
         get() = mutableState.value.currentUpNextTrack
-        set(value) = update { it.copy(currentUpNextTrack = value?.logicalPlaybackTrack()) }
+        set(value) {
+            val logicalTrack = value?.logicalPlaybackTrack()
+            val currentTrack = mutableState.value.currentUpNextTrack
+            currentUpNextEntryId = when {
+                logicalTrack == null -> null
+                currentUpNextEntryId != null && currentTrack?.id == logicalTrack.id -> currentUpNextEntryId
+                else -> nextQueueEntryId()
+            }
+            update { it.copy(currentUpNextTrack = logicalTrack) }
+        }
     var currentIsUpNext: Boolean
         get() = mutableState.value.currentIsUpNext
-        set(value) = update { it.copy(currentIsUpNext = value) }
+        set(value) {
+            if (!value) currentUpNextEntryId = null
+            update { it.copy(currentIsUpNext = value) }
+        }
     var queueFeature: ProviderFeature?
         get() = mutableState.value.queueFeature
         set(value) = update { it.copy(queueFeature = value) }
@@ -77,9 +124,151 @@ internal class PlaybackQueueController {
 
     fun currentTrack(): MusicTrack? = mutableState.value.currentTrack()
 
+    fun currentQueueEntryId(): Long? {
+        ensureQueueEntryIdsAligned()
+        val current = mutableState.value
+        return if (current.currentIsUpNext) {
+            current.currentUpNextTrack?.let {
+                currentUpNextEntryId ?: nextQueueEntryId().also { id -> currentUpNextEntryId = id }
+            }
+        } else {
+            mainQueueEntryIds.getOrNull(current.mainQueueIndex)
+        }
+    }
+
+    fun mainQueueEntries(): List<PlaybackQueueEntry> {
+        ensureQueueEntryIdsAligned()
+        return mutableState.value.mainQueue.mapIndexed { index, track ->
+            PlaybackQueueEntry(requireNotNull(mainQueueEntryIds.getOrNull(index)), track)
+        }
+    }
+
+    fun originalMainQueueEntries(): List<PlaybackQueueEntry> {
+        ensureQueueEntryIdsAligned()
+        return mutableState.value.originalMainQueue.mapIndexed { index, track ->
+            PlaybackQueueEntry(requireNotNull(originalMainQueueEntryIds.getOrNull(index)), track)
+        }
+    }
+
+    fun replaceMainQueueEntries(entries: List<PlaybackQueueEntry>) {
+        requireValidEntries(entries)
+        mainQueueEntryIds = entries.map(PlaybackQueueEntry::id)
+        queueEntrySequence = maxOf(queueEntrySequence, mainQueueEntryIds.maxOrNull() ?: 0L)
+        update { it.copy(mainQueue = entries.map { entry -> entry.track.logicalPlaybackTrack() }) }
+    }
+
+    fun replaceOriginalMainQueueEntries(entries: List<PlaybackQueueEntry>) {
+        requireValidEntries(entries)
+        originalMainQueueEntryIds = entries.map(PlaybackQueueEntry::id)
+        queueEntrySequence = maxOf(queueEntrySequence, originalMainQueueEntryIds.maxOrNull() ?: 0L)
+        update { it.copy(originalMainQueue = entries.map { entry -> entry.track.logicalPlaybackTrack() }) }
+    }
+
     fun displayQueue(): List<MusicTrack> = mutableState.value.displayQueue()
 
+    fun displayQueueEntries(): List<PlaybackQueueEntry> {
+        ensureQueueEntryIdsAligned()
+        val current = mutableState.value
+        return buildList {
+            currentEntry(current)?.let(::add)
+            current.upNextQueue.forEachIndexed { index, track ->
+                upNextQueueEntryIds.getOrNull(index)?.let { id ->
+                    add(PlaybackQueueEntry(id = id, track = track))
+                }
+            }
+            val nextMainIndex = when {
+                current.currentIsUpNext -> current.mainQueueIndex + 1
+                current.mainQueueIndex >= 0 -> current.mainQueueIndex + 1
+                else -> 0
+            }
+            if (nextMainIndex in 0..current.mainQueue.size) {
+                for (index in nextMainIndex until current.mainQueue.size) {
+                    val id = mainQueueEntryIds.getOrNull(index) ?: continue
+                    add(PlaybackQueueEntry(id = id, track = current.mainQueue[index]))
+                }
+            }
+        }
+    }
+
     fun displayQueueIndex(): Int = if (currentTrack() != null) 0 else -1
+
+    /** Activates a pending up-next occurrence without losing its queue-entry identity. */
+    fun activateUpNext(index: Int): MusicTrack? {
+        ensureQueueEntryIdsAligned()
+        val current = mutableState.value
+        val track = current.upNextQueue.getOrNull(index) ?: return null
+        val entryId = upNextQueueEntryIds.getOrNull(index) ?: return null
+        val remainingTracks = current.upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
+        upNextQueueEntryIds = upNextQueueEntryIds.filterIndexed { itemIndex, _ -> itemIndex != index }
+        currentUpNextEntryId = entryId
+        update {
+            it.copy(
+                upNextQueue = remainingTracks,
+                currentUpNextTrack = track,
+                currentIsUpNext = true,
+            )
+        }
+        return track
+    }
+
+    /**
+     * Reconciles the actual platform media item back to the exact queue occurrence.
+     *
+     * @return `null` when [entryId] is unknown and legacy track-id reconciliation should be used;
+     * `false` when the entry was already current; `true` when queue position/content changed.
+     */
+    fun synchronizePlaybackEntry(entryId: Long, track: MusicTrack): Boolean? {
+        ensureQueueEntryIdsAligned()
+        val logicalTrack = track.logicalPlaybackTrack()
+        val current = mutableState.value
+
+        if (currentQueueEntryId() == entryId) {
+            val changed = currentTrack() != logicalTrack
+            if (changed) updateCurrentTrack(logicalTrack)
+            return changed
+        }
+
+        val upNextIndex = upNextQueueEntryIds.indexOf(entryId)
+        if (upNextIndex >= 0) {
+            val queuedTrack = current.upNextQueue.getOrNull(upNextIndex) ?: return null
+            if (queuedTrack.id != logicalTrack.id) return null
+            val remainingTracks = current.upNextQueue.filterIndexed { index, _ -> index != upNextIndex }
+            upNextQueueEntryIds = upNextQueueEntryIds.filterIndexed { index, _ -> index != upNextIndex }
+            currentUpNextEntryId = entryId
+            update {
+                it.copy(
+                    upNextQueue = remainingTracks,
+                    currentUpNextTrack = logicalTrack,
+                    currentIsUpNext = true,
+                )
+            }
+            return true
+        }
+
+        val mainIndex = mainQueueEntryIds.indexOf(entryId)
+        if (mainIndex >= 0) {
+            val queuedTrack = current.mainQueue.getOrNull(mainIndex) ?: return null
+            if (queuedTrack.id != logicalTrack.id) return null
+            val originalIndex = originalMainQueueEntryIds.indexOf(entryId)
+            currentUpNextEntryId = null
+            update { snapshot ->
+                snapshot.copy(
+                    mainQueue = snapshot.mainQueue.mapIndexed { index, item ->
+                        if (index == mainIndex) logicalTrack else item
+                    },
+                    originalMainQueue = snapshot.originalMainQueue.mapIndexed { index, item ->
+                        if (index == originalIndex) logicalTrack else item
+                    },
+                    mainQueueIndex = mainIndex,
+                    currentUpNextTrack = null,
+                    currentIsUpNext = false,
+                )
+            }
+            return true
+        }
+
+        return null
+    }
 
     fun activePlaybackTransaction(): PlaybackTransaction? = mutableState.value.activePlaybackTransaction
 
@@ -120,19 +309,24 @@ internal class PlaybackQueueController {
     }
 
     fun updateCurrentTrack(track: MusicTrack) {
+        ensureQueueEntryIdsAligned()
         val logicalTrack = track.logicalPlaybackTrack()
         val current = mutableState.value
         when {
             current.currentIsUpNext -> update { it.copy(currentUpNextTrack = logicalTrack) }
-            current.mainQueueIndex in current.mainQueue.indices -> update { snapshot ->
-                snapshot.copy(
-                    mainQueue = snapshot.mainQueue.mapIndexed { index, item ->
-                        if (index == snapshot.mainQueueIndex) logicalTrack else item
-                    },
-                    originalMainQueue = snapshot.originalMainQueue.map { item ->
-                        if (item.id == logicalTrack.id) logicalTrack else item
-                    },
-                )
+            current.mainQueueIndex in current.mainQueue.indices -> {
+                val entryId = mainQueueEntryIds.getOrNull(current.mainQueueIndex)
+                val originalIndex = entryId?.let(originalMainQueueEntryIds::indexOf) ?: -1
+                update { snapshot ->
+                    snapshot.copy(
+                        mainQueue = snapshot.mainQueue.mapIndexed { index, item ->
+                            if (index == snapshot.mainQueueIndex) logicalTrack else item
+                        },
+                        originalMainQueue = snapshot.originalMainQueue.mapIndexed { index, item ->
+                            if (index == originalIndex) logicalTrack else item
+                        },
+                    )
+                }
             }
         }
     }
@@ -140,24 +334,49 @@ internal class PlaybackQueueController {
     /**
      * Applies the persisted startup queue only if no live durable queue mutation happened first.
      *
-     * An already-started playback transaction is intentionally preserved across hydration. A resume
-     * may begin from the independently restored engine state before the durable queue snapshot arrives;
-     * resetting its transaction here would make an in-flight provider result look stale.
-     * Legacy snapshots may still contain replacement-decorated tracks; hydration normalizes them back
-     * to logical queue identity before they become observable.
-     *
      * @return true when the snapshot was applied, false when a newer live queue mutation won the race.
      */
     fun restore(snapshot: PlaybackQueueSnapshot): Boolean {
         if (startupDirty) return false
         val current = mutableState.value
         val mainQueue = snapshot.mainQueue.logicalTracks()
+        val originalMainQueue = snapshot.originalMainQueue.logicalTracks()
+        val upNextQueue = snapshot.upNextQueue.logicalTracks()
+
+        val mainIdsValid = validIds(snapshot.mainQueueEntryIds, mainQueue.size)
+        val upNextIdsValid = validIds(snapshot.upNextQueueEntryIds, upNextQueue.size)
+        val originalIdsValid = when {
+            originalMainQueue.isEmpty() -> snapshot.originalMainQueueEntryIds.isEmpty()
+            !validIds(snapshot.originalMainQueueEntryIds, originalMainQueue.size) -> false
+            !mainIdsValid -> false
+            else -> snapshot.originalMainQueueEntryIds.toSet() == snapshot.mainQueueEntryIds.toSet()
+        }
+        val idsDoNotCrossQueues = mainIdsValid && upNextIdsValid &&
+            snapshot.mainQueueEntryIds.none(snapshot.upNextQueueEntryIds.toSet()::contains)
+        val canRestoreEntryIds = mainIdsValid && upNextIdsValid && originalIdsValid && idsDoNotCrossQueues
+
+        val persistedIds = snapshot.mainQueueEntryIds + snapshot.originalMainQueueEntryIds + snapshot.upNextQueueEntryIds
+        queueEntrySequence = maxOf(snapshot.queueEntrySequence, persistedIds.maxOrNull() ?: 0L)
+        if (canRestoreEntryIds) {
+            mainQueueEntryIds = snapshot.mainQueueEntryIds
+            originalMainQueueEntryIds = snapshot.originalMainQueueEntryIds
+            upNextQueueEntryIds = snapshot.upNextQueueEntryIds
+        } else {
+            mainQueueEntryIds = mainQueue.map { nextQueueEntryId() }
+            upNextQueueEntryIds = upNextQueue.map { nextQueueEntryId() }
+            originalMainQueueEntryIds = entryIdsForTracks(
+                sourceTracks = mainQueue,
+                sourceEntryIds = mainQueueEntryIds,
+                targetTracks = originalMainQueue,
+            ) ?: originalMainQueue.map { nextQueueEntryId() }
+        }
+        currentUpNextEntryId = null
         applyingStartupSnapshot = true
         try {
             mutableState.value = PlaybackQueueState(
                 mainQueue = mainQueue,
-                originalMainQueue = snapshot.originalMainQueue.logicalTracks(),
-                upNextQueue = snapshot.upNextQueue.logicalTracks(),
+                originalMainQueue = originalMainQueue,
+                upNextQueue = upNextQueue,
                 mainQueueIndex = snapshot.queueIndex.coerceIn(-1, mainQueue.lastIndex),
                 shuffleEnabled = snapshot.shuffleEnabled,
                 repeatMode = snapshot.repeatMode,
@@ -175,6 +394,7 @@ internal class PlaybackQueueController {
     }
 
     fun snapshot(): PlaybackQueueSnapshot {
+        ensureQueueEntryIdsAligned()
         val current = mutableState.value
         return PlaybackQueueSnapshot(
             mainQueue = current.mainQueue,
@@ -185,7 +405,111 @@ internal class PlaybackQueueController {
             repeatMode = current.repeatMode,
             isFmQueue = current.isFmQueue,
             shuffleBeforeFm = current.shuffleBeforeFm,
+            mainQueueEntryIds = mainQueueEntryIds,
+            originalMainQueueEntryIds = originalMainQueueEntryIds,
+            upNextQueueEntryIds = upNextQueueEntryIds,
+            queueEntrySequence = queueEntrySequence,
         )
+    }
+
+    private fun currentEntry(current: PlaybackQueueState): PlaybackQueueEntry? {
+        val track = current.currentTrack() ?: return null
+        val entryId = if (current.currentIsUpNext) {
+            currentUpNextEntryId ?: nextQueueEntryId().also { currentUpNextEntryId = it }
+        } else {
+            mainQueueEntryIds.getOrNull(current.mainQueueIndex)
+        } ?: return null
+        return PlaybackQueueEntry(id = entryId, track = track)
+    }
+
+    private fun ensureQueueEntryIdsAligned() {
+        val current = mutableState.value
+        if (mainQueueEntryIds.size != current.mainQueue.size) {
+            mainQueueEntryIds = reconcileEntryIds(current.mainQueue, mainQueueEntryIds, current.mainQueue)
+        }
+        if (originalMainQueueEntryIds.size != current.originalMainQueue.size) {
+            originalMainQueueEntryIds = reconcileOriginalEntryIds(current.originalMainQueue)
+        }
+        if (upNextQueueEntryIds.size != current.upNextQueue.size) {
+            upNextQueueEntryIds = reconcileEntryIds(current.upNextQueue, upNextQueueEntryIds, current.upNextQueue)
+        }
+    }
+
+    private fun reconcileOriginalEntryIds(newTracks: List<MusicTrack>): List<Long> {
+        val oldTracks = mutableState.value.originalMainQueue
+        val oldIdsByTrack = mutableMapOf<String, ArrayDeque<Long>>()
+        oldTracks.forEachIndexed { index, track ->
+            originalMainQueueEntryIds.getOrNull(index)?.let { id ->
+                oldIdsByTrack.getOrPut(track.id) { ArrayDeque() }.addLast(id)
+            }
+        }
+        val usedIds = mutableSetOf<Long>()
+        val mainIdsByTrack = mutableMapOf<String, ArrayDeque<Long>>()
+        mutableState.value.mainQueue.forEachIndexed { index, track ->
+            mainQueueEntryIds.getOrNull(index)?.let { id ->
+                mainIdsByTrack.getOrPut(track.id) { ArrayDeque() }.addLast(id)
+            }
+        }
+        return newTracks.map { track ->
+            val reused = oldIdsByTrack[track.id]?.removeFirstOrNull()
+            if (reused != null) {
+                usedIds += reused
+                reused
+            } else {
+                var shared = mainIdsByTrack[track.id]?.removeFirstOrNull()
+                while (shared != null && shared in usedIds) {
+                    shared = mainIdsByTrack[track.id]?.removeFirstOrNull()
+                }
+                (shared ?: nextQueueEntryId()).also(usedIds::add)
+            }
+        }
+    }
+
+    private fun reconcileEntryIds(
+        oldTracks: List<MusicTrack>,
+        oldEntryIds: List<Long>,
+        newTracks: List<MusicTrack>,
+    ): List<Long> {
+        val reusableByTrackId = mutableMapOf<String, ArrayDeque<Long>>()
+        oldTracks.forEachIndexed { index, track ->
+            val entryId = oldEntryIds.getOrNull(index) ?: nextQueueEntryId()
+            reusableByTrackId.getOrPut(track.id) { ArrayDeque() }.addLast(entryId)
+        }
+        return newTracks.map { track ->
+            reusableByTrackId[track.id]?.removeFirstOrNull() ?: nextQueueEntryId()
+        }
+    }
+
+    private fun entryIdsForTracks(
+        sourceTracks: List<MusicTrack>,
+        sourceEntryIds: List<Long>,
+        targetTracks: List<MusicTrack>,
+    ): List<Long>? {
+        if (sourceTracks.size != sourceEntryIds.size) return null
+        val available = mutableMapOf<String, ArrayDeque<Long>>()
+        sourceTracks.forEachIndexed { index, track ->
+            available.getOrPut(track.id) { ArrayDeque() }.addLast(sourceEntryIds[index])
+        }
+        val result = mutableListOf<Long>()
+        targetTracks.forEach { track ->
+            result += available[track.id]?.removeFirstOrNull() ?: return null
+        }
+        return result
+    }
+
+    private fun validIds(ids: List<Long>, expectedSize: Int): Boolean =
+        ids.size == expectedSize && ids.all { it > 0L } && ids.distinct().size == ids.size
+
+    private fun requireValidEntries(entries: List<PlaybackQueueEntry>) {
+        require(entries.all { it.id > 0L }) { "Queue entry ids must be positive" }
+        require(entries.map(PlaybackQueueEntry::id).distinct().size == entries.size) {
+            "Queue entry ids must be unique within a queue view"
+        }
+    }
+
+    private fun nextQueueEntryId(): Long {
+        queueEntrySequence += 1L
+        return queueEntrySequence
     }
 
     private inline fun update(

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueCoordinator.kt
@@ -23,10 +23,7 @@ interface PlaybackTransportCoordinator : PlaybackQueueUiPort {
     fun next()
 }
 
-/**
- * Owns queue/part transition policy while [PlaybackQueueController] remains the
- * durable queue state holder.
- */
+/** Owns queue/part transition policy while [PlaybackQueueController] remains the durable state holder. */
 internal class PlaybackQueueCoordinator(
     queue: PlaybackQueueController,
     private val scope: CoroutineScope,
@@ -73,35 +70,21 @@ internal class PlaybackQueueCoordinator(
     }
 
     override fun playTracks(tracks: List<MusicTrack>, index: Int) {
-        replaceSourceQueue(
-            tracks = tracks,
-            index = index,
-            sourceFeature = null,
-            sourcePlaylistId = null,
-            sourceContext = null,
-            keepSelectedTrack = true,
-        )
+        replaceSourceQueue(tracks, index, null, null, null, true)
     }
 
     override fun playTracks(tracks: List<MusicTrack>, index: Int, context: PlaybackContextSnapshot) {
-        replaceSourceQueue(
-            tracks = tracks,
-            index = index,
-            sourceFeature = null,
-            sourcePlaylistId = null,
-            sourceContext = context,
-            keepSelectedTrack = true,
-        )
+        replaceSourceQueue(tracks, index, null, null, context, true)
     }
 
     override fun playPlaylistTracks(tracks: List<MusicTrack>, index: Int, sourcePlaylistId: String) {
         replaceSourceQueue(
-            tracks = tracks,
-            index = index,
-            sourceFeature = null,
-            sourcePlaylistId = sourcePlaylistId,
-            sourceContext = fallbackPlaylistContext(sourcePlaylistId),
-            keepSelectedTrack = true,
+            tracks,
+            index,
+            null,
+            sourcePlaylistId,
+            fallbackPlaylistContext(sourcePlaylistId),
+            true,
         )
     }
 
@@ -111,24 +94,17 @@ internal class PlaybackQueueCoordinator(
         sourcePlaylistId: String,
         context: PlaybackContextSnapshot,
     ) {
-        replaceSourceQueue(
-            tracks = tracks,
-            index = index,
-            sourceFeature = null,
-            sourcePlaylistId = sourcePlaylistId,
-            sourceContext = context,
-            keepSelectedTrack = true,
-        )
+        replaceSourceQueue(tracks, index, null, sourcePlaylistId, context, true)
     }
 
     override fun playAllPlaylistTracks(tracks: List<MusicTrack>, sourcePlaylistId: String) {
         replaceSourceQueue(
-            tracks = tracks,
-            index = 0,
-            sourceFeature = null,
-            sourcePlaylistId = sourcePlaylistId,
-            sourceContext = fallbackPlaylistContext(sourcePlaylistId),
-            keepSelectedTrack = false,
+            tracks,
+            0,
+            null,
+            sourcePlaylistId,
+            fallbackPlaylistContext(sourcePlaylistId),
+            false,
         )
     }
 
@@ -137,14 +113,7 @@ internal class PlaybackQueueCoordinator(
         sourcePlaylistId: String,
         context: PlaybackContextSnapshot,
     ) {
-        replaceSourceQueue(
-            tracks = tracks,
-            index = 0,
-            sourceFeature = null,
-            sourcePlaylistId = sourcePlaylistId,
-            sourceContext = context,
-            keepSelectedTrack = false,
-        )
+        replaceSourceQueue(tracks, 0, null, sourcePlaylistId, context, false)
     }
 
     override fun appendPlaylistTracks(sourcePlaylistId: String, tracks: List<MusicTrack>) {
@@ -163,12 +132,12 @@ internal class PlaybackQueueCoordinator(
 
     override fun playFeatureTracks(tracks: List<MusicTrack>, index: Int, sourceFeature: ProviderFeature) {
         replaceSourceQueue(
-            tracks = tracks,
-            index = index,
-            sourceFeature = sourceFeature,
-            sourcePlaylistId = null,
-            sourceContext = sourceFeature.toPlaybackContextSnapshot(),
-            keepSelectedTrack = true,
+            tracks,
+            index,
+            sourceFeature,
+            null,
+            sourceFeature.toPlaybackContextSnapshot(),
+            true,
         )
     }
 
@@ -296,16 +265,26 @@ internal class PlaybackQueueCoordinator(
             publishQueueMutation()
             return
         }
-        val upNextIndex = queueState.upNextQueue.indexOfFirst { it.id == track.id }
+        val upNextIndex = queueState.upNextQueue.indexOfFirst { it == track }
+            .takeIf { it >= 0 }
+            ?: queueState.upNextQueue.indexOfFirst { it.id == track.id }
         if (upNextIndex >= 0) {
             queueState.upNextQueue = queueState.upNextQueue.filterIndexed { index, _ -> index != upNextIndex }
             publishQueueMutation()
             return
         }
-        val mainIndex = queueState.mainQueue.indexOfFirst { it.id == track.id }
+        val mainEntries = queueState.mainQueueEntries()
+        val mainIndex = mainEntries.indexOfFirst { it.track == track }
+            .takeIf { it >= 0 }
+            ?: mainEntries.indexOfFirst { it.track.id == track.id }
         if (mainIndex < 0) return
-        queueState.mainQueue = queueState.mainQueue.filterIndexed { index, _ -> index != mainIndex }
-        queueState.originalMainQueue = queueState.originalMainQueue.filterNot { it.id == track.id }
+        val removedEntryId = mainEntries[mainIndex].id
+        queueState.replaceMainQueueEntries(mainEntries.filterIndexed { index, _ -> index != mainIndex })
+        if (queueState.originalMainQueue.isNotEmpty()) {
+            queueState.replaceOriginalMainQueueEntries(
+                queueState.originalMainQueueEntries().filterNot { it.id == removedEntryId },
+            )
+        }
         queueState.mainQueueIndex = when {
             queueState.mainQueue.isEmpty() -> -1
             mainIndex < queueState.mainQueueIndex -> queueState.mainQueueIndex - 1
@@ -348,11 +327,7 @@ internal class PlaybackQueueCoordinator(
 
     override fun toggleShuffle() {
         if (queueState.isFmQueue) return
-        if (queueState.shuffleEnabled) {
-            disableShuffle()
-        } else {
-            enableShuffle()
-        }
+        if (queueState.shuffleEnabled) disableShuffle() else enableShuffle()
         publishQueueMutation()
     }
 
@@ -366,12 +341,10 @@ internal class PlaybackQueueCoordinator(
         publishQueueMutation()
     }
 
-    /** Compatibility entry point used by legacy feature callers; explicit selection moves forward. */
     fun playMainIndex(index: Int, skippedUnavailableCount: Int = 0) {
         playMainIndexInternal(index, skippedUnavailableCount, TrackChangeDirection.Next)
     }
 
-    /** Compatibility entry point used by unavailable/recovery flows; up-next is a forward move. */
     fun playUpNextIndex(index: Int) {
         playUpNextIndexInternal(index, TrackChangeDirection.Next)
     }
@@ -424,15 +397,13 @@ internal class PlaybackQueueCoordinator(
             if (keepSelectedTrack) {
                 enableShuffle()
             } else {
-                queueState.originalMainQueue = queueState.mainQueue
-                queueState.mainQueue = shuffledForPlaybackStart(queueState.mainQueue)
+                val originalEntries = queueState.mainQueueEntries()
+                queueState.replaceOriginalMainQueueEntries(originalEntries)
+                queueState.replaceMainQueueEntries(shuffledEntriesForPlaybackStart(originalEntries))
                 queueState.mainQueueIndex = 0
             }
         }
 
-        // Starting the selected track is part of the same queue-replacement transaction. Do not
-        // publish the new queue first: Android runtime observers may still republish a restored
-        // paused engine state in response and let the old track race the intended selection.
         playMainIndexInternal(
             queueState.mainQueueIndex,
             0,
@@ -461,11 +432,8 @@ internal class PlaybackQueueCoordinator(
         direction: TrackChangeDirection,
         reason: PlaybackStartReason = PlaybackStartReason.AUTO_NEXT,
     ) {
-        val track = queueState.upNextQueue.getOrNull(index) ?: return
         updateTrackChangeDirection(direction)
-        queueState.upNextQueue = queueState.upNextQueue.filterIndexed { itemIndex, _ -> itemIndex != index }
-        queueState.currentUpNextTrack = track
-        queueState.currentIsUpNext = true
+        val track = queueState.activateUpNext(index) ?: return
         startTrack(track, 0, null, reason)
         publishQueueMutation()
     }
@@ -500,24 +468,36 @@ internal class PlaybackQueueCoordinator(
             queueState.shuffleEnabled = !queueState.isFmQueue
             return
         }
-        val current = queueState.currentTrack()
-        queueState.originalMainQueue = if (queueState.originalMainQueue.isEmpty()) {
-            queueState.mainQueue
-        } else {
-            queueState.originalMainQueue
+        val entries = queueState.mainQueueEntries()
+        if (queueState.originalMainQueue.isEmpty()) {
+            queueState.replaceOriginalMainQueueEntries(entries)
         }
-        val currentInMain = current?.let { track -> queueState.mainQueue.firstOrNull { it.id == track.id } }
-        val shuffledRest = shuffleTracks(queueState.mainQueue.filterNot { it.id == currentInMain?.id })
-        queueState.mainQueue = listOfNotNull(currentInMain) + shuffledRest
-        queueState.mainQueueIndex = currentInMain?.let { 0 }
-            ?: queueState.mainQueueIndex.coerceIn(0, queueState.mainQueue.lastIndex)
+
+        if (queueState.currentIsUpNext) {
+            val prefixEnd = (queueState.mainQueueIndex + 1).coerceIn(0, entries.size)
+            queueState.replaceMainQueueEntries(
+                entries.take(prefixEnd) + shuffleQueueEntries(entries.drop(prefixEnd)),
+            )
+        } else {
+            val currentEntryId = queueState.currentQueueEntryId()
+            val currentIndex = entries.indexOfFirst { it.id == currentEntryId }
+            if (currentIndex >= 0) {
+                val currentEntry = entries[currentIndex]
+                val rest = entries.filterIndexed { index, _ -> index != currentIndex }
+                queueState.replaceMainQueueEntries(listOf(currentEntry) + shuffleQueueEntries(rest))
+                queueState.mainQueueIndex = 0
+            } else {
+                queueState.replaceMainQueueEntries(shuffleQueueEntries(entries))
+                queueState.mainQueueIndex = queueState.mainQueueIndex.coerceIn(0, queueState.mainQueue.lastIndex)
+            }
+        }
         queueState.shuffleEnabled = true
     }
 
-    private fun shuffledForPlaybackStart(tracks: List<MusicTrack>): List<MusicTrack> {
-        if (tracks.size <= 1) return tracks
-        val shuffled = shuffleTracks(tracks)
-        return if (shuffled.first().id == tracks.first().id) {
+    private fun shuffledEntriesForPlaybackStart(entries: List<PlaybackQueueEntry>): List<PlaybackQueueEntry> {
+        if (entries.size <= 1) return entries
+        val shuffled = shuffleQueueEntries(entries)
+        return if (shuffled.firstOrNull()?.id == entries.first().id) {
             shuffled.drop(1) + shuffled.first()
         } else {
             shuffled
@@ -526,23 +506,42 @@ internal class PlaybackQueueCoordinator(
 
     private fun reshufflePendingMainQueue() {
         if (!queueState.shuffleEnabled || queueState.isFmQueue || queueState.mainQueue.size <= 1) return
-        val firstPendingIndex = (queueState.mainQueueIndex + 1).coerceIn(0, queueState.mainQueue.size)
-        val pending = queueState.mainQueue.drop(firstPendingIndex)
+        val entries = queueState.mainQueueEntries()
+        val firstPendingIndex = (queueState.mainQueueIndex + 1).coerceIn(0, entries.size)
+        val pending = entries.drop(firstPendingIndex)
         if (pending.size <= 1) return
-        queueState.mainQueue = queueState.mainQueue.take(firstPendingIndex) + shuffleTracks(pending)
+        queueState.replaceMainQueueEntries(entries.take(firstPendingIndex) + shuffleQueueEntries(pending))
     }
 
     private fun disableShuffle() {
-        val current = queueState.currentTrack()
-        if (queueState.originalMainQueue.isNotEmpty()) {
-            queueState.mainQueue = queueState.originalMainQueue
-            queueState.mainQueueIndex = current?.let { track ->
-                queueState.mainQueue.indexOfFirst { it.id == track.id }
-            }?.takeIf { it >= 0 }
+        val originalEntries = queueState.originalMainQueueEntries()
+        if (originalEntries.isNotEmpty()) {
+            val currentEntries = queueState.mainQueueEntries()
+            val anchorEntryId = if (queueState.currentIsUpNext) {
+                currentEntries.getOrNull(queueState.mainQueueIndex)?.id
+            } else {
+                queueState.currentQueueEntryId()
+            }
+            queueState.replaceMainQueueEntries(originalEntries)
+            queueState.mainQueueIndex = anchorEntryId
+                ?.let { id -> originalEntries.indexOfFirst { it.id == id } }
+                ?.takeIf { it >= 0 }
                 ?: queueState.mainQueueIndex.coerceIn(-1, queueState.mainQueue.lastIndex)
         }
         queueState.originalMainQueue = emptyList()
         queueState.shuffleEnabled = false
+    }
+
+    private fun shuffleQueueEntries(entries: List<PlaybackQueueEntry>): List<PlaybackQueueEntry> {
+        if (entries.size <= 1) return entries
+        val shuffledTracks = shuffleTracks(entries.map(PlaybackQueueEntry::track))
+        if (shuffledTracks.size != entries.size) return entries
+        val entriesByTrack = mutableMapOf<MusicTrack, ArrayDeque<PlaybackQueueEntry>>()
+        entries.forEach { entry ->
+            entriesByTrack.getOrPut(entry.track) { ArrayDeque() }.addLast(entry)
+        }
+        val result = shuffledTracks.mapNotNull { track -> entriesByTrack[track]?.removeFirstOrNull() }
+        return result.takeIf { it.size == entries.size } ?: entries
     }
 
     private fun fallbackPlaylistContext(sourcePlaylistId: String) = PlaybackContextSnapshot(

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueIdentityBinding.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueIdentityBinding.kt
@@ -1,0 +1,23 @@
+package org.feeluown.mobile
+
+/**
+ * Stable fingerprint binding the occurrence-identity sidecar to the v2 queue payload it belongs to.
+ * A stale/partially-written sidecar is safer to discard than to attach occurrence ids to the wrong
+ * queue ordering.
+ */
+fun PlaybackQueueSnapshot.queueIdentityFingerprint(): String {
+    var hash = 1_125_899_906_842_597L
+    PlaybackQueueCodec.encode(this).forEach { char ->
+        hash = hash * 31L + char.code
+    }
+    return hash.toString()
+}
+
+fun PlaybackQueueSnapshot.withMatchingIdentitySnapshot(
+    identity: PlaybackQueueIdentitySnapshot?,
+    fingerprint: String?,
+): PlaybackQueueSnapshot {
+    if (identity == null || fingerprint.isNullOrBlank()) return this
+    if (fingerprint != queueIdentityFingerprint()) return this
+    return withIdentitySnapshot(identity)
+}

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueRestoration.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackQueueRestoration.kt
@@ -5,9 +5,9 @@ package org.feeluown.mobile
  * recreation.
  *
  * The active Up Next item is intentionally absent from [PlaybackQueueSnapshot.upNextQueue] while it
- * is playing. If the restored track is not present in either durable queue, keep it as the first
- * pending item so FuoPlayerController.synchronizePlaybackTrack can promote it back to the active Up
- * Next slot when the playback engine republishes its state.
+ * is playing. When the platform persisted a [currentQueueEntryId], occurrence identity takes
+ * precedence over logical track identity so a duplicate Up Next item can be reinserted even when the
+ * same logical track is still present in the main queue.
  *
  * Older builds could also overwrite the queue with an empty bootstrap snapshot. In that case the
  * playback plan is the best remaining source of truth, so recover the current item and its ordered
@@ -16,8 +16,55 @@ package org.feeluown.mobile
 fun PlaybackQueueSnapshot.reconcileRestoredPlayback(
     plan: PlaybackPlan?,
     currentTrack: MusicTrack?,
+    currentQueueEntryId: Long? = null,
 ): PlaybackQueueSnapshot {
     currentTrack ?: return this
+
+    val restoredEntryId = currentQueueEntryId?.takeIf { it > 0L }
+    if (restoredEntryId != null) {
+        val knownEntryIds = (mainQueueEntryIds + upNextQueueEntryIds).toSet()
+        if (restoredEntryId in knownEntryIds) return this
+
+        if (mainQueue.isEmpty() && upNextQueue.isEmpty()) {
+            val requests = plan?.requests.orEmpty()
+            val currentRequestIndex = requests.indexOfFirst { request ->
+                request.queueEntryId == restoredEntryId
+            }.takeIf { it >= 0 }
+                ?: requests.indexOfFirst { request -> request.track.id == currentTrack.id }
+                    .takeIf { it >= 0 }
+                ?: 0
+            val recoveredRequests = requests.drop(currentRequestIndex)
+            val recoveredTracks = recoveredRequests.map { it.track }
+                .let { tracks ->
+                    if (tracks.isEmpty()) listOf(currentTrack) else tracks
+                }
+            val recoveredEntryIds = recoveredRequests.mapNotNull(PlaybackRequest::queueEntryId)
+                .takeIf { ids ->
+                    ids.size == recoveredTracks.size &&
+                        ids.all { it > 0L } &&
+                        ids.distinct().size == ids.size
+                }
+                ?: emptyList()
+            return copy(
+                mainQueue = recoveredTracks,
+                mainQueueEntryIds = recoveredEntryIds,
+                queueIndex = 0,
+                queueEntrySequence = maxOf(
+                    queueEntrySequence,
+                    restoredEntryId,
+                    recoveredEntryIds.maxOrNull() ?: 0L,
+                ),
+            )
+        }
+
+        return copy(
+            upNextQueue = listOf(currentTrack) + upNextQueue,
+            upNextQueueEntryIds = listOf(restoredEntryId) + upNextQueueEntryIds,
+            queueEntrySequence = maxOf(queueEntrySequence, restoredEntryId),
+        )
+    }
+
+    // Legacy restoration has no occurrence identity and therefore falls back to logical track ids.
     val knownTrackIds = (mainQueue + upNextQueue).mapTo(mutableSetOf()) { it.id }
     if (currentTrack.id in knownTrackIds) return this
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackResumePersistence.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackResumePersistence.kt
@@ -20,6 +20,7 @@ data class PlaybackResumeSnapshot(
     val durationMs: Long,
     val playbackParts: List<PlaybackPart> = emptyList(),
     val currentPartIndex: Int = -1,
+    val currentQueueEntryId: Long? = null,
 ) {
     fun toPlaybackState(): PlaybackState {
         val normalizedDuration = durationMs.takeIf { it > 0L } ?: currentTrack.durationMs ?: 0L
@@ -33,6 +34,7 @@ data class PlaybackResumeSnapshot(
             durationMs = normalizedDuration,
             playbackParts = playbackParts,
             currentPartIndex = currentPartIndex.takeIf { it in playbackParts.indices } ?: -1,
+            playbackQueueEntryId = currentQueueEntryId?.takeIf { it > 0L },
             lyrics = currentTrack.lyrics,
         )
     }
@@ -67,6 +69,7 @@ object PlaybackResumeCodec {
                 snapshot.positionMs.coerceAtLeast(0L).toString(),
                 snapshot.durationMs.coerceAtLeast(0L).toString(),
                 snapshot.currentPartIndex.toString(),
+                snapshot.currentQueueEntryId?.takeIf { it > 0L }?.toString().orEmpty(),
             ).joinToString("\t")
         )
         snapshot.playbackParts.forEach { part ->
@@ -113,6 +116,7 @@ object PlaybackResumeCodec {
             durationMs = state.getOrNull(1)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
             playbackParts = parts,
             currentPartIndex = state.getOrNull(2)?.toIntOrNull() ?: -1,
+            currentQueueEntryId = state.getOrNull(3)?.toLongOrNull()?.takeIf { it > 0L },
         )
     }
 

--- a/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
+++ b/feature/playback/src/commonMain/kotlin/org/feeluown/mobile/PlaybackStartCoordinator.kt
@@ -139,6 +139,10 @@ internal class PlaybackStartCoordinator(
             setCurrentPartIndex(-1)
         }
         queue.updateCurrentTrack(logicalTrack)
+        val playbackQueueEntries = queue.displayQueueEntries()
+        val currentQueueEntryId = playbackQueueEntries.firstOrNull()
+            ?.takeIf { entry -> entry.track.id == logicalTrack.id }
+            ?.id
         if (!isManualSourceSwitch) {
             resetLyricsForPlaybackRequest()
         }
@@ -167,6 +171,7 @@ internal class PlaybackStartCoordinator(
                 currentPartIndex = requestedPartIndex.takeIf { isPlaybackPartRequest } ?: -1,
                 lyrics = preservedLyrics ?: logicalTrack.lyrics,
                 playbackGeneration = transaction.id,
+                playbackQueueEntryId = currentQueueEntryId,
                 errorMessage = null,
             )
         )
@@ -186,6 +191,7 @@ internal class PlaybackStartCoordinator(
                 transaction = transaction,
                 logicalTrack = logicalTrack,
                 resolveTrack = resolveTrack,
+                queueEntryId = currentQueueEntryId,
                 skippedUnavailableCount = skippedUnavailableCount,
                 requestedPartIndex = requestedPartIndex,
                 manualSelection = manualSelection,
@@ -202,6 +208,7 @@ internal class PlaybackStartCoordinator(
                         PlaybackRequest(
                             track = logicalTrack,
                             resolveTrack = resolveTrack,
+                            queueEntryId = currentQueueEntryId,
                             requestedPartIndex = requestedPartIndex,
                             unavailablePolicy = unavailablePlaybackPolicy(),
                             smartReplacementProviderIds = smartReplacementProviderIds(),
@@ -211,15 +218,16 @@ internal class PlaybackStartCoordinator(
                             resolveOnlySelectedReplacement = manualSelection != null,
                         )
                     )
-                    queue.displayQueue()
+                    playbackQueueEntries
                         .drop(1)
                         .take(PLAYBACK_START_PLAN_LOOKAHEAD)
-                        .forEach { queuedTrack ->
-                            val logicalQueuedTrack = queuedTrack.logicalPlaybackTrack()
+                        .forEach { queuedEntry ->
+                            val logicalQueuedTrack = queuedEntry.track.logicalPlaybackTrack()
                             add(
                                 PlaybackRequest(
                                     track = logicalQueuedTrack,
                                     resolveTrack = prepareTrack(logicalQueuedTrack),
+                                    queueEntryId = queuedEntry.id,
                                     unavailablePolicy = unavailablePlaybackPolicy(),
                                     smartReplacementProviderIds = smartReplacementProviderIds(),
                                     smartReplacementMinScore = smartReplacementMinScore(),
@@ -238,6 +246,7 @@ internal class PlaybackStartCoordinator(
         transaction: PlaybackTransaction,
         logicalTrack: MusicTrack,
         resolveTrack: MusicTrack,
+        queueEntryId: Long?,
         skippedUnavailableCount: Int,
         requestedPartIndex: Int?,
         manualSelection: SmartReplacementSelection?,
@@ -305,6 +314,7 @@ internal class PlaybackStartCoordinator(
                         playbackParts = playbackParts(),
                         currentPartIndex = currentPartIndex(),
                         playbackGeneration = transaction.id,
+                        playbackQueueEntryId = queueEntryId,
                     )
                 )
                 maybeLoadLyrics(logicalTrack)

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
@@ -77,7 +77,7 @@ class PlaybackQueueEntryIdentityTest {
     }
 
     @Test
-    fun snapshotCodecPreservesOccurrenceIdsAcrossRestart() {
+    fun v2QueuePayloadAndIdentitySidecarPreserveOccurrencesAcrossRestart() {
         val firstA = track("track:a", "A first")
         val trackB = track("track:b", "B")
         val secondA = track("track:a", "A second")
@@ -90,7 +90,14 @@ class PlaybackQueueEntryIdentityTest {
         }
         val snapshot = source.snapshot()
 
-        val decoded = PlaybackQueueCodec.decode(PlaybackQueueCodec.encode(snapshot))
+        val queuePayload = PlaybackQueueCodec.encode(snapshot)
+        assertTrue(queuePayload.startsWith("v2\n"))
+        val decodedQueue = PlaybackQueueCodec.decode(queuePayload)
+        assertTrue(decodedQueue.mainQueueEntryIds.isEmpty())
+
+        val identityPayload = PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot())
+        val identity = assertNotNull(PlaybackQueueIdentityCodec.decode(identityPayload))
+        val decoded = decodedQueue.withIdentitySnapshot(identity)
         val restored = PlaybackQueueController()
         assertTrue(restored.restore(decoded))
 

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
@@ -1,0 +1,136 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PlaybackQueueEntryIdentityTest {
+    @Test
+    fun duplicateTracksKeepDistinctQueueOccurrenceIdentity() {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 0
+        }
+
+        val entries = queue.displayQueueEntries()
+
+        assertEquals(listOf("track:a", "track:b", "track:a"), entries.map { it.track.id })
+        assertNotEquals(entries[0].id, entries[2].id)
+        assertEquals(entries[0].id, queue.currentQueueEntryId())
+    }
+
+    @Test
+    fun engineTransitionToSecondDuplicateSelectsExactOccurrence() {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 0
+        }
+        val secondAEntry = assertNotNull(queue.displayQueueEntries().getOrNull(2))
+
+        assertTrue(queue.synchronizePlaybackEntry(secondAEntry.id, secondA) == true)
+
+        assertEquals(2, queue.mainQueueIndex)
+        assertEquals(secondAEntry.id, queue.currentQueueEntryId())
+        assertEquals("A second", queue.currentTrack()?.title)
+    }
+
+    @Test
+    fun queueMutationPreservesExistingOccurrenceIdsInOrder() {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 0
+        }
+        val before = queue.displayQueueEntries()
+
+        queue.mainQueue = queue.mainQueue + track("track:c", "C")
+        val after = queue.displayQueueEntries()
+
+        assertEquals(before.map { it.id }, after.take(3).map { it.id })
+        assertNotEquals(after[2].id, after[3].id)
+    }
+
+    @Test
+    fun originalShuffleViewSharesOccurrenceIdsWithMainQueue() {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 1
+        }
+        val mainEntries = queue.mainQueueEntries()
+
+        queue.replaceOriginalMainQueueEntries(mainEntries)
+
+        assertEquals(mainEntries.map { it.id }, queue.originalMainQueueEntries().map { it.id })
+    }
+
+    @Test
+    fun snapshotCodecPreservesOccurrenceIdsAcrossRestart() {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val source = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 2
+            replaceOriginalMainQueueEntries(mainQueueEntries())
+            upNextQueue = listOf(track("track:c", "C"))
+            shuffleEnabled = true
+        }
+        val snapshot = source.snapshot()
+
+        val decoded = PlaybackQueueCodec.decode(PlaybackQueueCodec.encode(snapshot))
+        val restored = PlaybackQueueController()
+        assertTrue(restored.restore(decoded))
+
+        assertEquals(snapshot.mainQueueEntryIds, decoded.mainQueueEntryIds)
+        assertEquals(snapshot.originalMainQueueEntryIds, decoded.originalMainQueueEntryIds)
+        assertEquals(snapshot.upNextQueueEntryIds, decoded.upNextQueueEntryIds)
+        assertEquals(snapshot.queueEntrySequence, decoded.queueEntrySequence)
+        assertEquals(source.mainQueueEntries().map { it.id }, restored.mainQueueEntries().map { it.id })
+        assertEquals(source.originalMainQueueEntries().map { it.id }, restored.originalMainQueueEntries().map { it.id })
+        assertEquals(source.currentQueueEntryId(), restored.currentQueueEntryId())
+        assertNotEquals(restored.mainQueueEntries()[0].id, restored.mainQueueEntries()[2].id)
+    }
+
+    @Test
+    fun legacySnapshotWithoutEntryIdsAllocatesDistinctOccurrences() {
+        val firstA = track("track:a", "A first")
+        val secondA = track("track:a", "A second")
+        val restored = PlaybackQueueController()
+
+        assertTrue(
+            restored.restore(
+                PlaybackQueueSnapshot(
+                    mainQueue = listOf(firstA, secondA),
+                    queueIndex = 0,
+                )
+            )
+        )
+
+        val entries = restored.mainQueueEntries()
+        assertEquals(2, entries.size)
+        assertNotEquals(entries[0].id, entries[1].id)
+    }
+
+    private fun track(id: String, title: String) = MusicTrack(
+        id = id,
+        title = title,
+        artists = "Artist",
+        album = "Album",
+        source = "test",
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+    )
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryIdentityTest.kt
@@ -97,7 +97,10 @@ class PlaybackQueueEntryIdentityTest {
 
         val identityPayload = PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot())
         val identity = assertNotNull(PlaybackQueueIdentityCodec.decode(identityPayload))
-        val decoded = decodedQueue.withIdentitySnapshot(identity)
+        val decoded = decodedQueue.withMatchingIdentitySnapshot(
+            identity = identity,
+            fingerprint = snapshot.queueIdentityFingerprint(),
+        )
         val restored = PlaybackQueueController()
         assertTrue(restored.restore(decoded))
 
@@ -109,6 +112,33 @@ class PlaybackQueueEntryIdentityTest {
         assertEquals(source.originalMainQueueEntries().map { it.id }, restored.originalMainQueueEntries().map { it.id })
         assertEquals(source.currentQueueEntryId(), restored.currentQueueEntryId())
         assertNotEquals(restored.mainQueueEntries()[0].id, restored.mainQueueEntries()[2].id)
+    }
+
+    @Test
+    fun staleIdentitySidecarIsRejectedForDifferentQueuePayload() {
+        val original = PlaybackQueueController().apply {
+            mainQueue = listOf(track("track:a", "A"), track("track:b", "B"))
+            mainQueueIndex = 0
+        }.snapshot()
+        val identity = original.toIdentitySnapshot()
+        val differentQueue = PlaybackQueueCodec.decode(
+            PlaybackQueueCodec.encode(
+                PlaybackQueueSnapshot(
+                    mainQueue = listOf(track("track:b", "B"), track("track:a", "A")),
+                    queueIndex = 0,
+                )
+            )
+        )
+
+        val merged = differentQueue.withMatchingIdentitySnapshot(
+            identity = identity,
+            fingerprint = original.queueIdentityFingerprint(),
+        )
+
+        assertTrue(merged.mainQueueEntryIds.isEmpty())
+        assertTrue(merged.originalMainQueueEntryIds.isEmpty())
+        assertTrue(merged.upNextQueueEntryIds.isEmpty())
+        assertEquals(0L, merged.queueEntrySequence)
     }
 
     @Test

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryShuffleTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryShuffleTest.kt
@@ -17,7 +17,7 @@ class PlaybackQueueEntryShuffleTest {
             mainQueueIndex = 2
         }
         val currentEntryId = assertNotNull(queue.currentQueueEntryId())
-        val coordinator = coordinator(queue) { it.reversed() }
+        val coordinator = coordinator(queue, shuffleTracks = { it.reversed() })
 
         coordinator.toggleShuffle()
 

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryShuffleTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueEntryShuffleTest.kt
@@ -1,0 +1,90 @@
+package org.feeluown.mobile
+
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class PlaybackQueueEntryShuffleTest {
+    @Test
+    fun shuffleWithDuplicateTrackPreservesCurrentOccurrence() = runTest {
+        val firstA = track("track:a", "A first")
+        val trackB = track("track:b", "B")
+        val secondA = track("track:a", "A second")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(firstA, trackB, secondA)
+            mainQueueIndex = 2
+        }
+        val currentEntryId = assertNotNull(queue.currentQueueEntryId())
+        val coordinator = coordinator(queue) { it.reversed() }
+
+        coordinator.toggleShuffle()
+
+        assertEquals(3, queue.mainQueue.size)
+        assertEquals(secondA, queue.currentTrack())
+        assertEquals(currentEntryId, queue.currentQueueEntryId())
+        assertEquals(currentEntryId, queue.mainQueueEntries().first().id)
+        assertEquals(
+            queue.mainQueueEntries().map { it.id }.toSet(),
+            queue.originalMainQueueEntries().map { it.id }.toSet(),
+        )
+
+        coordinator.toggleShuffle()
+
+        assertEquals(listOf(firstA, trackB, secondA), queue.mainQueue)
+        assertEquals(2, queue.mainQueueIndex)
+        assertEquals(secondA, queue.currentTrack())
+        assertEquals(currentEntryId, queue.currentQueueEntryId())
+    }
+
+    @Test
+    fun playingUpNextKeepsPendingOccurrenceIdentity() = runTest {
+        val current = track("track:a", "Current A")
+        val pending = track("track:a", "Pending A")
+        val queue = PlaybackQueueController().apply {
+            mainQueue = listOf(current)
+            mainQueueIndex = 0
+            upNextQueue = listOf(pending)
+        }
+        val pendingEntryId = assertNotNull(queue.displayQueueEntries().getOrNull(1)).id
+        var started: MusicTrack? = null
+        val coordinator = coordinator(queue, onStart = { started = it })
+
+        coordinator.next()
+
+        assertEquals(pending, started)
+        assertEquals(pending, queue.currentTrack())
+        assertEquals(pendingEntryId, queue.currentQueueEntryId())
+    }
+
+    private fun TestScope.coordinator(
+        queue: PlaybackQueueController,
+        shuffleTracks: (List<MusicTrack>) -> List<MusicTrack> = { it },
+        onStart: (MusicTrack) -> Unit = {},
+    ) = PlaybackQueueCoordinator(
+        queue = queue,
+        scope = this,
+        fallbackTrack = { null },
+        playbackParts = { emptyList() },
+        currentPartIndex = { -1 },
+        startPlayback = { track, _, _ -> onStart(track) },
+        stopPlayback = {},
+        persistQueue = {},
+        updateQueueState = {},
+        appendFeatureQueue = { 0 },
+        setTrackChangeDirection = {},
+        setMessage = {},
+        shuffleTracks = shuffleTracks,
+    )
+
+    private fun track(id: String, title: String) = MusicTrack(
+        id = id,
+        title = title,
+        artists = "Artist",
+        album = "Album",
+        source = "test",
+        sourceType = TrackSourceType.Provider,
+        providerId = id,
+    )
+}

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueRestorationTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackQueueRestorationTest.kt
@@ -50,6 +50,40 @@ class PlaybackQueueRestorationTest {
     }
 
     @Test
+    fun activeUpNextDuplicateIsReinsertedByOccurrenceId() {
+        val duplicateMain = track("song:duplicate")
+        val second = track("song:2")
+        val activeUpNext = track("song:duplicate")
+        val pendingUpNext = track("song:pending")
+        val snapshot = PlaybackQueueSnapshot(
+            mainQueue = listOf(duplicateMain, second),
+            upNextQueue = listOf(pendingUpNext),
+            queueIndex = 0,
+            mainQueueEntryIds = listOf(10L, 11L),
+            upNextQueueEntryIds = listOf(13L),
+            queueEntrySequence = 13L,
+        )
+
+        val restored = snapshot.reconcileRestoredPlayback(
+            plan = PlaybackPlan(
+                generation = 1L,
+                requests = listOf(
+                    PlaybackRequest(activeUpNext, queueEntryId = 12L),
+                    PlaybackRequest(pendingUpNext, queueEntryId = 13L),
+                    PlaybackRequest(second, queueEntryId = 11L),
+                ),
+            ),
+            currentTrack = activeUpNext,
+            currentQueueEntryId = 12L,
+        )
+
+        assertEquals(listOf(activeUpNext, pendingUpNext), restored.upNextQueue)
+        assertEquals(listOf(12L, 13L), restored.upNextQueueEntryIds)
+        assertEquals(listOf(10L, 11L), restored.mainQueueEntryIds)
+        assertEquals(13L, restored.queueEntrySequence)
+    }
+
+    @Test
     fun emptyLegacySnapshotRecoversCurrentAndLookAheadFromPlaybackPlan() {
         val alreadyPlayed = track("song:old")
         val current = track("song:current")

--- a/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResumePersistenceTest.kt
+++ b/feature/playback/src/commonTest/kotlin/org/feeluown/mobile/PlaybackResumePersistenceTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertNull
 
 class PlaybackResumePersistenceTest {
     @Test
-    fun resumeSnapshotRoundTripsLogicalTrackAndParts() {
+    fun resumeSnapshotRoundTripsLogicalTrackPartsAndQueueEntryIdentity() {
         val track = MusicTrack(
             id = "bilibili:BV1",
             title = "Title",
@@ -28,6 +28,7 @@ class PlaybackResumePersistenceTest {
                 PlaybackPart("part-2", "第二段\tLive", 90_000L),
             ),
             currentPartIndex = 1,
+            currentQueueEntryId = 42L,
         )
 
         val decoded = PlaybackResumeCodec.decode(PlaybackResumeCodec.encode(snapshot))
@@ -35,6 +36,33 @@ class PlaybackResumePersistenceTest {
         assertEquals(snapshot, decoded)
         assertEquals(PlayerStatus.Paused, decoded?.toPlaybackState()?.status)
         assertEquals(42_000L, decoded?.toPlaybackState()?.positionMs)
+        assertEquals(42L, decoded?.toPlaybackState()?.playbackQueueEntryId)
+    }
+
+    @Test
+    fun legacyResumePayloadWithoutQueueEntryIdentityStillDecodes() {
+        val track = MusicTrack(
+            id = "song:legacy",
+            title = "Legacy",
+            artists = "Artist",
+            album = "Album",
+            source = "netease",
+            sourceType = TrackSourceType.Provider,
+            providerId = "song:legacy",
+        )
+        val encoded = PlaybackResumeCodec.encode(
+            PlaybackResumeSnapshot(
+                currentTrack = track,
+                positionMs = 1_000L,
+                durationMs = 2_000L,
+            )
+        )
+        val legacy = encoded.replace("1000\t2000\t-1\t\n", "1000\t2000\t-1\n")
+
+        val decoded = PlaybackResumeCodec.decode(legacy)
+
+        assertEquals(track, decoded?.currentTrack)
+        assertNull(decoded?.currentQueueEntryId)
     }
 
     @Test

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -16,11 +16,13 @@ internal fun createDesktopPlaybackQueueStore(
     resumeStore: PlaybackResumeStore,
 ): DesktopPlaybackQueueStore = DesktopPlaybackQueueStore(
     file = DesktopAppDirectories.state().resolve("playback-queue.txt"),
+    identityFile = DesktopAppDirectories.state().resolve("playback-queue-identity.txt"),
     resumeStore = resumeStore,
 )
 
 internal class DesktopPlaybackQueueStore(
     private val file: Path,
+    private val identityFile: Path,
     private val resumeStore: PlaybackResumeStore,
 ) : PlaybackQueueStore {
     private val writeVersionLock = Any()
@@ -39,11 +41,15 @@ internal class DesktopPlaybackQueueStore(
         val persisted = readTextIfExists(file)
             ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
             ?: PlaybackQueueSnapshot()
+        val identity = readTextIfExists(identityFile)
+            ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
         val restoredSession = resumeStore.load()
-        val snapshot = persisted.reconcileRestoredPlayback(
-            plan = null,
-            currentTrack = restoredSession?.currentTrack,
-        )
+        val snapshot = persisted
+            .withIdentitySnapshot(identity)
+            .reconcileRestoredPlayback(
+                plan = null,
+                currentTrack = restoredSession?.currentTrack,
+            )
         synchronized(writeVersionLock) {
             latestSnapshot = snapshot
         }
@@ -60,7 +66,7 @@ internal class DesktopPlaybackQueueStore(
         withContext(Dispatchers.IO) {
             synchronized(fileWriteLock) {
                 if (version <= lastWrittenVersion) return@synchronized
-                writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+                writeQueueSnapshot(snapshot)
                 lastWrittenVersion = version
             }
         }
@@ -75,9 +81,17 @@ internal class DesktopPlaybackQueueStore(
         }
         synchronized(fileWriteLock) {
             if (pending.first <= lastWrittenVersion) return
-            writeAtomicText(file, PlaybackQueueCodec.encode(pending.second))
+            writeQueueSnapshot(pending.second)
             lastWrittenVersion = pending.first
         }
+    }
+
+    private fun writeQueueSnapshot(snapshot: PlaybackQueueSnapshot) {
+        writeAtomicText(file, PlaybackQueueCodec.encode(snapshot))
+        writeAtomicText(
+            identityFile,
+            PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()),
+        )
     }
 }
 

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -17,12 +17,14 @@ internal fun createDesktopPlaybackQueueStore(
 ): DesktopPlaybackQueueStore = DesktopPlaybackQueueStore(
     file = DesktopAppDirectories.state().resolve("playback-queue.txt"),
     identityFile = DesktopAppDirectories.state().resolve("playback-queue-identity.txt"),
+    fingerprintFile = DesktopAppDirectories.state().resolve("playback-queue-identity-fingerprint.txt"),
     resumeStore = resumeStore,
 )
 
 internal class DesktopPlaybackQueueStore(
     private val file: Path,
     private val identityFile: Path,
+    private val fingerprintFile: Path,
     private val resumeStore: PlaybackResumeStore,
 ) : PlaybackQueueStore {
     private val writeVersionLock = Any()
@@ -43,9 +45,10 @@ internal class DesktopPlaybackQueueStore(
             ?: PlaybackQueueSnapshot()
         val identity = readTextIfExists(identityFile)
             ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
+        val fingerprint = readTextIfExists(fingerprintFile)?.takeIf { it.isNotBlank() }
         val restoredSession = resumeStore.load()
         val snapshot = persisted
-            .withIdentitySnapshot(identity)
+            .withMatchingIdentitySnapshot(identity, fingerprint)
             .reconcileRestoredPlayback(
                 plan = null,
                 currentTrack = restoredSession?.currentTrack,
@@ -92,6 +95,7 @@ internal class DesktopPlaybackQueueStore(
             identityFile,
             PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()),
         )
+        writeAtomicText(fingerprintFile, snapshot.queueIdentityFingerprint())
     }
 }
 

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopPlaybackPersistence.kt
@@ -52,6 +52,7 @@ internal class DesktopPlaybackQueueStore(
             .reconcileRestoredPlayback(
                 plan = null,
                 currentTrack = restoredSession?.currentTrack,
+                currentQueueEntryId = restoredSession?.currentQueueEntryId,
             )
         synchronized(writeVersionLock) {
             latestSnapshot = snapshot
@@ -123,6 +124,7 @@ private class DesktopPlaybackResumeStore(
             durationMs = state.durationMs.coerceAtLeast(0L),
             playbackParts = state.playbackParts,
             currentPartIndex = state.currentPartIndex,
+            currentQueueEntryId = state.playbackQueueEntryId?.takeIf { it > 0L },
         )
         latest = snapshot
         loaded = true

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
@@ -15,7 +15,9 @@ class IosPlaybackQueueStore : PlaybackQueueStore {
         val identity = defaults.stringForKey(KEY_QUEUE_IDENTITY)
             ?.takeIf { it.isNotBlank() }
             ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
-        snapshot.withIdentitySnapshot(identity)
+        val fingerprint = defaults.stringForKey(KEY_QUEUE_IDENTITY_FINGERPRINT)
+            ?.takeIf { it.isNotBlank() }
+        snapshot.withMatchingIdentitySnapshot(identity, fingerprint)
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
@@ -25,6 +27,7 @@ class IosPlaybackQueueStore : PlaybackQueueStore {
                 PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()),
                 KEY_QUEUE_IDENTITY,
             )
+            defaults.setObject(snapshot.queueIdentityFingerprint(), KEY_QUEUE_IDENTITY_FINGERPRINT)
             defaults.synchronize()
         }
     }
@@ -32,5 +35,6 @@ class IosPlaybackQueueStore : PlaybackQueueStore {
     private companion object {
         private const val KEY_QUEUE_SNAPSHOT = "playback_queue_snapshot"
         private const val KEY_QUEUE_IDENTITY = "playback_queue_identity"
+        private const val KEY_QUEUE_IDENTITY_FINGERPRINT = "playback_queue_identity_fingerprint"
     }
 }

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/IosPlaybackQueueStore.kt
@@ -8,20 +8,29 @@ class IosPlaybackQueueStore : PlaybackQueueStore {
     private val defaults = NSUserDefaults.standardUserDefaults
 
     override suspend fun load(): PlaybackQueueSnapshot = withContext(Dispatchers.Default) {
-        defaults.stringForKey(KEY_QUEUE_SNAPSHOT)
+        val snapshot = defaults.stringForKey(KEY_QUEUE_SNAPSHOT)
             ?.takeIf { it.isNotBlank() }
             ?.let { raw -> runCatching { PlaybackQueueCodec.decode(raw) }.getOrNull() }
             ?: PlaybackQueueSnapshot()
+        val identity = defaults.stringForKey(KEY_QUEUE_IDENTITY)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { raw -> runCatching { PlaybackQueueIdentityCodec.decode(raw) }.getOrNull() }
+        snapshot.withIdentitySnapshot(identity)
     }
 
     override suspend fun save(snapshot: PlaybackQueueSnapshot) {
         withContext(Dispatchers.Default) {
             defaults.setObject(PlaybackQueueCodec.encode(snapshot), KEY_QUEUE_SNAPSHOT)
+            defaults.setObject(
+                PlaybackQueueIdentityCodec.encode(snapshot.toIdentitySnapshot()),
+                KEY_QUEUE_IDENTITY,
+            )
             defaults.synchronize()
         }
     }
 
     private companion object {
         private const val KEY_QUEUE_SNAPSHOT = "playback_queue_snapshot"
+        private const val KEY_QUEUE_IDENTITY = "playback_queue_identity"
     }
 }


### PR DESCRIPTION
## 背景

#188 修复了 Android 后台自动下一首时同 generation 新 track 被误判为 stale state；#189 进一步让 Runtime 以 engine 的实际播放媒体为权威来源。本 PR 处理剩余的结构性歧义：同一逻辑歌曲可以在队列中出现多次，`trackId` 不能作为队列 occurrence identity。

## 调整

- 为队列中的每个 occurrence 分配稳定 `queueEntryId`，不污染通用 `MusicTrack` 模型。
- `PlaybackRequest` / `PlaybackPlan` 携带 `queueEntryId`，Android plan codec、Service、Engine state 原样透传。
- `PlaybackFeatureOwner` 优先按 entry ID 同步实际播放项，只对旧 engine/restored state 保留 `trackId` 兼容路径。
- `A -> B -> A` 可精确定位到第二个 A，不再通过 `indexOfFirst(trackId)` 回到第一个 A。
- up-next 激活保留原 occurrence ID。
- shuffle 直接重排 `PlaybackQueueEntry`；`originalMainQueue` 与 shuffled main queue 共享同一批 occurrence IDs，开关 shuffle 不交换重复歌曲身份。
- **保持现有 `PlaybackQueueCodec` v2 主格式不变**；occurrence identity 使用独立 `i1` sidecar 持久化，Android / iOS / Desktop 均已接入，旧版本完全忽略 sidecar，新版本在无 sidecar 时自动分配 identity。
- sidecar 通过 v2 queue payload fingerprint 绑定；如果发生部分写入或 sidecar 与当前 queue 不匹配，identity 会被安全丢弃并重新生成，不会把旧 occurrence ID 套到新队列。
- Android resume store 记录当前 queue entry ID，恢复计划优先按 occurrence 定位。

## 回归测试

- duplicate logical tracks receive distinct occurrence IDs
- engine transition to second duplicate selects exact occurrence
- queue mutation preserves existing occurrence IDs
- v2 queue payload + identity sidecar preserve occurrence IDs across restart
- stale/mismatched identity sidecar is rejected
- legacy snapshot without IDs allocates distinct occurrences
- shuffle with duplicate tracks preserves current occurrence and restores exact position
- up-next transition preserves pending occurrence identity

## Stacked PR

Base: #189 `refactor: enforce playback runtime state consistency`

建议按 #188 -> #189 -> 本 PR 的顺序合并。