### PR TITLE
Fix macOS Keychain credential writes

### DIFF
--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
@@ -9,6 +9,7 @@ import com.microsoft.credentialstorage.model.StoredToken
 import com.microsoft.credentialstorage.model.StoredTokenType
 import com.sun.jna.NativeLibrary
 import java.security.MessageDigest
+import java.util.Base64
 import java.util.UUID
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -145,6 +146,39 @@ private class MicrosoftDesktopSecretStore(
     override fun delete(key: String): Boolean = delegate.delete(key)
 }
 
+/**
+ * credential-secure-storage writes macOS Keychain values through `security -i` and surrounds each
+ * argument with quotes, but it does not escape quotes/newlines inside the password itself. Provider
+ * credentials are JSON, so passing them through unchanged can make `security add-generic-password`
+ * parse the command incorrectly. Encode only the macOS payload before handing it to the library.
+ *
+ * Prefixing the encoded form lets us continue reading any values that were successfully stored by
+ * older builds without encoding.
+ */
+internal class MacOsSafeDesktopSecretStore(
+    private val delegate: DesktopSecretStore,
+) : DesktopSecretStore {
+    override fun get(key: String): CharArray? {
+        val stored = delegate.get(key) ?: return null
+        return try {
+            decodeMacOsSecret(stored)
+        } finally {
+            stored.fill('\u0000')
+        }
+    }
+
+    override fun put(key: String, value: CharArray): Boolean {
+        val encoded = encodeMacOsSecret(value)
+        return try {
+            delegate.put(key, encoded)
+        } finally {
+            encoded.fill('\u0000')
+        }
+    }
+
+    override fun delete(key: String): Boolean = delegate.delete(key)
+}
+
 private fun createMicrosoftSecretStore(): DesktopSecretStore? =
     if (System.getProperty("os.name") == "Linux") {
         createLinuxLibSecretStore()
@@ -152,7 +186,13 @@ private fun createMicrosoftSecretStore(): DesktopSecretStore? =
         StorageProvider.getTokenStorage(true, SecureOption.REQUIRED)
             ?.takeIf { it.isSecure }
             ?.let(::MicrosoftDesktopSecretStore)
+            ?.let { store ->
+                if (isMacOs()) MacOsSafeDesktopSecretStore(store) else store
+            }
     }
+
+private fun isMacOs(): Boolean =
+    System.getProperty("os.name").orEmpty().contains("mac", ignoreCase = true)
 
 private fun createLinuxLibSecretStore(): DesktopSecretStore {
     // AppImage ships a compatibility libsecret closure, but an installed package and a portable
@@ -276,6 +316,34 @@ private fun writeSecret(store: DesktopSecretStore, key: String, value: String): 
     }
 }
 
+private fun encodeMacOsSecret(value: CharArray): CharArray {
+    val bytes = value.concatToString().encodeToByteArray()
+    return try {
+        val encoded = Base64.getEncoder().encodeToString(bytes)
+        "$MACOS_SECRET_ENCODING_PREFIX$encoded".toCharArray()
+    } finally {
+        bytes.fill(0)
+    }
+}
+
+private fun decodeMacOsSecret(value: CharArray): CharArray {
+    val stored = value.concatToString()
+    if (!stored.startsWith(MACOS_SECRET_ENCODING_PREFIX)) return value.copyOf()
+
+    val encoded = stored.removePrefix(MACOS_SECRET_ENCODING_PREFIX)
+    return runCatching {
+        val bytes = Base64.getDecoder().decode(encoded)
+        try {
+            bytes.toString(Charsets.UTF_8).toCharArray()
+        } finally {
+            bytes.fill(0)
+        }
+    }.getOrElse {
+        // Be tolerant of an unlikely legacy value that happens to use the prefix.
+        value.copyOf()
+    }
+}
+
 private fun manifestKey(providerId: String): String = "$SECRET_KEY_PREFIX.${providerKey(providerId)}.manifest"
 
 private fun chunkKey(providerId: String, generation: String, index: Int): String =
@@ -299,6 +367,7 @@ private val BUNDLED_LIBSECRET_JNA_NAMES = listOf(
     "gobject-2.0",
     "gio-2.0",
 )
+private const val MACOS_SECRET_ENCODING_PREFIX = "fuoevolve-b64-v1:"
 private const val SECRET_KEY_PREFIX = "org.feeluown.mobile.provider.credentials.v1"
 private const val MANIFEST_VERSION = "v1"
 private const val SECRET_CHUNK_CHAR_LIMIT = 768

