### PR TITLE
fix: prefer visionOS for YouTube Music playback

### DIFF
--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProvider.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProvider.kt
@@ -191,16 +191,9 @@ class YtMusicProvider(
     )
 
     private suspend fun playablePlayer(videoId: String): PlayedStream? {
-        ensureYoutubeVisitorId()
-        if (!visitorId.isNullOrBlank()) {
-            val androidVr = runCatching { androidVrPlayer(videoId) }.getOrNull()
-            if (androidVr != null && hasPlayableAudio(androidVr, requireDirectUrl = true)) {
-                return PlayedStream(root = androidVr, playbackHeaders = emptyMap())
-            }
-        }
-        val android = runCatching { androidPlayer(videoId) }.getOrNull()
-        if (android != null && hasPlayableAudio(android, requireDirectUrl = true)) {
-            return PlayedStream(root = android, playbackHeaders = emptyMap())
+        val visionOs = runCatching { visionOsPlayer(videoId) }.getOrNull()
+        if (visionOs != null && hasPlayableAudio(visionOs, requireDirectUrl = true)) {
+            return PlayedStream(root = visionOs, playbackHeaders = emptyMap())
         }
         val web = runCatching { player(videoId) }.getOrNull()
         if (web != null && hasPlayableAudio(web, requireDirectUrl = false)) {
@@ -212,6 +205,10 @@ class YtMusicProvider(
                     "User-Agent" to YtMusicOAuth.USER_AGENT,
                 ),
             )
+        }
+        val android = runCatching { androidPlayer(videoId) }.getOrNull()
+        if (android != null && hasPlayableAudio(android, requireDirectUrl = true)) {
+            return PlayedStream(root = android, playbackHeaders = emptyMap())
         }
         return null
     }
@@ -248,47 +245,42 @@ class YtMusicProvider(
         )
     }
 
