### PR TITLE
feat: align YouTube Music playback extraction with yt-dlp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jna = "5.19.1"
 credentialSecureStorage = "1.0.3"
 jaudiotagger = "3.0.1"
 dbusJava = "5.2.0"
+quickJsKt = "1.0.15"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -66,6 +67,7 @@ credential-secure-storage = { module = "com.microsoft:credential-secure-storage"
 jaudiotagger = { module = "net.jthink:jaudiotagger", version.ref = "jaudiotagger" }
 dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbusJava" }
 dbus-java-transport-native-unixsocket = { module = "com.github.hypfvieh:dbus-java-transport-native-unixsocket", version.ref = "dbusJava" }
+quickjs-kt = { module = "io.github.dokar3:quickjs-kt", version.ref = "quickJsKt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/provider/ytmusic/build.gradle.kts
+++ b/provider/ytmusic/build.gradle.kts
@@ -36,9 +36,13 @@ kotlin {
 }
 
 // quickjs-kt's Android artifact contains native Android libraries and cannot be
-// loaded by the JVM used for Android host tests. Mirror quickjs-kt's documented
-// setup and substitute the JVM artifact for local/CI host test runtimes.
-configurations.matching { it.name.endsWith("UnitTestRuntimeClasspath") }.configureEach {
+// loaded by the desktop JVM used for Android host tests. The Android KMP library
+// plugin names that runtime `androidHostTestRuntimeClasspath` rather than the
+// legacy `*UnitTestRuntimeClasspath`, so cover both forms here.
+configurations.matching {
+    it.name.endsWith("UnitTestRuntimeClasspath") ||
+        it.name.endsWith("AndroidHostTestRuntimeClasspath", ignoreCase = true)
+}.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute(module("io.github.dokar3:quickjs-kt-android"))
             .using(module("io.github.dokar3:quickjs-kt-jvm:${libs.versions.quickJsKt.get()}"))

--- a/provider/ytmusic/build.gradle.kts
+++ b/provider/ytmusic/build.gradle.kts
@@ -25,12 +25,23 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.ktor.client.core)
+            implementation(libs.quickjs.kt)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.ktor.client.mock)
         }
