### PR TITLE
Fix Linux desktop playback sync and AppImage credential reuse

### DIFF
--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -70,11 +70,12 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 APPDIR="$WORK_DIR/FuoEvolve.AppDir"
 BUNDLED_APP="$APPDIR/usr/lib/fuoevolve"
 NATIVE_LIB_DIR="$BUNDLED_APP/resources/native/mpv"
+LIBSECRET_LIB_DIR="$BUNDLED_APP/resources/native/libsecret"
 WEBVIEW_ROOT="$BUNDLED_APP/resources/native/webview"
 WEBVIEW_LIB_DIR="$WEBVIEW_ROOT/lib"
 WEBKIT_RUNTIME_DIR="$WEBVIEW_ROOT/webkit2gtk-4.1"
 GIO_MODULE_DIR="$WEBVIEW_ROOT/gio/modules"
-mkdir -p "$NATIVE_LIB_DIR" "$WEBVIEW_LIB_DIR" "$WEBKIT_RUNTIME_DIR" "$GIO_MODULE_DIR"
+mkdir -p "$NATIVE_LIB_DIR" "$LIBSECRET_LIB_DIR" "$WEBVIEW_LIB_DIR" "$WEBKIT_RUNTIME_DIR" "$GIO_MODULE_DIR"
 # Copy the contents of the Compose app image into the runtime root. Copying the source directory
 # itself into the already-created BUNDLED_APP directory would add an unintended FuoEvolve/ layer.
 cp -a "$APP_IMAGE/." "$BUNDLED_APP/"
@@ -138,16 +139,16 @@ copy_elf_closure() {
   done < <(lddtree -l "$root" | awk '!seen[$0]++')
 }
 
-# libmpv contributes codecs/audio clients; libsecret is bundled as a compatibility fallback while
-# the Secret Service D-Bus daemon itself remains a host service. The main AppImage process does not
-# put this directory on LD_LIBRARY_PATH: libmpv is loaded explicitly and libsecret is host-first.
-for root_library in "$LIBMPV" "$LIBSECRET"; do
-  copy_library_to "$root_library" "$NATIVE_LIB_DIR"
-  copy_elf_closure "$root_library" "$NATIVE_LIB_DIR"
-done
+# Keep libmpv and the compatibility libsecret closure physically separate. Compose adds the mpv
+# resource directory to jna.library.path, so placing libsecret there would make the AppImage shadow
+# the host libsecret before the credential layer gets a chance to prefer the host Secret Service.
+copy_library_to "$LIBMPV" "$NATIVE_LIB_DIR"
+copy_elf_closure "$LIBMPV" "$NATIVE_LIB_DIR"
+copy_library_to "$LIBSECRET" "$LIBSECRET_LIB_DIR"
+copy_elf_closure "$LIBSECRET" "$LIBSECRET_LIB_DIR"
 
 BUNDLED_LIBMPV="$(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -name 'libmpv.so.*' -print -quit)"
-BUNDLED_LIBSECRET="$(find "$NATIVE_LIB_DIR" -maxdepth 1 -type f -name 'libsecret-1.so.0*' -print -quit)"
+BUNDLED_LIBSECRET="$(find "$LIBSECRET_LIB_DIR" -maxdepth 1 -type f -name 'libsecret-1.so.0*' -print -quit)"
 if [[ -z "$BUNDLED_LIBMPV" ]]; then
   echo "libmpv was not copied into the AppImage dependency closure" >&2
   exit 1
@@ -157,7 +158,7 @@ if [[ -z "$BUNDLED_LIBSECRET" ]]; then
   exit 1
 fi
 ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$NATIVE_LIB_DIR/libmpv.so"
-ln -sfn "$(basename "$BUNDLED_LIBSECRET")" "$NATIVE_LIB_DIR/libsecret-1.so"
+ln -sfn "$(basename "$BUNDLED_LIBSECRET")" "$LIBSECRET_LIB_DIR/libsecret-1.so"
 
 # wry links to WebKitGTK on Linux. Bundle both the helper's ELF closure and WebKit's separately
 # executed subprocesses; the latter are not visible from the helper's normal DT_NEEDED graph.