-    private suspend fun androidVrPlayer(videoId: String): kotlinx.serialization.json.JsonObject {
+    private suspend fun visionOsPlayer(videoId: String): kotlinx.serialization.json.JsonObject {
         ensureConfig()
-        ensureYoutubeVisitorId()
-        val visitor = visitorId?.takeIf { it.isNotBlank() }
-            ?: error("ANDROID_VR player requires X-Goog-Visitor-Id")
-        val sts = ensureSignatureTimestamp()
         val body =
             "{" +
                 "\"context\":{\"client\":{" +
-                "\"clientName\":\"ANDROID_VR\"," +
-                "\"clientVersion\":\"$ANDROID_VR_CLIENT_VERSION\"," +
-                "\"deviceMake\":\"Oculus\"," +
-                "\"deviceModel\":\"Quest 3\"," +
-                "\"androidSdkVersion\":32," +
-                "\"userAgent\":${quote(ANDROID_VR_USER_AGENT)}," +
-                "\"osName\":\"Android\"," +
-                "\"osVersion\":\"12L\"," +
+                "\"clientName\":\"VISIONOS\"," +
+                "\"clientVersion\":\"$VISIONOS_CLIENT_VERSION\"," +
+                "\"deviceMake\":\"Apple\"," +
+                "\"deviceModel\":\"RealityDevice17,1\"," +
+                "\"userAgent\":${quote(VISIONOS_USER_AGENT)}," +
+                "\"osName\":\"visionOS\"," +
+                "\"osVersion\":\"26.5.23O471\"," +
                 "\"hl\":\"en\"," +
                 "\"timeZone\":\"UTC\"," +
                 "\"utcOffsetMinutes\":0" +
                 "},\"user\":{}}," +
                 "\"videoId\":${quote(videoId)}," +
                 "\"playbackContext\":{\"contentPlaybackContext\":{" +
-                "\"html5Preference\":\"HTML5_PREF_WANTS\"," +
-                "\"signatureTimestamp\":$sts" +
+                "\"html5Preference\":\"HTML5_PREF_WANTS\"" +
                 "}}," +
                 "\"contentCheckOk\":true," +
                 "\"racyCheckOk\":true" +
                 "}"
+        val headers = buildMap {
+            put("Content-Type", "application/json")
+            put("User-Agent", VISIONOS_USER_AGENT)
+            put("Origin", "https://www.youtube.com")
+            put("X-Youtube-Client-Name", VISIONOS_CLIENT_NAME)
+            put("X-Youtube-Client-Version", VISIONOS_CLIENT_VERSION)
+            visitorId?.takeIf { it.isNotBlank() }?.let { put("X-Goog-Visitor-Id", it) }
+        }
         return http.postJson(
             providerId = ID,
             url = "$YOUTUBE_API_BASE/player?prettyPrint=false",
             json = body,
-            headers = mapOf(
-                "Content-Type" to "application/json",
-                "User-Agent" to ANDROID_VR_USER_AGENT,
-                "Origin" to "https://www.youtube.com",
-                "X-Youtube-Client-Name" to ANDROID_VR_CLIENT_NAME,
-                "X-Youtube-Client-Version" to ANDROID_VR_CLIENT_VERSION,
-                "X-Goog-Visitor-Id" to visitor,
-            ),
+            headers = headers,
         ).value.let { providerJson.parseToJsonElement(it).asObject() }
     }
 
@@ -300,6 +292,9 @@ class YtMusicProvider(
                 "\"clientName\":\"ANDROID\"," +
                 "\"clientVersion\":\"$ANDROID_CLIENT_VERSION\"," +
                 "\"androidSdkVersion\":30," +
+                "\"userAgent\":${quote(ANDROID_USER_AGENT)}," +
+                "\"osName\":\"Android\"," +
+                "\"osVersion\":\"11\"," +
                 "\"hl\":\"zh_CN\"" +
                 "},\"user\":{}}," +
                 "\"videoId\":${quote(videoId)}," +
@@ -892,6 +887,9 @@ class YtMusicProvider(
         const val DATA_API_BASE = YtMusicProviderDefinition.DATA_API_BASE
         const val YOUTUBE_API_BASE = YtMusicProviderDefinition.YOUTUBE_API_BASE
         const val FALLBACK_API_KEY = YtMusicProviderDefinition.FALLBACK_API_KEY
+        const val VISIONOS_CLIENT_NAME = YtMusicProviderDefinition.VISIONOS_CLIENT_NAME
+        const val VISIONOS_CLIENT_VERSION = YtMusicProviderDefinition.VISIONOS_CLIENT_VERSION
+        const val VISIONOS_USER_AGENT = YtMusicProviderDefinition.VISIONOS_USER_AGENT
         const val ANDROID_VR_CLIENT_NAME = YtMusicProviderDefinition.ANDROID_VR_CLIENT_NAME
         const val ANDROID_VR_CLIENT_VERSION = YtMusicProviderDefinition.ANDROID_VR_CLIENT_VERSION
         const val ANDROID_VR_USER_AGENT = YtMusicProviderDefinition.ANDROID_VR_USER_AGENT

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderDefinition.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderDefinition.kt
@@ -15,14 +15,18 @@ internal object YtMusicProviderDefinition {
     const val DATA_API_BASE = "https://www.googleapis.com/youtube/v3"
     const val YOUTUBE_API_BASE = "https://www.youtube.com/youtubei/v1"
     const val FALLBACK_API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
+    const val VISIONOS_CLIENT_NAME = "101"
+    const val VISIONOS_CLIENT_VERSION = "1.02"
+    const val VISIONOS_USER_AGENT =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
     const val ANDROID_VR_CLIENT_NAME = "28"
     const val ANDROID_VR_CLIENT_VERSION = "1.65.10"
     const val ANDROID_VR_USER_AGENT =
         "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip"
     const val ANDROID_CLIENT_NAME = "3"
-    const val ANDROID_CLIENT_VERSION = "20.10.38"
+    const val ANDROID_CLIENT_VERSION = "21.26.364"
     const val ANDROID_USER_AGENT =
-        "com.google.android.youtube/20.10.38 (Linux; U; Android 14) gzip"
+        "com.google.android.youtube/21.26.364 (Linux; U; Android 11) gzip"
 
     val info = ProviderInfo(
         providerId = ID,

--- a/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicProviderTest.kt
+++ b/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicProviderTest.kt
@@ -386,7 +386,7 @@ class YtMusicProviderTest {
     }
 
     @Test
-    fun resolveUsesAndroidVrPlayerLikeYtDlp() = runTest {
+    fun resolveUsesVisionOsPlayerLikeYtDlp() = runTest {
         val requests = mutableListOf<CapturedRequest>()
         val store = InMemoryProviderCredentialStore()
         val providerHttp = ProviderHttpClient(
@@ -400,10 +400,7 @@ class YtMusicProviderTest {
                             request.method == HttpMethod.Get && url.contains("music.youtube.com") && !url.contains("/s/player") -> respond(
                                 """<html>ytcfg.set({"INNERTUBE_API_KEY":"AIzaSyTestKey","INNERTUBE_CLIENT_VERSION":"1.20260807.01.00","VISITOR_DATA":"visitor-token"});</html>""",
                             )
-                            request.method == HttpMethod.Get && (url.contains("/s/player") || url.contains("youtube.com/watch")) -> respond(
-                                """{"VISITOR_DATA":"visitor-token"} var signatureTimestamp=20668;""",
-                            )
-                            body.contains("ANDROID_VR") -> respond(
+                            body.contains("VISIONOS") -> respond(
                                 """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/webm; codecs=\"opus\"","bitrate":140000,"url":"https://cdn.example/a.webm","approxDurationMs":"10000"},{"mimeType":"audio/mp4; codecs=\"mp4a.40.2\"","bitrate":130000,"url":"https://cdn.example/a.m4a","approxDurationMs":"10000","audioQuality":"AUDIO_QUALITY_MEDIUM"}]}}""",
                             )
                             else -> respond("""{"playabilityStatus":{"status":"UNPLAYABLE"}}""")
@@ -427,18 +424,18 @@ class YtMusicProviderTest {
 
         val payload = provider.resolve(track, AudioQualityPolicy.High.policy)
 
-        // Prefer m4a like FeelUOwn ytdl format m4a/bestaudio/best
         assertEquals("https://cdn.example/a.m4a", payload?.url)
         assertTrue(payload?.headers.isNullOrEmpty(), "yt-dlp/FeelUOwn path uses empty playback headers")
-        val vr = requests.first { it.body.contains("ANDROID_VR") }
-        assertTrue(vr.url.contains("www.youtube.com/youtubei/v1/player"), vr.url)
-        assertEquals(YtMusicProvider.ANDROID_VR_USER_AGENT, vr.headers["User-Agent"])
-        assertEquals(YtMusicProvider.ANDROID_VR_CLIENT_NAME, vr.headers["X-Youtube-Client-Name"])
+        val visionOs = requests.first { it.body.contains("VISIONOS") }
+        assertTrue(visionOs.url.contains("www.youtube.com/youtubei/v1/player"), visionOs.url)
+        assertEquals(YtMusicProvider.VISIONOS_USER_AGENT, visionOs.headers["User-Agent"])
+        assertEquals(YtMusicProvider.VISIONOS_CLIENT_NAME, visionOs.headers["X-Youtube-Client-Name"])
+        assertTrue(requests.none { it.body.contains("ANDROID_VR") }, "ANDROID_VR 1.65.10 must not be used")
         providerHttp.close()
     }
 
     @Test
-    fun resolveFallsBackToWebRemixWhenAndroidVrUnplayable() = runTest {
+    fun resolveFallsBackToWebRemixWhenVisionOsUnplayable() = runTest {
         val requests = mutableListOf<CapturedRequest>()
         val store = InMemoryProviderCredentialStore()
         val providerHttp = ProviderHttpClient(
@@ -455,11 +452,10 @@ class YtMusicProviderTest {
                             request.method == HttpMethod.Get && (url.contains("/s/player") || url.contains("youtube.com/watch")) -> respond(
                                 """var signatureTimestamp=20668;""",
                             )
-                            body.contains("ANDROID_VR") -> respond(
+                            body.contains("VISIONOS") -> respond(
                                 """{"playabilityStatus":{"status":"LOGIN_REQUIRED"}}""",
                             )
                             body.contains("signatureTimestamp") && body.contains("WEB_REMIX").not() && url.contains("music.youtube.com") -> respond(
-                                // innerTube wraps WEB_REMIX context around payload
                                 """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/mp4","bitrate":128000,"url":"https://cdn.example/web.m4a","approxDurationMs":"10000"}]}}""",
                             )
                             url.contains("music.youtube.com/youtubei/v1/player") -> respond(
@@ -487,13 +483,14 @@ class YtMusicProviderTest {
         val payload = provider.resolve(track, AudioQualityPolicy.High.policy)
 
         assertEquals("https://cdn.example/web.m4a", payload?.url)
-        assertTrue(requests.any { it.body.contains("ANDROID_VR") })
+        assertTrue(requests.any { it.body.contains("VISIONOS") })
+        assertTrue(requests.none { it.body.contains("ANDROID_VR") })
         assertTrue(requests.any { it.url.contains("music.youtube.com/youtubei/v1/player") })
         providerHttp.close()
     }
 
     @Test
-    fun resolveFallsBackToAndroidWhenVisitorMissing() = runTest {
+    fun resolveFallsBackToAndroidWhenVisionOsAndWebAreUnplayable() = runTest {
         val requests = mutableListOf<CapturedRequest>()
         val store = InMemoryProviderCredentialStore()
         val providerHttp = ProviderHttpClient(
@@ -504,16 +501,14 @@ class YtMusicProviderTest {
                         val url = request.url.toString()
                         val body = (request.body as? TextContent)?.text.orEmpty()
                         when {
-                            // music landing stub: no visitor
                             request.method == HttpMethod.Get && url.contains("music.youtube.com") -> respond(
                                 """<html>YouTube Music is not available in your area</html>""",
                             )
-                            // youtube watch also fails to expose visitor (consent stub)
                             request.method == HttpMethod.Get && url.contains("youtube.com/watch") -> respond(
                                 """<html><title>Before you continue</title></html>""",
                             )
-                            body.contains("ANDROID_VR") -> respond(
-                                """{"playabilityStatus":{"status":"LOGIN_REQUIRED"}}""",
+                            body.contains("VISIONOS") -> respond(
+                                """{"playabilityStatus":{"status":"UNPLAYABLE"}}""",
                             )
                             body.contains("\"clientName\":\"ANDROID\"") -> respond(
                                 """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/mp4","bitrate":130000,"url":"https://cdn.example/android.m4a","approxDurationMs":"10000"}]}}""",
@@ -540,7 +535,8 @@ class YtMusicProviderTest {
         val payload = provider.resolve(track, AudioQualityPolicy.High.policy)
 
         assertEquals("https://cdn.example/android.m4a", payload?.url)
-        assertTrue(requests.none { it.body.contains("ANDROID_VR") }, "skip ANDROID_VR without visitor")
+        assertTrue(requests.any { it.body.contains("VISIONOS") })
+        assertTrue(requests.none { it.body.contains("ANDROID_VR") }, "deprecated ANDROID_VR must never be requested")
         assertTrue(requests.any { it.body.contains("\"clientName\":\"ANDROID\"") })
         assertTrue(payload?.headers.isNullOrEmpty())
         providerHttp.close()


### PR DESCRIPTION
## Summary
- replace the deprecated `ANDROID_VR 1.65.10` playback path with the current yt-dlp-style `VISIONOS 1.02` client
- prefer `VISIONOS -> WEB_REMIX -> ANDROID` for playback resolution
- update the Android client metadata to the current yt-dlp values
- add regression coverage ensuring `ANDROID_VR` is no longer requested

## Context
YouTube started returning HTTP 403 for all `ANDROID_VR 1.65.10` formats on 2026-08-17. yt-dlp removed that client from its defaults on 2026-08-18 and now uses `visionos` as the JS-less/default logged-out path.

OAuth remains intentionally separate from playback extraction.