### PR TITLE
Fix Bluetooth car route detection for lyrics

### DIFF
--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BluetoothLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BluetoothLyricsPublisher.kt
@@ -62,6 +62,7 @@ internal class BluetoothLyricsPublisher(
     private var cachedLyricsRaw: String? = null
     private var cachedTimedLines: List<LyricLine> = emptyList()
     private var lastApplied: AppliedMetadata? = null
+    private var lastRouteDecision: BluetoothMediaRouteDecision? = null
 
     fun start() {
         if (collectJob != null || closed) return
@@ -137,7 +138,12 @@ internal class BluetoothLyricsPublisher(
 
     private fun applyForPosition(snapshot: Snapshot, positionMs: Long) {
         val track = snapshot.track ?: return
-        if (!isBluetoothMediaOutputActive(audioManager, mediaRouter)) {
+        val routeDecision = bluetoothMediaRouteDecision(audioManager, mediaRouter)
+        if (routeDecision != lastRouteDecision) {
+            lastRouteDecision = routeDecision
+            AppLogger.i(TAG, "Bluetooth media route ${routeDecision.toDiagnosticString()}")
+        }
+        if (!routeDecision.active) {
             restoreOriginalMetadata()
             return
         }
@@ -374,36 +380,100 @@ internal fun bluetoothLyricsDisplay(
     )
 }
 
+internal data class BluetoothMediaRouteDecision(
+    val active: Boolean,
+    val routedDeviceTypes: List<Int>,
+    val routedDeviceQueryAvailable: Boolean,
+    val mediaRouterBluetooth: Boolean,
+    val legacyA2dpOn: Boolean,
+    val legacyScoOn: Boolean,
+    val connectedBluetoothOutputTypes: List<Int>,
+) {
+    fun toDiagnosticString(): String =
+        "active=$active routedTypes=$routedDeviceTypes routedQueryAvailable=$routedDeviceQueryAvailable " +
+            "mediaRouterBluetooth=$mediaRouterBluetooth a2dpOn=$legacyA2dpOn scoOn=$legacyScoOn " +
+            "connectedBluetoothTypes=$connectedBluetoothOutputTypes"
+}
+
+internal fun resolveBluetoothMediaRouteActive(
+    routedBluetooth: Boolean,
+    routedDeviceQueryAvailable: Boolean,
+    mediaRouterBluetooth: Boolean,
+    legacyBluetoothRoute: Boolean,
+    connectedBluetoothOutput: Boolean,
+): Boolean =
+    routedBluetooth ||
+        mediaRouterBluetooth ||
+        legacyBluetoothRoute ||
+        (!routedDeviceQueryAvailable && connectedBluetoothOutput)
+
 @Suppress("DEPRECATION")
 internal fun isBluetoothMediaOutputActive(
     audioManager: AudioManager?,
     mediaRouter: MediaRouter?,
-): Boolean {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        if (audioManager == null) return false
-        val devices = runCatching {
+): Boolean = bluetoothMediaRouteDecision(audioManager, mediaRouter).active
+
+@Suppress("DEPRECATION")
+internal fun bluetoothMediaRouteDecision(
+    audioManager: AudioManager?,
+    mediaRouter: MediaRouter?,
+): BluetoothMediaRouteDecision {
+    val routedDeviceResult = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && audioManager != null) {
+        runCatching {
             audioManager.getAudioDevicesForAttributes(
                 AudioAttributes.Builder()
                     .setUsage(AudioAttributes.USAGE_MEDIA)
                     .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
                     .build(),
-            )
-        }.getOrElse { emptyList() }
-        return devices.any { device ->
-            when (device.type) {
-                AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
-                AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-                AudioDeviceInfo.TYPE_HEARING_AID,
-                AudioDeviceInfo.TYPE_BLE_HEADSET,
-                AudioDeviceInfo.TYPE_BLE_SPEAKER,
-                -> true
-                else -> Build.VERSION.SDK_INT >= 37 && device.type == AudioDeviceInfo.TYPE_BLE_HEARING_AID
-            }
+            ).map(AudioDeviceInfo::getType)
         }
+    } else {
+        null
     }
+    val routedDeviceTypes = routedDeviceResult?.getOrNull().orEmpty()
+    val routedDeviceQueryAvailable = routedDeviceResult?.isSuccess == true && routedDeviceTypes.isNotEmpty()
+    val routedBluetooth = routedDeviceTypes.any(::isBluetoothAudioDeviceType)
 
     val selectedRoute = runCatching {
         mediaRouter?.getSelectedRoute(MediaRouter.ROUTE_TYPE_LIVE_AUDIO)
-    }.getOrNull() ?: return false
-    return selectedRoute.deviceType == MediaRouter.RouteInfo.DEVICE_TYPE_BLUETOOTH
+    }.getOrNull()
+    val mediaRouterBluetooth = selectedRoute?.deviceType == MediaRouter.RouteInfo.DEVICE_TYPE_BLUETOOTH
+
+    val legacyA2dpOn = runCatching { audioManager?.isBluetoothA2dpOn == true }.getOrDefault(false)
+    val legacyScoOn = runCatching { audioManager?.isBluetoothScoOn == true }.getOrDefault(false)
+    val connectedBluetoothOutputTypes = runCatching {
+        audioManager
+            ?.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .orEmpty()
+            .map(AudioDeviceInfo::getType)
+            .filter(::isBluetoothAudioDeviceType)
+            .distinct()
+    }.getOrElse { emptyList() }
+
+    val active = resolveBluetoothMediaRouteActive(
+        routedBluetooth = routedBluetooth,
+        routedDeviceQueryAvailable = routedDeviceQueryAvailable,
+        mediaRouterBluetooth = mediaRouterBluetooth,
+        legacyBluetoothRoute = legacyA2dpOn || legacyScoOn,
+        connectedBluetoothOutput = connectedBluetoothOutputTypes.isNotEmpty(),
+    )
+    return BluetoothMediaRouteDecision(
+        active = active,
+        routedDeviceTypes = routedDeviceTypes,
+        routedDeviceQueryAvailable = routedDeviceQueryAvailable,
+        mediaRouterBluetooth = mediaRouterBluetooth,
+        legacyA2dpOn = legacyA2dpOn,
+        legacyScoOn = legacyScoOn,
+        connectedBluetoothOutputTypes = connectedBluetoothOutputTypes,
+    )
+}
+
+private fun isBluetoothAudioDeviceType(type: Int): Boolean = when (type) {
+    AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+    AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+    AudioDeviceInfo.TYPE_HEARING_AID,
+    AudioDeviceInfo.TYPE_BLE_HEADSET,
+    AudioDeviceInfo.TYPE_BLE_SPEAKER,
+    -> true
+    else -> Build.VERSION.SDK_INT >= 37 && type == AudioDeviceInfo.TYPE_BLE_HEARING_AID
 }

--- a/androidApp/src/main/kotlin/org/feeluown/mobile/BluetoothLyricsPublisher.kt
+++ b/androidApp/src/main/kotlin/org/feeluown/mobile/BluetoothLyricsPublisher.kt
@@ -401,11 +401,12 @@ internal fun resolveBluetoothMediaRouteActive(
     mediaRouterBluetooth: Boolean,
     legacyBluetoothRoute: Boolean,
     connectedBluetoothOutput: Boolean,
+    connectedOutputFallbackAllowed: Boolean,
 ): Boolean =
     routedBluetooth ||
         mediaRouterBluetooth ||
         legacyBluetoothRoute ||
-        (!routedDeviceQueryAvailable && connectedBluetoothOutput)
+        (connectedOutputFallbackAllowed && !routedDeviceQueryAvailable && connectedBluetoothOutput)
 
 @Suppress("DEPRECATION")
 internal fun isBluetoothMediaOutputActive(
@@ -456,6 +457,7 @@ internal fun bluetoothMediaRouteDecision(
         mediaRouterBluetooth = mediaRouterBluetooth,
         legacyBluetoothRoute = legacyA2dpOn || legacyScoOn,
         connectedBluetoothOutput = connectedBluetoothOutputTypes.isNotEmpty(),
+        connectedOutputFallbackAllowed = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU,
     )
     return BluetoothMediaRouteDecision(
         active = active,

--- a/androidApp/src/test/kotlin/org/feeluown/mobile/BluetoothLyricsPublisherTest.kt
+++ b/androidApp/src/test/kotlin/org/feeluown/mobile/BluetoothLyricsPublisherTest.kt
@@ -2,7 +2,9 @@ package org.feeluown.mobile
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class BluetoothLyricsPublisherTest {
     @Test
@@ -41,5 +43,53 @@ class BluetoothLyricsPublisherTest {
         )
 
         assertEquals("原文", bluetoothLyricLine(lyrics, 0L))
+    }
+
+    @Test
+    fun bluetoothRouteAcceptsMediaRouterFallbackWhenPrimaryRouteMissesCar() {
+        assertTrue(
+            resolveBluetoothMediaRouteActive(
+                routedBluetooth = false,
+                routedDeviceQueryAvailable = true,
+                mediaRouterBluetooth = true,
+                legacyBluetoothRoute = false,
+                connectedBluetoothOutput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun bluetoothRouteAcceptsLegacyActiveRouteFallback() {
+        assertTrue(
+            resolveBluetoothMediaRouteActive(
+                routedBluetooth = false,
+                routedDeviceQueryAvailable = true,
+                mediaRouterBluetooth = false,
+                legacyBluetoothRoute = true,
+                connectedBluetoothOutput = false,
+            ),
+        )
+    }
+
+    @Test
+    fun bluetoothRouteUsesConnectedOutputOnlyWhenPrimaryRouteIsUnavailable() {
+        assertTrue(
+            resolveBluetoothMediaRouteActive(
+                routedBluetooth = false,
+                routedDeviceQueryAvailable = false,
+                mediaRouterBluetooth = false,
+                legacyBluetoothRoute = false,
+                connectedBluetoothOutput = true,
+            ),
+        )
+        assertFalse(
+            resolveBluetoothMediaRouteActive(
+                routedBluetooth = false,
+                routedDeviceQueryAvailable = true,
+                mediaRouterBluetooth = false,
+                legacyBluetoothRoute = false,
+                connectedBluetoothOutput = true,
+            ),
+        )
     }
 }

--- a/androidApp/src/test/kotlin/org/feeluown/mobile/BluetoothLyricsPublisherTest.kt
+++ b/androidApp/src/test/kotlin/org/feeluown/mobile/BluetoothLyricsPublisherTest.kt
@@ -54,6 +54,7 @@ class BluetoothLyricsPublisherTest {
                 mediaRouterBluetooth = true,
                 legacyBluetoothRoute = false,
                 connectedBluetoothOutput = false,
+                connectedOutputFallbackAllowed = true,
             ),
         )
     }
@@ -67,12 +68,13 @@ class BluetoothLyricsPublisherTest {
                 mediaRouterBluetooth = false,
                 legacyBluetoothRoute = true,
                 connectedBluetoothOutput = false,
+                connectedOutputFallbackAllowed = true,
             ),
         )
     }
 
     @Test
-    fun bluetoothRouteUsesConnectedOutputOnlyWhenPrimaryRouteIsUnavailable() {
+    fun bluetoothRouteUsesConnectedOutputOnlyWhenPrimaryRouteIsUnavailableOnSupportedVersions() {
         assertTrue(
             resolveBluetoothMediaRouteActive(
                 routedBluetooth = false,
@@ -80,6 +82,7 @@ class BluetoothLyricsPublisherTest {
                 mediaRouterBluetooth = false,
                 legacyBluetoothRoute = false,
                 connectedBluetoothOutput = true,
+                connectedOutputFallbackAllowed = true,
             ),
         )
         assertFalse(
@@ -89,6 +92,21 @@ class BluetoothLyricsPublisherTest {
                 mediaRouterBluetooth = false,
                 legacyBluetoothRoute = false,
                 connectedBluetoothOutput = true,
+                connectedOutputFallbackAllowed = true,
+            ),
+        )
+    }
+
+    @Test
+    fun bluetoothRouteDoesNotTreatConnectedOutputAsActiveOnPreAndroid13() {
+        assertFalse(
+            resolveBluetoothMediaRouteActive(
+                routedBluetooth = false,
+                routedDeviceQueryAvailable = false,
+                mediaRouterBluetooth = false,
+                legacyBluetoothRoute = false,
+                connectedBluetoothOutput = true,
+                connectedOutputFallbackAllowed = false,
             ),
         )
     }


### PR DESCRIPTION
## Summary
- keep `getAudioDevicesForAttributes()` as the primary Android 13+ route signal
- fall back to the selected `MediaRouter` Bluetooth route and legacy active Bluetooth route flags for car/head-unit cases that are not reported as A2DP/BLE by the primary API
- only use connected Bluetooth output devices when the primary routed-device query is unavailable/empty, avoiding false positives when a concrete non-Bluetooth route is reported
- log route decision signals when they change so diagnostics can show why Bluetooth lyrics are enabled or skipped
- add regression tests for MediaRouter, legacy route, and unavailable-primary fallbacks

## Context
On the same phone, Bluetooth lyrics worked with a Bluetooth speaker but not with an in-car Bluetooth connection. The phone media card also stayed on the original song title, which indicates the Bluetooth route gate was preventing metadata publication before AVRCP was involved.