@@ -197,7 +198,7 @@ copy_elf_closure "$SYSTEM_GIO_TLS_MODULE" "$WEBVIEW_LIB_DIR"
 
 while IFS= read -r library; do
   patchelf --set-rpath '$ORIGIN' "$library" 2>/dev/null || true
-done < <(find "$NATIVE_LIB_DIR" "$WEBVIEW_LIB_DIR" -maxdepth 1 -type f -print)
+done < <(find "$NATIVE_LIB_DIR" "$LIBSECRET_LIB_DIR" "$WEBVIEW_LIB_DIR" -maxdepth 1 -type f -print)
 while IFS= read -r executable; do
   patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../../lib' "$executable" 2>/dev/null || true
 done < <(find "$WEBKIT_RUNTIME_DIR" -maxdepth 1 -type f -perm -u+x -print)
@@ -210,13 +211,14 @@ set -e
 APPDIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 APP_ROOT="$APPDIR/usr/lib/fuoevolve"
 NATIVE_LIB_DIR="$APP_ROOT/resources/native/mpv"
+LIBSECRET_LIB_DIR="$APP_ROOT/resources/native/libsecret"
 WEBVIEW_ROOT="$APP_ROOT/resources/native/webview"
 WEBVIEW_LIB_DIR="$WEBVIEW_ROOT/lib"
 # Keep portable native libraries scoped to the components that need them. In particular, do not
 # globally override a host libsecret/GLib stack: installed and AppImage builds must use the same
 # Secret Service/keyring when the host client library is available.
 export FUOEVOLVE_LIBMPV_PATH="$NATIVE_LIB_DIR/libmpv.so"
-export FUOEVOLVE_LIBSECRET_DIR="$NATIVE_LIB_DIR"
+export FUOEVOLVE_LIBSECRET_DIR="$LIBSECRET_LIB_DIR"
 export FUOEVOLVE_WEBVIEW_LIB_DIR="$WEBVIEW_LIB_DIR"
 export FUOEVOLVE_WEBKIT_EXEC_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1"
 export FUOEVOLVE_WEBKIT_INJECTED_BUNDLE_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1/injected-bundle"
@@ -274,10 +276,14 @@ chmod +x "$OUTPUT_FILE"
     echo "Packaged AppImage is missing the bundled libmpv loader alias" >&2
     exit 1
   }
