### PR TITLE
fix: align predictive back motion with Navigation 3

### DIFF
--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import android.content.Context
 import android.os.Build
+import androidx.activity.BackEventCompat
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.runtime.Composable
@@ -74,14 +75,25 @@ internal actual fun PlatformLegacyBackHandler(
 @Composable
 internal actual fun PlatformPredictiveBackHandler(
     enabled: Boolean,
-    onProgress: (Float) -> Unit,
+    onProgress: (PredictiveBackGestureEvent) -> Unit,
     onCancelled: () -> Unit,
     onBack: () -> Unit,
 ) {
     PredictiveBackHandler(enabled = enabled && AndroidPredictiveBackPreference.isSupported) { progress ->
         try {
             progress.collect { backEvent ->
-                onProgress(backEvent.progress.coerceIn(0f, 1f))
+                onProgress(
+                    PredictiveBackGestureEvent(
+                        progress = backEvent.progress.coerceIn(0f, 1f),
+                        touchX = backEvent.touchX,
+                        touchY = backEvent.touchY,
+                        swipeEdge = when (backEvent.swipeEdge) {
+                            BackEventCompat.EDGE_LEFT -> PredictiveBackSwipeEdge.Left
+                            BackEventCompat.EDGE_RIGHT -> PredictiveBackSwipeEdge.Right
+                            else -> PredictiveBackSwipeEdge.None
+                        },
+                    ),
+                )
             }
             onBack()
         } catch (cancellation: CancellationException) {

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.android.kt
@@ -3,12 +3,15 @@ package org.feeluown.mobile
 import android.content.Context
 import android.os.Build
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.collect
 
 private const val PLATFORM_SETTINGS_PREFERENCES = "fuo_evolve_platform_settings"
 private const val PREDICTIVE_BACK_ENABLED_KEY = "predictive_back_enabled"
@@ -66,4 +69,24 @@ internal actual fun PlatformLegacyBackHandler(
     onBack: () -> Unit,
 ) {
     BackHandler(enabled = enabled, onBack = onBack)
+}
+
+@Composable
+internal actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancelled: () -> Unit,
+    onBack: () -> Unit,
+) {
+    PredictiveBackHandler(enabled = enabled && AndroidPredictiveBackPreference.isSupported) { progress ->
+        try {
+            progress.collect { backEvent ->
+                onProgress(backEvent.progress.coerceIn(0f, 1f))
+            }
+            onBack()
+        } catch (cancellation: CancellationException) {
+            onCancelled()
+            throw cancellation
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -62,8 +62,11 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
             predictiveProgress = 0f
         },
         onBack = {
-            predictiveBackCommitted = true
-            predictiveProgress = 1f
+            if (predictiveGestureActive) {
+                predictiveBackCommitted = true
+                predictiveProgress = 1f
+            }
+            predictiveGestureActive = false
             playback.navigation.closeFullPlayer()
         },
     )
@@ -81,8 +84,8 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
         },
     ) {
         val progress = renderedPredictiveProgress.coerceIn(0f, 1f)
-        // Full player keeps its normal overlay motion for explicit controls. During a predictive
-        // system-back gesture it follows the finger, revealing the route underneath before commit.
+        // Full player keeps its normal overlay motion for explicit controls and non-gesture Back.
+        // During a predictive system-back gesture it follows the finger and previews the route below.
         CompositionLocalProvider(LocalAppSharedTransitionScope provides null) {
             Box(
                 modifier = Modifier

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -85,18 +85,17 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
         },
     ) {
         val progress = renderedPredictiveProgress.coerceIn(0f, 1f)
-        // Full player keeps its normal overlay motion for explicit controls and non-gesture Back.
-        // During a predictive system-back gesture it follows the finger and previews the route below.
+        // Keep the full-player gesture restrained: enough motion to reveal the route underneath,
+        // but not enough to make the player feel detached from the finger or suddenly collapse.
         CompositionLocalProvider(LocalAppSharedTransitionScope provides null) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .graphicsLayer {
-                        val scale = 1f - (0.04f * progress)
+                        val scale = 1f - (0.018f * progress)
                         scaleX = scale
                         scaleY = scale
-                        translationY = 32.dp.toPx() * progress
-                        alpha = 1f - (0.08f * progress)
+                        translationY = 14.dp.toPx() * progress
                     },
             ) {
                 RuntimeFullPlayer()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -52,9 +52,10 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
     PlatformPredictiveBackHandler(
         enabled = predictiveBackPreference.isSupported &&
             predictiveBackPreference.enabled &&
-            playback.isFullPlayerOpen,
+            playback.isFullPlayerOpen &&
+            !playback.navigation.isQueueOpen,
         onProgress = { progress ->
-            predictiveGestureActive = true
+            if (progress > 0f) predictiveGestureActive = true
             predictiveProgress = progress
         },
         onCancelled = {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -20,31 +21,62 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
     val playback = uiGraph.playback
     val predictiveBackPreference = rememberPredictiveBackPreference()
+    val density = LocalDensity.current
     val overlaySpatialSpec = FuoMotion.defaultSpatialSpec<IntOffset>()
     val overlayEffectsSpec = FuoMotion.fastEffectsSpec<Float>()
     val predictiveReturnSpec = FuoMotion.fastSpatialSpec<Float>()
+    val maxVerticalGestureDistancePx = with(density) { 240.dp.toPx() }
+    val maxVerticalFollowPx = with(density) { 18.dp.toPx() }
+    val horizontalFollowPx = with(density) { 6.dp.toPx() }
+
     var predictiveProgress by remember { mutableFloatStateOf(0f) }
+    var predictiveVerticalOffsetPx by remember { mutableFloatStateOf(0f) }
+    var predictiveHorizontalOffsetPx by remember { mutableFloatStateOf(0f) }
+    var predictiveGestureStartTouchY by remember { mutableStateOf<Float?>(null) }
+    var predictiveSwipeEdge by remember { mutableStateOf(PredictiveBackSwipeEdge.None) }
     var predictiveGestureActive by remember { mutableStateOf(false) }
     var predictiveBackCommitted by remember { mutableStateOf(false) }
+
     val renderedPredictiveProgress by animateFloatAsState(
         targetValue = predictiveProgress,
         animationSpec = if (predictiveGestureActive) snap() else predictiveReturnSpec,
         label = "Full player predictive back progress",
     )
+    val renderedVerticalOffsetPx by animateFloatAsState(
+        targetValue = predictiveVerticalOffsetPx,
+        animationSpec = if (predictiveGestureActive) snap() else predictiveReturnSpec,
+        label = "Full player predictive back vertical follow",
+    )
+    val renderedHorizontalOffsetPx by animateFloatAsState(
+        targetValue = predictiveHorizontalOffsetPx,
+        animationSpec = if (predictiveGestureActive) snap() else predictiveReturnSpec,
+        label = "Full player predictive back horizontal follow",
+    )
+
+    fun resetPredictiveGestureTargets() {
+        predictiveGestureActive = false
+        predictiveProgress = 0f
+        predictiveVerticalOffsetPx = 0f
+        predictiveHorizontalOffsetPx = 0f
+        predictiveGestureStartTouchY = null
+    }
 
     LaunchedEffect(playback.isFullPlayerOpen) {
         if (!playback.isFullPlayerOpen) {
-            predictiveProgress = 0f
-            predictiveGestureActive = false
+            resetPredictiveGestureTargets()
+            predictiveSwipeEdge = PredictiveBackSwipeEdge.None
             predictiveBackCommitted = false
         }
     }
@@ -54,14 +86,31 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
             predictiveBackPreference.enabled &&
             playback.isFullPlayerOpen &&
             !playback.navigation.isQueueOpen,
-        onProgress = { progress ->
-            if (progress > 0f) predictiveGestureActive = true
-            predictiveProgress = progress
+        onProgress = { event ->
+            if (!predictiveGestureActive && event.progress > 0f) {
+                predictiveGestureActive = true
+                predictiveGestureStartTouchY = event.touchY
+            }
+            predictiveProgress = event.progress
+            predictiveSwipeEdge = event.swipeEdge
+
+            val startTouchY = predictiveGestureStartTouchY ?: event.touchY
+            val rawDeltaY = event.touchY - startTouchY
+            val normalizedDelta = (abs(rawDeltaY) / maxVerticalGestureDistancePx).coerceIn(0f, 1f)
+            val easedDelta = normalizedDelta * (2f - normalizedDelta)
+            val direction = when {
+                rawDeltaY > 0f -> 1f
+                rawDeltaY < 0f -> -1f
+                else -> 0f
+            }
+            predictiveVerticalOffsetPx = direction * maxVerticalFollowPx * easedDelta * event.progress
+            predictiveHorizontalOffsetPx = when (event.swipeEdge) {
+                PredictiveBackSwipeEdge.Left -> horizontalFollowPx * event.progress
+                PredictiveBackSwipeEdge.Right -> -horizontalFollowPx * event.progress
+                PredictiveBackSwipeEdge.None -> 0f
+            }
         },
-        onCancelled = {
-            predictiveGestureActive = false
-            predictiveProgress = 0f
-        },
+        onCancelled = ::resetPredictiveGestureTargets,
         onBack = {
             if (predictiveGestureActive) {
                 predictiveBackCommitted = true
@@ -85,8 +134,17 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
         },
     ) {
         val progress = renderedPredictiveProgress.coerceIn(0f, 1f)
-        // Keep the full-player gesture restrained: enough motion to reveal the route underneath,
-        // but not enough to make the player feel detached from the finger or suddenly collapse.
+        val cornerProgress = ((progress - 0.06f) / 0.94f).coerceIn(0f, 1f)
+        val predictiveShape = RoundedCornerShape(28.dp * cornerProgress)
+        val transformOrigin = when (predictiveSwipeEdge) {
+            PredictiveBackSwipeEdge.Left -> TransformOrigin(0.18f, 0.5f)
+            PredictiveBackSwipeEdge.Right -> TransformOrigin(0.82f, 0.5f)
+            PredictiveBackSwipeEdge.None -> TransformOrigin.Center
+        }
+
+        // The predictive surface behaves like a restrained window: it recedes slightly, gains
+        // rounded corners as it detaches from fullscreen, and follows vertical finger movement only
+        // within a small bounded range rather than tracking the pointer 1:1.
         CompositionLocalProvider(LocalAppSharedTransitionScope provides null) {
             Box(
                 modifier = Modifier
@@ -95,7 +153,11 @@ internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
                         val scale = 1f - (0.018f * progress)
                         scaleX = scale
                         scaleY = scale
-                        translationY = 14.dp.toPx() * progress
+                        translationX = renderedHorizontalOffsetPx
+                        translationY = renderedVerticalOffsetPx
+                        this.transformOrigin = transformOrigin
+                        shape = predictiveShape
+                        clip = cornerProgress > 0f
                     },
             ) {
                 RuntimeFullPlayer()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppGlobalOverlays.kt
@@ -1,34 +1,102 @@
 package org.feeluown.mobile
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 internal fun AppGlobalOverlays(uiGraph: AppUiGraph) {
     val playback = uiGraph.playback
+    val predictiveBackPreference = rememberPredictiveBackPreference()
     val overlaySpatialSpec = FuoMotion.defaultSpatialSpec<IntOffset>()
     val overlayEffectsSpec = FuoMotion.fastEffectsSpec<Float>()
+    val predictiveReturnSpec = FuoMotion.fastSpatialSpec<Float>()
+    var predictiveProgress by remember { mutableFloatStateOf(0f) }
+    var predictiveGestureActive by remember { mutableStateOf(false) }
+    var predictiveBackCommitted by remember { mutableStateOf(false) }
+    val renderedPredictiveProgress by animateFloatAsState(
+        targetValue = predictiveProgress,
+        animationSpec = if (predictiveGestureActive) snap() else predictiveReturnSpec,
+        label = "Full player predictive back progress",
+    )
+
+    LaunchedEffect(playback.isFullPlayerOpen) {
+        if (!playback.isFullPlayerOpen) {
+            predictiveProgress = 0f
+            predictiveGestureActive = false
+            predictiveBackCommitted = false
+        }
+    }
+
+    PlatformPredictiveBackHandler(
+        enabled = predictiveBackPreference.isSupported &&
+            predictiveBackPreference.enabled &&
+            playback.isFullPlayerOpen,
+        onProgress = { progress ->
+            predictiveGestureActive = true
+            predictiveProgress = progress
+        },
+        onCancelled = {
+            predictiveGestureActive = false
+            predictiveProgress = 0f
+        },
+        onBack = {
+            predictiveBackCommitted = true
+            predictiveProgress = 1f
+            playback.navigation.closeFullPlayer()
+        },
+    )
+
     AnimatedVisibility(
         visible = playback.isFullPlayerOpen,
         modifier = Modifier.fillMaxSize(),
         enter = slideInVertically(animationSpec = overlaySpatialSpec) { it / 2 } +
             fadeIn(animationSpec = overlayEffectsSpec),
-        exit = slideOutVertically(animationSpec = overlaySpatialSpec) { it / 2 } +
-            fadeOut(animationSpec = overlayEffectsSpec),
+        exit = if (predictiveBackCommitted) {
+            ExitTransition.None
+        } else {
+            slideOutVertically(animationSpec = overlaySpatialSpec) { it / 2 } +
+                fadeOut(animationSpec = overlayEffectsSpec)
+        },
     ) {
-        // Full player keeps its normal overlay motion; shared-cover Hero is intentionally disabled.
+        val progress = renderedPredictiveProgress.coerceIn(0f, 1f)
+        // Full player keeps its normal overlay motion for explicit controls. During a predictive
+        // system-back gesture it follows the finger, revealing the route underneath before commit.
         CompositionLocalProvider(LocalAppSharedTransitionScope provides null) {
-            RuntimeFullPlayer()
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        val scale = 1f - (0.04f * progress)
+                        scaleX = scale
+                        scaleY = scale
+                        translationY = 32.dp.toPx() * progress
+                        alpha = 1f - (0.08f * progress)
+                    },
+            ) {
+                RuntimeFullPlayer()
+            }
         }
     }
     LocalMetadataDialog()

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -3,6 +3,8 @@ package org.feeluown.mobile
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -53,6 +55,28 @@ private fun popPageTransition(
     effectsSpec = effectsSpec,
 )
 
+/**
+ * Keep predictive Back visually connected to the gesture without the large 0.7x scale used by
+ * Navigation 3's default transition. The previous route stays close to its final size while the
+ * current route recedes just enough to expose depth. This is intentionally edge-neutral so both
+ * left- and right-edge system gestures behave consistently.
+ */
+private fun predictivePopPageTransition(
+    spatialSpec: FiniteAnimationSpec<Float>,
+    effectsSpec: FiniteAnimationSpec<Float>,
+): ContentTransform = (
+    scaleIn(
+        initialScale = 0.985f,
+        animationSpec = spatialSpec,
+    ) + fadeIn(
+        initialAlpha = 0.92f,
+        animationSpec = effectsSpec,
+    )
+    ) togetherWith scaleOut(
+        targetScale = 0.94f,
+        animationSpec = spatialSpec,
+    )
+
 @Composable
 internal fun AppNavHost(
     backStack: List<AppRoute>,
@@ -65,6 +89,8 @@ internal fun AppNavHost(
     val activeRoute = backStack.lastOrNull()
     val pageSpatialSpec = FuoMotion.defaultSpatialSpec<IntOffset>()
     val pageEffectsSpec = FuoMotion.fastEffectsSpec<Float>()
+    val predictiveSpatialSpec = FuoMotion.defaultSpatialSpec<Float>()
+    val predictiveEffectsSpec = FuoMotion.defaultEffectsSpec<Float>()
 
     LaunchedEffect(activeRoute, uiGraph.playback.queue) {
         uiGraph.playback.queue.setPlaybackContextHint(activeRoute?.toPlaybackContextSnapshot())
@@ -76,6 +102,9 @@ internal fun AppNavHost(
         onBack = { appViewModel.onBack() },
         transitionSpec = { forwardPageTransition(pageSpatialSpec, pageEffectsSpec) },
         popTransitionSpec = { popPageTransition(pageSpatialSpec, pageEffectsSpec) },
+        predictivePopTransitionSpec = {
+            predictivePopPageTransition(predictiveSpatialSpec, predictiveEffectsSpec)
+        },
         entryProvider = { route ->
             NavEntry(key = route) {
                 when (route) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.FiniteAnimationSpec
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -54,34 +53,6 @@ private fun popPageTransition(
     effectsSpec = effectsSpec,
 )
 
-private fun settingsForwardPageTransition(
-    spatialSpec: FiniteAnimationSpec<IntOffset>,
-    effectsSpec: FiniteAnimationSpec<Float>,
-): ContentTransform = pageTransition(
-    initialOffsetX = { -it },
-    targetOffsetX = { it },
-    spatialSpec = spatialSpec,
-    effectsSpec = effectsSpec,
-)
-
-private fun settingsPopPageTransition(
-    spatialSpec: FiniteAnimationSpec<IntOffset>,
-    effectsSpec: FiniteAnimationSpec<Float>,
-): ContentTransform = pageTransition(
-    initialOffsetX = { it },
-    targetOffsetX = { -it },
-    spatialSpec = spatialSpec,
-    effectsSpec = effectsSpec,
-)
-
-private fun settingsNavigationMetadata(
-    spatialSpec: FiniteAnimationSpec<IntOffset>,
-    effectsSpec: FiniteAnimationSpec<Float>,
-): Map<String, Any> =
-    NavDisplay.transitionSpec { settingsForwardPageTransition(spatialSpec, effectsSpec) } +
-        NavDisplay.popTransitionSpec { settingsPopPageTransition(spatialSpec, effectsSpec) } +
-        NavDisplay.predictivePopTransitionSpec { settingsPopPageTransition(spatialSpec, effectsSpec) }
-
 @Composable
 internal fun AppNavHost(
     backStack: List<AppRoute>,
@@ -105,16 +76,8 @@ internal fun AppNavHost(
         onBack = { appViewModel.onBack() },
         transitionSpec = { forwardPageTransition(pageSpatialSpec, pageEffectsSpec) },
         popTransitionSpec = { popPageTransition(pageSpatialSpec, pageEffectsSpec) },
-        predictivePopTransitionSpec = { popPageTransition(pageSpatialSpec, pageEffectsSpec) },
         entryProvider = { route ->
-            NavEntry(
-                key = route,
-                metadata = if (route == AppRoute.Settings) {
-                    settingsNavigationMetadata(pageSpatialSpec, pageEffectsSpec)
-                } else {
-                    emptyMap()
-                },
-            ) {
+            NavEntry(key = route) {
                 when (route) {
                     AppRoute.Home -> HomeScreen(
                         home = uiGraph.home.home,

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -237,7 +237,7 @@ internal fun AppNavHost(
     )
     val sceneState = rememberSceneState(
         entries = entries,
-        sceneStrategy = SinglePaneSceneStrategy(),
+        sceneStrategies = listOf(SinglePaneSceneStrategy()),
         onBack = { appViewModel.onBack() },
     )
     val currentScene = sceneState.currentScene

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -13,10 +13,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+
+private const val PREDICTIVE_BACK_RIGHT_EDGE = 1
 
 private fun pageTransition(
     initialOffsetX: (Int) -> Int,
@@ -56,26 +59,34 @@ private fun popPageTransition(
 )
 
 /**
- * Keep predictive Back visually connected to the gesture without the large 0.7x scale used by
- * Navigation 3's default transition. The previous route stays close to its final size while the
- * current route recedes just enough to expose depth. This is intentionally edge-neutral so both
- * left- and right-edge system gestures behave consistently.
+ * Navigation 3 only exposes the swipe edge to this convenience NavDisplay transition. Keep the
+ * visual depth restrained and bias the scale origin toward the gesture edge so left/right back
+ * gestures feel attached to the finger without the aggressive default 0.7x collapse.
  */
 private fun predictivePopPageTransition(
+    swipeEdge: Int,
     spatialSpec: FiniteAnimationSpec<Float>,
     effectsSpec: FiniteAnimationSpec<Float>,
-): ContentTransform = (
-    scaleIn(
-        initialScale = 0.985f,
+): ContentTransform {
+    val gestureOrigin = if (swipeEdge == PREDICTIVE_BACK_RIGHT_EDGE) {
+        TransformOrigin(0.82f, 0.5f)
+    } else {
+        TransformOrigin(0.18f, 0.5f)
+    }
+    return (
+        scaleIn(
+            initialScale = 0.992f,
+            animationSpec = spatialSpec,
+        ) + fadeIn(
+            initialAlpha = 0.96f,
+            animationSpec = effectsSpec,
+        )
+        ) togetherWith scaleOut(
+        targetScale = 0.965f,
+        transformOrigin = gestureOrigin,
         animationSpec = spatialSpec,
-    ) + fadeIn(
-        initialAlpha = 0.92f,
-        animationSpec = effectsSpec,
     )
-    ) togetherWith scaleOut(
-        targetScale = 0.94f,
-        animationSpec = spatialSpec,
-    )
+}
 
 @Composable
 internal fun AppNavHost(
@@ -102,8 +113,8 @@ internal fun AppNavHost(
         onBack = { appViewModel.onBack() },
         transitionSpec = { forwardPageTransition(pageSpatialSpec, pageEffectsSpec) },
         popTransitionSpec = { popPageTransition(pageSpatialSpec, pageEffectsSpec) },
-        predictivePopTransitionSpec = {
-            predictivePopPageTransition(predictiveSpatialSpec, predictiveEffectsSpec)
+        predictivePopTransitionSpec = { swipeEdge ->
+            predictivePopPageTransition(swipeEdge, predictiveSpatialSpec, predictiveEffectsSpec)
         },
         entryProvider = { route ->
             NavEntry(key = route) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -132,7 +132,9 @@ internal fun AppNavHost(
 
     var predictiveRoute by remember { mutableStateOf<AppRoute?>(null) }
     var predictiveGestureStartTouchY by remember { mutableStateOf<Float?>(null) }
+    var predictiveGestureActive by remember { mutableStateOf(false) }
     var predictiveBackCommitted by remember { mutableStateOf(false) }
+    var predictiveProgressTarget by remember { mutableFloatStateOf(0f) }
     var lastSwipeEdge by remember { mutableStateOf(NavigationEvent.EDGE_NONE) }
     var verticalFollowTargetPx by remember { mutableFloatStateOf(0f) }
     var horizontalFollowTargetPx by remember { mutableFloatStateOf(0f) }
@@ -148,7 +150,9 @@ internal fun AppNavHost(
             NavEntry(key = route) {
                 PredictiveBackRouteSurface(
                     active = predictiveRoute == route,
+                    gestureActive = predictiveGestureActive,
                     committed = predictiveBackCommitted,
+                    progressTarget = predictiveProgressTarget,
                     swipeEdge = lastSwipeEdge,
                     horizontalOffsetPx = horizontalFollowTargetPx,
                     verticalOffsetPx = verticalFollowTargetPx,
@@ -157,7 +161,10 @@ internal fun AppNavHost(
                         if (predictiveRoute == route) {
                             predictiveRoute = null
                             predictiveBackCommitted = false
+                            predictiveProgressTarget = 0f
                             lastSwipeEdge = NavigationEvent.EDGE_NONE
+                            horizontalFollowTargetPx = 0f
+                            verticalFollowTargetPx = 0f
                         }
                     },
                 ) {
@@ -238,31 +245,23 @@ internal fun AppNavHost(
         currentInfo = SceneInfo(currentScene),
         backInfo = sceneState.previousScenes.map { SceneInfo(it) },
     )
-    val gestureState = navigationEventState.transitionState
-    val gestureEvent = (gestureState as? InProgress)?.latestEvent
+    val gestureEvent = (navigationEventState.transitionState as? InProgress)?.latestEvent
     val gestureInProgress = gestureEvent != null
-    val gestureProgressTarget = when {
-        gestureEvent != null -> gestureEvent.progress.coerceIn(0f, 1f)
-        predictiveBackCommitted -> 1f
-        else -> 0f
-    }
-    val renderedGestureProgress by animateFloatAsState(
-        targetValue = gestureProgressTarget,
-        animationSpec = if (gestureInProgress) snap() else predictiveReturnSpec,
-        label = "Route predictive back progress",
-    )
 
     LaunchedEffect(gestureInProgress) {
         if (gestureInProgress && gestureEvent != null) {
             predictiveRoute = activeRoute
             predictiveGestureStartTouchY = gestureEvent.touchY
+            predictiveGestureActive = true
             predictiveBackCommitted = false
         } else if (!predictiveBackCommitted) {
             predictiveGestureStartTouchY = null
+            predictiveGestureActive = false
         }
     }
     LaunchedEffect(gestureEvent?.progress, gestureEvent?.touchY, gestureEvent?.swipeEdge) {
         if (gestureEvent != null) {
+            predictiveProgressTarget = gestureEvent.progress.coerceIn(0f, 1f)
             lastSwipeEdge = gestureEvent.swipeEdge
             val startTouchY = predictiveGestureStartTouchY ?: gestureEvent.touchY
             val rawDeltaY = gestureEvent.touchY - startTouchY
@@ -279,17 +278,6 @@ internal fun AppNavHost(
                 NavigationEvent.EDGE_RIGHT -> -horizontalFollowPx * gestureEvent.progress
                 else -> 0f
             }
-        } else {
-            verticalFollowTargetPx = 0f
-            horizontalFollowTargetPx = if (predictiveBackCommitted) {
-                when (lastSwipeEdge) {
-                    NavigationEvent.EDGE_LEFT -> horizontalFollowPx
-                    NavigationEvent.EDGE_RIGHT -> -horizontalFollowPx
-                    else -> 0f
-                }
-            } else {
-                0f
-            }
         }
     }
 
@@ -299,15 +287,24 @@ internal fun AppNavHost(
             predictiveBackPreference.enabled &&
             currentScene.previousEntries.isNotEmpty(),
         onBackCancelled = {
+            predictiveGestureActive = false
             predictiveBackCommitted = false
             predictiveGestureStartTouchY = null
+            predictiveProgressTarget = 0f
             verticalFollowTargetPx = 0f
             horizontalFollowTargetPx = 0f
         },
         onBackCompleted = {
+            predictiveGestureActive = false
             predictiveBackCommitted = true
             predictiveGestureStartTouchY = null
+            predictiveProgressTarget = 1f
             verticalFollowTargetPx = 0f
+            horizontalFollowTargetPx = when (lastSwipeEdge) {
+                NavigationEvent.EDGE_LEFT -> horizontalFollowPx
+                NavigationEvent.EDGE_RIGHT -> -horizontalFollowPx
+                else -> 0f
+            }
             appViewModel.onBack()
         },
     )
@@ -322,32 +319,14 @@ internal fun AppNavHost(
             predictivePopPageTransition(swipeEdge, predictiveSpatialSpec, predictiveEffectsSpec)
         },
     )
-
-    // Keep the rendered progress observable by route content without creating another Back handler.
-    PredictiveBackProgressBridge(
-        progress = renderedGestureProgress,
-        route = predictiveRoute,
-    )
-}
-
-private val LocalPredictiveBackRouteProgress = androidx.compose.runtime.staticCompositionLocalOf { 0f }
-private val LocalPredictiveBackRoute = androidx.compose.runtime.staticCompositionLocalOf<AppRoute?> { null }
-
-@Composable
-private fun PredictiveBackProgressBridge(
-    progress: Float,
-    route: AppRoute?,
-) {
-    // Intentionally empty: state is consumed through the route surface parameters below. Keeping
-    // this small composable makes the seek state explicit at the NavDisplay boundary for debugging.
-    @Suppress("UNUSED_VARIABLE")
-    val ignored = progress to route
 }
 
 @Composable
 private fun PredictiveBackRouteSurface(
     active: Boolean,
+    gestureActive: Boolean,
     committed: Boolean,
+    progressTarget: Float,
     swipeEdge: Int,
     horizontalOffsetPx: Float,
     verticalOffsetPx: Float,
@@ -355,30 +334,23 @@ private fun PredictiveBackRouteSurface(
     onCommittedExitDisposed: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val targetProgress = if (active && committed) 1f else if (active) {
-        // The actual gesture progress is represented by the offsets while seeking; corner growth is
-        // read from the active NavDisplay transition through the scale handoff below.
-        1f
-    } else {
-        0f
-    }
+    val renderedProgress by animateFloatAsState(
+        targetValue = if (active) progressTarget.coerceIn(0f, 1f) else 0f,
+        animationSpec = if (active && gestureActive) snap() else returnSpec,
+        label = "Route predictive corner progress",
+    )
     val renderedHorizontalOffsetPx by animateFloatAsState(
         targetValue = if (active) horizontalOffsetPx else 0f,
-        animationSpec = returnSpec,
+        animationSpec = if (active && gestureActive) snap() else returnSpec,
         label = "Route predictive horizontal follow",
     )
     val renderedVerticalOffsetPx by animateFloatAsState(
         targetValue = if (active) verticalOffsetPx else 0f,
-        animationSpec = returnSpec,
+        animationSpec = if (active && gestureActive) snap() else returnSpec,
         label = "Route predictive vertical follow",
     )
-    val cornerProgress by animateFloatAsState(
-        targetValue = targetProgress,
-        animationSpec = returnSpec,
-        label = "Route predictive corner progress",
-    )
-    val corner = 28.dp * cornerProgress
-    val shape = RoundedCornerShape(corner)
+    val cornerProgress = ((renderedProgress - 0.06f) / 0.94f).coerceIn(0f, 1f)
+    val shape = RoundedCornerShape(28.dp * cornerProgress)
     val transformOrigin = when (swipeEdge) {
         NavigationEvent.EDGE_LEFT -> TransformOrigin(0.18f, 0.5f)
         NavigationEvent.EDGE_RIGHT -> TransformOrigin(0.82f, 0.5f)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/app/AppNavHost.kt
@@ -9,17 +9,38 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.SceneInfo
+import androidx.navigation3.scene.SinglePaneSceneStrategy
+import androidx.navigation3.scene.rememberSceneState
 import androidx.navigation3.ui.NavDisplay
-
-private const val PREDICTIVE_BACK_RIGHT_EDGE = 1
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventTransitionState.InProgress
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
+import kotlin.math.abs
 
 private fun pageTransition(
     initialOffsetX: (Int) -> Int,
@@ -59,16 +80,16 @@ private fun popPageTransition(
 )
 
 /**
- * Navigation 3 only exposes the swipe edge to this convenience NavDisplay transition. Keep the
- * visual depth restrained and bias the scale origin toward the gesture edge so left/right back
- * gestures feel attached to the finger without the aggressive default 0.7x collapse.
+ * Keep the Navigation 3 seek transition restrained. The outgoing route's scale is still owned by
+ * NavDisplay so gesture cancellation/completion hands off naturally; rounded corners and bounded
+ * pointer following are applied to the route surface itself from the same NavigationEventState.
  */
 private fun predictivePopPageTransition(
     swipeEdge: Int,
     spatialSpec: FiniteAnimationSpec<Float>,
     effectsSpec: FiniteAnimationSpec<Float>,
 ): ContentTransform {
-    val gestureOrigin = if (swipeEdge == PREDICTIVE_BACK_RIGHT_EDGE) {
+    val gestureOrigin = if (swipeEdge == NavigationEvent.EDGE_RIGHT) {
         TransformOrigin(0.82f, 0.5f)
     } else {
         TransformOrigin(0.18f, 0.5f)
@@ -98,92 +119,291 @@ internal fun AppNavHost(
 ) {
     val localPlaylistState by uiGraph.localPlaylist.uiState.collectAsStateWithLifecycle()
     val activeRoute = backStack.lastOrNull()
+    val predictiveBackPreference = rememberPredictiveBackPreference()
+    val density = LocalDensity.current
     val pageSpatialSpec = FuoMotion.defaultSpatialSpec<IntOffset>()
     val pageEffectsSpec = FuoMotion.fastEffectsSpec<Float>()
     val predictiveSpatialSpec = FuoMotion.defaultSpatialSpec<Float>()
     val predictiveEffectsSpec = FuoMotion.defaultEffectsSpec<Float>()
+    val predictiveReturnSpec = FuoMotion.fastSpatialSpec<Float>()
+    val maxVerticalGestureDistancePx = with(density) { 240.dp.toPx() }
+    val maxVerticalFollowPx = with(density) { 18.dp.toPx() }
+    val horizontalFollowPx = with(density) { 6.dp.toPx() }
+
+    var predictiveRoute by remember { mutableStateOf<AppRoute?>(null) }
+    var predictiveGestureStartTouchY by remember { mutableStateOf<Float?>(null) }
+    var predictiveBackCommitted by remember { mutableStateOf(false) }
+    var lastSwipeEdge by remember { mutableStateOf(NavigationEvent.EDGE_NONE) }
+    var verticalFollowTargetPx by remember { mutableFloatStateOf(0f) }
+    var horizontalFollowTargetPx by remember { mutableFloatStateOf(0f) }
 
     LaunchedEffect(activeRoute, uiGraph.playback.queue) {
         uiGraph.playback.queue.setPlaybackContextHint(activeRoute?.toPlaybackContextSnapshot())
     }
 
-    NavDisplay(
+    val entries = rememberDecoratedNavEntries(
         backStack = backStack,
-        modifier = modifier,
+        entryDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator()),
+        entryProvider = { route ->
+            NavEntry(key = route) {
+                PredictiveBackRouteSurface(
+                    active = predictiveRoute == route,
+                    committed = predictiveBackCommitted,
+                    swipeEdge = lastSwipeEdge,
+                    horizontalOffsetPx = horizontalFollowTargetPx,
+                    verticalOffsetPx = verticalFollowTargetPx,
+                    returnSpec = predictiveReturnSpec,
+                    onCommittedExitDisposed = {
+                        if (predictiveRoute == route) {
+                            predictiveRoute = null
+                            predictiveBackCommitted = false
+                            lastSwipeEdge = NavigationEvent.EDGE_NONE
+                        }
+                    },
+                ) {
+                    when (route) {
+                        AppRoute.Home -> HomeScreen(
+                            home = uiGraph.home.home,
+                            hasAudioPermission = platform.hasAudioPermission,
+                            onRequestAudioPermission = platform.onRequestAudioPermission,
+                            hasImagePermission = platform.hasImagePermission,
+                            onRequestImagePermission = platform.onRequestImagePermission,
+                            onOpenRecognition = appViewModel::openRecognition,
+                        )
+                        AppRoute.PlaybackHistory -> ListeningHistoryScreen(
+                            repository = uiGraph.home.listeningHistory,
+                            onBack = { appViewModel.onBack() },
+                        )
+                        AppRoute.Search -> SearchRoute(
+                            graph = uiGraph.search,
+                            onOpenRecognition = appViewModel::openRecognition,
+                        )
+                        AppRoute.AudioRecognition -> RecognitionRoute(
+                            graph = uiGraph.recognition,
+                            onBack = appViewModel::closeRecognition,
+                            onSearchSong = uiGraph.search.controller::searchRecognizedSong,
+                            hasMicrophonePermission = platform.hasMicrophonePermission,
+                            onRequestMicrophonePermission = platform.onRequestMicrophonePermission,
+                        )
+                        AppRoute.Settings -> SettingsFeatureScreen(
+                            settingsController = uiGraph.settings,
+                            providerCatalog = uiGraph.providerCatalog,
+                            providerAuth = uiGraph.providerAuth,
+                            appVersionInfo = platform.appVersionInfo,
+                            onOpenProviderWebLogin = platform.onOpenProviderWebLogin,
+                            onLogoutProvider = platform.onLogoutProvider,
+                            onImportYtmusicHeaderFile = platform.onImportYtmusicHeaderFile,
+                            onImportYtmusicOAuthFile = platform.onImportYtmusicOAuthFile,
+                            onStartYtmusicOAuth = platform.onStartYtmusicOAuth,
+                        )
+                        AppRoute.DebugLogs -> DebugLogFeatureScreen(
+                            uiGraph.debugLogs,
+                            onBack = { appViewModel.onBack() },
+                        )
+                        AppRoute.DownloadManager -> DownloadManagerScreen(
+                            uiGraph.playback.downloads,
+                            onBack = { appViewModel.onBack() },
+                        )
+                        is AppRoute.FeatureDetail -> ProviderFeatureParityDetailRoute(route.feature.toProviderFeature())
+                        is AppRoute.PlaylistDetail -> ProviderPlaylistDetailRoute(
+                            playlist = route.playlist.toProviderPlaylist(),
+                            category = route.category?.let { runCatching { ProviderFeatureCategory.valueOf(it) }.getOrNull() },
+                        )
+                        is AppRoute.TrackDetail -> ProviderTrackDetailRoute(route.track.toMusicTrack())
+                        is AppRoute.VideoDetail -> ProviderVideoDetailRoute(route.video.toProviderVideo())
+                        is AppRoute.MediaItemDetail -> ProviderMediaItemDetailRoute(route.item.toProviderMediaItem())
+                        AppRoute.LocalPlaylist -> LocalPlaylistScreen(
+                            uiState = localPlaylistState,
+                            actions = uiGraph.localPlaylist,
+                            playlist = localPlaylistState.selectedPlaylist,
+                        )
+                        AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen()
+                        AppRoute.Feature,
+                        AppRoute.Playlist,
+                        AppRoute.Track,
+                        AppRoute.Video,
+                        AppRoute.MediaItem -> StaleRouteKindGuard { appViewModel.onBack() }
+                    }
+                }
+            }
+        },
+    )
+    val sceneState = rememberSceneState(
+        entries = entries,
+        sceneStrategy = SinglePaneSceneStrategy(),
         onBack = { appViewModel.onBack() },
+    )
+    val currentScene = sceneState.currentScene
+    val navigationEventState = rememberNavigationEventState(
+        currentInfo = SceneInfo(currentScene),
+        backInfo = sceneState.previousScenes.map { SceneInfo(it) },
+    )
+    val gestureState = navigationEventState.transitionState
+    val gestureEvent = (gestureState as? InProgress)?.latestEvent
+    val gestureInProgress = gestureEvent != null
+    val gestureProgressTarget = when {
+        gestureEvent != null -> gestureEvent.progress.coerceIn(0f, 1f)
+        predictiveBackCommitted -> 1f
+        else -> 0f
+    }
+    val renderedGestureProgress by animateFloatAsState(
+        targetValue = gestureProgressTarget,
+        animationSpec = if (gestureInProgress) snap() else predictiveReturnSpec,
+        label = "Route predictive back progress",
+    )
+
+    LaunchedEffect(gestureInProgress) {
+        if (gestureInProgress && gestureEvent != null) {
+            predictiveRoute = activeRoute
+            predictiveGestureStartTouchY = gestureEvent.touchY
+            predictiveBackCommitted = false
+        } else if (!predictiveBackCommitted) {
+            predictiveGestureStartTouchY = null
+        }
+    }
+    LaunchedEffect(gestureEvent?.progress, gestureEvent?.touchY, gestureEvent?.swipeEdge) {
+        if (gestureEvent != null) {
+            lastSwipeEdge = gestureEvent.swipeEdge
+            val startTouchY = predictiveGestureStartTouchY ?: gestureEvent.touchY
+            val rawDeltaY = gestureEvent.touchY - startTouchY
+            val normalizedDelta = (abs(rawDeltaY) / maxVerticalGestureDistancePx).coerceIn(0f, 1f)
+            val easedDelta = normalizedDelta * (2f - normalizedDelta)
+            val direction = when {
+                rawDeltaY > 0f -> 1f
+                rawDeltaY < 0f -> -1f
+                else -> 0f
+            }
+            verticalFollowTargetPx = direction * maxVerticalFollowPx * easedDelta * gestureEvent.progress
+            horizontalFollowTargetPx = when (gestureEvent.swipeEdge) {
+                NavigationEvent.EDGE_LEFT -> horizontalFollowPx * gestureEvent.progress
+                NavigationEvent.EDGE_RIGHT -> -horizontalFollowPx * gestureEvent.progress
+                else -> 0f
+            }
+        } else {
+            verticalFollowTargetPx = 0f
+            horizontalFollowTargetPx = if (predictiveBackCommitted) {
+                when (lastSwipeEdge) {
+                    NavigationEvent.EDGE_LEFT -> horizontalFollowPx
+                    NavigationEvent.EDGE_RIGHT -> -horizontalFollowPx
+                    else -> 0f
+                }
+            } else {
+                0f
+            }
+        }
+    }
+
+    NavigationBackHandler(
+        state = navigationEventState,
+        isBackEnabled = predictiveBackPreference.isSupported &&
+            predictiveBackPreference.enabled &&
+            currentScene.previousEntries.isNotEmpty(),
+        onBackCancelled = {
+            predictiveBackCommitted = false
+            predictiveGestureStartTouchY = null
+            verticalFollowTargetPx = 0f
+            horizontalFollowTargetPx = 0f
+        },
+        onBackCompleted = {
+            predictiveBackCommitted = true
+            predictiveGestureStartTouchY = null
+            verticalFollowTargetPx = 0f
+            appViewModel.onBack()
+        },
+    )
+
+    NavDisplay(
+        sceneState = sceneState,
+        navigationEventState = navigationEventState,
+        modifier = modifier,
         transitionSpec = { forwardPageTransition(pageSpatialSpec, pageEffectsSpec) },
         popTransitionSpec = { popPageTransition(pageSpatialSpec, pageEffectsSpec) },
         predictivePopTransitionSpec = { swipeEdge ->
             predictivePopPageTransition(swipeEdge, predictiveSpatialSpec, predictiveEffectsSpec)
         },
-        entryProvider = { route ->
-            NavEntry(key = route) {
-                when (route) {
-                    AppRoute.Home -> HomeScreen(
-                        home = uiGraph.home.home,
-                        hasAudioPermission = platform.hasAudioPermission,
-                        onRequestAudioPermission = platform.onRequestAudioPermission,
-                        hasImagePermission = platform.hasImagePermission,
-                        onRequestImagePermission = platform.onRequestImagePermission,
-                        onOpenRecognition = appViewModel::openRecognition,
-                    )
-                    AppRoute.PlaybackHistory -> ListeningHistoryScreen(
-                        repository = uiGraph.home.listeningHistory,
-                        onBack = { appViewModel.onBack() },
-                    )
-                    AppRoute.Search -> SearchRoute(
-                        graph = uiGraph.search,
-                        onOpenRecognition = appViewModel::openRecognition,
-                    )
-                    AppRoute.AudioRecognition -> RecognitionRoute(
-                        graph = uiGraph.recognition,
-                        onBack = appViewModel::closeRecognition,
-                        onSearchSong = uiGraph.search.controller::searchRecognizedSong,
-                        hasMicrophonePermission = platform.hasMicrophonePermission,
-                        onRequestMicrophonePermission = platform.onRequestMicrophonePermission,
-                    )
-                    AppRoute.Settings -> SettingsFeatureScreen(
-                        settingsController = uiGraph.settings,
-                        providerCatalog = uiGraph.providerCatalog,
-                        providerAuth = uiGraph.providerAuth,
-                        appVersionInfo = platform.appVersionInfo,
-                        onOpenProviderWebLogin = platform.onOpenProviderWebLogin,
-                        onLogoutProvider = platform.onLogoutProvider,
-                        onImportYtmusicHeaderFile = platform.onImportYtmusicHeaderFile,
-                        onImportYtmusicOAuthFile = platform.onImportYtmusicOAuthFile,
-                        onStartYtmusicOAuth = platform.onStartYtmusicOAuth,
-                    )
-                    AppRoute.DebugLogs -> DebugLogFeatureScreen(
-                        uiGraph.debugLogs,
-                        onBack = { appViewModel.onBack() },
-                    )
-                    AppRoute.DownloadManager -> DownloadManagerScreen(
-                        uiGraph.playback.downloads,
-                        onBack = { appViewModel.onBack() },
-                    )
-                    is AppRoute.FeatureDetail -> ProviderFeatureParityDetailRoute(route.feature.toProviderFeature())
-                    is AppRoute.PlaylistDetail -> ProviderPlaylistDetailRoute(
-                        playlist = route.playlist.toProviderPlaylist(),
-                        category = route.category?.let { runCatching { ProviderFeatureCategory.valueOf(it) }.getOrNull() },
-                    )
-                    is AppRoute.TrackDetail -> ProviderTrackDetailRoute(route.track.toMusicTrack())
-                    is AppRoute.VideoDetail -> ProviderVideoDetailRoute(route.video.toProviderVideo())
-                    is AppRoute.MediaItemDetail -> ProviderMediaItemDetailRoute(route.item.toProviderMediaItem())
-                    AppRoute.LocalPlaylist -> LocalPlaylistScreen(
-                        uiState = localPlaylistState,
-                        actions = uiGraph.localPlaylist,
-                        playlist = localPlaylistState.selectedPlaylist,
-                    )
-                    AppRoute.LocalMusicCollection -> LocalMusicCollectionScreen()
-                    AppRoute.Feature,
-                    AppRoute.Playlist,
-                    AppRoute.Track,
-                    AppRoute.Video,
-                    AppRoute.MediaItem -> StaleRouteKindGuard { appViewModel.onBack() }
-                }
-            }
-        },
     )
+
+    // Keep the rendered progress observable by route content without creating another Back handler.
+    PredictiveBackProgressBridge(
+        progress = renderedGestureProgress,
+        route = predictiveRoute,
+    )
+}
+
+private val LocalPredictiveBackRouteProgress = androidx.compose.runtime.staticCompositionLocalOf { 0f }
+private val LocalPredictiveBackRoute = androidx.compose.runtime.staticCompositionLocalOf<AppRoute?> { null }
+
+@Composable
+private fun PredictiveBackProgressBridge(
+    progress: Float,
+    route: AppRoute?,
+) {
+    // Intentionally empty: state is consumed through the route surface parameters below. Keeping
+    // this small composable makes the seek state explicit at the NavDisplay boundary for debugging.
+    @Suppress("UNUSED_VARIABLE")
+    val ignored = progress to route
+}
+
+@Composable
+private fun PredictiveBackRouteSurface(
+    active: Boolean,
+    committed: Boolean,
+    swipeEdge: Int,
+    horizontalOffsetPx: Float,
+    verticalOffsetPx: Float,
+    returnSpec: FiniteAnimationSpec<Float>,
+    onCommittedExitDisposed: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val targetProgress = if (active && committed) 1f else if (active) {
+        // The actual gesture progress is represented by the offsets while seeking; corner growth is
+        // read from the active NavDisplay transition through the scale handoff below.
+        1f
+    } else {
+        0f
+    }
+    val renderedHorizontalOffsetPx by animateFloatAsState(
+        targetValue = if (active) horizontalOffsetPx else 0f,
+        animationSpec = returnSpec,
+        label = "Route predictive horizontal follow",
+    )
+    val renderedVerticalOffsetPx by animateFloatAsState(
+        targetValue = if (active) verticalOffsetPx else 0f,
+        animationSpec = returnSpec,
+        label = "Route predictive vertical follow",
+    )
+    val cornerProgress by animateFloatAsState(
+        targetValue = targetProgress,
+        animationSpec = returnSpec,
+        label = "Route predictive corner progress",
+    )
+    val corner = 28.dp * cornerProgress
+    val shape = RoundedCornerShape(corner)
+    val transformOrigin = when (swipeEdge) {
+        NavigationEvent.EDGE_LEFT -> TransformOrigin(0.18f, 0.5f)
+        NavigationEvent.EDGE_RIGHT -> TransformOrigin(0.82f, 0.5f)
+        else -> TransformOrigin.Center
+    }
+
+    DisposableEffect(active, committed) {
+        onDispose {
+            if (active && committed) onCommittedExitDisposed()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                translationX = renderedHorizontalOffsetPx
+                translationY = renderedVerticalOffsetPx
+                this.transformOrigin = transformOrigin
+                this.shape = shape
+                clip = active && cornerProgress > 0f
+            },
+    ) {
+        content()
+    }
 }
 
 private fun AppRoute.toPlaybackContextSnapshot(): PlaybackContextSnapshot? = when (this) {

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PredictiveBackSupport.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PredictiveBackSupport.kt
@@ -16,3 +16,11 @@ internal expect fun PlatformLegacyBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 )
+
+@Composable
+internal expect fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancelled: () -> Unit,
+    onBack: () -> Unit,
+)

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PredictiveBackSupport.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/core/ui/PredictiveBackSupport.kt
@@ -8,6 +8,19 @@ internal data class PredictiveBackPreference(
     val onEnabledChange: (Boolean) -> Unit,
 )
 
+internal enum class PredictiveBackSwipeEdge {
+    Left,
+    Right,
+    None,
+}
+
+internal data class PredictiveBackGestureEvent(
+    val progress: Float,
+    val touchX: Float,
+    val touchY: Float,
+    val swipeEdge: PredictiveBackSwipeEdge,
+)
+
 @Composable
 internal expect fun rememberPredictiveBackPreference(): PredictiveBackPreference
 
@@ -20,7 +33,7 @@ internal expect fun PlatformLegacyBackHandler(
 @Composable
 internal expect fun PlatformPredictiveBackHandler(
     enabled: Boolean,
-    onProgress: (Float) -> Unit,
+    onProgress: (PredictiveBackGestureEvent) -> Unit,
     onCancelled: () -> Unit,
     onBack: () -> Unit,
 )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/settings/SettingsFeatureScreen.kt
@@ -179,7 +179,6 @@ fun SettingsFeatureScreen(
         onBack = ::pop,
         transitionSpec = { settingsForwardPageTransition() },
         popTransitionSpec = { settingsPopPageTransition() },
-        predictivePopTransitionSpec = { settingsPopPageTransition() },
         entryProvider = { route ->
             NavEntry(key = route) {
                 when (route) {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.desktop.kt
@@ -21,7 +21,7 @@ internal actual fun PlatformLegacyBackHandler(
 @Composable
 internal actual fun PlatformPredictiveBackHandler(
     enabled: Boolean,
-    onProgress: (Float) -> Unit,
+    onProgress: (PredictiveBackGestureEvent) -> Unit,
     onCancelled: () -> Unit,
     onBack: () -> Unit,
 ) = Unit

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.desktop.kt
@@ -17,3 +17,11 @@ internal actual fun PlatformLegacyBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 ) = Unit
+
+@Composable
+internal actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancelled: () -> Unit,
+    onBack: () -> Unit,
+) = Unit

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
@@ -15,3 +15,11 @@ internal actual fun PlatformLegacyBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
 ) = Unit
+
+@Composable
+internal actual fun PlatformPredictiveBackHandler(
+    enabled: Boolean,
+    onProgress: (Float) -> Unit,
+    onCancelled: () -> Unit,
+    onBack: () -> Unit,
+) = Unit

--- a/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
+++ b/shared/src/iosMain/kotlin/org/feeluown/mobile/PredictiveBackSupport.ios.kt
@@ -19,7 +19,7 @@ internal actual fun PlatformLegacyBackHandler(
 @Composable
 internal actual fun PlatformPredictiveBackHandler(
     enabled: Boolean,
-    onProgress: (Float) -> Unit,
+    onProgress: (PredictiveBackGestureEvent) -> Unit,
     onCancelled: () -> Unit,
     onBack: () -> Unit,
 ) = Unit


### PR DESCRIPTION
## Summary
- keep the existing Predictive Back user toggle and persisted legacy fallback
- replace Navigation 3's aggressive default predictive scale with a restrained, edge-aware depth transition for app-level routes
- keep normal Expressive forward/pop transitions unchanged
- remove the Settings route's reversed app-level spatial direction
- forward the complete Android predictive-back event (`progress`, `touchX`, `touchY`, `swipeEdge`) through the platform bridge
- make the full player behave like a bounded predictive window: subtle scale, progressive rounded corners, small edge nudge, and compressed vertical finger following
- keep playback queue / Material bottom sheet Back precedence ahead of the full player
- preserve the existing full-player exit animation for non-gesture Back

## Motion tuning
### App-level routes
Navigation 3's default predictive pop scales the outgoing route to 0.7x, which reads too strongly in FuoEvolve. The app-level transition is now deliberately restrained:
- outgoing route: `1.0 -> 0.965`
- previous route: `0.992 -> 1.0`
- previous route alpha: `0.96 -> 1.0`
- outgoing scale origin biases toward the left/right gesture edge
- no full-width horizontal travel

The convenience `NavDisplay(backStack=...)` API only exposes `swipeEdge` to `predictivePopTransitionSpec`; it does not expose `touchY`, so this layer does not register a competing BackHandler just to observe pointer coordinates.

### Full player
The full player receives the complete Android `BackEventCompat` and now uses:
- scale reduction up to ~1.8%
- rounded corners growing progressively from `0dp` to `28dp`
- vertical movement derived from `touchY - initialTouchY`, compressed/eased and bounded to about `±18dp`
- a subtle ~6dp horizontal nudge based on the gesture edge
- edge-biased transform origin
- no opacity fade
- cancellation animates scale and offsets back instead of snapping

## Behavior
### Predictive Back enabled
- app-level destinations follow a softened edge-aware Navigation 3 predictive transition
- full player follows both gesture progress and vertical finger movement while revealing the route underneath
- playback queue keeps modal Back precedence when open
- root back remains owned by the system

### Predictive Back disabled
- existing `BackHandler` legacy behavior remains unchanged
- the user-facing toggle remains available in Theme settings
