### PR TITLE
fix: harden Bilibili video playback fallbacks

### DIFF
--- a/provider/api/src/commonMain/kotlin/org/feeluown/mobile/ProviderContracts.kt
+++ b/provider/api/src/commonMain/kotlin/org/feeluown/mobile/ProviderContracts.kt
@@ -148,6 +148,9 @@ data class VideoPlaybackPayload(
     val audioUrl: String = "",
     val headers: Map<String, String> = emptyMap(),
     val quality: String? = null,
+    val fallbackUrls: List<String> = emptyList(),
+    val fallbackVideoUrls: List<String> = emptyList(),
+    val fallbackAudioUrls: List<String> = emptyList(),
 )
 
 const val PROVIDER_PAGE_SIZE = 50

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProtocolSupport.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProtocolSupport.kt
@@ -1,8 +1,11 @@
 package org.feeluown.mobile.provider.bilibili
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import org.feeluown.mobile.AudioQualityPolicy
 import org.feeluown.mobile.provider.core.ProviderCredentials
+import org.feeluown.mobile.provider.core.array
 import org.feeluown.mobile.provider.core.long
 import org.feeluown.mobile.provider.core.parseCookies
 import org.feeluown.mobile.provider.core.splitResourceId
@@ -40,10 +43,18 @@ internal fun selectAudio(
     return SelectedAudio(selected, selected.qualityLabel())
 }
 
