### PR TITLE
Unify application logging and diagnostics export

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppLogger.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppLogger.kt
@@ -1,0 +1,96 @@
+package org.feeluown.mobile
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private const val MAX_APP_LOG_BYTES = 4L * 1024L * 1024L
+
+internal object AndroidAppLogFiles {
+    fun directory(context: Context): File = File(context.filesDir, "logs")
+    fun active(context: Context): File = File(directory(context), "application.log")
+    fun previous(context: Context): File = File(directory(context), "application.previous.log")
+}
+
+/** Install before constructing the application container so startup failures are persisted too. */
+internal fun installAndroidAppLogger(context: Context) {
+    AppLogger.install(AndroidAppLogSink(context.applicationContext))
+    AppLogger.i("AppLogger", "Android application logging initialized")
+}
+
+private class AndroidAppLogSink(
+    context: Context,
+) : AppLogSink {
+    private val activeFile = AndroidAppLogFiles.active(context)
+    private val previousFile = AndroidAppLogFiles.previous(context)
+    private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    private var output: FileOutputStream
+
+    init {
+        activeFile.parentFile?.mkdirs()
+        if (activeFile.isFile && activeFile.length() >= MAX_APP_LOG_BYTES) rotate()
+        output = FileOutputStream(activeFile, true)
+    }
+
+    @Synchronized
+    override fun write(level: AppLogLevel, tag: String, message: String, throwableText: String?) {
+        val text = buildString {
+            append(formatter.format(Date()))
+            append(' ')
+            append(level.code)
+            append('/')
+            append(tag)
+            append(": ")
+            append(message)
+            if (!throwableText.isNullOrBlank()) {
+                append('\n')
+                append(throwableText)
+            }
+            append('\n')
+        }
+        val consoleText = if (throwableText.isNullOrBlank()) message else "$message\n$throwableText"
+        Log.println(level.androidPriority, tag, consoleText)
+
+        runCatching {
+            val bytes = text.toByteArray(Charsets.UTF_8)
+            if (activeFile.length() + bytes.size > MAX_APP_LOG_BYTES) {
+                output.flush()
+                output.close()
+                rotate()
+                output = FileOutputStream(activeFile, true)
+            }
+            output.write(bytes)
+            output.flush()
+        }.onFailure { failure ->
+            Log.e("AppLogger", "Unable to persist application log: ${failure.message.orEmpty()}")
+        }
+    }
+
+    private fun rotate() {
+        if (previousFile.exists()) previousFile.delete()
+        if (activeFile.exists() && !activeFile.renameTo(previousFile)) {
+            activeFile.copyTo(previousFile, overwrite = true)
+            activeFile.delete()
+        }
+    }
+}
+
+private val AppLogLevel.code: Char
+    get() = when (this) {
+        AppLogLevel.Debug -> 'D'
+        AppLogLevel.Info -> 'I'
+        AppLogLevel.Warning -> 'W'
+        AppLogLevel.Error -> 'E'
+    }
+
+private val AppLogLevel.androidPriority: Int
+    get() = when (this) {
+        AppLogLevel.Debug -> Log.DEBUG
+        AppLogLevel.Info -> Log.INFO
+        AppLogLevel.Warning -> Log.WARN
+        AppLogLevel.Error -> Log.ERROR
+    }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDebugLogRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDebugLogRepository.kt
@@ -2,69 +2,97 @@ package org.feeluown.mobile
 
 import android.content.Context
 import android.content.Intent
-import android.os.Process
+import android.os.Build
 import androidx.core.content.FileProvider
 import java.io.File
+import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private const val MAX_DEBUG_LOG_LINES = 2_000
+private const val MAX_DIAGNOSTIC_LOG_LINES = 2_000
 