-  test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libsecret-1.so || {
+  test -e squashfs-root/usr/lib/fuoevolve/resources/native/libsecret/libsecret-1.so || {
     echo "Packaged AppImage is missing the bundled libsecret fallback alias" >&2
     exit 1
   }
+  if find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -maxdepth 1 -name 'libsecret-1.so*' -print -quit | grep -q .; then
+    echo "Bundled libsecret must stay outside the Compose JNA mpv search path" >&2
+    exit 1
+  fi
   grep -q 'FUOEVOLVE_LIBMPV_PATH=' squashfs-root/AppRun || {
     echo "AppImage launcher does not explicitly scope bundled libmpv" >&2
     exit 1

--- a/desktopApp/packaging/linux/package-appimage.sh
+++ b/desktopApp/packaging/linux/package-appimage.sh
@@ -138,8 +138,9 @@ copy_elf_closure() {
   done < <(lddtree -l "$root" | awk '!seen[$0]++')
 }
 
-# libmpv contributes codecs/audio clients; libsecret is bundled as a client library while the
-# Secret Service D-Bus daemon itself remains a host service.
+# libmpv contributes codecs/audio clients; libsecret is bundled as a compatibility fallback while
+# the Secret Service D-Bus daemon itself remains a host service. The main AppImage process does not
+# put this directory on LD_LIBRARY_PATH: libmpv is loaded explicitly and libsecret is host-first.
 for root_library in "$LIBMPV" "$LIBSECRET"; do
   copy_library_to "$root_library" "$NATIVE_LIB_DIR"
   copy_elf_closure "$root_library" "$NATIVE_LIB_DIR"
@@ -156,6 +157,7 @@ if [[ -z "$BUNDLED_LIBSECRET" ]]; then
   exit 1
 fi
 ln -sfn "$(basename "$BUNDLED_LIBMPV")" "$NATIVE_LIB_DIR/libmpv.so"
+ln -sfn "$(basename "$BUNDLED_LIBSECRET")" "$NATIVE_LIB_DIR/libsecret-1.so"
 
 # wry links to WebKitGTK on Linux. Bundle both the helper's ELF closure and WebKit's separately
 # executed subprocesses; the latter are not visible from the helper's normal DT_NEEDED graph.
@@ -184,7 +186,7 @@ cp -L "$SYSTEM_INJECTED_BUNDLE" "$WEBKIT_RUNTIME_DIR/injected-bundle/libwebkit2g
 copy_elf_closure "$SYSTEM_INJECTED_BUNDLE" "$WEBVIEW_LIB_DIR"
 
 # HTTPS support is dynamically discovered by GIO and therefore is not part of WebKit's direct ELF
-# closure. Bundle the GLib TLS module and make it discoverable through GIO_EXTRA_MODULES.
+# closure. Bundle the GLib TLS module and make it discoverable only to the WebView helper process.
 SYSTEM_GIO_TLS_MODULE="$(find /usr/lib /lib -type f -path '*/gio/modules/libgiognutls.so' -print -quit 2>/dev/null || true)"
 if [[ -z "$SYSTEM_GIO_TLS_MODULE" || ! -f "$SYSTEM_GIO_TLS_MODULE" ]]; then
   echo "GLib GnuTLS module was not found; install glib-networking" >&2
@@ -210,10 +212,15 @@ APP_ROOT="$APPDIR/usr/lib/fuoevolve"
 NATIVE_LIB_DIR="$APP_ROOT/resources/native/mpv"
 WEBVIEW_ROOT="$APP_ROOT/resources/native/webview"
 WEBVIEW_LIB_DIR="$WEBVIEW_ROOT/lib"
-export LD_LIBRARY_PATH="$NATIVE_LIB_DIR:$WEBVIEW_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export WEBKIT_EXEC_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1"
-export WEBKIT_INJECTED_BUNDLE_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1/injected-bundle"
-export GIO_EXTRA_MODULES="$WEBVIEW_ROOT/gio/modules${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
+# Keep portable native libraries scoped to the components that need them. In particular, do not
+# globally override a host libsecret/GLib stack: installed and AppImage builds must use the same
+# Secret Service/keyring when the host client library is available.
+export FUOEVOLVE_LIBMPV_PATH="$NATIVE_LIB_DIR/libmpv.so"
+export FUOEVOLVE_LIBSECRET_DIR="$NATIVE_LIB_DIR"
+export FUOEVOLVE_WEBVIEW_LIB_DIR="$WEBVIEW_LIB_DIR"
+export FUOEVOLVE_WEBKIT_EXEC_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1"
+export FUOEVOLVE_WEBKIT_INJECTED_BUNDLE_PATH="$WEBVIEW_ROOT/webkit2gtk-4.1/injected-bundle"
+export FUOEVOLVE_GIO_EXTRA_MODULES="$WEBVIEW_ROOT/gio/modules${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
 exec "$APP_ROOT/bin/FuoEvolve" "$@"
 APPRUN
 chmod +x "$APPDIR/AppRun"
@@ -267,10 +274,18 @@ chmod +x "$OUTPUT_FILE"
     echo "Packaged AppImage is missing the bundled libmpv loader alias" >&2
     exit 1
   }
-  find squashfs-root/usr/lib/fuoevolve/resources/native/mpv -name 'libsecret-1.so.0*' -print -quit | grep -q . || {
-    echo "Packaged AppImage is missing bundled libsecret" >&2
+  test -e squashfs-root/usr/lib/fuoevolve/resources/native/mpv/libsecret-1.so || {
+    echo "Packaged AppImage is missing the bundled libsecret fallback alias" >&2
     exit 1
   }
+  grep -q 'FUOEVOLVE_LIBMPV_PATH=' squashfs-root/AppRun || {
+    echo "AppImage launcher does not explicitly scope bundled libmpv" >&2
+    exit 1
+  }
+  if grep -q '^export LD_LIBRARY_PATH=' squashfs-root/AppRun; then
+    echo "AppImage launcher must not globally override host native libraries" >&2
+    exit 1
+  fi
   find squashfs-root/usr/lib/fuoevolve -type f -name fuoevolve-web-login -perm -u+x -print -quit | grep -q . || {
     echo "Packaged AppImage is missing the WebView login helper" >&2
     exit 1

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopMpvPlaybackEngine.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopMpvPlaybackEngine.kt
@@ -648,9 +648,22 @@ private class LibMpvBackend(
             return true
         }
 
-        val currentPath = getPropertyString("path") ?: return false
-        if (currentPath != requestedPath) return false
-        val playlistEntryId = currentPlaylistEntryId() ?: expectedPlaylistEntryId
+        val currentPlaylistEntryId = currentPlaylistEntryId()
+        val currentPath = getPropertyString("path")
+        val currentPlaylistFilename = currentPlaylistEntryFilename()
+        if (
+            !desktopMpvSourceMatchesRequest(
+                requestedPath = requestedPath,
+                expectedPlaylistEntryId = expectedPlaylistEntryId,
+                currentPlaylistEntryId = currentPlaylistEntryId,
+                currentPath = currentPath,
+                currentPlaylistFilename = currentPlaylistFilename,
+            )
+        ) {
+            return false
+        }
+
+        val playlistEntryId = currentPlaylistEntryId ?: expectedPlaylistEntryId
         if (playlistEntryId != null) expectedPlaylistEntryId = playlistEntryId
         polledActivePath = requestedPath
         listener(
@@ -663,12 +676,18 @@ private class LibMpvBackend(
     }
 
     private fun currentPlaylistEntryId(): Long? {
-        val playingPosition = getPropertyString("playlist-playing-pos")
-            ?.toIntOrNull()
-            ?.takeIf { it >= 0 }
-            ?: return null
+        val playingPosition = currentPlaylistPlayingPosition() ?: return null
         return getPropertyString("playlist/$playingPosition/id")?.toLongOrNull()
     }
+
+    private fun currentPlaylistEntryFilename(): String? {
+        val playingPosition = currentPlaylistPlayingPosition() ?: return null
+        return getPropertyString("playlist/$playingPosition/filename")
+    }
+
+    private fun currentPlaylistPlayingPosition(): Int? = getPropertyString("playlist-playing-pos")
+        ?.toIntOrNull()
+        ?.takeIf { it >= 0 }
 
     private fun publishPolledState() {
         if (!activateCurrentRequestFromPolling()) return
@@ -710,6 +729,19 @@ private class LibMpvBackend(
     private fun ensureOpen() {
         check(!closed.get()) { "libmpv backend is closed" }
     }
+}
+
+internal fun desktopMpvSourceMatchesRequest(
+    requestedPath: String,
+    expectedPlaylistEntryId: Long?,
+    currentPlaylistEntryId: Long?,
+    currentPath: String?,
+    currentPlaylistFilename: String?,
+): Boolean {
+    if (expectedPlaylistEntryId != null && currentPlaylistEntryId != null) {
+        return expectedPlaylistEntryId == currentPlaylistEntryId
+    }
+    return currentPath == requestedPath || currentPlaylistFilename == requestedPath
 }
 
 internal interface MpvNative : Library {

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
@@ -7,11 +7,13 @@ import com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretB
 import com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretLibrary
 import com.microsoft.credentialstorage.model.StoredToken
 import com.microsoft.credentialstorage.model.StoredTokenType
+import com.sun.jna.NativeLibrary
 import java.security.MessageDigest
 import java.util.UUID
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
+import org.feeluown.mobile.AppLogger
 import org.feeluown.mobile.provider.core.ProviderCredentialStore
 import org.feeluown.mobile.provider.core.ProviderCredentials
 
@@ -81,6 +83,13 @@ internal class DesktopSecureProviderCredentialStore(
             val result = runCatching(secretStoreProvider)
             secretStore = result.getOrNull()
             secretStoreFailure = result.exceptionOrNull()
+            secretStoreFailure?.let { failure ->
+                AppLogger.e(
+                    DESKTOP_CREDENTIAL_LOG_TAG,
+                    "Failed to initialize desktop secure credential storage",
+                    failure,
+                )
+            }
             secretStoreResolved = true
         }
         return secretStore
@@ -146,12 +155,46 @@ private fun createMicrosoftSecretStore(): DesktopSecretStore? =
     }
 
 private fun createLinuxLibSecretStore(): DesktopSecretStore {
+    // AppImage ships a compatibility libsecret closure, but an installed package and a portable
+    // image must see the same host Secret Service/keyring. Prefer the host client library and only
+    // add the bundled directory to JNA's search path when the host libsecret cannot be loaded.
+    configureLinuxLibSecretRuntime()
+
     // StorageProvider performs a preflight that rejects a locked default collection before
     // normal libsecret interaction can display the system unlock prompt. Use its underlying
     // libsecret store directly on Linux instead: reads request SECRET_SEARCH_UNLOCK and writes
     // use libsecret's default collection, so the Secret Service can handle user interaction.
     LibSecretLibrary.INSTANCE
     return MicrosoftDesktopSecretStore(LibSecretBackedTokenStore())
+}
+
+@Volatile
+private var hostLibSecretHandle: NativeLibrary? = null
+
+private fun configureLinuxLibSecretRuntime() {
+    val hostAvailable = runCatching {
+        NativeLibrary.getInstance(LIBSECRET_JNA_NAME).also { library ->
+            REQUIRED_LIBSECRET_SYMBOLS.forEach(library::getFunction)
+            hostLibSecretHandle = library
+        }
+    }.isSuccess
+    if (hostAvailable) return
+
+    val bundledLibraryDir = System.getProperty("fuoevolve.libsecret.dir")
+        ?.takeIf(String::isNotBlank)
+        ?: System.getenv("FUOEVOLVE_LIBSECRET_DIR")?.takeIf(String::isNotBlank)
+        ?: return
+    registerBundledLinuxLibSecretSearchPaths(bundledLibraryDir, NativeLibrary::addSearchPath)
+}
+
+internal fun registerBundledLinuxLibSecretSearchPaths(
+    bundledLibraryDir: String,
+    addSearchPath: (String, String) -> Unit,
+) {
+    if (bundledLibraryDir.isBlank()) return
+    BUNDLED_LIBSECRET_JNA_NAMES.forEach { libraryName ->
+        addSearchPath(libraryName, bundledLibraryDir)
+    }
 }
 
 private fun secretStoreUnavailableMessage(failure: Throwable?): String {
@@ -243,6 +286,19 @@ private fun providerKey(providerId: String): String {
     return digest.take(16).joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
 }
 
+private const val DESKTOP_CREDENTIAL_LOG_TAG = "DesktopCredentials"
+private const val LIBSECRET_JNA_NAME = "secret-1"
+private val REQUIRED_LIBSECRET_SYMBOLS = listOf(
+    "secret_service_search_sync",
+    "secret_password_store_sync",
+    "secret_password_clear_sync",
+)
+private val BUNDLED_LIBSECRET_JNA_NAMES = listOf(
+    "secret-1",
+    "glib-2.0",
+    "gobject-2.0",
+    "gio-2.0",
+)
 private const val SECRET_KEY_PREFIX = "org.feeluown.mobile.provider.credentials.v1"
 private const val MANIFEST_VERSION = "v1"
 private const val SECRET_CHUNK_CHAR_LIMIT = 768

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopLibSecretFallbackTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopLibSecretFallbackTest.kt
@@ -1,0 +1,36 @@
+package org.feeluown.mobile.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopLibSecretFallbackTest {
+    @Test
+    fun bundledFallbackRegistersAllJnaLibrariesInSameDirectory() {
+        val registered = mutableListOf<Pair<String, String>>()
+
+        registerBundledLinuxLibSecretSearchPaths("/app/native") { name, path ->
+            registered += name to path
+        }
+
+        assertEquals(
+            listOf(
+                "secret-1" to "/app/native",
+                "glib-2.0" to "/app/native",
+                "gobject-2.0" to "/app/native",
+                "gio-2.0" to "/app/native",
+            ),
+            registered,
+        )
+    }
+
+    @Test
+    fun blankFallbackDirectoryDoesNotChangeJnaSearchPath() {
+        val registered = mutableListOf<Pair<String, String>>()
+
+        registerBundledLinuxLibSecretSearchPaths(" ") { name, path ->
+            registered += name to path
+        }
+
+        assertEquals(emptyList(), registered)
+    }
+}

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopMpvRequestCorrelationTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopMpvRequestCorrelationTest.kt
@@ -1,0 +1,59 @@
+package org.feeluown.mobile.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DesktopMpvRequestCorrelationTest {
+    @Test
+    fun playlistEntryIdentityAcceptsNormalizedRuntimePath() {
+        assertTrue(
+            desktopMpvSourceMatchesRequest(
+                requestedPath = "https://media.example.test/audio?id=42",
+                expectedPlaylistEntryId = 17L,
+                currentPlaylistEntryId = 17L,
+                currentPath = "https://cdn.example.test/resolved/audio.m4a",
+                currentPlaylistFilename = "https://media.example.test/audio?id=42",
+            ),
+        )
+    }
+
+    @Test
+    fun playlistFilenameActivatesWhenEntryIdIsTemporarilyUnavailable() {
+        assertTrue(
+            desktopMpvSourceMatchesRequest(
+                requestedPath = "https://media.example.test/audio?id=42",
+                expectedPlaylistEntryId = null,
+                currentPlaylistEntryId = null,
+                currentPath = "https://cdn.example.test/resolved/audio.m4a",
+                currentPlaylistFilename = "https://media.example.test/audio?id=42",
+            ),
+        )
+    }
+
+    @Test
+    fun playlistEntryMismatchRejectsStaleSameUrlEvent() {
+        assertFalse(
+            desktopMpvSourceMatchesRequest(
+                requestedPath = "https://media.example.test/audio?id=42",
+                expectedPlaylistEntryId = 18L,
+                currentPlaylistEntryId = 17L,
+                currentPath = "https://media.example.test/audio?id=42",
+                currentPlaylistFilename = "https://media.example.test/audio?id=42",
+            ),
+        )
+    }
+
+    @Test
+    fun unrelatedSourceDoesNotActivatePolling() {
+        assertFalse(
+            desktopMpvSourceMatchesRequest(
+                requestedPath = "https://media.example.test/new.m4a",
+                expectedPlaylistEntryId = null,
+                currentPlaylistEntryId = null,
+                currentPath = "https://media.example.test/old.m4a",
+                currentPlaylistFilename = "https://media.example.test/old.m4a",
+            ),
+        )
+    }
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopWebLoginLauncher.kt
@@ -58,7 +58,9 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
                 userAgent = loginUserAgent(provider.providerId),
             )
             runCatching {
-                val process = ProcessBuilder(helper.absolutePath).start()
+                val processBuilder = ProcessBuilder(helper.absolutePath)
+                configureDesktopWebLoginProcessEnvironment(processBuilder.environment())
+                val process = processBuilder.start()
                 activeProcesses += process
                 coroutineScope {
                     val diagnosticsDeferred = async(Dispatchers.IO) {
@@ -123,4 +125,50 @@ internal class DesktopWebLoginLauncher : AutoCloseable {
             "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
     }
+}
+
+internal fun configureDesktopWebLoginProcessEnvironment(
+    environment: MutableMap<String, String>,
+    sourceEnvironment: Map<String, String> = System.getenv(),
+) {
+    sourceEnvironment["FUOEVOLVE_WEBVIEW_LIB_DIR"]
+        ?.takeIf(String::isNotBlank)
+        ?.let { bundledLibraryDir ->
+            val inherited = environment["LD_LIBRARY_PATH"]?.takeIf(String::isNotBlank)
+            environment["LD_LIBRARY_PATH"] = if (inherited == null) {
+                bundledLibraryDir
+            } else {
+                "$bundledLibraryDir:$inherited"
+            }
+        }
+
+    copyDesktopWebLoginEnvironment(
+        sourceEnvironment = sourceEnvironment,
+        sourceName = "FUOEVOLVE_WEBKIT_EXEC_PATH",
+        targetEnvironment = environment,
+        targetName = "WEBKIT_EXEC_PATH",
+    )
+    copyDesktopWebLoginEnvironment(
+        sourceEnvironment = sourceEnvironment,
+        sourceName = "FUOEVOLVE_WEBKIT_INJECTED_BUNDLE_PATH",
+        targetEnvironment = environment,
+        targetName = "WEBKIT_INJECTED_BUNDLE_PATH",
+    )
+    copyDesktopWebLoginEnvironment(
+        sourceEnvironment = sourceEnvironment,
+        sourceName = "FUOEVOLVE_GIO_EXTRA_MODULES",
+        targetEnvironment = environment,
+        targetName = "GIO_EXTRA_MODULES",
+    )
+}
+
+private fun copyDesktopWebLoginEnvironment(
+    sourceEnvironment: Map<String, String>,
+    sourceName: String,
+    targetEnvironment: MutableMap<String, String>,
+    targetName: String,
+) {
+    sourceEnvironment[sourceName]
+        ?.takeIf(String::isNotBlank)
+        ?.let { targetEnvironment[targetName] = it }
 }


### PR DESCRIPTION
## Summary
- make libmpv polling correlate the active request by playlist entry identity first, with the playlist's original filename as a fallback when mpv normalizes or redirects `path`
- keep stale replacement events isolated when playlist entry ids disagree
- make AppImage load bundled libmpv explicitly instead of globally prepending the native dependency closure to `LD_LIBRARY_PATH`
- keep the bundled libsecret fallback in a separate directory from Compose's `jna.library.path`, so the host libsecret/GLib stack is actually preferred and Arch/AppImage resolve the same Secret Service/keyring entries
- scope bundled WebKitGTK/GLib/GIO libraries to the web-login helper subprocess instead of the main JVM
- log secure credential-store initialization failures instead of silently presenting them only as a logged-out state

## Reported failure modes
1. On Arch Linux audio is audible, but the in-app player/MPRIS state remains stopped and position stays at 0.
2. The AppImage does not see provider login state previously written by the Arch package.

## Root causes addressed
- the authoritative 250 ms libmpv polling fallback added in #202 still required `mpv path == requested URL` before activating. That comparison is too strict when libmpv normalizes or redirects a source URL, so all subsequent state/timeline samples can still be discarded.
- the AppImage launcher globally prepended its build-time native dependency closures to `LD_LIBRARY_PATH`. In addition, Compose already adds `resources/native/mpv` to `jna.library.path`; keeping libsecret in that same directory would still shadow the host client library even after removing the global `LD_LIBRARY_PATH`. The AppImage now separates mpv and libsecret closures and only registers the bundled libsecret directory as a fallback when the host client library is unavailable.

## Tests / safeguards
- cover normalized mpv runtime paths, playlist-filename fallback, stale entry-id rejection, and unrelated-source rejection
- cover bundled libsecret fallback search-path registration
- AppImage structural validation rejects global `LD_LIBRARY_PATH`, verifies explicit bundled libmpv loading, verifies the libsecret fallback directory, and rejects libsecret leaking back into the mpv/JNA directory

## Notes
No credential format/key migration is introduced. Existing secure-store keys remain unchanged, so an AppImage should reuse login state already stored by an installed Linux package once both reach the same host Secret Service.