+internal fun orderVideoStreams(video: List<VideoStream>): List<VideoStream> =
+    video.sortedWith(
+        compareByDescending<VideoStream> { it.codecCompatibilityRank() }
+            .thenByDescending { it.bandwidth },
+    )
+
 internal fun JsonObject.toAudioStream(isFlac: Boolean = false): AudioStream? {
-    val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
+    val urls = mediaUrls()
+    val url = urls.firstOrNull() ?: return null
     return AudioStream(
         url = url,
+        backupUrls = urls.drop(1),
         bandwidth = long("bandwidth") ?: 0L,
         durationMs = long("length"),
         isFlac = isFlac,
@@ -51,10 +62,14 @@ internal fun JsonObject.toAudioStream(isFlac: Boolean = false): AudioStream? {
 }
 
 internal fun JsonObject.toVideoStream(): VideoStream? {
-    val url = stringOrNull("baseUrl") ?: stringOrNull("base_url") ?: return null
+    val urls = mediaUrls()
+    val url = urls.firstOrNull() ?: return null
     return VideoStream(
         url = url,
+        backupUrls = urls.drop(1),
         bandwidth = long("bandwidth") ?: 0L,
+        codecId = long("codecid"),
+        codecs = stringOrNull("codecs"),
     )
 }
 
@@ -121,10 +136,14 @@ internal data class WbiKeys(val mixinKey: String)
 
 internal data class AudioStream(
     val url: String,
+    val backupUrls: List<String> = emptyList(),
     val bandwidth: Long,
     val durationMs: Long?,
     val isFlac: Boolean = false,
-)
+) {
+    val urls: List<String>
+        get() = listOf(url) + backupUrls
+}
 
 internal data class SelectedAudio(
     val stream: AudioStream,
@@ -133,8 +152,34 @@ internal data class SelectedAudio(
 
 internal data class VideoStream(
     val url: String,
+    val backupUrls: List<String> = emptyList(),
     val bandwidth: Long,
-)
+    val codecId: Long? = null,
+    val codecs: String? = null,
+) {
+    val urls: List<String>
+        get() = listOf(url) + backupUrls
+}
+
+private fun JsonObject.mediaUrls(): List<String> = buildList {
+    val baseUrl = stringOrNull("baseUrl") ?: stringOrNull("base_url")
+    if (!baseUrl.isNullOrBlank()) add(baseUrl)
+    array("backupUrl").forEach { element ->
+        element.jsonPrimitive.contentOrNull?.takeIf { it.isNotBlank() }?.let(::add)
+    }
+    array("backup_url").forEach { element ->
+        element.jsonPrimitive.contentOrNull?.takeIf { it.isNotBlank() }?.let(::add)
+    }
+}.distinct()
+
+private fun VideoStream.codecCompatibilityRank(): Int = when {
+    codecId == 7L || codecs.orEmpty().startsWith("avc", ignoreCase = true) -> 3
+    codecId == 12L ||
+        codecs.orEmpty().startsWith("hev", ignoreCase = true) ||
+        codecs.orEmpty().startsWith("hvc", ignoreCase = true) -> 2
+    codecId == 13L || codecs.orEmpty().startsWith("av01", ignoreCase = true) -> 1
+    else -> 0
+}
 
 private fun AudioStream.qualityLabel(): String = when {
     isFlac -> "SHQ"

--- a/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
+++ b/provider/bilibili/src/commonMain/kotlin/org/feeluown/mobile/provider/bilibili/BilibiliProvider.kt
@@ -214,21 +214,26 @@ class BilibiliProvider(
         val cid = pageInfo?.long("cid") ?: info.long("cid") ?: return VideoPlaybackPayload(video = video)
         val data = playUrlData(bvid, cid) ?: return VideoPlaybackPayload(video = video)
         val dash = data.obj("dash")
-        val videoStream = dash?.array("video").orEmpty()
-            .mapNotNull { it.asObject().toVideoStream() }
-            .maxByOrNull { it.bandwidth }
+        val videoStreams = orderVideoStreams(
+            dash?.array("video").orEmpty().mapNotNull { it.asObject().toVideoStream() },
+        )
+        val videoStream = videoStreams.firstOrNull()
         val audio = selectAudio(
             qualityPolicy = AudioQualityPolicy.High.policy,
             audio = dash?.array("audio").orEmpty().mapNotNull { it.asObject().toAudioStream() },
             flac = dash?.obj("flac")?.obj("audio")?.toAudioStream(isFlac = true),
         )
         if (videoStream != null && audio != null) {
+            val videoUrls = videoStreams.flatMap { it.urls }.distinct()
+            val audioUrls = audio.stream.urls.distinct()
             return VideoPlaybackPayload(
                 video = video,
                 videoUrl = videoStream.url,
                 audioUrl = audio.stream.url,
                 headers = mediaHeaders(),
                 quality = "video",
+                fallbackVideoUrls = videoUrls.filterNot { it == videoStream.url },
+                fallbackAudioUrls = audioUrls.filterNot { it == audio.stream.url },
             )
         }
         val durl = data.array("durl").firstOrNull()?.asObject()?.stringOrNull("url")

--- a/provider/bilibili/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
+++ b/provider/bilibili/src/commonTest/kotlin/org/feeluown/mobile/BilibiliProviderTest.kt
@@ -177,7 +177,7 @@ class BilibiliProviderTest {
     }
 
     @Test
-    fun videoPlaybackUsesSeparateDashVideoAndAudioStreams() = runTest {
+    fun videoPlaybackPrefersAvcAndPreservesDashFallbacks() = runTest {
         val client = ProviderHttpClient(
             HttpClient(MockEngine) {
                 engine {
@@ -193,7 +193,7 @@ class BilibiliProviderTest {
                                 assertEquals("16", request.url.parameters["fnval"])
                                 assertEquals("123", request.url.parameters["cid"])
                                 respond(
-                                    """{"code":0,"data":{"dash":{"video":[{"baseUrl":"https://example.test/video-lq.m4s","bandwidth":500000},{"base_url":"https://example.test/video-hq.m4s","bandwidth":2000000}],"audio":[{"baseUrl":"https://example.test/audio-lq.m4s","bandwidth":96000},{"base_url":"https://example.test/audio-hq.m4s","bandwidth":320000}]}}}""",
+                                    """{"code":0,"data":{"dash":{"video":[{"baseUrl":"https://example.test/video-av1.m4s","backupUrl":["https://backup.test/video-av1.m4s"],"bandwidth":3000000,"codecid":13,"codecs":"av01.0.08M.08"},{"base_url":"https://example.test/video-avc.m4s","backup_url":["https://backup.test/video-avc.m4s"],"bandwidth":1800000,"codecid":7,"codecs":"avc1.640028"},{"baseUrl":"https://example.test/video-hevc.m4s","bandwidth":2500000,"codecid":12,"codecs":"hev1.1.6.L120.90"}],"audio":[{"baseUrl":"https://example.test/audio-lq.m4s","bandwidth":96000},{"base_url":"https://example.test/audio-hq.m4s","backupUrl":["https://backup.test/audio-hq.m4s"],"bandwidth":320000}]}}}""",
                                 )
                             }
                             else -> error("unexpected Bilibili request: ${request.url.encodedPath}")
@@ -213,8 +213,18 @@ class BilibiliProviderTest {
         val payload = provider.videoPlaybackPayload(video)
 
         assertEquals("", payload.url)
-        assertEquals("https://example.test/video-hq.m4s", payload.videoUrl)
+        assertEquals("https://example.test/video-avc.m4s", payload.videoUrl)
         assertEquals("https://example.test/audio-hq.m4s", payload.audioUrl)
+        assertEquals(
+            listOf(
+                "https://backup.test/video-avc.m4s",
+                "https://example.test/video-hevc.m4s",
+                "https://example.test/video-av1.m4s",
+                "https://backup.test/video-av1.m4s",
+            ),
+            payload.fallbackVideoUrls,
+        )
+        assertEquals(listOf("https://backup.test/audio-hq.m4s"), payload.fallbackAudioUrls)
         assertEquals("video", payload.quality)
         client.close()
     }

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
@@ -44,9 +44,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 private const val VIDEO_PLAYER_TAG = "FuoVideoPlayer"
+private const val MAX_VIDEO_SOURCE_CANDIDATES = 24
+
+private data class VideoSourceCandidate(
+    val url: String = "",
+    val videoUrl: String = "",
+    val audioUrl: String = "",
+) {
+    val isMerged: Boolean
+        get() = url.isBlank()
+}
 
 @OptIn(UnstableApi::class)
 private class AndroidPlatformVideoController(context: Context) : PlatformVideoController {
+    private val appContext = context.applicationContext
     private val _state = MutableStateFlow(PlatformVideoPlaybackState())
     override val state: StateFlow<PlatformVideoPlaybackState> = _state
 
@@ -54,6 +65,8 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
     private var videoWidth: Int = 0
     private var videoHeight: Int = 0
     private var activePayload: VideoPlaybackPayload? = null
+    private var activeCandidates: List<VideoSourceCandidate> = emptyList()
+    private var activeCandidateIndex: Int = -1
 
     val player: ExoPlayer = ExoPlayer.Builder(context)
         .setRenderersFactory(
@@ -66,13 +79,17 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
             exoPlayer.addListener(object : Player.Listener {
                 override fun onPlayerError(error: PlaybackException) {
                     val rootCause = error.rootCause()
+                    val candidate = activeCandidates.getOrNull(activeCandidateIndex)
                     Log.e(
                         VIDEO_PLAYER_TAG,
                         "Video playback failed: code=${error.errorCodeName}, " +
                             "cause=${rootCause::class.java.name}: ${rootCause.message.orEmpty()}, " +
+                            "candidate=${activeCandidateIndex + 1}/${activeCandidates.size}, " +
+                            "source=${candidate?.debugDescription().orEmpty()}, " +
                             "payload=${activePayload?.debugDescription().orEmpty()}",
                         error,
                     )
+                    if (retryNextCandidate()) return
                     playbackError = "视频播放失败：${error.errorCodeName}"
                     publishState()
                 }
@@ -94,18 +111,28 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
         }
 
     fun setPayload(context: Context, payload: VideoPlaybackPayload?) {
-        if (payload == null || !payload.isPlayable()) {
+        if (payload == null) {
+            clear()
+            return
+        }
+        val candidates = payload.sourceCandidates()
+        if (candidates.isEmpty()) {
             clear()
             return
         }
         if (payload == activePayload) return
         activePayload = payload
+        activeCandidates = candidates
+        activeCandidateIndex = 0
         playbackError = null
         videoWidth = 0
         videoHeight = 0
-        player.setMediaSource(payload.toMediaSource(context))
-        player.prepare()
-        player.playWhenReady = true
+        prepareCandidate(
+            context = context.applicationContext,
+            index = activeCandidateIndex,
+            positionMs = 0,
+            playWhenReady = true,
+        )
         publishState()
     }
 
@@ -142,6 +169,8 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
         player.stop()
         player.clearMediaItems()
         activePayload = null
+        activeCandidates = emptyList()
+        activeCandidateIndex = -1
         playbackError = null
         videoWidth = 0
         videoHeight = 0
@@ -150,6 +179,42 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
 
     fun release() {
         player.release()
+    }
+
+    private fun retryNextCandidate(): Boolean {
+        val nextIndex = activeCandidateIndex + 1
+        if (nextIndex !in activeCandidates.indices) return false
+        val positionMs = player.currentPosition.coerceAtLeast(0)
+        val shouldPlay = player.playWhenReady || player.isPlaying
+        activeCandidateIndex = nextIndex
+        playbackError = null
+        Log.w(
+            VIDEO_PLAYER_TAG,
+            "Retrying video playback with candidate ${nextIndex + 1}/${activeCandidates.size}: " +
+                activeCandidates[nextIndex].debugDescription(),
+        )
+        prepareCandidate(
+            context = appContext,
+            index = nextIndex,
+            positionMs = positionMs,
+            playWhenReady = shouldPlay,
+        )
+        publishState()
+        return true
+    }
+
+    private fun prepareCandidate(
+        context: Context,
+        index: Int,
+        positionMs: Long,
+        playWhenReady: Boolean,
+    ) {
+        val payload = activePayload ?: return
+        val candidate = activeCandidates.getOrNull(index) ?: return
+        player.setMediaSource(candidate.toMediaSource(context, payload.headers))
+        player.prepare()
+        if (positionMs > 0) player.seekTo(positionMs)
+        player.playWhenReady = playWhenReady
     }
 
     private fun publishState() {
@@ -203,7 +268,15 @@ actual fun PlatformVideoPlayer(
         VideoPlaceholder("视频地址不可用", modifier)
         return
     }
-    LaunchedEffect(payload.url, payload.videoUrl, payload.audioUrl, payload.headers) {
+    LaunchedEffect(
+        payload.url,
+        payload.videoUrl,
+        payload.audioUrl,
+        payload.headers,
+        payload.fallbackUrls,
+        payload.fallbackVideoUrls,
+        payload.fallbackAudioUrls,
+    ) {
         androidController.setPayload(context.applicationContext, payload)
     }
     AndroidView(
@@ -280,26 +353,56 @@ private fun VideoPlaceholder(text: String, modifier: Modifier) {
     }
 }
 
-private fun VideoPlaybackPayload.isPlayable(): Boolean =
-    url.isNotBlank() || (videoUrl.isNotBlank() && audioUrl.isNotBlank())
+private fun VideoPlaybackPayload.isPlayable(): Boolean = sourceCandidates().isNotEmpty()
+
+private fun VideoPlaybackPayload.sourceCandidates(): List<VideoSourceCandidate> {
+    val candidates = mutableListOf<VideoSourceCandidate>()
+    (listOf(url) + fallbackUrls)
+        .filter { it.isNotBlank() }
+        .distinct()
+        .forEach { mediaUrl -> candidates += VideoSourceCandidate(url = mediaUrl) }
+
+    if (videoUrl.isNotBlank() && audioUrl.isNotBlank()) {
+        val videos = (listOf(videoUrl) + fallbackVideoUrls).filter { it.isNotBlank() }.distinct()
+        val audios = (listOf(audioUrl) + fallbackAudioUrls).filter { it.isNotBlank() }.distinct()
+        if (videos.isNotEmpty() && audios.isNotEmpty()) {
+            candidates += VideoSourceCandidate(videoUrl = videos.first(), audioUrl = audios.first())
+            videos.drop(1).forEach { fallbackVideo ->
+                candidates += VideoSourceCandidate(videoUrl = fallbackVideo, audioUrl = audios.first())
+            }
+            audios.drop(1).forEach { fallbackAudio ->
+                candidates += VideoSourceCandidate(videoUrl = videos.first(), audioUrl = fallbackAudio)
+            }
+            videos.drop(1).forEach { fallbackVideo ->
+                audios.drop(1).forEach { fallbackAudio ->
+                    candidates += VideoSourceCandidate(videoUrl = fallbackVideo, audioUrl = fallbackAudio)
+                }
+            }
+        }
+    }
+
+    return candidates.distinct().take(MAX_VIDEO_SOURCE_CANDIDATES)
+}
 
 @OptIn(UnstableApi::class)
-private fun VideoPlaybackPayload.toMediaSource(context: Context) =
-    if (url.isNotBlank()) {
-        ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
-            .createMediaSource(MediaItem.fromUri(Uri.parse(url)))
-    } else {
-        val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
-            .createMediaSource(MediaItem.fromUri(Uri.parse(videoUrl)))
-        val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
-            .createMediaSource(MediaItem.fromUri(Uri.parse(audioUrl)))
-        MergingMediaSource(
-            true,
-            true,
-            videoSource,
-            audioSource,
-        )
-    }
+private fun VideoSourceCandidate.toMediaSource(
+    context: Context,
+    headers: Map<String, String>,
+) = if (url.isNotBlank()) {
+    ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
+        .createMediaSource(MediaItem.fromUri(Uri.parse(url)))
+} else {
+    val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
+        .createMediaSource(MediaItem.fromUri(Uri.parse(videoUrl)))
+    val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
+        .createMediaSource(MediaItem.fromUri(Uri.parse(audioUrl)))
+    MergingMediaSource(
+        true,
+        true,
+        videoSource,
+        audioSource,
+    )
+}
 
 @OptIn(UnstableApi::class)
 private fun dataSourceFactory(context: Context, headers: Map<String, String>): DefaultDataSource.Factory {
@@ -324,8 +427,13 @@ private fun VideoPlaybackPayload.debugDescription(): String = buildString {
     append(video.providerId)
     append(", videoId=")
     append(video.id)
-    append(", merged=")
-    append(url.isBlank())
+    append(", candidates=")
+    append(sourceCandidates().size)
+}
+
+private fun VideoSourceCandidate.debugDescription(): String = buildString {
+    append("merged=")
+    append(isMerged)
     append(", videoHost=")
     append(videoUrl.hostForLog())
     append(", audioHost=")

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
@@ -6,6 +6,7 @@ import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.net.Uri
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
@@ -42,6 +43,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+private const val VIDEO_PLAYER_TAG = "FuoVideoPlayer"
+
 @OptIn(UnstableApi::class)
 private class AndroidPlatformVideoController(context: Context) : PlatformVideoController {
     private val _state = MutableStateFlow(PlatformVideoPlaybackState())
@@ -62,6 +65,14 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
         .also { exoPlayer ->
             exoPlayer.addListener(object : Player.Listener {
                 override fun onPlayerError(error: PlaybackException) {
+                    val rootCause = error.rootCause()
+                    Log.e(
+                        VIDEO_PLAYER_TAG,
+                        "Video playback failed: code=${error.errorCodeName}, " +
+                            "cause=${rootCause::class.java.name}: ${rootCause.message.orEmpty()}, " +
+                            "payload=${activePayload?.debugDescription().orEmpty()}",
+                        error,
+                    )
                     playbackError = "视频播放失败：${error.errorCodeName}"
                     publishState()
                 }
@@ -278,11 +289,15 @@ private fun VideoPlaybackPayload.toMediaSource(context: Context) =
         ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
             .createMediaSource(MediaItem.fromUri(Uri.parse(url)))
     } else {
+        val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
+            .createMediaSource(MediaItem.fromUri(Uri.parse(videoUrl)))
+        val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
+            .createMediaSource(MediaItem.fromUri(Uri.parse(audioUrl)))
         MergingMediaSource(
-            ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
-                .createMediaSource(MediaItem.fromUri(Uri.parse(videoUrl))),
-            ProgressiveMediaSource.Factory(dataSourceFactory(context, headers))
-                .createMediaSource(MediaItem.fromUri(Uri.parse(audioUrl))),
+            true,
+            true,
+            videoSource,
+            audioSource,
         )
     }
 
@@ -295,6 +310,34 @@ private fun dataSourceFactory(context: Context, headers: Map<String, String>): D
         .setAllowCrossProtocolRedirects(true)
     return DefaultDataSource.Factory(context, httpFactory)
 }
+
+private fun PlaybackException.rootCause(): Throwable {
+    var current: Throwable = this
+    while (current.cause != null && current.cause !== current) {
+        current = current.cause!!
+    }
+    return current
+}
+
+private fun VideoPlaybackPayload.debugDescription(): String = buildString {
+    append("provider=")
+    append(video.providerId)
+    append(", videoId=")
+    append(video.id)
+    append(", merged=")
+    append(url.isBlank())
+    append(", videoHost=")
+    append(videoUrl.hostForLog())
+    append(", audioHost=")
+    append(audioUrl.hostForLog())
+    append(", mediaHost=")
+    append(url.hostForLog())
+}
+
+private fun String.hostForLog(): String =
+    takeIf { it.isNotBlank() }
+        ?.let { value -> runCatching { Uri.parse(value).host.orEmpty() }.getOrDefault("") }
+        .orEmpty()
 
 private tailrec fun Context.findActivity(): Activity? = when (this) {
     is Activity -> this


### PR DESCRIPTION
## Summary

- prefer Bilibili AVC DASH video streams first for broad Android decoder compatibility, while preserving HEVC/AV1 as fallbacks
- preserve Bilibili `backupUrl` / `backup_url` CDN candidates for DASH video and audio
- extend `VideoPlaybackPayload` with provider-neutral fallback URL lists
- automatically retry Android video playback across alternate CDN/codec candidates instead of failing on the first source
- align split video/audio timestamps and clip durations when building `MergingMediaSource`
- log the complete Media3 cause chain plus provider/video/CDN host context after source failures without exposing signed URLs

## Why

`BV18qtR6CE9h` can fail immediately on Android with `ERROR_CODE_IO_UNSPECIFIED`. The previous path selected the single highest-bandwidth Bilibili video representation, discarded codec/CDN fallback information, and used the default `MergingMediaSource` behavior. Any source/extractor/CDN problem therefore ended playback immediately, while the useful underlying exception was hidden.

The new path uses a compatibility-first primary representation and keeps the remaining representations/CDNs as ordered fallbacks. Android retries those candidates automatically, so a failing Bilibili CDN or representation no longer makes the whole video unplayable.

## Tests

- verify AVC is selected ahead of higher-bandwidth HEVC/AV1 representations
- verify Bilibili video/audio backup URLs are preserved in the playback payload
- existing provider and Android/shared CI checks remain enabled

Target regression scenario: `https://www.bilibili.com/video/BV18qtR6CE9h`.