+    }
+}
+
+// quickjs-kt's Android artifact contains native Android libraries and cannot be
+// loaded by the JVM used for Android host tests. Mirror quickjs-kt's documented
+// setup and substitute the JVM artifact for local/CI host test runtimes.
+configurations.matching { it.name.endsWith("UnitTestRuntimeClasspath") }.configureEach {
+    resolutionStrategy.dependencySubstitution {
+        substitute(module("io.github.dokar3:quickjs-kt-android"))
+            .using(module("io.github.dokar3:quickjs-kt-jvm:${libs.versions.quickJsKt.get()}"))
     }
 }
 

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicJsChallengeSolver.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicJsChallengeSolver.kt
@@ -1,0 +1,281 @@
+package org.feeluown.mobile.provider.ytmusic
+
+import com.dokar.quickjs.quickJs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.serialization.json.JsonPrimitive
+import org.feeluown.mobile.provider.core.providerJson
+
+/**
+ * Executes the two player.js challenges yt-dlp models as SIG and N.
+ *
+ * The extraction strategy deliberately keeps the JS execution boundary small:
+ * only the discovered transform and its helper declarations are evaluated in
+ * QuickJS. This avoids relying on a browser DOM while still executing YouTube's
+ * current JavaScript instead of reimplementing the transform operations in Kotlin.
+ */
+internal class YtMusicJsChallengeSolver {
+    private val signaturePrograms = mutableMapOf<Int, String>()
+    private val nPrograms = mutableMapOf<Int, Pair<String, String>>()
+    private val nResults = mutableMapOf<Pair<Int, String>, String>()
+
+    fun signatureTimestamp(playerJs: String): Int? =
+        Regex("""signatureTimestamp\s*[:=]\s*(\d+)""")
+            .find(playerJs)?.groupValues?.getOrNull(1)?.toIntOrNull()
+
+    suspend fun solveSignature(playerJs: String, challenge: String): String? {
+        val key = playerJs.hashCode()
+        val program = signaturePrograms[key] ?: extractSignatureProgram(playerJs)?.also {
+            signaturePrograms[key] = it
+        } ?: return null
+        return execute(program, SIGNATURE_ENTRY_POINT, challenge)
+    }
+
+    suspend fun solveN(playerJs: String, challenge: String): String? {
+        val key = playerJs.hashCode()
+        nResults[key to challenge]?.let { return it }
+        val (program, functionName) = nPrograms[key] ?: extractNProgram(playerJs)?.also {
+            nPrograms[key] = it
+        } ?: return null
+        return execute(program, functionName, challenge)?.takeIf { it.isNotBlank() }?.also {
+            nResults[key to challenge] = it
+        }
+    }
+
+    private suspend fun execute(program: String, functionName: String, argument: String): String? =
+        runCatching {
+            quickJs(Dispatchers.Default) {
+                evaluationTimeoutMillis = 2_000
+                evaluate<String>(
+                    buildString {
+                        append(program)
+                        append('\n')
+                        append(functionName)
+                        append('(')
+                        append(quote(argument))
+                        append(')')
+                    },
+                )
+            }
+        }.getOrNull()
+
+    private fun extractSignatureProgram(playerJs: String): String? {
+        val (functionName, extraParams) = signatureFunction(playerJs) ?: return null
+        val function = extractFunction(playerJs, functionName) ?: return null
+        val declarations = linkedSetOf<String>()
+
+        // Modern signature transforms typically reference a small helper object.
+        Regex("""([A-Za-z0-9_$]{2,})[.\[]""").findAll(function).forEach { match ->
+            val name = match.groupValues[1]
+            if (name != functionName && name !in JS_GLOBALS) {
+                extractDeclaration(playerJs, name)?.let(declarations::add)
+            }
+        }
+
+        // Some player versions keep a shared split-string lookup in a global.
+        Regex("""(?:var|let|const)\s+[A-Za-z0-9_$]+\s*=\s*["'][^"']*["']\.split\(["'][;{]["']\)\s*;""")
+            .find(playerJs)?.value?.let(declarations::add)
+
+        return buildString {
+            declarations.forEach { appendLine(it) }
+            appendLine(function)
+            append("function $SIGNATURE_ENTRY_POINT(a){return $functionName(")
+            append(extraParams)
+            append("a);}")
+        }
+    }
+
+    private fun signatureFunction(playerJs: String): Pair<String, String>? {
+        val patterns = listOf(
+            Regex("""\b[A-Za-z0-9_$]+&&\([A-Za-z0-9_$]+=([A-Za-z0-9_$]{2,})\((\d+,)decodeURIComponent\([A-Za-z0-9_$]+\)\)"""),
+            Regex("""\b[A-Za-z0-9_$]+&&\([A-Za-z0-9_$]+=([A-Za-z0-9_$]{2,})\(decodeURIComponent\([A-Za-z0-9_$]+\)\)"""),
+            Regex("""\bm=([A-Za-z0-9_$]{2,})\(decodeURIComponent\(h\.s\)\)"""),
+            Regex("""\bc&&\(c=([A-Za-z0-9_$]{2,})\(decodeURIComponent\(c\)\)"""),
+            Regex("""(?:\b|[^A-Za-z0-9_$])([A-Za-z0-9_$]{2,})\s*=\s*function\(\s*a\s*\)\s*\{\s*a\s*=\s*a\.split\(\s*["']["']\s*\)"""),
+        )
+        for (pattern in patterns) {
+            val match = pattern.find(playerJs) ?: continue
+            return match.groupValues[1] to match.groupValues.getOrNull(2).orEmpty()
+        }
+        return null
+    }
+
+    private fun extractNProgram(playerJs: String): Pair<String, String>? {
+        val reference = nFunctionReference(playerJs) ?: return null
+        val functionName = resolveArrayFunction(playerJs, reference.first, reference.second) ?: reference.first
+        val original = extractFunction(playerJs, functionName) ?: return null
+        val function = stripNGuard(original)
+        val declarations = linkedSetOf<String>()
+
+        Regex("""([A-Za-z0-9_$]{2,})[.\[]""").findAll(function).forEach { match ->
+            val name = match.groupValues[1]
+            if (name != functionName && name !in JS_GLOBALS) {
+                extractDeclaration(playerJs, name)?.let(declarations::add)
+            }
+        }
+
+        return buildString {
+            declarations.forEach { appendLine(it) }
+            append(function)
+        } to functionName
+    }
+
+    private fun nFunctionReference(playerJs: String): Pair<String, Int?>? {
+        val patterns = listOf(
+            Regex("""\.get\(["']n["']\)\)\s*&&\s*\([A-Za-z0-9_$]+=([A-Za-z0-9_$]+)(?:\[(\d+)])?\([A-Za-z0-9_$]+\)"""),
+            Regex("""String\.fromCharCode\(110\).*?&&\s*\([A-Za-z0-9_$]+=([A-Za-z0-9_$]+)(?:\[(\d+)])?\([A-Za-z0-9_$]+\)"""),
+            Regex("""[A-Za-z0-9_$]+=["']nn["']\[\+[A-Za-z0-9_$]+\.[A-Za-z0-9_$]+].*?&&\s*\([A-Za-z0-9_$]+=([A-Za-z0-9_$]+)(?:\[(\d+)])?\([A-Za-z0-9_$]+\)"""),
+            Regex("""([A-Za-z0-9_$]{2,})=function[\s\S]{0,1200}?return [A-Z]\[\d+]"""),
+        )
+        for (pattern in patterns) {
+            val match = pattern.find(playerJs) ?: continue
+            return match.groupValues[1] to match.groupValues.getOrNull(2)?.toIntOrNull()
+        }
+        return null
+    }
+
+    private fun resolveArrayFunction(playerJs: String, name: String, index: Int?): String? {
+        if (index == null) return name
+        val declaration = Regex(
+            """(?:var|let|const)\s+${Regex.escape(name)}\s*=\s*\[([^]]+)]""",
+        ).find(playerJs)?.groupValues?.getOrNull(1) ?: return null
+        return declaration.split(',').getOrNull(index)?.trim()
+            ?.removePrefix("function ")
+            ?.takeWhile { it.isLetterOrDigit() || it == '_' || it == '$' }
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun stripNGuard(function: String): String = function.replaceFirst(
+        Regex(""";?\s*if\s*\(\s*typeof\s+[A-Za-z0-9_$]+\s*={2,3}\s*(["'])undefined\1\s*\)\s*return\s+[A-Za-z0-9_$]+\s*;"""),
+        ";",
+    )
+
+    private fun extractFunction(source: String, name: String): String? {
+        val escaped = Regex.escape(name)
+        val assignment = Regex("""(?:var\s+)?$escaped\s*=\s*function\s*\(""").find(source)
+        if (assignment != null) {
+            val functionIndex = source.indexOf("function", assignment.range.first)
+            val brace = source.indexOf('{', functionIndex)
+            val end = matchClosing(source, brace, '{', '}') ?: return null
+            val prefix = if (source.substring(assignment.range.first, functionIndex).trimStart().startsWith("var ")) {
+                ""
+            } else {
+                "var "
+            }
+            return prefix + source.substring(assignment.range.first, end + 1) + ";"
+        }
+
+        val declaration = Regex("""function\s+$escaped\s*\(""").find(source) ?: return null
+        val brace = source.indexOf('{', declaration.range.first)
+        val end = matchClosing(source, brace, '{', '}') ?: return null
+        return source.substring(declaration.range.first, end + 1)
+    }
+
+    private fun extractDeclaration(source: String, name: String): String? {
+        val escaped = Regex.escape(name)
+        val match = Regex("""(?:var|let|const)\s+$escaped\s*=""").find(source) ?: return null
+        var index = match.range.last + 1
+        var round = 0
+        var square = 0
+        var curly = 0
+        var quote: Char? = null
+        var escapedChar = false
+        var lineComment = false
+        var blockComment = false
+        while (index < source.length) {
+            val ch = source[index]
+            val next = source.getOrNull(index + 1)
+            if (lineComment) {
+                if (ch == '\n') lineComment = false
+                index++
+                continue
+            }
+            if (blockComment) {
+                if (ch == '*' && next == '/') {
+                    blockComment = false
+                    index += 2
+                } else index++
+                continue
+            }
+            if (quote != null) {
+                if (escapedChar) escapedChar = false
+                else if (ch == '\\') escapedChar = true
+                else if (ch == quote) quote = null
+                index++
+                continue
+            }
+            when {
+                ch == '/' && next == '/' -> { lineComment = true; index += 2; continue }
+                ch == '/' && next == '*' -> { blockComment = true; index += 2; continue }
+                ch == '\'' || ch == '"' || ch == '`' -> quote = ch
+                ch == '(' -> round++
+                ch == ')' -> round--
+                ch == '[' -> square++
+                ch == ']' -> square--
+                ch == '{' -> curly++
+                ch == '}' -> curly--
+                ch == ';' && round <= 0 && square <= 0 && curly <= 0 ->
+                    return source.substring(match.range.first, index + 1)
+            }
+            index++
+        }
+        return null
+    }
+
+    private fun matchClosing(source: String, openIndex: Int, open: Char, close: Char): Int? {
+        if (openIndex !in source.indices || source[openIndex] != open) return null
+        var depth = 0
+        var quote: Char? = null
+        var escapedChar = false
+        var lineComment = false
+        var blockComment = false
+        var index = openIndex
+        while (index < source.length) {
+            val ch = source[index]
+            val next = source.getOrNull(index + 1)
+            if (lineComment) {
+                if (ch == '\n') lineComment = false
+                index++
+                continue
+            }
+            if (blockComment) {
+                if (ch == '*' && next == '/') {
+                    blockComment = false
+                    index += 2
+                } else index++
+                continue
+            }
+            if (quote != null) {
+                if (escapedChar) escapedChar = false
+                else if (ch == '\\') escapedChar = true
+                else if (ch == quote) quote = null
+                index++
+                continue
+            }
+            when {
+                ch == '/' && next == '/' -> { lineComment = true; index += 2; continue }
+                ch == '/' && next == '*' -> { blockComment = true; index += 2; continue }
+                ch == '\'' || ch == '"' || ch == '`' -> quote = ch
+                ch == open -> depth++
+                ch == close -> {
+                    depth--
+                    if (depth == 0) return index
+                }
+            }
+            index++
+        }
+        return null
+    }
+
+    private fun quote(value: String): String = providerJson.encodeToString(
+        JsonPrimitive.serializer(),
+        JsonPrimitive(value),
+    )
+
+    private companion object {
+        const val SIGNATURE_ENTRY_POINT = "__fuo_sig"
+        val JS_GLOBALS = setOf(
+            "Array", "Date", "Error", "JSON", "Math", "Object", "RegExp", "String",
+            "decodeURIComponent", "encodeURIComponent", "parseInt", "undefined", "window",
+        )
+    }
+}

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPlaybackProvider.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPlaybackProvider.kt
@@ -1,0 +1,502 @@
+package org.feeluown.mobile.provider.ytmusic
+
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.AudioQualityPolicy
+import org.feeluown.mobile.MusicTrack
+import org.feeluown.mobile.PlaybackPayload
+import org.feeluown.mobile.ProviderVideo
+import org.feeluown.mobile.VideoPlaybackPayload
+import org.feeluown.mobile.provider.core.KotlinMusicProvider
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.array
+import org.feeluown.mobile.provider.core.asObject
+import org.feeluown.mobile.provider.core.cookieHeader
+import org.feeluown.mobile.provider.core.int
+import org.feeluown.mobile.provider.core.long
+import org.feeluown.mobile.provider.core.obj
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.splitResourceId
+import org.feeluown.mobile.provider.core.string
+import org.feeluown.mobile.provider.core.stringOrNull
+import org.feeluown.mobile.provider.core.network.ProviderCachePolicies
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRequestKind
+
+/**
+ * Playback-only YouTube extractor modelled after yt-dlp's current YouTube pipeline.
+ *
+ * Account/catalogue concerns deliberately remain in [YtMusicProvider] and
+ * [YtMusicContentProvider]. This class owns the volatile playback protocol:
+ * client selection, player responses, signature/n challenges, PO-token policy,
+ * SABR avoidance, HLS fallback and final CDN probing.
+ */
+internal class YtMusicPlaybackProvider(
+    private val delegate: KotlinMusicProvider,
+    http: ProviderHttpClient,
+    credentials: ProviderCredentialStore,
+    poTokenProvider: YtPoTokenProvider = CredentialYtPoTokenProvider(credentials),
+) : KotlinMusicProvider by delegate {
+    private val extractor = YtMusicPlaybackExtractor(http, credentials, poTokenProvider)
+
+    override suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload? =
+        extractor.resolve(track, qualityPolicy)
+
+    override suspend fun videoPlaybackPayload(video: ProviderVideo): VideoPlaybackPayload {
+        val videoId = splitResourceId(video.id, "video").second
+        val track = delegate.trackDetail(videoId) ?: return VideoPlaybackPayload(video = video)
+        val payload = resolve(track, AudioQualityPolicy.High.policy)
+            ?: return VideoPlaybackPayload(video = video)
+        return VideoPlaybackPayload(
+            video = video,
+            url = payload.url,
+            audioUrl = payload.url,
+            headers = payload.headers,
+            quality = payload.audioQuality,
+        )
+    }
+}
+
+internal class YtMusicPlaybackExtractor(
+    private val http: ProviderHttpClient,
+    private val credentials: ProviderCredentialStore,
+    private val poTokenProvider: YtPoTokenProvider,
+    private val challengeSolver: YtMusicJsChallengeSolver = YtMusicJsChallengeSolver(),
+) {
+    private data class PlayerSession(
+        val videoId: String,
+        val apiKey: String,
+        val visitorData: String?,
+        val playerJsUrl: String?,
+        val playerJs: String?,
+        val signatureTimestamp: Int?,
+        val cookie: String,
+        val hasBrowserSession: Boolean,
+    )
+
+    private data class PlayerResponse(
+        val client: YtPlayerClientProfile,
+        val root: JsonObject,
+        val playerToken: String?,
+    )
+
+    private data class Candidate(
+        val url: String,
+        val bitrate: Int,
+        val mimeType: String,
+        val durationMs: Long?,
+        val audioQuality: String?,
+        val client: YtPlayerClientProfile,
+        val manifest: Boolean = false,
+    )
+
+    suspend fun resolve(track: MusicTrack, qualityPolicy: String): PlaybackPayload? {
+        val videoId = splitResourceId(track.providerId ?: track.id).second
+            .ifBlank { track.providerId ?: track.id }
+        if (videoId.isBlank()) return null
+
+        val session = createSession(videoId)
+        val clients = YtMusicPlayerClients.ordered(session.hasBrowserSession)
+        for (client in clients) {
+            val response = fetchPlayer(session, client) ?: continue
+            if (!isPlayable(response.root)) continue
+            val candidates = extractCandidates(session, response)
+            for (candidate in selectCandidates(candidates, qualityPolicy)) {
+                if (!probe(candidate)) continue
+                return PlaybackPayload(
+                    url = candidate.url,
+                    title = track.title,
+                    artists = track.artists,
+                    album = track.album,
+                    source = YtMusicProvider.ID,
+                    // FeelUOwn/yt-dlp intentionally hand the signed media URL to
+                    // the media stack without copying InnerTube request headers.
+                    headers = emptyMap(),
+                    coverUrl = track.coverUrl,
+                    durationMs = candidate.durationMs ?: track.durationMs,
+                    audioQuality = candidate.audioQuality
+                        ?: candidate.bitrate.takeIf { it > 0 }?.toString()
+                        ?: if (candidate.manifest) "HLS" else null,
+                    providerName = YtMusicProvider.NAME,
+                )
+            }
+        }
+        return null
+    }
+
+    private suspend fun createSession(videoId: String): PlayerSession {
+        val stored = credentials.read(YtMusicProvider.ID)
+        val cookie = cookieHeader(stored)
+        val hasBrowserSession = cookie.isNotBlank()
+        val watchHeaders = buildMap {
+            put("User-Agent", YtMusicOAuth.USER_AGENT)
+            put("Accept", "text/html,*/*")
+            put("Accept-Language", "en-US,en;q=0.9")
+            put("Cookie", mergeCookies("SOCS=CAI", cookie))
+        }
+        val html = runCatching {
+            http.getText(
+                providerId = YtMusicProvider.ID,
+                url = "https://www.youtube.com/watch?v=$videoId&bpctr=9999999999&has_verified=1",
+                headers = watchHeaders,
+                kind = ProviderRequestKind.SafeRead,
+                cacheKey = null,
+                cachePolicy = ProviderCachePolicies.none,
+            ).value
+        }.getOrDefault("")
+
+        val apiKey = extractConfigValue(html, "INNERTUBE_API_KEY")
+            ?: YtMusicProvider.FALLBACK_API_KEY
+        val visitor = extractConfigValue(html, "VISITOR_DATA")
+        val jsUrl = extractPlayerJsUrl(html)
+        val playerJs = jsUrl?.let { url ->
+            runCatching {
+                http.getText(
+                    providerId = YtMusicProvider.ID,
+                    url = absolutePlayerJsUrl(url),
+                    headers = mapOf("User-Agent" to YtMusicOAuth.USER_AGENT, "Accept" to "*/*"),
+                    cacheKey = "ytmusic:playback:playerjs:${playerJsId(url)}",
+                    cachePolicy = ProviderCachePolicies.detail,
+                ).value
+            }.getOrNull()
+        }
+        return PlayerSession(
+            videoId = videoId,
+            apiKey = apiKey,
+            visitorData = visitor,
+            playerJsUrl = jsUrl,
+            playerJs = playerJs,
+            signatureTimestamp = playerJs?.let(challengeSolver::signatureTimestamp),
+            cookie = cookie,
+            hasBrowserSession = hasBrowserSession,
+        )
+    }
+
+    private suspend fun fetchPlayer(
+        session: PlayerSession,
+        client: YtPlayerClientProfile,
+    ): PlayerResponse? {
+        if (client.requireAuth && !session.hasBrowserSession) return null
+
+        val playerToken = if (client.playerPoTokenRecommended) {
+            poTokenProvider.token(
+                YtPoTokenRequest(
+                    context = YtPoTokenContext.Player,
+                    client = client,
+                    videoId = session.videoId,
+                    visitorData = session.visitorData,
+                ),
+            )
+        } else null
+
+        val body = playerBody(session, client, playerToken)
+        val origin = "https://${client.host}"
+        val headers = buildMap {
+            put("Content-Type", "application/json")
+            put("User-Agent", client.userAgent)
+            put("Origin", origin)
+            put("X-Youtube-Client-Name", client.clientId)
+            put("X-Youtube-Client-Version", client.clientVersion)
+            session.visitorData?.takeIf { it.isNotBlank() }?.let {
+                put("X-Goog-Visitor-Id", it)
+            }
+            if (client.supportsCookies && session.cookie.isNotBlank()) {
+                put("Cookie", mergeCookies("SOCS=CAI", session.cookie))
+                YtMusicProvider.sapisidFromCookie(session.cookie)?.let { sapisid ->
+                    put("Authorization", YtMusicProvider.sapisidHashAuthorization(sapisid, origin))
+                    put("X-Origin", origin)
+                }
+            }
+        }
+        val url = buildString {
+            append("https://")
+            append(client.host)
+            append("/youtubei/v1/player?prettyPrint=false&key=")
+            append(encodeUrlComponent(session.apiKey))
+        }
+        val root = runCatching {
+            http.postJson(
+                providerId = YtMusicProvider.ID,
+                url = url,
+                json = body,
+                headers = headers,
+                kind = ProviderRequestKind.SafeRead,
+                cacheKey = null,
+                cachePolicy = ProviderCachePolicies.none,
+            ).value.let { providerJson.parseToJsonElement(it).asObject() }
+        }.getOrNull() ?: return null
+        return PlayerResponse(client, root, playerToken)
+    }
+
+    private fun playerBody(
+        session: PlayerSession,
+        client: YtPlayerClientProfile,
+        playerToken: String?,
+    ): String = buildString {
+        append("{\"context\":{\"client\":{")
+        append("\"clientName\":").append(quote(client.clientName)).append(',')
+        append("\"clientVersion\":").append(quote(client.clientVersion)).append(',')
+        append("\"userAgent\":").append(quote(client.userAgent)).append(',')
+        append("\"hl\":\"en\",\"timeZone\":\"UTC\",\"utcOffsetMinutes\":0")
+        client.deviceMake?.let { append(",\"deviceMake\":").append(quote(it)) }
+        client.deviceModel?.let { append(",\"deviceModel\":").append(quote(it)) }
+        client.osName?.let { append(",\"osName\":").append(quote(it)) }
+        client.osVersion?.let { append(",\"osVersion\":").append(quote(it)) }
+        client.androidSdkVersion?.let { append(",\"androidSdkVersion\":").append(it) }
+        append("},\"user\":{}")
+        if (client.embedded) {
+            append(",\"thirdParty\":{\"embedUrl\":\"https://www.reddit.com/\"}")
+        }
+        append("},\"videoId\":").append(quote(session.videoId))
+        append(",\"playbackContext\":{\"contentPlaybackContext\":{")
+        append("\"html5Preference\":\"HTML5_PREF_WANTS\"")
+        if (client.requireJsPlayer) {
+            session.signatureTimestamp?.let { append(",\"signatureTimestamp\":").append(it) }
+        }
+        append("}}")
+        append(",\"contentCheckOk\":true,\"racyCheckOk\":true")
+        if (!playerToken.isNullOrBlank()) {
+            append(",\"serviceIntegrityDimensions\":{\"poToken\":")
+                .append(quote(playerToken)).append('}')
+        }
+        append('}')
+    }
+
+    private fun isPlayable(root: JsonObject): Boolean {
+        val status = root.obj("playabilityStatus")?.stringOrNull("status")
+        return status == null || status == "OK"
+    }
+
+    private suspend fun extractCandidates(
+        session: PlayerSession,
+        response: PlayerResponse,
+    ): List<Candidate> {
+        val streaming = response.root.obj("streamingData") ?: return emptyList()
+        val output = mutableListOf<Candidate>()
+        val formats = buildList {
+            addAll(streaming.array("adaptiveFormats"))
+            addAll(streaming.array("formats"))
+        }.map { it.asObject() }
+
+        for (format in formats) {
+            val mime = format.string("mimeType")
+            // Audio-only formats are preferred for a music player. Muxed formats
+            // are left to HLS fallback instead of downloading unnecessary video.
+            if (!mime.startsWith("audio/")) continue
+            val baseUrl = format.stringOrNull("url")
+                ?: decipherCipher(session, format.stringOrNull("signatureCipher") ?: format.stringOrNull("cipher"))
+                ?: continue // Missing URL/cipher is commonly a SABR-only response.
+            var url = solveN(session, baseUrl) ?: continue
+            val policy = response.client.policy(YtStreamingProtocol.Https)
+            val tokenRequired = policy.required &&
+                !(policy.notRequiredWithPlayerToken && !response.playerToken.isNullOrBlank())
+            val gvsToken = if (policy.required || policy.recommended) {
+                poTokenProvider.token(
+                    YtPoTokenRequest(
+                        context = YtPoTokenContext.Gvs,
+                        client = response.client,
+                        videoId = session.videoId,
+                        visitorData = session.visitorData,
+                    ),
+                )
+            } else null
+            if (tokenRequired && gvsToken.isNullOrBlank()) continue
+            if (!gvsToken.isNullOrBlank()) url = appendQuery(url, "pot", gvsToken)
+            output += Candidate(
+                url = url,
+                bitrate = format.int("bitrate") ?: 0,
+                mimeType = mime,
+                durationMs = format.long("approxDurationMs"),
+                audioQuality = format.stringOrNull("audioQuality"),
+                client = response.client,
+            )
+        }
+
+        streaming.stringOrNull("hlsManifestUrl")?.let { manifest ->
+            val policy = response.client.policy(YtStreamingProtocol.Hls)
+            val tokenRequired = policy.required &&
+                !(policy.notRequiredWithPlayerToken && !response.playerToken.isNullOrBlank())
+            val token = if (policy.required || policy.recommended) {
+                poTokenProvider.token(
+                    YtPoTokenRequest(
+                        context = YtPoTokenContext.Gvs,
+                        client = response.client,
+                        videoId = session.videoId,
+                        visitorData = session.visitorData,
+                    ),
+                )
+            } else null
+            if (!tokenRequired || !token.isNullOrBlank()) {
+                var url = solveManifestN(session, manifest) ?: manifest
+                if (!token.isNullOrBlank()) url = appendManifestPot(url, token)
+                output += Candidate(
+                    url = url,
+                    bitrate = 0,
+                    mimeType = "application/x-mpegURL",
+                    durationMs = null,
+                    audioQuality = "HLS",
+                    client = response.client,
+                    manifest = true,
+                )
+            }
+        }
+        return output.distinctBy { it.url }
+    }
+
+    private suspend fun decipherCipher(session: PlayerSession, value: String?): String? {
+        if (value.isNullOrBlank()) return null
+        val params = parseQuery(value)
+        var url = params["url"] ?: return null
+        val signature = params["s"]
+        if (!signature.isNullOrBlank()) {
+            val js = session.playerJs ?: return null
+            val solved = challengeSolver.solveSignature(js, signature)
+                ?: return null
+            url = appendQuery(url, params["sp"].orEmpty().ifBlank { "sig" }, solved)
+        }
+        return url
+    }
+
+    private suspend fun solveN(session: PlayerSession, url: String): String? {
+        val raw = Regex("""([?&])n=([^&]+)""").find(url)?.groupValues?.getOrNull(2)
+            ?: return url
+        val js = session.playerJs ?: return null
+        val challenge = decodeUrl(raw)
+        val solved = challengeSolver.solveN(js, challenge) ?: return null
+        return url.replaceFirst("n=$raw", "n=${encodeUrlComponent(solved)}")
+    }
+
+    private suspend fun solveManifestN(session: PlayerSession, url: String): String? {
+        val raw = Regex("""/n/([^/]+)""").find(url)?.groupValues?.getOrNull(1)
+            ?: return solveN(session, url)
+        val js = session.playerJs ?: return null
+        val solved = challengeSolver.solveN(js, decodeUrl(raw)) ?: return null
+        return url.replaceFirst("/n/$raw", "/n/${encodeUrlComponent(solved)}")
+    }
+
+    private fun selectCandidates(candidates: List<Candidate>, qualityPolicy: String): List<Candidate> {
+        val direct = candidates.filterNot { it.manifest }.sortedWith(
+            compareByDescending<Candidate> { it.mimeType.startsWith("audio/mp4") }
+                .thenByDescending { it.bitrate },
+        )
+        val orderedDirect = when (qualityPolicy) {
+            AudioQualityPolicy.Low.policy -> direct.sortedBy { it.bitrate }
+            AudioQualityPolicy.Standard.policy -> {
+                if (direct.size <= 2) direct
+                else {
+                    val center = direct.size / 2
+                    direct.sortedBy { kotlin.math.abs(direct.indexOf(it) - center) }
+                }
+            }
+            else -> direct
+        }
+        return orderedDirect + candidates.filter { it.manifest }
+    }
+
+    private suspend fun probe(candidate: Candidate): Boolean = runCatching {
+        val headers = if (candidate.manifest) {
+            mapOf("User-Agent" to candidate.client.userAgent, "Accept" to "*/*")
+        } else {
+            mapOf(
+                "User-Agent" to candidate.client.userAgent,
+                "Accept" to "*/*",
+                "Range" to "bytes=0-0",
+            )
+        }
+        http.getText(
+            providerId = YtMusicProvider.ID,
+            url = candidate.url,
+            headers = headers,
+            kind = ProviderRequestKind.Media,
+            cacheKey = null,
+            cachePolicy = ProviderCachePolicies.none,
+        )
+        true
+    }.getOrDefault(false)
+
+    private fun extractConfigValue(html: String, key: String): String? =
+        Regex("""["']?${Regex.escape(key)}["']?\s*[:=]\s*["']([^"']+)["']""")
+            .find(html)?.groupValues?.getOrNull(1)
+
+    private fun extractPlayerJsUrl(html: String): String? =
+        Regex("""["']jsUrl["']\s*:\s*["']([^"']+)["']""")
+            .find(html)?.groupValues?.getOrNull(1)?.replace("\\/", "/")
+            ?: Regex("""["']PLAYER_JS_URL["']\s*:\s*["']([^"']+)["']""")
+                .find(html)?.groupValues?.getOrNull(1)?.replace("\\/", "/")
+            ?: Regex("""/s/player/[^"'\s]+/base\.js""").find(html)?.value
+
+    private fun absolutePlayerJsUrl(url: String): String = when {
+        url.startsWith("http") -> url
+        url.startsWith("//") -> "https:$url"
+        else -> "https://www.youtube.com$url"
+    }
+
+    private fun playerJsId(url: String): String =
+        Regex("""/s/player/([^/]+)/""").find(url)?.groupValues?.getOrNull(1)
+            ?: url.hashCode().toString()
+
+    private fun mergeCookies(vararg values: String): String = values
+        .map { it.trim().trim(';') }
+        .filter { it.isNotBlank() }
+        .joinToString("; ")
+
+    private fun parseQuery(value: String): Map<String, String> = value.split('&').mapNotNull { part ->
+        val index = part.indexOf('=')
+        if (index <= 0) null
+        else decodeUrl(part.substring(0, index)) to decodeUrl(part.substring(index + 1))
+    }.toMap()
+
+    private fun appendQuery(url: String, name: String, value: String): String {
+        val separator = if ('?' in url) '&' else '?'
+        return "$url$separator${encodeUrlComponent(name)}=${encodeUrlComponent(value)}"
+    }
+
+    private fun appendManifestPot(url: String, token: String): String {
+        val queryIndex = url.indexOf('?')
+        val path = if (queryIndex >= 0) url.substring(0, queryIndex) else url
+        val query = if (queryIndex >= 0) url.substring(queryIndex) else ""
+        return path.trimEnd('/') + "/pot/$token" + query
+    }
+
+    private fun decodeUrl(value: String): String {
+        val bytes = ArrayList<Byte>()
+        var index = 0
+        while (index < value.length) {
+            val character = value[index]
+            when {
+                character == '%' && index + 2 < value.length -> {
+                    val number = value.substring(index + 1, index + 3).toIntOrNull(16)
+                    if (number != null) {
+                        bytes += number.toByte()
+                        index += 3
+                        continue
+                    }
+                    bytes += character.code.toByte()
+                }
+                character == '+' -> bytes += ' '.code.toByte()
+                else -> bytes += character.code.toByte()
+            }
+            index += 1
+        }
+        return bytes.toByteArray().decodeToString()
+    }
+
+    private fun encodeUrlComponent(value: String): String = buildString {
+        for (byte in value.encodeToByteArray()) {
+            val number = byte.toInt() and 0xff
+            if (number in 0x30..0x39 || number in 0x41..0x5a || number in 0x61..0x7a ||
+                number in setOf(45, 46, 95, 126)
+            ) {
+                append(number.toChar())
+            } else {
+                append('%')
+                append("0123456789ABCDEF"[number ushr 4])
+                append("0123456789ABCDEF"[number and 0x0f])
+            }
+        }
+    }
+
+    private fun quote(value: String): String = providerJson.encodeToString(
+        kotlinx.serialization.json.JsonPrimitive.serializer(),
+        kotlinx.serialization.json.JsonPrimitive(value),
+    )
+}

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPlayerClients.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPlayerClients.kt
@@ -1,0 +1,151 @@
+package org.feeluown.mobile.provider.ytmusic
+
+internal enum class YtStreamingProtocol {
+    Https,
+    Hls,
+    Dash,
+}
+
+internal data class YtPoTokenPolicy(
+    val required: Boolean = false,
+    val recommended: Boolean = false,
+    val notRequiredWithPlayerToken: Boolean = false,
+)
+
+internal data class YtPlayerClientProfile(
+    val key: String,
+    val clientName: String,
+    val clientId: String,
+    val clientVersion: String,
+    val userAgent: String,
+    val host: String = "www.youtube.com",
+    val requireJsPlayer: Boolean = true,
+    val supportsCookies: Boolean = false,
+    val requireAuth: Boolean = false,
+    val deviceMake: String? = null,
+    val deviceModel: String? = null,
+    val osName: String? = null,
+    val osVersion: String? = null,
+    val androidSdkVersion: Int? = null,
+    val embedded: Boolean = false,
+    val gvsPoTokenPolicy: Map<YtStreamingProtocol, YtPoTokenPolicy> = emptyMap(),
+    val playerPoTokenRecommended: Boolean = false,
+) {
+    fun policy(protocol: YtStreamingProtocol): YtPoTokenPolicy =
+        gvsPoTokenPolicy[protocol] ?: YtPoTokenPolicy()
+}
+
+/**
+ * Player profiles tracked from yt-dlp's current YouTube extractor.
+ *
+ * Keep these definitions data-only so the fallback order can evolve independently
+ * from request/format extraction. ANDROID_VR is intentionally absent: yt-dlp
+ * removed 1.65.10 after all formats started returning HTTP 403 in August 2026.
+ */
+internal object YtMusicPlayerClients {
+    private val webPoPolicies = mapOf(
+        YtStreamingProtocol.Https to YtPoTokenPolicy(required = true, recommended = true),
+        YtStreamingProtocol.Dash to YtPoTokenPolicy(required = true, recommended = true),
+        YtStreamingProtocol.Hls to YtPoTokenPolicy(required = false, recommended = true),
+    )
+
+    val VisionOs = YtPlayerClientProfile(
+        key = "visionos",
+        clientName = "VISIONOS",
+        clientId = "101",
+        clientVersion = "1.02",
+        userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+        requireJsPlayer = false,
+        deviceMake = "Apple",
+        deviceModel = "RealityDevice17,1",
+        osName = "visionOS",
+        osVersion = "26.5.23O471",
+    )
+
+    val Web = YtPlayerClientProfile(
+        key = "web",
+        clientName = "WEB",
+        clientId = "1",
+        clientVersion = "2.20260708.00.00",
+        userAgent = YtMusicOAuth.USER_AGENT,
+        supportsCookies = true,
+        gvsPoTokenPolicy = webPoPolicies,
+    )
+
+    val WebEmbedded = YtPlayerClientProfile(
+        key = "web_embedded",
+        clientName = "WEB_EMBEDDED_PLAYER",
+        clientId = "56",
+        clientVersion = "2.20260708.00.00",
+        userAgent = YtMusicOAuth.USER_AGENT,
+        supportsCookies = true,
+        embedded = true,
+    )
+
+    val WebMusic = YtPlayerClientProfile(
+        key = "web_music",
+        clientName = "WEB_REMIX",
+        clientId = "67",
+        clientVersion = "1.20260707.12.00",
+        userAgent = YtMusicOAuth.USER_AGENT,
+        host = "music.youtube.com",
+        supportsCookies = true,
+        gvsPoTokenPolicy = webPoPolicies,
+    )
+
+    val Tv = YtPlayerClientProfile(
+        key = "tv",
+        clientName = "TVHTML5",
+        clientId = "7",
+        clientVersion = "7.20260707.07.00",
+        userAgent = "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold (unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)",
+        supportsCookies = true,
+    )
+
+    val TvDowngraded = YtPlayerClientProfile(
+        key = "tv_downgraded",
+        clientName = "TVHTML5",
+        clientId = "7",
+        clientVersion = "5.20260707",
+        userAgent = "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version",
+        supportsCookies = true,
+    )
+
+    val Android = YtPlayerClientProfile(
+        key = "android",
+        clientName = "ANDROID",
+        clientId = "3",
+        clientVersion = "21.26.364",
+        userAgent = "com.google.android.youtube/21.26.364 (Linux; U; Android 11) gzip",
+        requireJsPlayer = false,
+        deviceMake = "Google",
+        osName = "Android",
+        osVersion = "11",
+        androidSdkVersion = 30,
+        gvsPoTokenPolicy = mapOf(
+            YtStreamingProtocol.Https to YtPoTokenPolicy(
+                required = true,
+                recommended = true,
+                notRequiredWithPlayerToken = true,
+            ),
+            YtStreamingProtocol.Dash to YtPoTokenPolicy(
+                required = true,
+                recommended = true,
+                notRequiredWithPlayerToken = true,
+            ),
+            YtStreamingProtocol.Hls to YtPoTokenPolicy(
+                required = false,
+                recommended = true,
+                notRequiredWithPlayerToken = true,
+            ),
+        ),
+        playerPoTokenRecommended = true,
+    )
+
+    /** yt-dlp's authenticated defaults plus resilient no-POT fallbacks. */
+    fun ordered(hasBrowserSession: Boolean): List<YtPlayerClientProfile> = if (hasBrowserSession) {
+        listOf(WebEmbedded, TvDowngraded, Web, VisionOs, Tv, WebMusic, Android)
+    } else {
+        listOf(VisionOs, TvDowngraded, WebEmbedded, Tv, Web, WebMusic, Android)
+    }
+}

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPoTokenProvider.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicPoTokenProvider.kt
@@ -1,0 +1,67 @@
+package org.feeluown.mobile.provider.ytmusic
+
+import kotlinx.serialization.json.JsonObject
+import org.feeluown.mobile.provider.core.ProviderCredentialStore
+import org.feeluown.mobile.provider.core.providerJson
+import org.feeluown.mobile.provider.core.stringOrNull
+
+internal enum class YtPoTokenContext {
+    Player,
+    Gvs,
+    Subs,
+}
+
+internal data class YtPoTokenRequest(
+    val context: YtPoTokenContext,
+    val client: YtPlayerClientProfile,
+    val videoId: String,
+    val visitorData: String?,
+)
+
+/** Mirrors yt-dlp's provider boundary: token generation is intentionally pluggable. */
+internal fun interface YtPoTokenProvider {
+    suspend fun token(request: YtPoTokenRequest): String?
+}
+
+/**
+ * Reads explicitly supplied PO tokens without coupling playback extraction to a
+ * specific BotGuard implementation. yt-dlp follows the same design: its core
+ * contains the policy/provider framework while actual token minting may come
+ * from an external provider.
+ *
+ * Existing header-file login JSON can optionally carry one of:
+ *
+ *   "player_po_token": "..."
+ *   "gvs_po_token": "..."
+ *   "subs_po_token": "..."
+ *   "poTokens": {
+ *     "visionos": { "gvs": "...", "player": "..." },
+ *     "web": { "gvs": "..." }
+ *   }
+ *
+ * The fields are additive and do not alter browser/OAuth authentication.
+ */
+internal class CredentialYtPoTokenProvider(
+    private val credentials: ProviderCredentialStore,
+) : YtPoTokenProvider {
+    override suspend fun token(request: YtPoTokenRequest): String? {
+        val raw = credentials.read(YtMusicProvider.ID)?.headerFileJson?.takeIf { it.isNotBlank() }
+            ?: return null
+        val root = runCatching { providerJson.parseToJsonElement(raw) as? JsonObject }.getOrNull()
+            ?: return null
+        val contextKey = request.context.key
+        val perClient = root["poTokens"] as? JsonObject
+        val client = perClient?.get(request.client.key) as? JsonObject
+            ?: perClient?.get(request.client.clientName.lowercase()) as? JsonObject
+        return client?.stringOrNull(contextKey)
+            ?: root.stringOrNull("${contextKey}_po_token")
+            ?: root.stringOrNull("po_token")
+    }
+
+    private val YtPoTokenContext.key: String
+        get() = when (this) {
+            YtPoTokenContext.Player -> "player"
+            YtPoTokenContext.Gvs -> "gvs"
+            YtPoTokenContext.Subs -> "subs"
+        }
+}

--- a/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
+++ b/provider/ytmusic/src/commonMain/kotlin/org/feeluown/mobile/provider/ytmusic/YtMusicProviderFactory.kt
@@ -20,6 +20,11 @@ object YtMusicProviderFactory : KotlinProviderFactory {
     override fun create(dependencies: ProviderRuntimeDependencies): KotlinMusicProvider {
         val base = YtMusicProvider(dependencies.http, dependencies.credentials)
         val content = YtMusicContentProvider(base, dependencies.http, dependencies.credentials)
+        val playback = YtMusicPlaybackProvider(
+            delegate = content,
+            http = dependencies.http,
+            credentials = dependencies.credentials,
+        )
         val provider = CapabilityDelegatingProvider(
             base = base,
             presentation = content,
@@ -27,7 +32,7 @@ object YtMusicProviderFactory : KotlinProviderFactory {
             discovery = content,
             content = content,
             library = content,
-            playback = content,
+            playback = playback,
         )
         val reportingProvider = YtMusicPlaybackReportingProvider(
             delegate = provider,

--- a/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
+++ b/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
@@ -1,0 +1,185 @@
+package org.feeluown.mobile
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.feeluown.mobile.provider.core.InMemoryProviderCredentialStore
+import org.feeluown.mobile.provider.core.network.ProviderHttpClient
+import org.feeluown.mobile.provider.core.network.ProviderRetryPolicy
+import org.feeluown.mobile.provider.ytmusic.YtMusicJsChallengeSolver
+import org.feeluown.mobile.provider.ytmusic.YtMusicPlaybackExtractor
+
+class YtMusicPlaybackProviderTest {
+    @Test
+    fun jsChallengeSolverExecutesSignatureAndNTransforms() = runTest {
+        val solver = YtMusicJsChallengeSolver()
+        val javascript = """
+            var AB=function(a){a=a.split("");a.reverse();return a.join("")};
+            var NZ=function(a){a=a.split("");a.reverse();return a.join("")};
+            c&&(c=AB(decodeURIComponent(c)));
+            x.get("n"))&&(b=NZ(b),x.set("n",b));
+            var config={signatureTimestamp:20999};
+        """.trimIndent()
+
+        assertEquals(20999, solver.signatureTimestamp(javascript))
+        assertEquals("dcba", solver.solveSignature(javascript, "abcd"))
+        assertEquals("4321", solver.solveN(javascript, "1234"))
+    }
+
+    @Test
+    fun resolveUsesVisionOsDirectAudioAndProbesCdn() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val providerHttp = http(requests) { request ->
+            val url = request.url.toString()
+            val body = (request.body as? TextContent)?.text.orEmpty()
+            when {
+                request.method == HttpMethod.Get && url.contains("youtube.com/watch") -> respond(WATCH_HTML)
+                body.contains("\"clientName\":\"VISIONOS\"") -> respond(
+                    """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/mp4; codecs=\"mp4a.40.2\"","bitrate":129000,"url":"https://cdn.example/vision.m4a","approxDurationMs":"10000","audioQuality":"AUDIO_QUALITY_MEDIUM"}]}}""",
+                )
+                url == "https://cdn.example/vision.m4a" -> respond(
+                    "x",
+                    status = HttpStatusCode.PartialContent,
+                )
+                else -> respond("""{"playabilityStatus":{"status":"UNPLAYABLE"}}""")
+            }
+        }
+        val extractor = YtMusicPlaybackExtractor(
+            providerHttp,
+            InMemoryProviderCredentialStore(),
+            poTokenProvider = { null },
+        )
+
+        val payload = extractor.resolve(track(), AudioQualityPolicy.High.policy)
+
+        assertEquals("https://cdn.example/vision.m4a", payload?.url)
+        assertTrue(payload?.headers.isNullOrEmpty())
+        val player = requests.first { it.body.contains("VISIONOS") }
+        assertEquals("101", player.headers["X-Youtube-Client-Name"])
+        assertTrue(requests.any { it.url == "https://cdn.example/vision.m4a" && it.headers["Range"] == "bytes=0-0" })
+        providerHttp.close()
+    }
+
+    @Test
+    fun resolveFallsBackWhenFirstSignedUrlReturns403() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val providerHttp = http(requests) { request ->
+            val url = request.url.toString()
+            val body = (request.body as? TextContent)?.text.orEmpty()
+            when {
+                request.method == HttpMethod.Get && url.contains("youtube.com/watch") -> respond(WATCH_HTML)
+                body.contains("\"clientName\":\"VISIONOS\"") -> respond(
+                    playerWithAudio("https://cdn.example/blocked.m4a"),
+                )
+                url == "https://cdn.example/blocked.m4a" -> respond(
+                    "forbidden",
+                    status = HttpStatusCode.Forbidden,
+                )
+                body.contains("\"clientName\":\"TVHTML5\"") && body.contains("\"clientVersion\":\"5.20260707\"") -> respond(
+                    playerWithAudio("https://cdn.example/tv.m4a"),
+                )
+                url == "https://cdn.example/tv.m4a" -> respond(
+                    "x",
+                    status = HttpStatusCode.PartialContent,
+                )
+                else -> respond("""{"playabilityStatus":{"status":"UNPLAYABLE"}}""")
+            }
+        }
+        val extractor = YtMusicPlaybackExtractor(
+            providerHttp,
+            InMemoryProviderCredentialStore(),
+            poTokenProvider = { null },
+        )
+
+        val payload = extractor.resolve(track(), AudioQualityPolicy.High.policy)
+
+        assertEquals("https://cdn.example/tv.m4a", payload?.url)
+        assertTrue(requests.any { it.url == "https://cdn.example/blocked.m4a" })
+        assertTrue(requests.any { it.body.contains("\"clientVersion\":\"5.20260707\"") })
+        providerHttp.close()
+    }
+
+    @Test
+    fun resolveUsesHlsWhenAdaptiveFormatsAreSabrOnly() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val providerHttp = http(requests) { request ->
+            val url = request.url.toString()
+            val body = (request.body as? TextContent)?.text.orEmpty()
+            when {
+                request.method == HttpMethod.Get && url.contains("youtube.com/watch") -> respond(WATCH_HTML)
+                body.contains("\"clientName\":\"VISIONOS\"") -> respond(
+                    """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/mp4","bitrate":128000}],"hlsManifestUrl":"https://manifest.example/audio.m3u8"}}""",
+                )
+                url == "https://manifest.example/audio.m3u8" -> respond("#EXTM3U\n#EXT-X-VERSION:3")
+                else -> respond("""{"playabilityStatus":{"status":"UNPLAYABLE"}}""")
+            }
+        }
+        val extractor = YtMusicPlaybackExtractor(
+            providerHttp,
+            InMemoryProviderCredentialStore(),
+            poTokenProvider = { null },
+        )
+
+        val payload = extractor.resolve(track(), AudioQualityPolicy.High.policy)
+
+        assertNotNull(payload)
+        assertEquals("https://manifest.example/audio.m3u8", payload.url)
+        assertEquals("HLS", payload.audioQuality)
+        providerHttp.close()
+    }
+
+    private fun http(
+        requests: MutableList<CapturedRequest>,
+        handler: suspend (io.ktor.client.request.HttpRequestData) -> io.ktor.client.engine.mock.HttpResponseData,
+    ): ProviderHttpClient = ProviderHttpClient(
+        httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    requests += capture(request)
+                    handler(request)
+                }
+            }
+        },
+        retryPolicy = ProviderRetryPolicy(maxRetries = 0),
+    )
+
+    private fun track() = MusicTrack(
+        id = "ytmusic:vid1",
+        title = "T",
+        artists = "A",
+        album = "",
+        source = "ytmusic",
+        sourceType = TrackSourceType.Provider,
+        providerId = "ytmusic:vid1",
+        providerName = "YouTube Music",
+    )
+
+    private fun playerWithAudio(url: String): String =
+        """{"playabilityStatus":{"status":"OK"},"streamingData":{"adaptiveFormats":[{"mimeType":"audio/mp4","bitrate":128000,"url":"$url","approxDurationMs":"10000"}]}}"""
+
+    private data class CapturedRequest(
+        val method: HttpMethod,
+        val url: String,
+        val headers: Map<String, String>,
+        val body: String,
+    )
+
+    private fun capture(request: io.ktor.client.request.HttpRequestData): CapturedRequest = CapturedRequest(
+        method = request.method,
+        url = request.url.toString(),
+        headers = request.headers.entries().associate { it.key to it.value.joinToString(",") },
+        body = (request.body as? TextContent)?.text.orEmpty(),
+    )
+
+    private companion object {
+        const val WATCH_HTML = """<html>ytcfg.set({"INNERTUBE_API_KEY":"AIzaSyTestKey","VISITOR_DATA":"visitor-token"});</html>"""
+    }
+}

