### PR TITLE
fix: avoid navigation controls overlapping mini player

### DIFF
--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppShell.kt
@@ -4,9 +4,15 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.tappableElement
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -51,6 +57,9 @@ internal fun AppShell(
         } else {
             16.dp
         }
+        val bottomOverlayInsets = WindowInsets.navigationBars
+            .union(WindowInsets.tappableElement)
+            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
 
         CompositionLocalProvider(
             LocalPlaybackSession provides uiGraph.playbackSession,
@@ -100,7 +109,7 @@ internal fun AppShell(
                                     Box(
                                         modifier = Modifier
                                             .align(Alignment.BottomCenter)
-                                            .navigationBarsPadding(),
+                                            .windowInsetsPadding(bottomOverlayInsets),
                                     ) {
                                         PlaybackMiniPlayerOverlay()
                                     }
@@ -108,7 +117,7 @@ internal fun AppShell(
                                 AppGlobalOverlays(uiGraph)
                                 val feedbackModifier = Modifier
                                     .align(Alignment.BottomCenter)
-                                    .navigationBarsPadding()
+                                    .windowInsetsPadding(bottomOverlayInsets)
                                     .padding(
                                         start = 16.dp,
                                         top = 16.dp,


### PR DESCRIPTION
## Summary

- use a shared bottom overlay inset for the shell-hosted mini player and feedback host
- combine `navigationBars` with `tappableElement` so Android three-button navigation is treated as a non-interactive system area
- keep edge-to-edge rendering and avoid device/manufacturer-specific padding
- include horizontal navigation-bar insets for landscape/side navigation bars

## Background

A Xiaomi/HyperOS device using three-button navigation was reported with the system navigation buttons rendered over the mini player. The shell already used `navigationBarsPadding()`, so this change broadens the safety inset to the union of navigation-bar and system-tappable-element insets instead of adding fixed Xiaomi-specific padding.

## Validation

- change is limited to the app-shell bottom overlays
- no behavior change for route-level mini-player hosting
- PR checks should validate common/Android compilation across the existing CI matrix

Manual device validation is still recommended on Xiaomi/HyperOS with three-button navigation and gesture navigation.