### PR TITLE
feat(android): support opening provider web links

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -190,7 +190,7 @@
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
-                android:name="android.support.FILEProvider_PATHS"
+                android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
 

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -71,6 +71,25 @@
                     android:pathPrefix="/FuoEvolve/r"
                     android:scheme="https" />
             </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开音源链接">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="music.163.com" />
+                <data android:host="y.music.163.com" />
+                <data android:host="www.bilibili.com" />
+                <data android:host="m.bilibili.com" />
+                <data android:host="bilibili.com" />
+                <data android:host="y.qq.com" />
+                <data android:host="i.y.qq.com" />
+                <data android:host="music.youtube.com" />
+                <data android:host="www.youtube.com" />
+                <data android:host="youtube.com" />
+                <data android:host="youtu.be" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".AppUpdateSavePermissionActivity"

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -71,24 +71,91 @@
                     android:pathPrefix="/FuoEvolve/r"
                     android:scheme="https" />
             </intent-filter>
-            <intent-filter android:autoVerify="false" android:label="打开音源链接">
+            <intent-filter android:autoVerify="false" android:label="打开网易云音乐链接">
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
                 <data android:host="music.163.com" />
                 <data android:host="y.music.163.com" />
+                <data android:path="/song" />
+                <data android:path="/playlist" />
+                <data android:path="/artist" />
+                <data android:path="/album" />
+                <data android:path="/m/song" />
+                <data android:path="/m/playlist" />
+                <data android:path="/m/artist" />
+                <data android:path="/m/album" />
+                <data android:path="/f/song" />
+                <data android:path="/f/playlist" />
+                <data android:path="/f/artist" />
+                <data android:path="/f/album" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开哔哩哔哩链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="bilibili.com" />
                 <data android:host="www.bilibili.com" />
                 <data android:host="m.bilibili.com" />
-                <data android:host="bilibili.com" />
+                <data android:pathPrefix="/video/BV" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开 QQ 音乐链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="y.qq.com" />
+                <data android:pathPrefix="/n/ryqq/songDetail/" />
+                <data android:pathPrefix="/n/ryqq/playlist/" />
+                <data android:pathPrefix="/n/ryqq/singer/" />
+                <data android:pathPrefix="/n/ryqq/albumDetail/" />
+                <data android:pathPrefix="/n/ryqq/album/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开 QQ 音乐分享链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="i.y.qq.com" />
+                <data android:path="/n2/m/share/details/taoge.html" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开 YouTube Music 链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="music.youtube.com" />
-                <data android:host="www.youtube.com" />
+                <data android:path="/watch" />
+                <data android:path="/playlist" />
+                <data android:pathPrefix="/channel/" />
+                <data android:pathPrefix="/browse/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开 YouTube 链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="youtube.com" />
+                <data android:host="www.youtube.com" />
+                <data android:path="/watch" />
+                <data android:path="/playlist" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false" android:label="打开 YouTube 短链接">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="youtu.be" />
+                <data android:pathPrefix="/" />
             </intent-filter>
         </activity>
         <activity
@@ -123,7 +190,7 @@
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:name="android.support.FILEProvider_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
 

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.android.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun rememberSupportedLinksSettingsAction(): (() -> Unit)? {
+    val context = LocalContext.current
+    return remember(context) {
+        {
+            val packageUri = Uri.parse("package:${context.packageName}")
+            val primaryIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                Intent(Settings.ACTION_APP_OPEN_BY_DEFAULT_SETTINGS, packageUri)
+            } else {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+            }
+            val fallbackIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, packageUri)
+            val intent = primaryIntent.takeIf { it.resolveActivity(context.packageManager) != null } ?: fallbackIntent
+            runCatching { context.startActivity(intent) }
+            Unit
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -568,6 +568,7 @@ private fun ProviderCatalogSettings(
     onOpenCredentialBackup: () -> Unit,
 ) {
     val credentialBackupActions = LocalProviderCredentialBackupActions.current
+    val openSupportedLinksSettings = rememberSupportedLinksSettingsAction()
     val ordered = remember(state.availableProviders, state.providerOrderIds) {
         val order = state.providerOrderIds.withIndex().associate { it.value to it.index }
         state.availableProviders.sortedBy { order[it.providerId] ?: Int.MAX_VALUE }
@@ -649,6 +650,23 @@ private fun ProviderCatalogSettings(
                 },
             )
             if (index < ordered.lastIndex) SettingsDivider()
+        }
+    }
+    openSupportedLinksSettings?.let { action ->
+        SettingsGroup(title = "链接打开") {
+            SettingsRow(
+                title = "支持的链接",
+                supportingText = "前往系统设置，按需开启网易云、QQ 音乐、哔哩哔哩和 YouTube Music 链接",
+                leadingContent = { Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null) },
+                trailingContent = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                onClick = action,
+            )
         }
     }
     if (credentialBackupActions.isAvailable) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SupportedLinksSettings.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SupportedLinksSettings.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun rememberSupportedLinksSettingsAction(): (() -> Unit)?

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.desktop.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun rememberSupportedLinksSettingsAction(): (() -> Unit)? = null

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/SupportedLinksSettings.ios.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun rememberSupportedLinksSettingsAction(): (() -> Unit)? = null


### PR DESCRIPTION
## 变更

- 保留 `feeluown.github.io` 的已验证 App Link 配置不变
- 为网易云音乐、哔哩哔哩、QQ 音乐、YouTube Music 已支持的网页链接域名注册非验证 `VIEW` intent-filter
- 复用现有分享链接解析与资源详情路由，支持冷启动及 `singleTop` 前台 `onNewIntent` 打开对应歌曲/歌单/歌手/专辑页面
- 在「设置 > 音源与账号」增加「支持的链接」入口
  - Android 12+ 直接打开系统「默认打开 / 支持的链接」页面
  - 较旧 Android 回退到应用详情页
  - iOS / Desktop 不展示 Android 专属入口

## 注册域名

- 网易云：`music.163.com`、`y.music.163.com`
- 哔哩哔哩：`bilibili.com`、`www.bilibili.com`、`m.bilibili.com`
- QQ 音乐：`y.qq.com`、`i.y.qq.com`
- YouTube Music：`music.youtube.com`、`youtube.com`、`www.youtube.com`、`youtu.be`

这些域名不启用 `autoVerify`，由用户在系统应用详情中按需勾选。