--- a/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
+++ b/desktopApp/src/main/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStore.kt
@@ -49,7 +49,7 @@ internal class DesktopSecureProviderCredentialStore(
             val previous = readManifest(store, providerId)
             val serialized = json.encodeToString(ProviderCredentials.serializer(), credentials)
             val generation = generationProvider()
-            val chunks = serialized.chunked(SECRET_CHUNK_CHAR_LIMIT).ifEmpty { listOf("") }
+            val chunks = chunkCredentialPayload(serialized).ifEmpty { listOf("") }
             val writtenKeys = mutableListOf<String>()
 
             try {
@@ -296,6 +296,30 @@ private data class DesktopCredentialManifest(
             return DesktopCredentialManifest(generation, chunkCount)
         }
     }
+}
+
+internal fun chunkCredentialPayload(
+    value: String,
+    maxChars: Int = SECRET_CHUNK_CHAR_LIMIT,
+): List<String> {
+    require(maxChars >= 2) { "credential chunk size must leave room for a surrogate pair" }
+    if (value.isEmpty()) return emptyList()
+
+    val chunks = mutableListOf<String>()
+    var start = 0
+    while (start < value.length) {
+        var end = minOf(start + maxChars, value.length)
+        if (
+            end < value.length &&
+            Character.isHighSurrogate(value[end - 1]) &&
+            Character.isLowSurrogate(value[end])
+        ) {
+            end--
+        }
+        chunks += value.substring(start, end)
+        start = end
+    }
+    return chunks
 }
 
 private fun readSecret(store: DesktopSecretStore, key: String): String? {

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStoreTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStoreTest.kt
@@ -26,6 +26,27 @@ class DesktopSecureProviderCredentialStoreTest {
     }
 
     @Test
+    fun credentialChunkingPreservesSupplementaryUnicodeAtBoundary() {
+        val original = "a".repeat(767) + "🎵" + "tail"
+        val chunks = chunkCredentialPayload(original, maxChars = 768)
+
+        assertEquals(original, chunks.joinToString(""))
+        assertEquals(767, chunks.first().length)
+        assertTrue(chunks.none { chunk -> chunk.isNotEmpty() && Character.isHighSurrogate(chunk.last()) })
+        assertTrue(chunks.drop(1).none { chunk -> chunk.isNotEmpty() && Character.isLowSurrogate(chunk.first()) })
+
+        val backend = FakeDesktopSecretStore()
+        val macOsStore = MacOsSafeDesktopSecretStore(backend)
+        chunks.forEachIndexed { index, chunk ->
+            assertTrue(macOsStore.put("chunk-$index", chunk.toCharArray()))
+        }
+        val roundTripped = chunks.indices.joinToString("") { index ->
+            macOsStore.get("chunk-$index")!!.concatToString()
+        }
+        assertEquals(original, roundTripped)
+    }
+
+    @Test
     fun successfulOverwriteSwitchesGenerationAndRemovesOldChunks() = runBlocking {
         val backend = FakeDesktopSecretStore()
         val generations = ArrayDeque(listOf("generation1", "generation2"))

--- a/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStoreTest.kt
+++ b/desktopApp/src/test/kotlin/org/feeluown/mobile/desktop/DesktopSecureProviderCredentialStoreTest.kt
@@ -129,6 +129,30 @@ class DesktopSecureProviderCredentialStoreTest {
         assertTrue(error.message.orEmpty().contains("凭证数据"))
     }
 
+    @Test
+    fun macOsSafeStoreEncodesInteractiveSecurityPayloadAndRoundTrips() {
+        val backend = FakeDesktopSecretStore()
+        val store = MacOsSafeDesktopSecretStore(backend)
+        val original = "{\"cookie\":\"uin=123; p_skey=quote\\\"value\",\n\"unicode\":\"中文\"}"
+
+        assertTrue(store.put("qqmusic", original.toCharArray()))
+
+        val persisted = backend.values.getValue("qqmusic").concatToString()
+        assertTrue('"' !in persisted, "encoded Keychain payload must not contain quotes")
+        assertTrue('\n' !in persisted, "encoded Keychain payload must stay on one security -i command line")
+        assertEquals(original, store.get("qqmusic")?.concatToString())
+    }
+
+    @Test
+    fun macOsSafeStoreReadsLegacyUnencodedValues() {
+        val backend = FakeDesktopSecretStore()
+        val legacy = "v1:generation1:3"
+        backend.values["manifest"] = legacy.toCharArray()
+        val store = MacOsSafeDesktopSecretStore(backend)
+
+        assertEquals(legacy, store.get("manifest")?.concatToString())
+    }
+
     private fun largeCredentials(cookiePrefix: String = "cookie"): ProviderCredentials = ProviderCredentials(
         cookies = (1..80).associate { index ->
             "key$index" to "$cookiePrefix-$index-${"x".repeat(48)}"


### PR DESCRIPTION
## Summary
- wrap the macOS secure credential backend with a Keychain-safe encoding layer
- Base64-encode provider credential chunks before `credential-secure-storage` passes them to `security -i`
- preserve compatibility with any previously stored unencoded values
- add regression coverage for JSON quotes, embedded newlines, Unicode, and legacy reads

## Root cause
`com.microsoft:credential-secure-storage:1.0.3` writes macOS Keychain values by feeding `security -i` a quoted `add-generic-password` command, but its command builder does not escape quotes or newlines inside the password value. FuoEvolve stores provider credentials as JSON, so the JSON quotes break the interactive command and `/usr/bin/security` exits with usage error code 2, matching the reported screenshot.

The encoding is applied only on macOS; Windows Credential Manager and Linux Libsecret behavior stays unchanged.