+/**
+ * Compatibility adapter for the old debug-log feature contract.
+ *
+ * The UI no longer exposes raw logs; this repository now reads AppLogger's rolling files and
+ * exports a user-shareable diagnostics archive. Availability is intentionally enabled in release
+ * builds as diagnostics are a support feature rather than a developer-only tool.
+ */
 class AndroidDebugLogRepository(
     private val context: Context,
-    override val isAvailable: Boolean,
+    @Suppress("UNUSED_PARAMETER") legacyDebuggableOnly: Boolean,
 ) : DebugLogRepository {
-    override suspend fun logLines(): List<String> {
-        if (!isAvailable) return emptyList()
-        return withContext(Dispatchers.IO) {
-            val process = Runtime.getRuntime().exec(
-                arrayOf(
-                    "logcat",
-                    "-d",
-                    "-v",
-                    "threadtime",
-                    "--pid=${Process.myPid()}",
-                    "*:D",
-                ),
-            )
-            try {
-                val output = process.inputStream.bufferedReader().use { it.readText() }
-                val error = process.errorStream.bufferedReader().use { it.readText() }
-                val exitCode = process.waitFor()
-                if (exitCode != 0) {
-                    throw IllegalStateException(error.ifBlank { "logcat failed: $exitCode" })
-                }
-                output.lines()
-                    .map { it.trimEnd() }
-                    .filter { it.isNotBlank() }
-                    .takeLast(MAX_DEBUG_LOG_LINES)
-            } finally {
-                process.destroy()
-            }
-        }
+    override val isAvailable: Boolean = true
+
+    override suspend fun logLines(): List<String> = withContext(Dispatchers.IO) {
+        listOf(AndroidAppLogFiles.previous(context), AndroidAppLogFiles.active(context))
+            .filter(File::isFile)
+            .flatMap { file -> file.readLines(Charsets.UTF_8) }
+            .map(String::trimEnd)
+            .filter(String::isNotBlank)
+            .takeLast(MAX_DIAGNOSTIC_LOG_LINES)
     }
 
     override suspend fun exportLogFile(lines: List<String>): String {
-        if (!isAvailable || lines.isEmpty()) return "没有可导出的日志"
-        val file = withContext(Dispatchers.IO) {
-            val dir = File(context.cacheDir, "debug-logs").also { it.mkdirs() }
+        val archive = withContext(Dispatchers.IO) {
+            val dir = File(context.cacheDir, "diagnostics").also { it.mkdirs() }
             val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
-            val file = File(dir, "fuo-evolve-log-$timestamp.txt")
-            file.writeText(lines.joinToString(separator = "\n"))
-            file
+            val archive = File(dir, "FuoEvolve-Diagnostics-$timestamp.zip")
+            ZipOutputStream(FileOutputStream(archive)).use { zip ->
+                zip.putNextEntry(ZipEntry("diagnostics.txt"))
+                zip.write(diagnosticsSummary().toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+
+                listOf(AndroidAppLogFiles.active(context), AndroidAppLogFiles.previous(context))
+                    .filter(File::isFile)
+                    .forEach { logFile ->
+                        zip.putNextEntry(ZipEntry(logFile.name))
+                        logFile.inputStream().use { input -> input.copyTo(zip) }
+                        zip.closeEntry()
+                    }
+            }
+            archive
         }
-        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", archive)
         val sendIntent = Intent(Intent.ACTION_SEND)
-            .setType("text/plain")
+            .setType("application/zip")
             .putExtra(Intent.EXTRA_STREAM, uri)
-            .putExtra(Intent.EXTRA_SUBJECT, file.name)
+            .putExtra(Intent.EXTRA_SUBJECT, archive.name)
             .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        val chooser = Intent.createChooser(sendIntent, "导出应用日志")
+        val chooser = Intent.createChooser(sendIntent, "导出诊断信息")
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(chooser)
-        return "已准备导出日志文件：${file.name}"
+        return "已准备导出诊断信息：${archive.name}"
+    }
+
+    @Suppress("DEPRECATION")
+    private fun diagnosticsSummary(): String {
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        val versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode
+        } else {
+            packageInfo.versionCode.toLong()
+        }
+        return buildString {
+            appendLine("FuoEvolve diagnostics")
+            appendLine("generatedAt=${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())}")
+            appendLine("package=${context.packageName}")
+            appendLine("versionName=${packageInfo.versionName.orEmpty()}")
+            appendLine("versionCode=$versionCode")
+            appendLine("platform=Android")
+            appendLine("androidRelease=${Build.VERSION.RELEASE.orEmpty()}")
+            appendLine("sdk=${Build.VERSION.SDK_INT}")
+            appendLine("manufacturer=${Build.MANUFACTURER.orEmpty()}")
+            appendLine("model=${Build.MODEL.orEmpty()}")
+            appendLine("device=${Build.DEVICE.orEmpty()}")
+            appendLine("abis=${Build.SUPPORTED_ABIS.joinToString()}")
+            appendLine()
+            appendLine("Logs are redacted by AppLogger before persistence. Credentials and app databases are not included.")
+        }
     }
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidDownloadRepository.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -249,7 +248,7 @@ class AndroidDownloadRepository(
             // pause() has already persisted the paused state and intentionally retains the partial file.
         } catch (throwable: Throwable) {
             target?.let { finishTarget(it, success = false) }
-            Log.e(TAG, "download failed taskId=$taskId", throwable)
+            AppLogger.e(TAG, "download failed taskId=$taskId", throwable)
             taskMutex.withLock {
                 taskRecords[taskId]?.let { updateTask(it.copy(
                     status = DownloadTaskStatus.Failed,
@@ -457,7 +456,7 @@ class AndroidDownloadRepository(
             if (!directory.exists()) directory.mkdirs()
             target.writeText(lyrics, Charsets.UTF_8)
         }.onFailure { throwable ->
-            Log.w(TAG, "save lyrics failed fileName=$fileName", throwable)
+            AppLogger.w(TAG, "save lyrics failed fileName=$fileName", throwable)
         }
     }
 
@@ -549,7 +548,7 @@ class AndroidDownloadRepository(
                 )
             }
         }.onFailure { throwable ->
-            Log.w(TAG, "load download resume metadata failed", throwable)
+            AppLogger.w(TAG, "load download resume metadata failed", throwable)
         }
     }
 
@@ -787,7 +786,7 @@ class AndroidDownloadRepository(
         runCatching {
             insertM4aMetadata(file, title, artists, album, coverImage)
         }.onFailure { throwable ->
-            Log.w(TAG, "failed to write m4a metadata file=${file.name}", throwable)
+            AppLogger.w(TAG, "failed to write m4a metadata file=${file.name}", throwable)
         }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/AndroidNativeAudioEngine.kt
@@ -3,7 +3,6 @@ package org.feeluown.mobile
 import android.content.ComponentName
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -68,7 +67,7 @@ class AndroidNativeAudioEngine(
                     )
                 ) {
                     PlaybackServiceStateAction.Ignore -> {
-                        Log.d(
+                        AppLogger.d(
                             TAG,
                             "ignoring stale service state phase=${startupState.phase} " +
                                 "serviceTrackId=${serviceTrackId.orEmpty()} " +
@@ -155,7 +154,7 @@ class AndroidNativeAudioEngine(
             restoredSession = resumedSession
             activePlan = resumedSession.plan
             connectController()
-            Log.d(TAG, "prepared restored resume trackId=${track.id} reason=$reason")
+            AppLogger.d(TAG, "prepared restored resume trackId=${track.id} reason=$reason")
             return
         }
 
@@ -240,7 +239,7 @@ class AndroidNativeAudioEngine(
             .onFailure { throwable ->
                 startupState.markIdle()
                 activePlan = null
-                Log.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
+                AppLogger.e(TAG, "start playback service failed trackId=${first.track.id}", throwable)
                 mutableState.value = mutableState.value.copy(
                     status = PlayerStatus.Error,
                     errorMessage = throwable.message ?: "无法启动播放器服务",
@@ -274,7 +273,7 @@ class AndroidNativeAudioEngine(
                 activePlan = session.plan
                 pendingResumePositionMs = null
                 playbackResumeStore.saveSession(session.plan, session.toPlaybackState())
-                Log.e(TAG, "restore playback service failed trackId=${session.currentTrack.id}", throwable)
+                AppLogger.e(TAG, "restore playback service failed trackId=${session.currentTrack.id}", throwable)
                 mutableState.value = session.toPlaybackState().copy(
                     status = PlayerStatus.Error,
                     errorMessage = throwable.message ?: "无法恢复播放进度",
@@ -388,9 +387,9 @@ class AndroidNativeAudioEngine(
                 controller.stop()
             }
         }.onSuccess {
-            Log.d(TAG, "discarded paused Media3 session before active selection trackId=$nextTrackId")
+            AppLogger.d(TAG, "discarded paused Media3 session before active selection trackId=$nextTrackId")
         }.onFailure { throwable ->
-            Log.w(TAG, "failed to discard paused Media3 session before trackId=$nextTrackId", throwable)
+            AppLogger.w(TAG, "failed to discard paused Media3 session before trackId=$nextTrackId", throwable)
         }
     }
 
@@ -409,7 +408,7 @@ class AndroidNativeAudioEngine(
                         applyPendingLockScreenLyrics()
                     }
                     .onFailure { throwable ->
-                        Log.e(TAG, "connect media controller failed", throwable)
+                        AppLogger.e(TAG, "connect media controller failed", throwable)
                         mutableState.value = mutableState.value.copy(
                             status = PlayerStatus.Error,
                             errorMessage = throwable.message ?: "无法连接播放器服务",
@@ -494,7 +493,7 @@ class AndroidNativeAudioEngine(
         val track = mutableState.value.currentTrack ?: return
         if (track.id != pending.trackId) return
         if (!controller.isCommandAvailable(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
-            Log.w(TAG, "media session does not allow metadata replacement for ColorOS lyrics")
+            AppLogger.w(TAG, "media session does not allow metadata replacement for ColorOS lyrics")
             return
         }
         val currentItem = controller.currentMediaItem ?: return
@@ -519,10 +518,10 @@ class AndroidNativeAudioEngine(
         replaceMediaItemMetadata(controller, currentIndex, currentItem, extras)
             .onSuccess {
                 pendingLockScreenLyrics = null
-                Log.d(TAG, "published ColorOS lock-screen lyrics trackId=${track.id}")
+                AppLogger.d(TAG, "published ColorOS lock-screen lyrics trackId=${track.id}")
             }
             .onFailure { throwable ->
-                Log.w(TAG, "failed to publish ColorOS lock-screen lyrics trackId=${track.id}", throwable)
+                AppLogger.w(TAG, "failed to publish ColorOS lock-screen lyrics trackId=${track.id}", throwable)
             }
     }
 
@@ -540,7 +539,7 @@ class AndroidNativeAudioEngine(
         }
         replaceMediaItemMetadata(controller, currentIndex, currentItem, extras)
             .onFailure { throwable ->
-                Log.w(TAG, "failed to clear ColorOS lock-screen lyrics", throwable)
+                AppLogger.w(TAG, "failed to clear ColorOS lock-screen lyrics", throwable)
             }
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BydInstrumentLyricsPublisher.kt
@@ -2,7 +2,6 @@ package org.feeluown.mobile
 
 import android.content.Context
 import android.os.SystemClock
-import android.util.Log
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import kotlinx.coroutines.CoroutineScope
@@ -198,11 +197,11 @@ internal class BydInstrumentLyricsPublisher(
         bridgeInitializationAttempted = true
         return BydInstrumentLyricsBridge.create(appContext)
             .onFailure { throwable ->
-                Log.w(TAG, "Unable to initialize BYD instrument lyrics; playback is unaffected", throwable)
+                AppLogger.w(TAG, "Unable to initialize BYD instrument lyrics; playback is unaffected", throwable)
             }
             .getOrNull()
             ?.also { createdBridge ->
-                Log.i(TAG, "Using BYD instrument lyrics transport=${createdBridge.transportName}")
+                AppLogger.i(TAG, "Using BYD instrument lyrics transport=${createdBridge.transportName}")
                 bridge = createdBridge
             }
     }
@@ -287,7 +286,7 @@ private class BydInstrumentLyricsBridge(
             }
             if (musicNameMethod == null) return false
             useMusicNameTransport = true
-            Log.w(TAG, "Falling back to BYD sendMusicName after three-line lyrics publishing failed")
+            AppLogger.w(TAG, "Falling back to BYD sendMusicName after three-line lyrics publishing failed")
         }
 
         val nameMethod = musicNameMethod ?: return false
@@ -362,19 +361,19 @@ private class BydInstrumentLyricsBridge(
         val result = method.invoke(device, *args)
         commandSucceeded(result)
     }.onFailure { throwable ->
-        Log.w(TAG, "Failed to publish lyrics through ${method.name}", unwrapInvocationException(throwable))
+        AppLogger.w(TAG, "Failed to publish lyrics through ${method.name}", unwrapInvocationException(throwable))
     }.getOrDefault(false)
 
     private fun invokeOptional(method: Method, vararg args: Any): Boolean = runCatching {
         val result = method.invoke(device, *args)
         commandSucceeded(result)
     }.onFailure { throwable ->
-        Log.d(TAG, "Optional BYD instrument call ${method.name} failed", unwrapInvocationException(throwable))
+        AppLogger.d(TAG, "Optional BYD instrument call ${method.name} failed", unwrapInvocationException(throwable))
     }.getOrDefault(false)
 
     private fun commandSucceeded(result: Any?): Boolean {
         val success = (result as? Number)?.toInt()?.let { it == 0 } ?: true
-        if (!success) Log.w(TAG, "BYD instrument command returned $result")
+        if (!success) AppLogger.w(TAG, "BYD instrument command returned $result")
         return success
     }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoEvolveApplication.kt
@@ -11,6 +11,11 @@ import android.app.Application
 class FuoEvolveApplication : Application() {
     private var containerHolder: AndroidAppContainer? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        installAndroidAppLogger(this)
+    }
+
     private fun container(): AndroidAppContainer =
         containerHolder ?: AndroidAppContainer(this).also { containerHolder = it }
 

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/FuoPlaybackService.kt
@@ -6,7 +6,6 @@ import android.media.MediaCodecList
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.KeyEvent
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -141,7 +140,7 @@ class FuoPlaybackService : MediaSessionService() {
 
                     override fun onPlayerError(error: PlaybackException) {
                         val item = player.currentMediaItem
-                        Log.e(
+                        AppLogger.e(
                             TAG,
                             "exo playback error trackId=${item?.mediaId.orEmpty()} " +
                                 "source=${item?.mediaMetadata?.extras?.getString("source").orEmpty()} " +
@@ -205,7 +204,7 @@ class FuoPlaybackService : MediaSessionService() {
                 val rawPlan = intent.getStringExtra(EXTRA_PLAN) ?: error("Missing playback plan")
                 playPlan(rawPlan.toPlaybackPlan())
             }.onFailure { throwable ->
-                Log.e(TAG, "play plan failed", throwable)
+                AppLogger.e(TAG, "play plan failed", throwable)
                 player?.stop()
                 mutablePlaybackState.value = PlaybackState(
                     status = PlayerStatus.Error,
@@ -309,7 +308,7 @@ class FuoPlaybackService : MediaSessionService() {
                 throw cancelled
             } catch (throwable: Throwable) {
                 if (activeGeneration != plan.generation) return@launch
-                Log.e(TAG, "resolve failed trackId=${first.track.id} generation=${plan.generation}", throwable)
+                AppLogger.e(TAG, "resolve failed trackId=${first.track.id} generation=${plan.generation}", throwable)
                 mutablePlaybackState.value = PlaybackState(
                     status = PlayerStatus.Error,
                     currentTrack = first.track,
@@ -347,13 +346,13 @@ class FuoPlaybackService : MediaSessionService() {
                             play()
                         }
                     }
-                    Log.i(TAG, "preloaded trackId=${prepared.track.id} generation=$generation")
+                    AppLogger.i(TAG, "preloaded trackId=${prepared.track.id} generation=$generation")
                 }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (throwable: Throwable) {
                 if (activeGeneration == generation) {
-                    Log.w(TAG, "preload failed trackId=${request.track.id}", throwable)
+                    AppLogger.w(TAG, "preload failed trackId=${request.track.id}", throwable)
                     if (
                         request.unavailablePolicy == UnavailablePlaybackPolicy.Skip ||
                         (
@@ -575,7 +574,7 @@ class FuoPlaybackService : MediaSessionService() {
 
     private fun createMediaSource(mediaItem: MediaItem, headers: Map<String, String>): ProgressiveMediaSource {
         val url = mediaItem.localConfiguration?.uri?.toString().orEmpty()
-        Log.i(
+        AppLogger.i(
             TAG,
             "play source trackId=${mediaItem.mediaId} " +
                 "source=${mediaItem.mediaMetadata.extras?.getString("source").orEmpty()} url=${mediaItem.localConfiguration?.uri.toString().summarizePlaybackUrl()} " +

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/LyriconLyricsPublisher.kt
@@ -2,7 +2,6 @@ package org.feeluown.mobile
 
 import android.content.Context
 import android.os.SystemClock
-import android.util.Log
 import io.github.proify.lyricon.lyric.model.LyricWord as LyriconLyricWord
 import io.github.proify.lyricon.lyric.model.RichLyricLine as LyriconRichLyricLine
 import io.github.proify.lyricon.lyric.model.Song as LyriconSong
@@ -52,21 +51,21 @@ internal class LyriconLyricsPublisher(
 
     private val connectionListener = object : ConnectionListener {
         override fun onConnected(provider: LyriconProvider) {
-            Log.d(TAG, "Lyricon connected")
+            AppLogger.d(TAG, "Lyricon connected")
             syncManualPlaybackState(provider)
         }
 
         override fun onReconnected(provider: LyriconProvider) {
-            Log.d(TAG, "Lyricon reconnected")
+            AppLogger.d(TAG, "Lyricon reconnected")
             syncManualPlaybackState(provider)
         }
 
         override fun onDisconnected(provider: LyriconProvider) {
-            Log.w(TAG, "Lyricon disconnected")
+            AppLogger.w(TAG, "Lyricon disconnected")
         }
 
         override fun onConnectTimeout(provider: LyriconProvider) {
-            Log.w(TAG, "Lyricon connection timed out; playback continues normally")
+            AppLogger.w(TAG, "Lyricon connection timed out; playback continues normally")
         }
     }
 
@@ -175,7 +174,7 @@ internal class LyriconLyricsPublisher(
             }
             lastPublishedStatus = snapshot.status
         }.onFailure { throwable ->
-            Log.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
+            AppLogger.w(TAG, "Failed to publish Lyricon state; playback is unaffected", throwable)
         }
 
         if (snapshot.status == PlaybackSessionStatus.Playing) {
@@ -234,7 +233,7 @@ internal class LyriconLyricsPublisher(
                 ensurePositionSyncLoop()
             }
         }.onFailure { throwable ->
-            Log.w(TAG, "Unable to resync Lyricon playback state", throwable)
+            AppLogger.w(TAG, "Unable to resync Lyricon playback state", throwable)
         }
     }
 
@@ -253,7 +252,7 @@ internal class LyriconLyricsPublisher(
     private fun ensureProvider(): LyriconProvider? {
         provider?.let { return it }
         if (!isLyriconInstalled(appContext)) {
-            Log.d(TAG, "Lyricon is not installed; skip status bar lyrics")
+            AppLogger.d(TAG, "Lyricon is not installed; skip status bar lyrics")
             return null
         }
         return runCatching {
@@ -263,12 +262,12 @@ internal class LyriconLyricsPublisher(
                 created.player.setDisplayRoma(true)
                 created.service.addConnectionListener(connectionListener)
                 if (!created.register()) {
-                    Log.w(TAG, "Lyricon provider registration was not started; playback is unaffected")
+                    AppLogger.w(TAG, "Lyricon provider registration was not started; playback is unaffected")
                 }
                 provider = created
             }
         }.onFailure { throwable ->
-            Log.w(TAG, "Unable to initialize Lyricon; playback is unaffected", throwable)
+            AppLogger.w(TAG, "Unable to initialize Lyricon; playback is unaffected", throwable)
         }.getOrNull()
     }
 
@@ -280,15 +279,15 @@ internal class LyriconLyricsPublisher(
             activeProvider.player.setPlaybackState(false)
             activeProvider.player.setSong(null)
         }.onFailure { throwable ->
-            Log.w(TAG, "Unable to clear Lyricon song", throwable)
+            AppLogger.w(TAG, "Unable to clear Lyricon song", throwable)
         }
         runCatching { activeProvider.unregister() }
-            .onFailure { throwable -> Log.w(TAG, "Unable to unregister Lyricon", throwable) }
+            .onFailure { throwable -> AppLogger.w(TAG, "Unable to unregister Lyricon", throwable) }
         runCatching {
             activeProvider.service.removeConnectionListener(connectionListener)
             activeProvider.destroy()
         }.onFailure { throwable ->
-            Log.w(TAG, "Unable to destroy Lyricon provider", throwable)
+            AppLogger.w(TAG, "Unable to destroy Lyricon provider", throwable)
         }
         provider = null
         lastTrackKey = null

--- a/androidApp/src/main/res/xml/file_paths.xml
+++ b/androidApp/src/main/res/xml/file_paths.xml
@@ -4,6 +4,9 @@
         name="debug_logs"
         path="debug-logs/" />
     <cache-path
+        name="diagnostics"
+        path="diagnostics/" />
+    <cache-path
         name="local_playlists"
         path="local-playlists/" />
     <cache-path

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNonBlockingUriHandler.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopNonBlockingUriHandler.kt
@@ -3,6 +3,7 @@ package org.feeluown.mobile.desktop
 import androidx.compose.ui.platform.UriHandler
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import org.feeluown.mobile.AppLogger
 
 /**
  * Desktop URI launching may synchronously wait for the OS browser launcher (notably xdg-open on
@@ -17,8 +18,10 @@ internal class DesktopNonBlockingUriHandler(
         executor.execute {
             runCatching { delegate.openUri(uri) }
                 .onFailure { error ->
-                    System.err.println(
-                        "FuoEvolve: failed to open external URI: ${error.message ?: error::class.simpleName}",
+                    AppLogger.e(
+                        "DesktopUri",
+                        "Failed to open external URI",
+                        error,
                     )
                 }
         }

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopProtocolRegistration.kt
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import org.feeluown.mobile.AppLogger
 
 /** Runtime registration is needed on Windows/Linux; macOS receives the URL scheme from Info.plist. */
 internal fun registerDesktopFuoProtocolHandler() {
@@ -14,7 +15,7 @@ internal fun registerDesktopFuoProtocolHandler() {
             isLinux() -> registerLinuxProtocol(launcher)
         }
     }.onFailure { throwable ->
-        System.err.println("FuoEvolve: unable to register fuo:// protocol: ${throwable.message}")
+        AppLogger.w("DesktopProtocol", "Unable to register fuo:// protocol", throwable)
     }
 }
 

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSystemMediaSession.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSystemMediaSession.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import org.feeluown.mobile.AppLogger
 import org.feeluown.mobile.RepeatMode
 import org.feeluown.mobile.core.model.TrackRef
 import org.feeluown.mobile.playback.api.PlaybackSession
@@ -29,7 +30,7 @@ internal fun createDesktopSystemMediaSession(playbackSession: PlaybackSession): 
     if (!os.contains("linux")) return AutoCloseable { }
     return runCatching { LinuxMprisSession(playbackSession) }
         .getOrElse { error ->
-            System.err.println("FuoEvolve: MPRIS unavailable: ${error.message.orEmpty()}")
+            AppLogger.w("SystemMediaSession", "MPRIS unavailable", error)
             AutoCloseable { }
         }
 }

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopTrayController.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopTrayController.kt
@@ -19,6 +19,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
 import javax.swing.SwingUtilities
+import org.feeluown.mobile.AppLogger
 
 internal interface DesktopTrayController : AutoCloseable {
     val isAvailable: Boolean
@@ -103,7 +104,7 @@ private class AwtDesktopTrayController(
             tray.add(icon)
             tray to icon
         }.onFailure { error ->
-            System.err.println("FuoEvolve: desktop tray unavailable: ${error.message.orEmpty()}")
+            AppLogger.w("DesktopTray", "Desktop tray unavailable", error)
         }.getOrNull()
 
         systemTray = initialized?.first
@@ -142,13 +143,13 @@ private class LinuxStatusNotifierTrayController(
                 errorCapacity = ERROR_BUFFER_BYTES.toLong(),
             )
         }.onFailure { failure ->
-            System.err.println("FuoEvolve: Linux StatusNotifier tray unavailable: ${failure.message.orEmpty()}")
+            AppLogger.w("DesktopTray", "Linux StatusNotifier tray unavailable", failure)
         }.getOrNull()
 
         if (handle == null) {
             val message = error.getString(0, Charsets.UTF_8.name()).trim()
             if (message.isNotEmpty()) {
-                System.err.println("FuoEvolve: Linux StatusNotifier tray unavailable: $message")
+                AppLogger.w("DesktopTray", "Linux StatusNotifier tray unavailable: $message")
             }
         }
     }
@@ -162,7 +163,7 @@ private class UnavailableDesktopTrayController(reason: String) : DesktopTrayCont
     override val isAvailable: Boolean = false
 
     init {
-        System.err.println("FuoEvolve: desktop tray unavailable: $reason")
+        AppLogger.w("DesktopTray", "Desktop tray unavailable: $reason")
     }
 
     override fun close() = Unit

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopWindowSystemMediaSession.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopWindowSystemMediaSession.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile.desktop
 
 import java.awt.Window
 import java.util.Locale
+import org.feeluown.mobile.AppLogger
 import org.feeluown.mobile.playback.api.PlaybackSession
 
 internal fun createDesktopSystemMediaSessionForWindow(
@@ -12,13 +13,13 @@ internal fun createDesktopSystemMediaSessionForWindow(
     return when {
         os.contains("windows") -> runCatching { WindowsSmtcSession(playbackSession, window) }
             .getOrElse { error ->
-                System.err.println("FuoEvolve: Windows SMTC unavailable: ${error.message.orEmpty()}")
+                AppLogger.w("SystemMediaSession", "Windows SMTC unavailable", error)
                 AutoCloseable { }
             }
 
         os.contains("mac") || os.contains("darwin") -> runCatching { MacNowPlayingSession(playbackSession) }
             .getOrElse { error ->
-                System.err.println("FuoEvolve: macOS Now Playing unavailable: ${error.message.orEmpty()}")
+                AppLogger.w("SystemMediaSession", "macOS Now Playing unavailable", error)
                 AutoCloseable { }
             }
 

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/Main.kt
@@ -18,10 +18,11 @@ import com.sun.jna.Native
 import com.sun.jna.Platform
 import java.awt.Window as AwtWindow
 import javax.swing.SwingUtilities
+import org.feeluown.mobile.AppLogger
 import org.feeluown.mobile.DesktopAppHost
 import org.feeluown.mobile.DesktopExternalActivationSession
 import org.feeluown.mobile.createDesktopPlaybackResumeStore
-import org.feeluown.mobile.installDesktopDebugLogCapture
+import org.feeluown.mobile.installDesktopAppLogger
 import org.feeluown.mobile.installDesktopListeningHistorySinkFactory
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
 import org.feeluown.mobile.installDesktopPlatformVideoControllerFactory
@@ -52,7 +53,7 @@ private fun configureLibMpvNumericLocale() {
 }
 
 fun main(args: Array<String>) {
-    installDesktopDebugLogCapture()
+    installDesktopAppLogger()
     val activation = DesktopExternalActivationSession.open(args.toList()) ?: return
     registerDesktopFuoProtocolHandler()
     installDesktopListeningHistorySinkFactory { databasePath ->
@@ -111,8 +112,9 @@ fun main(args: Array<String>) {
                 onCloseRequest = {
                     when (desktopCloseBehavior(trayController?.isAvailable == true)) {
                         DesktopCloseBehavior.HideToTray -> windowVisible = false
-                        DesktopCloseBehavior.KeepVisible -> System.err.println(
-                            "FuoEvolve: close-to-tray ignored because no usable tray integration is available",
+                        DesktopCloseBehavior.KeepVisible -> AppLogger.w(
+                            "DesktopWindow",
+                            "Close-to-tray ignored because no usable tray integration is available",
                         )
                     }
                 },

--- a/gradle/ci-verification.gradle.kts
+++ b/gradle/ci-verification.gradle.kts
@@ -2,10 +2,70 @@
 // the repository's feature/provider module topology. New modules are picked up by
 // their standard Gradle test task names and Kover conventions.
 
+val appLoggerSourceRoots = listOf(
+    "androidApp/src/main/kotlin",
+    "desktopApp/src/main/kotlin",
+    "shared/src/androidMain/kotlin",
+    "shared/src/desktopMain/kotlin",
+    "shared/src/iosMain/kotlin",
+)
+val appLoggerPlatformSinkFiles = setOf(
+    "androidApp/src/main/kotlin/org/feeluown/mobile/AndroidAppLogger.kt",
+    "shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppLogger.kt",
+    "shared/src/iosMain/kotlin/org/feeluown/mobile/IosAppLogger.kt",
+)
+
+val checkAppLoggerUsage = tasks.register("checkAppLoggerUsage") {
+    group = "verification"
+    description = "Rejects direct platform logging outside AppLogger platform sinks."
+    val sources = provider {
+        appLoggerSourceRoots.flatMap { path ->
+            val root = rootProject.file(path)
+            if (root.isDirectory) {
+                root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+            } else {
+                emptyList()
+            }
+        }
+    }
+    inputs.files(sources)
+
+    doLast {
+        val forbiddenPatterns = listOf(
+            "android.util.Log" to Regex("\\bandroid\\.util\\.Log\\b|^\\s*import\\s+android\\.util\\.Log\\b"),
+            "System.out/System.err" to Regex("\\bSystem\\.(?:out|err)\\.(?:print|println)\\s*\\("),
+            "NSLog" to Regex("\\bNSLog\\s*\\("),
+        )
+        val violations = sources.get().flatMap { file ->
+            val relative = file.relativeTo(rootProject.projectDir).invariantSeparatorsPath
+            if (relative in appLoggerPlatformSinkFiles) return@flatMap emptyList()
+            file.readLines().mapIndexedNotNull { index, line ->
+                val trimmed = line.trimStart()
+                val commentOnly = trimmed.startsWith("//") ||
+                    trimmed.startsWith("/**") ||
+                    trimmed.startsWith("*") ||
+                    trimmed.startsWith("*/")
+                if (commentOnly) return@mapIndexedNotNull null
+                forbiddenPatterns.firstOrNull { (_, pattern) -> pattern.containsMatchIn(line) }
+                    ?.let { (api, _) -> "$relative:${index + 1} ($api)" }
+            }
+        }
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("Direct platform logging bypasses AppLogger:")
+                    violations.forEach { appendLine(" - $it") }
+                    append("Route application logs through AppLogger; platform APIs are reserved for sink implementations.")
+                },
+            )
+        }
+    }
+}
+
 val ciArchitectureCheck = tasks.register("ciArchitectureCheck") {
     group = "verification"
     description = "Runs all repository architecture-boundary checks."
-    dependsOn("checkArchitectureBoundaries")
+    dependsOn("checkArchitectureBoundaries", checkAppLoggerUsage)
 }
 
 val ciAndroidTest = tasks.register("ciAndroidTest") {

--- a/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.android.kt
@@ -6,7 +6,6 @@ import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.net.Uri
-import android.util.Log
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
@@ -80,7 +79,7 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
                 override fun onPlayerError(error: PlaybackException) {
                     val rootCause = error.rootCause()
                     val candidate = activeCandidates.getOrNull(activeCandidateIndex)
-                    Log.e(
+                    AppLogger.e(
                         VIDEO_PLAYER_TAG,
                         "Video playback failed: code=${error.errorCodeName}, " +
                             "cause=${rootCause::class.java.name}: ${rootCause.message.orEmpty()}, " +
@@ -188,7 +187,7 @@ private class AndroidPlatformVideoController(context: Context) : PlatformVideoCo
         val shouldPlay = player.playWhenReady || player.isPlaying
         activeCandidateIndex = nextIndex
         playbackError = null
-        Log.w(
+        AppLogger.w(
             VIDEO_PLAYER_TAG,
             "Retrying video playback with candidate ${nextIndex + 1}/${activeCandidates.size}: " +
                 activeCandidates[nextIndex].debugDescription(),

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
@@ -40,12 +40,13 @@ object AppLogger {
         log(AppLogLevel.Error, tag, message, throwable)
 
     fun redact(value: String): String {
-        var redacted = AUTHORIZATION_PATTERN.replace(value, "Authorization=<redacted>")
+        var redacted = COOKIE_HEADER_PATTERN.replace(value) { match ->
+            "${match.groupValues[1]}=<redacted>"
+        }
+        redacted = AUTHORIZATION_PATTERN.replace(redacted, "Authorization=<redacted>")
         redacted = BEARER_PATTERN.replace(redacted, "Bearer <redacted>")
-        SECRET_ASSIGNMENT_PATTERNS.forEach { pattern ->
-            redacted = pattern.replace(redacted) { match ->
-                "${match.groupValues[1]}=<redacted>"
-            }
+        redacted = SECRET_ASSIGNMENT_PATTERN.replace(redacted) { match ->
+            "${match.groupValues[1]}<redacted>"
         }
         redacted = URL_SECRET_PATTERN.replace(redacted) { match ->
             "${match.groupValues[1]}${match.groupValues[2]}=<redacted>"
@@ -59,15 +60,16 @@ object AppLogger {
         sink.write(level, tag, safeMessage, safeThrowable)
     }
 
+    private val COOKIE_HEADER_PATTERN = Regex(
+        pattern = """(?im)\b(cookie|set-cookie)\s*:\s*[^\r\n]*""",
+    )
     private val AUTHORIZATION_PATTERN = Regex(
         pattern = "(?i)\\bauthorization\\s*[:=]\\s*(?:(?:bearer|basic|digest)\\s+)?[^\\s,;]+",
     )
-    private val SECRET_ASSIGNMENT_PATTERNS = listOf(
-        Regex(
-            pattern = "(?i)\\b(cookie|set-cookie|access[_-]?token|refresh[_-]?token|password|passwd|secret|api[_-]?key)\\s*[:=]\\s*[^\\s,;]+",
-        ),
-    )
     private val BEARER_PATTERN = Regex("(?i)\\bBearer\\s+[^\\s,;]+")
+    private val SECRET_ASSIGNMENT_PATTERN = Regex(
+        pattern = """(?i)(["']?(?:cookie|set-cookie|access[_-]?token|refresh[_-]?token|password|passwd|secret|api[_-]?key)["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)""",
+    )
     private val URL_SECRET_PATTERN = Regex(
         pattern = "(?i)([?&])(token|access_token|refresh_token|key|api_key|signature|sig|auth|code)=[^&#\\s]+",
     )

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
@@ -40,13 +40,13 @@ object AppLogger {
         log(AppLogLevel.Error, tag, message, throwable)
 
     fun redact(value: String): String {
-        var redacted = value
+        var redacted = AUTHORIZATION_PATTERN.replace(value, "Authorization=<redacted>")
+        redacted = BEARER_PATTERN.replace(redacted, "Bearer <redacted>")
         SECRET_ASSIGNMENT_PATTERNS.forEach { pattern ->
             redacted = pattern.replace(redacted) { match ->
                 "${match.groupValues[1]}=<redacted>"
             }
         }
-        redacted = BEARER_PATTERN.replace(redacted, "Bearer <redacted>")
         redacted = URL_SECRET_PATTERN.replace(redacted) { match ->
             "${match.groupValues[1]}${match.groupValues[2]}=<redacted>"
         }
@@ -59,9 +59,12 @@ object AppLogger {
         sink.write(level, tag, safeMessage, safeThrowable)
     }
 
+    private val AUTHORIZATION_PATTERN = Regex(
+        pattern = "(?i)\\bauthorization\\s*[:=]\\s*(?:(?:bearer|basic|digest)\\s+)?[^\\s,;]+",
+    )
     private val SECRET_ASSIGNMENT_PATTERNS = listOf(
         Regex(
-            pattern = "(?i)\\b(authorization|cookie|set-cookie|access[_-]?token|refresh[_-]?token|password|passwd|secret|api[_-]?key)\\s*[:=]\\s*[^\\s,;]+",
+            pattern = "(?i)\\b(cookie|set-cookie|access[_-]?token|refresh[_-]?token|password|passwd|secret|api[_-]?key)\\s*[:=]\\s*[^\\s,;]+",
         ),
     )
     private val BEARER_PATTERN = Regex("(?i)\\bBearer\\s+[^\\s,;]+")

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/AppLogger.kt
@@ -1,0 +1,71 @@
+package org.feeluown.mobile
+
+/** Log levels shared by every FuoEvolve target. */
+enum class AppLogLevel {
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+/** Platform sink installed once during process startup. */
+fun interface AppLogSink {
+    fun write(level: AppLogLevel, tag: String, message: String, throwableText: String?)
+}
+
+/**
+ * Single application logging facade.
+ *
+ * Application code must log through this object rather than Android Log, println, NSLog, or other
+ * platform APIs. Sensitive values are redacted before a record reaches any sink, so persisted
+ * diagnostics and console output follow the same privacy policy.
+ */
+object AppLogger {
+    private var sink: AppLogSink = AppLogSink { _, _, _, _ -> }
+
+    fun install(sink: AppLogSink) {
+        this.sink = sink
+    }
+
+    fun d(tag: String, message: String, throwable: Throwable? = null) =
+        log(AppLogLevel.Debug, tag, message, throwable)
+
+    fun i(tag: String, message: String, throwable: Throwable? = null) =
+        log(AppLogLevel.Info, tag, message, throwable)
+
+    fun w(tag: String, message: String, throwable: Throwable? = null) =
+        log(AppLogLevel.Warning, tag, message, throwable)
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) =
+        log(AppLogLevel.Error, tag, message, throwable)
+
+    fun redact(value: String): String {
+        var redacted = value
+        SECRET_ASSIGNMENT_PATTERNS.forEach { pattern ->
+            redacted = pattern.replace(redacted) { match ->
+                "${match.groupValues[1]}=<redacted>"
+            }
+        }
+        redacted = BEARER_PATTERN.replace(redacted, "Bearer <redacted>")
+        redacted = URL_SECRET_PATTERN.replace(redacted) { match ->
+            "${match.groupValues[1]}${match.groupValues[2]}=<redacted>"
+        }
+        return redacted
+    }
+
+    private fun log(level: AppLogLevel, tag: String, message: String, throwable: Throwable?) {
+        val safeMessage = redact(message)
+        val safeThrowable = throwable?.stackTraceToString()?.let(::redact)
+        sink.write(level, tag, safeMessage, safeThrowable)
+    }
+
+    private val SECRET_ASSIGNMENT_PATTERNS = listOf(
+        Regex(
+            pattern = "(?i)\\b(authorization|cookie|set-cookie|access[_-]?token|refresh[_-]?token|password|passwd|secret|api[_-]?key)\\s*[:=]\\s*[^\\s,;]+",
+        ),
+    )
+    private val BEARER_PATTERN = Regex("(?i)\\bBearer\\s+[^\\s,;]+")
+    private val URL_SECRET_PATTERN = Regex(
+        pattern = "(?i)([?&])(token|access_token|refresh_token|key|api_key|signature|sig|auth|code)=[^&#\\s]+",
+    )
+}

--- a/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
+++ b/shared/src/commonMain/kotlin/org/feeluown/mobile/feature/debug/DebugLogFeatureScreen.kt
@@ -1,29 +1,19 @@
 package org.feeluown.mobile
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -33,59 +23,35 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
-private val FEATURE_DEBUG_LOG_THREADTIME_LEVEL_REGEX =
-    Regex("""^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+\d+\s+\d+\s+([DIWEAF])\s+""")
-private val FEATURE_DEBUG_LOG_TIME_LEVEL_REGEX =
-    Regex("""^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+([DIWEAF])/""")
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+/**
+ * User-facing diagnostics export.
+ *
+ * The former raw log viewer intentionally no longer exposes individual log lines. Users only need
+ * a single support action while AppLogger and the platform repository own collection, redaction,
+ * rotation, and archive generation.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DebugLogFeatureScreen(
     controller: DebugLogFeatureController,
     onBack: () -> Unit,
 ) {
     val uiState by controller.uiState.collectAsStateWithLifecycle()
-    // Compose Multiplatform does not yet expose a common plain-text ClipEntry factory for Android and iOS.
-    @Suppress("DEPRECATION")
-    val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
-    var selectionMode by remember { mutableStateOf(false) }
-    var selectedLineIndexes by remember { mutableStateOf<Set<Int>>(emptySet()) }
-    val visibleLogLines = remember(uiState.lines, uiState.levelFilters) {
-        uiState.lines.mapIndexedNotNull { index, line ->
-            val level = parseFeatureDebugLogLevel(line) ?: DebugLogLevel.Info
-            if (level in uiState.levelFilters) index to line else null
-        }
-    }
-    val selectedLines = remember(uiState.lines, selectedLineIndexes) {
-        selectedLineIndexes.sorted().mapNotNull { uiState.lines.getOrNull(it) }
-    }
 
     LaunchedEffect(Unit) {
         controller.refresh()
-    }
-    LaunchedEffect(uiState.lines) {
-        selectedLineIndexes = selectedLineIndexes.filter { it in uiState.lines.indices }.toSet()
-    }
-    LaunchedEffect(selectedLineIndexes) {
-        if (selectedLineIndexes.isEmpty()) {
-            selectionMode = false
-        }
     }
     LaunchedEffect(uiState.feedback) {
         val feedback = uiState.feedback ?: return@LaunchedEffect
@@ -95,19 +61,11 @@ fun DebugLogFeatureScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("应用日志") },
+            TopAppBar(
+                title = { Text("诊断信息") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
-                    }
-                },
-                actions = {
-                    IconButton(
-                        enabled = !uiState.isLoading,
-                        onClick = controller::refresh,
-                    ) {
-                        Icon(Icons.Filled.Refresh, contentDescription = "刷新")
                     }
                 },
             )
@@ -118,189 +76,74 @@ fun DebugLogFeatureScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
             if (uiState.isLoading) {
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(28.dp))
             }
-            uiState.errorMessage?.let { ProviderContentMessage(it) }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+
+            Surface(
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.secondaryContainer,
             ) {
-                DebugLogLevel.entries.forEach { level ->
-                    FilterChip(
-                        selected = level in uiState.levelFilters,
-                        onClick = {
-                            controller.onLevelFilterChange(
-                                level,
-                                level !in uiState.levelFilters,
-                            )
-                        },
-                        label = { Text(featureDebugLogLevelLabel(level)) },
-                        colors = settingsFilterChipColors(),
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Filled.BugReport,
+                    contentDescription = null,
+                    modifier = Modifier.padding(20.dp).size(40.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
             }
-            if (selectionMode) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "已选 ${selectedLineIndexes.size}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    TextButton(
-                        enabled = visibleLogLines.isNotEmpty(),
-                        onClick = {
-                            val visibleIndexes = visibleLogLines.map { it.first }.toSet()
-                            selectedLineIndexes = if (visibleIndexes.all { it in selectedLineIndexes }) {
-                                selectedLineIndexes - visibleIndexes
-                            } else {
-                                selectedLineIndexes + visibleIndexes
-                            }
-                        },
-                    ) {
-                        Text("全选")
-                    }
-                    TextButton(
-                        enabled = selectedLines.isNotEmpty(),
-                        onClick = {
-                            clipboardManager.setText(AnnotatedString(selectedLines.joinToString(separator = "\n")))
-                        },
-                    ) {
-                        Icon(Icons.Filled.ContentCopy, contentDescription = null)
-                        Spacer(Modifier.size(8.dp))
-                        Text("复制所选")
-                    }
-                    TextButton(
-                        enabled = selectedLines.isNotEmpty() && !uiState.isLoading,
-                        onClick = { controller.export(selectedLines) },
-                    ) {
-                        Icon(Icons.Filled.Download, contentDescription = null)
-                        Spacer(Modifier.size(8.dp))
-                        Text("导出所选")
-                    }
-                }
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = "导出诊断信息",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                text = "遇到播放、登录、更新或平台集成问题时，可将诊断文件随 Issue 一并提交，帮助定位问题。",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "诊断文件包含应用版本、平台环境和经过脱敏的滚动日志，不包含登录凭据或应用数据库。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            uiState.errorMessage?.let { error ->
+                Spacer(Modifier.height(20.dp))
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
+                )
             }
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
+
+            Spacer(Modifier.height(28.dp))
+            Button(
+                enabled = !uiState.isLoading && uiState.lines.isNotEmpty(),
+                onClick = { controller.export(uiState.lines) },
             ) {
-                if (visibleLogLines.isEmpty() && !uiState.isLoading && uiState.errorMessage == null) {
-                    item { ProviderContentMessage("暂无日志") }
-                } else {
-                    itemsIndexed(visibleLogLines) { _, indexedLine ->
-                        val originalIndex = indexedLine.first
-                        val line = indexedLine.second
-                        val level = parseFeatureDebugLogLevel(line)
-                        val selected = originalIndex in selectedLineIndexes
-                        Surface(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp)
-                                .combinedClickable(
-                                    onClick = {
-                                        if (selectionMode) {
-                                            selectedLineIndexes = if (selected) {
-                                                selectedLineIndexes - originalIndex
-                                            } else {
-                                                selectedLineIndexes + originalIndex
-                                            }
-                                        }
-                                    },
-                                    onLongClick = {
-                                        selectionMode = true
-                                        selectedLineIndexes = selectedLineIndexes + originalIndex
-                                    },
-                                ),
-                            color = featureDebugLogLevelContainerColor(level),
-                            shape = MaterialTheme.shapes.medium,
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalAlignment = Alignment.Top,
-                            ) {
-                                if (selectionMode) {
-                                    Checkbox(
-                                        checked = selected,
-                                        onCheckedChange = { checked ->
-                                            selectedLineIndexes = if (checked) {
-                                                selectedLineIndexes + originalIndex
-                                            } else {
-                                                selectedLineIndexes - originalIndex
-                                            }
-                                        },
-                                    )
-                                }
-                                Text(
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(top = 10.dp),
-                                    text = line,
-                                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                                    color = featureDebugLogLevelContentColor(level),
-                                )
-                                IconButton(
-                                    modifier = Modifier.fuoInteractive().size(48.dp),
-                                    onClick = { clipboardManager.setText(AnnotatedString(line)) },
-                                ) {
-                                    Icon(Icons.Filled.ContentCopy, contentDescription = "复制")
-                                }
-                            }
-                        }
-                        HorizontalDivider()
-                    }
-                }
+                Icon(Icons.Filled.Download, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text("导出诊断信息")
+            }
+
+            if (!uiState.isLoading && uiState.lines.isEmpty() && uiState.errorMessage == null) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "当前暂无可导出的运行日志",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }
-}
-
-private fun parseFeatureDebugLogLevel(line: String): DebugLogLevel? {
-    val code = FEATURE_DEBUG_LOG_THREADTIME_LEVEL_REGEX.find(line)?.groupValues?.getOrNull(1)
-        ?: FEATURE_DEBUG_LOG_TIME_LEVEL_REGEX.find(line)?.groupValues?.getOrNull(1)
-        ?: return null
-    return when (code) {
-        "D" -> DebugLogLevel.Debug
-        "I" -> DebugLogLevel.Info
-        "W" -> DebugLogLevel.Warning
-        "E", "A", "F" -> DebugLogLevel.Error
-        else -> null
-    }
-}
-
-private fun featureDebugLogLevelLabel(level: DebugLogLevel): String = when (level) {
-    DebugLogLevel.Debug -> "Debug"
-    DebugLogLevel.Info -> "Info"
-    DebugLogLevel.Warning -> "Warn"
-    DebugLogLevel.Error -> "Error"
-}
-
-@Composable
-private fun featureDebugLogLevelContainerColor(level: DebugLogLevel?) = when (level) {
-    DebugLogLevel.Debug -> MaterialTheme.colorScheme.surfaceContainerHigh
-    DebugLogLevel.Info -> MaterialTheme.colorScheme.secondaryContainer
-    DebugLogLevel.Warning -> MaterialTheme.colorScheme.tertiaryContainer
-    DebugLogLevel.Error -> MaterialTheme.colorScheme.errorContainer
-    null -> MaterialTheme.colorScheme.surface
-}
-
-@Composable
-private fun featureDebugLogLevelContentColor(level: DebugLogLevel?) = when (level) {
-    DebugLogLevel.Info -> MaterialTheme.colorScheme.onSecondaryContainer
-    DebugLogLevel.Warning -> MaterialTheme.colorScheme.onTertiaryContainer
-    DebugLogLevel.Error -> MaterialTheme.colorScheme.onErrorContainer
-    else -> MaterialTheme.colorScheme.onSurface
 }

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppLoggerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppLoggerTest.kt
@@ -1,0 +1,46 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppLoggerTest {
+    @Test
+    fun redactsCredentialsBeforeTheyReachSink() {
+        var record: CapturedRecord? = null
+        AppLogger.install(AppLogSink { level, tag, message, throwableText ->
+            record = CapturedRecord(level, tag, message, throwableText)
+        })
+
+        AppLogger.e(
+            tag = "Auth",
+            message = "Authorization: Bearer abc.def access_token=secret-value url=https://x.test?a=1&signature=signed",
+            throwable = IllegalStateException("refresh_token=refresh-secret"),
+        )
+
+        val captured = requireNotNull(record)
+        assertEquals(AppLogLevel.Error, captured.level)
+        assertEquals("Auth", captured.tag)
+        assertFalse(captured.message.contains("abc.def"))
+        assertFalse(captured.message.contains("secret-value"))
+        assertFalse(captured.message.contains("signed"))
+        assertTrue(captured.message.contains("<redacted>"))
+        assertFalse(captured.throwableText.orEmpty().contains("refresh-secret"))
+    }
+
+    @Test
+    fun keepsNonSensitiveContext() {
+        assertEquals(
+            "playback trackId=123 provider=netease",
+            AppLogger.redact("playback trackId=123 provider=netease"),
+        )
+    }
+
+    private data class CapturedRecord(
+        val level: AppLogLevel,
+        val tag: String,
+        val message: String,
+        val throwableText: String?,
+    )
+}

--- a/shared/src/commonTest/kotlin/org/feeluown/mobile/AppLoggerTest.kt
+++ b/shared/src/commonTest/kotlin/org/feeluown/mobile/AppLoggerTest.kt
@@ -30,6 +30,43 @@ class AppLoggerTest {
     }
 
     @Test
+    fun redactsStructuredCredentials() {
+        val redacted = AppLogger.redact(
+            """payload={"access_token":"json-secret","refresh_token":"json-refresh","password":"json-password"}""",
+        )
+
+        assertFalse(redacted.contains("json-secret"))
+        assertFalse(redacted.contains("json-refresh"))
+        assertFalse(redacted.contains("json-password"))
+        assertTrue(redacted.contains("<redacted>"))
+    }
+
+    @Test
+    fun redactsEntireCookieHeader() {
+        val redacted = AppLogger.redact(
+            "Cookie: first=value; SESSDATA=cookie-secret; MUSIC_U=music-secret\nrequestId=123",
+        )
+
+        assertFalse(redacted.contains("first=value"))
+        assertFalse(redacted.contains("cookie-secret"))
+        assertFalse(redacted.contains("music-secret"))
+        assertTrue(redacted.contains("Cookie=<redacted>"))
+        assertTrue(redacted.contains("requestId=123"))
+    }
+
+    @Test
+    fun redactsSensitiveUrlParameters() {
+        val redacted = AppLogger.redact(
+            "url=https://x.test?a=1&access_token=url-secret&signature=signed-value requestId=123",
+        )
+
+        assertFalse(redacted.contains("url-secret"))
+        assertFalse(redacted.contains("signed-value"))
+        assertTrue(redacted.contains("a=1"))
+        assertTrue(redacted.contains("requestId=123"))
+    }
+
+    @Test
     fun keepsNonSensitiveContext() {
         assertEquals(
             "playback trackId=123 provider=netease",

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppLogger.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppLogger.kt
@@ -1,0 +1,62 @@
+package org.feeluown.mobile
+
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private const val DESKTOP_APP_LOG_MAX_BYTES = 4L * 1024L * 1024L
+
+fun installDesktopAppLogger() {
+    val logDirectory = DesktopAppDirectories.state().resolve("logs")
+    val logFile = logDirectory.resolve("application.log")
+    val previousLogFile = logDirectory.resolve("application.previous.log")
+    val fileSink = RollingFileOutputStream(
+        activeFile = logFile,
+        previousFile = previousLogFile,
+        maxBytes = DESKTOP_APP_LOG_MAX_BYTES,
+    )
+    AppLogger.install(DesktopAppLogSink(fileSink))
+    AppLogger.i("AppLogger", "Desktop application logging initialized at $logFile")
+}
+
+private class DesktopAppLogSink(
+    private val fileSink: RollingFileOutputStream,
+) : AppLogSink {
+    private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+    @Synchronized
+    override fun write(level: AppLogLevel, tag: String, message: String, throwableText: String?) {
+        val line = buildString {
+            append(formatter.format(Date()))
+            append(' ')
+            append(level.code)
+            append('/')
+            append(tag)
+            append(": ")
+            append(message)
+            if (!throwableText.isNullOrBlank()) {
+                append('\n')
+                append(throwableText)
+            }
+            append('\n')
+        }
+        val console = if (level == AppLogLevel.Warning || level == AppLogLevel.Error) System.err else System.out
+        console.print(line)
+        runCatching {
+            val bytes = line.toByteArray(StandardCharsets.UTF_8)
+            fileSink.write(bytes)
+            fileSink.flush()
+        }.onFailure { failure ->
+            System.err.println("FuoEvolve: unable to persist application log: ${failure.message.orEmpty()}")
+        }
+    }
+}
+
+private val AppLogLevel.code: Char
+    get() = when (this) {
+        AppLogLevel.Debug -> 'D'
+        AppLogLevel.Info -> 'I'
+        AppLogLevel.Warning -> 'W'
+        AppLogLevel.Error -> 'E'
+    }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppLogger.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopAppLogger.kt
@@ -8,20 +8,32 @@ import java.util.Locale
 private const val DESKTOP_APP_LOG_MAX_BYTES = 4L * 1024L * 1024L
 
 fun installDesktopAppLogger() {
-    val logDirectory = DesktopAppDirectories.state().resolve("logs")
-    val logFile = logDirectory.resolve("application.log")
-    val previousLogFile = logDirectory.resolve("application.previous.log")
-    val fileSink = RollingFileOutputStream(
-        activeFile = logFile,
-        previousFile = previousLogFile,
-        maxBytes = DESKTOP_APP_LOG_MAX_BYTES,
-    )
-    AppLogger.install(DesktopAppLogSink(fileSink))
-    AppLogger.i("AppLogger", "Desktop application logging initialized at $logFile")
+    val logTarget = runCatching {
+        val logDirectory = DesktopAppDirectories.state().resolve("logs")
+        val logFile = logDirectory.resolve("application.log")
+        val previousLogFile = logDirectory.resolve("application.previous.log")
+        logFile to RollingFileOutputStream(
+            activeFile = logFile,
+            previousFile = previousLogFile,
+            maxBytes = DESKTOP_APP_LOG_MAX_BYTES,
+        )
+    }.onFailure { failure ->
+        System.err.println(
+            "FuoEvolve: unable to initialize persisted application logging; " +
+                "continuing with console logging: ${failure.message.orEmpty()}",
+        )
+    }.getOrNull()
+
+    AppLogger.install(DesktopAppLogSink(logTarget?.second))
+    if (logTarget != null) {
+        AppLogger.i("AppLogger", "Desktop application logging initialized at ${logTarget.first}")
+    } else {
+        AppLogger.w("AppLogger", "Persisted desktop logging unavailable; using console logging only")
+    }
 }
 
 private class DesktopAppLogSink(
-    private val fileSink: RollingFileOutputStream,
+    private val fileSink: RollingFileOutputStream?,
 ) : AppLogSink {
     private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 
@@ -43,10 +55,11 @@ private class DesktopAppLogSink(
         }
         val console = if (level == AppLogLevel.Warning || level == AppLogLevel.Error) System.err else System.out
         console.print(line)
+        val persistentSink = fileSink ?: return
         runCatching {
             val bytes = line.toByteArray(StandardCharsets.UTF_8)
-            fileSink.write(bytes)
-            fileSink.flush()
+            persistentSink.write(bytes)
+            persistentSink.flush()
         }.onFailure { failure ->
             System.err.println("FuoEvolve: unable to persist application log: ${failure.message.orEmpty()}")
         }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopDebugLogRepository.kt
@@ -1,7 +1,7 @@
 package org.feeluown.mobile
 
+import java.io.File
 import java.io.OutputStream
-import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -10,54 +10,20 @@ import java.nio.file.StandardOpenOption
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.swing.JFileChooser
+import javax.swing.filechooser.FileNameExtensionFilter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private const val MAX_DEBUG_LOG_LINES = 2_000
-private const val MAX_DEBUG_LOG_BYTES = 4L * 1024L * 1024L
-
-/** Install as early as possible so native/platform startup diagnostics are available in Settings. */
-fun installDesktopDebugLogCapture() {
-    DesktopDebugLogCapture.install()
-}
+private const val MAX_DIAGNOSTIC_LOG_LINES = 2_000
 
 internal fun createDesktopDebugLogRepository(): DebugLogRepository = DesktopDebugLogRepository()
 
-private object DesktopDebugLogCapture {
-    private val logDirectory
-        get() = DesktopAppDirectories.state().resolve("logs")
-    val logFile
-        get() = logDirectory.resolve("application.log")
-
-    private var installed = false
-
-    @Synchronized
-    fun install() {
-        if (installed) return
-        runCatching {
-            Files.createDirectories(logDirectory)
-            val sink = RollingFileOutputStream(
-                activeFile = logFile,
-                previousFile = logDirectory.resolve("application.previous.log"),
-                maxBytes = MAX_DEBUG_LOG_BYTES,
-            )
-            val originalOut = System.out
-            val originalErr = System.err
-            System.setOut(PrintStream(TeeOutputStream(originalOut, sink), true, StandardCharsets.UTF_8))
-            System.setErr(PrintStream(TeeOutputStream(originalErr, sink), true, StandardCharsets.UTF_8))
-            installed = true
-            System.err.println("FuoEvolve: desktop debug log capture enabled at $logFile")
-        }.onFailure { throwable ->
-            System.err.println("FuoEvolve: unable to enable desktop debug log capture: ${throwable.message}")
-        }
-    }
-}
-
 /**
- * A small platform filesystem primitive used by desktop log capture.
- *
- * Rotation happens at write time, so a long-running process cannot grow the active log without
- * bound. Both stdout and stderr share the same instance, making rotation and file writes serialized.
+ * Small desktop filesystem primitive shared by AppLogger and diagnostics export.
+ * Rotation happens at write time and keeps only the active and immediately previous file.
  */
 internal class RollingFileOutputStream(
     private val activeFile: Path,
@@ -129,55 +95,82 @@ internal class RollingFileOutputStream(
     )
 }
 
-private class TeeOutputStream(
-    private val console: OutputStream,
-    private val file: OutputStream,
-) : OutputStream() {
-    @Synchronized
-    override fun write(value: Int) {
-        console.write(value)
-        file.write(value)
-    }
-
-    @Synchronized
-    override fun write(buffer: ByteArray, offset: Int, length: Int) {
-        console.write(buffer, offset, length)
-        file.write(buffer, offset, length)
-    }
-
-    @Synchronized
-    override fun flush() {
-        console.flush()
-        file.flush()
-    }
-}
-
 private class DesktopDebugLogRepository : DebugLogRepository {
     override val isAvailable: Boolean = true
 
+    private val logDirectory: Path
+        get() = DesktopAppDirectories.state().resolve("logs")
+    private val activeLog: Path
+        get() = logDirectory.resolve("application.log")
+    private val previousLog: Path
+        get() = logDirectory.resolve("application.previous.log")
+
     override suspend fun logLines(): List<String> = withContext(Dispatchers.IO) {
-        val file = DesktopDebugLogCapture.logFile
-        if (!Files.isRegularFile(file)) return@withContext emptyList()
-        Files.readAllLines(file, StandardCharsets.UTF_8)
+        listOf(previousLog, activeLog)
+            .filter(Files::isRegularFile)
+            .flatMap { file -> Files.readAllLines(file, StandardCharsets.UTF_8) }
             .map(String::trimEnd)
             .filter(String::isNotBlank)
-            .takeLast(MAX_DEBUG_LOG_LINES)
+            .takeLast(MAX_DIAGNOSTIC_LOG_LINES)
     }
 
     override suspend fun exportLogFile(lines: List<String>): String {
-        if (lines.isEmpty()) return "没有可导出的日志"
         val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
-        val fileName = "fuo-evolve-log-$timestamp.txt"
-        // The common feature invokes export from its UI scope. Keep JFileChooser on that thread;
-        // only log reading itself belongs on Dispatchers.IO.
-        val saved = saveDesktopTextFile(
-            dialogTitle = "导出应用日志",
-            suggestedFileName = fileName,
-            filterDescription = "文本日志 (*.txt)",
-            extensions = listOf("txt"),
-            content = lines.joinToString("\n"),
-            onFeedback = {},
-        )
-        return if (saved) "日志已导出：$fileName" else "已取消导出日志"
+        val fileName = "FuoEvolve-Diagnostics-$timestamp.zip"
+        val tempFile = withContext(Dispatchers.IO) { createDiagnosticsArchive() }
+        return try {
+            val chooser = JFileChooser().apply {
+                dialogTitle = "导出诊断信息"
+                selectedFile = File(fileName)
+                fileFilter = FileNameExtensionFilter("FuoEvolve 诊断文件 (*.zip)", "zip")
+            }
+            if (chooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) {
+                "已取消导出诊断信息"
+            } else {
+                val selected = chooser.selectedFile
+                val destination = if (selected.name.endsWith(".zip", ignoreCase = true)) {
+                    selected.toPath()
+                } else {
+                    selected.toPath().resolveSibling("${selected.name}.zip")
+                }
+                withContext(Dispatchers.IO) {
+                    destination.parent?.let(Files::createDirectories)
+                    Files.copy(tempFile, destination, StandardCopyOption.REPLACE_EXISTING)
+                }
+                "诊断信息已导出：${destination.fileName}"
+            }
+        } finally {
+            withContext(Dispatchers.IO) { Files.deleteIfExists(tempFile) }
+        }
+    }
+
+    private fun createDiagnosticsArchive(): Path {
+        val tempFile = Files.createTempFile("FuoEvolve-Diagnostics-", ".zip")
+        ZipOutputStream(Files.newOutputStream(tempFile)).use { zip ->
+            zip.putNextEntry(ZipEntry("diagnostics.txt"))
+            zip.write(diagnosticsSummary().toByteArray(StandardCharsets.UTF_8))
+            zip.closeEntry()
+
+            listOf(activeLog, previousLog)
+                .filter(Files::isRegularFile)
+                .forEach { logFile ->
+                    zip.putNextEntry(ZipEntry(logFile.fileName.toString()))
+                    Files.newInputStream(logFile).use { input -> input.copyTo(zip) }
+                    zip.closeEntry()
+                }
+        }
+        return tempFile
+    }
+
+    private fun diagnosticsSummary(): String = buildString {
+        appendLine("FuoEvolve diagnostics")
+        appendLine("generatedAt=${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())}")
+        appendLine("platform=Desktop")
+        appendLine("osName=${System.getProperty("os.name").orEmpty()}")
+        appendLine("osVersion=${System.getProperty("os.version").orEmpty()}")
+        appendLine("osArch=${System.getProperty("os.arch").orEmpty()}")
+        appendLine("javaVersion=${System.getProperty("java.version").orEmpty()}")
+        appendLine()
+        appendLine("Logs are redacted by AppLogger before persistence. Credentials and app databases are not included.")
     }
 }


### PR DESCRIPTION
## Summary

- introduce a cross-platform `AppLogger` facade with centralized redaction
- persist Android and desktop application logs with rolling files
- migrate platform-owned logging away from direct platform logging APIs
- replace the legacy raw log viewer with user-facing diagnostics export

## Status

Draft while the remaining logging call sites and diagnostics UI/export are being migrated.