### PR TITLE
fix: keep provider auth session state after OAuth login

### DIFF
--- a/feature/providerauth/src/commonMain/kotlin/org/feeluown/mobile/ProviderAuthFeature.kt
+++ b/feature/providerauth/src/commonMain/kotlin/org/feeluown/mobile/ProviderAuthFeature.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
@@ -476,6 +477,6 @@ private class DefaultProviderAuthFeatureOwner<Provider, Auth, Session>(
     }
 
     private inline fun update(block: ProviderAuthFeatureState<Session>.() -> ProviderAuthFeatureState<Session>) {
-        mutableState.value = mutableState.value.block()
+        mutableState.update { current -> current.block() }
     }
 }

--- a/feature/providerauth/src/commonTest/kotlin/org/feeluown/mobile/feature/providerauth/ProviderAuthFeatureTest.kt
+++ b/feature/providerauth/src/commonTest/kotlin/org/feeluown/mobile/feature/providerauth/ProviderAuthFeatureTest.kt
@@ -45,6 +45,7 @@ class ProviderAuthFeatureTest {
         runCurrent()
 
         assertTrue(session.oauthLoggedIn)
+        assertTrue(owner.authStateFor(Provider("ytmusic")).loggedIn)
         assertEquals(null, owner.state.value.oauthFlow)
         assertTrue(owner.state.value.feedback.orEmpty().contains("已通过 OAuth 登录"))
     }


### PR DESCRIPTION
## Summary
- make `ProviderAuthFeature` state mutations atomic with `MutableStateFlow.update`
- prevent concurrent feedback/UI updates from overwriting a newly published provider session
- extend the OAuth flow test to assert the feature itself observes the logged-in session

## Root cause
OAuth credentials were persisted correctly, but `ProviderAuthFeature` performed non-atomic read-modify-write updates (`mutableState.value = mutableState.value.block()`). The session collector and OAuth feedback coroutine could race, allowing the feedback update to restore an older `sessions` snapshot. This produced the observed state where the UI showed “未登录” while feedback said OAuth login succeeded; restarting the app reloaded the persisted credentials and restored the correct state.