--- a/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
+++ b/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
@@ -138,7 +138,7 @@ class YtMusicPlaybackProviderTest {
 
     private fun http(
         requests: MutableList<CapturedRequest>,
-        handler: suspend (io.ktor.client.request.HttpRequestData) -> io.ktor.client.engine.mock.HttpResponseData,
+        handler: suspend (io.ktor.client.request.HttpRequestData) -> io.ktor.client.request.HttpResponseData,
     ): ProviderHttpClient = ProviderHttpClient(
         httpClient = HttpClient(MockEngine) {
             engine {

--- a/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
+++ b/provider/ytmusic/src/commonTest/kotlin/org/feeluown/mobile/YtMusicPlaybackProviderTest.kt
@@ -2,7 +2,10 @@ package org.feeluown.mobile
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
@@ -138,13 +141,13 @@ class YtMusicPlaybackProviderTest {
 
     private fun http(
         requests: MutableList<CapturedRequest>,
-        handler: suspend (io.ktor.client.request.HttpRequestData) -> io.ktor.client.request.HttpResponseData,
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
     ): ProviderHttpClient = ProviderHttpClient(
         httpClient = HttpClient(MockEngine) {
             engine {
                 addHandler { request ->
                     requests += capture(request)
-                    handler(request)
+                    handler.invoke(this, request)
                 }
             }
         },
@@ -172,7 +175,7 @@ class YtMusicPlaybackProviderTest {
         val body: String,
     )
 
-    private fun capture(request: io.ktor.client.request.HttpRequestData): CapturedRequest = CapturedRequest(
+    private fun capture(request: HttpRequestData): CapturedRequest = CapturedRequest(
         method = request.method,
         url = request.url.toString(),
         headers = request.headers.entries().associate { it.key to it.value.joinToString(",") },


### PR DESCRIPTION
## Summary
- split volatile YouTube playback extraction out of the account/catalogue provider
- model current yt-dlp client profiles and fallback order instead of hard-coding one player path
- execute YouTube `s` and `n` player.js challenges with a multiplatform QuickJS runtime
- model yt-dlp-style PLAYER/GVS/SUBS PO-token provider and per-client policy
- skip SABR-only formats without a usable URL/cipher
- support HLS manifest fallback in addition to `adaptiveFormats`
- probe signed media URLs with a one-byte range request so HTTP 403 falls through to another format/client
- keep OAuth/account authentication independent from playback extraction

## Why
PR #199 removed the known-broken `ANDROID_VR 1.65.10` path, but changing the client alone is insufficient. Current YouTube playback also requires handling `n` throttling challenges, PO-token policy, SABR responses, HLS fallback and CDN-level failures. This PR moves those responsibilities into a dedicated playback extractor modeled after yt-dlp's current YouTube pipeline.

## PO token scope
Like yt-dlp core, this PR provides the PO-token policy/provider boundary rather than hard-coding a BotGuard implementation. Explicit PLAYER/GVS/SUBS tokens can be supplied through the existing header-file credential JSON. Clients that do not currently require POT remain preferred so normal playback does not depend on a token generator.

## Tests
Adds regression coverage for:
- real JS execution of signature and `n` transforms
- VISIONOS direct audio resolution
- CDN HTTP 403 fallback to another client
- HLS fallback when adaptive formats are SABR-only