### PR TITLE
feat: provide bundled and system JVM Arch packages

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -307,7 +307,7 @@ jobs:
           if-no-files-found: error
 
   linux-system:
-    name: Package Linux DEB RPM and Arch
+    name: Package Linux DEB RPM and Arch variants
     runs-on: ubuntu-24.04
     timeout-minutes: 75
 
@@ -417,7 +417,7 @@ jobs:
           bash desktopApp/packaging/linux/package-system.sh deb "${{ steps.app.outputs.app_image }}" "${{ steps.app.outputs.version }}" build/desktop-packages/system
           bash desktopApp/packaging/linux/package-system.sh rpm "${{ steps.app.outputs.app_image }}" "${{ steps.app.outputs.version }}" build/desktop-packages/system
 
-      - name: Build Arch Linux package
+      - name: Build Arch Linux JVM variants
         run: >-
           bash desktopApp/packaging/linux/package-arch.sh
           "${{ steps.app.outputs.app_image }}"
@@ -428,16 +428,33 @@ jobs:
         run: |
           DEB="$(find build/desktop-packages/system -name '*.deb' -print -quit)"
           RPM="$(find build/desktop-packages/system -name '*.rpm' -print -quit)"
-          ARCH="$(find build/desktop-packages/system -name '*.pkg.tar.zst' -print -quit)"
-          test -n "$DEB" && test -n "$RPM" && test -n "$ARCH"
+          ARCH_BUNDLED="$(find build/desktop-packages/system -name 'fuoevolve-*.pkg.tar.zst' ! -name 'fuoevolve-system-jvm-*' -print -quit)"
+          ARCH_SYSTEM="$(find build/desktop-packages/system -name 'fuoevolve-system-jvm-*.pkg.tar.zst' -print -quit)"
+          test -n "$DEB" && test -n "$RPM" && test -n "$ARCH_BUNDLED" && test -n "$ARCH_SYSTEM"
           dpkg-deb -I "$DEB" | tee build/desktop-packages/system/deb-info.txt
           grep -q 'libmpv2' build/desktop-packages/system/deb-info.txt
           grep -q 'libwebkit2gtk-4.1-0' build/desktop-packages/system/deb-info.txt
           rpm -qp --requires "$RPM" | tee build/desktop-packages/system/rpm-requires.txt
           grep -q 'libmpv.so.2' build/desktop-packages/system/rpm-requires.txt
           grep -q 'libwebkit2gtk-4.1.so.0' build/desktop-packages/system/rpm-requires.txt
-          tar -tf "$ARCH" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
-          tar -xOf "$ARCH" .PKGINFO | grep -q 'depend = webkit2gtk-4.1'
+
+          tar -tf "$ARCH_BUNDLED" | grep 'opt/fuoevolve/bin/FuoEvolve' >/dev/null
+          tar -tf "$ARCH_BUNDLED" | grep 'opt/fuoevolve/runtime/' >/dev/null
+          tar -xOf "$ARCH_BUNDLED" .PKGINFO | tee build/desktop-packages/system/arch-bundled-pkginfo.txt
+          grep -q 'depend = webkit2gtk-4.1' build/desktop-packages/system/arch-bundled-pkginfo.txt
+          grep -q 'conflict = fuoevolve-system-jvm' build/desktop-packages/system/arch-bundled-pkginfo.txt
+
+          tar -tf "$ARCH_SYSTEM" | grep 'usr/bin/fuoevolve' >/dev/null
+          tar -tf "$ARCH_SYSTEM" | grep 'usr/lib/fuoevolve/lib/app/' >/dev/null
+          if tar -tf "$ARCH_SYSTEM" | grep '/runtime/' >/dev/null; then
+            echo "System-JVM Arch package unexpectedly contains a bundled JVM runtime" >&2
+            exit 1
+          fi
+          tar -xOf "$ARCH_SYSTEM" .PKGINFO | tee build/desktop-packages/system/arch-system-jvm-pkginfo.txt
+          grep -q 'depend = java-runtime>=21' build/desktop-packages/system/arch-system-jvm-pkginfo.txt
+          grep -q 'depend = webkit2gtk-4.1' build/desktop-packages/system/arch-system-jvm-pkginfo.txt
+          grep -q 'provides = fuoevolve=' build/desktop-packages/system/arch-system-jvm-pkginfo.txt
+          grep -q 'conflict = fuoevolve' build/desktop-packages/system/arch-system-jvm-pkginfo.txt
 
       - name: Report Linux package sizes
         run: du -h build/desktop-packages/system/*.deb build/desktop-packages/system/*.rpm build/desktop-packages/system/*.pkg.tar.zst
@@ -460,11 +477,20 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-      - name: Upload Arch Linux package
+      - name: Upload Arch Linux bundled-JVM package
         uses: actions/upload-artifact@v7
         with:
-          name: fuoevolve-linux-x64.pkg.tar.zst
-          path: build/desktop-packages/system/*.pkg.tar.zst
+          path: |
+            build/desktop-packages/system/fuoevolve-*.pkg.tar.zst
+            !build/desktop-packages/system/fuoevolve-system-jvm-*.pkg.tar.zst
+          archive: false
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload Arch Linux system-JVM package
+        uses: actions/upload-artifact@v7
+        with:
+          path: build/desktop-packages/system/fuoevolve-system-jvm-*.pkg.tar.zst
           archive: false
           retention-days: 14
           if-no-files-found: error

--- a/desktopApp/packaging/linux/package-arch.sh
+++ b/desktopApp/packaging/linux/package-arch.sh
@@ -17,50 +17,66 @@ if [[ ! -d "$APP_IMAGE" || ! -x "$APP_IMAGE/bin/FuoEvolve" ]]; then
   echo "invalid Compose app image: $APP_IMAGE" >&2
   exit 1
 fi
+if [[ ! -d "$APP_IMAGE/lib/app" ]] || ! find "$APP_IMAGE/lib/app" -maxdepth 1 -type f -name '*.jar' -print -quit | grep -q .; then
+  echo "Compose app image is missing application JARs: $APP_IMAGE/lib/app" >&2
+  exit 1
+fi
 if [[ ! -f "$ICON" ]]; then
   echo "desktop package icon is missing: $ICON" >&2
   exit 1
 fi
 if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required to build the Arch package in a clean Arch environment" >&2
+  echo "Docker is required to build the Arch packages in a clean Arch environment" >&2
   exit 1
 fi
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
+BUNDLED_DIR="$WORK_DIR/bundled"
+SYSTEM_DIR="$WORK_DIR/system-jvm"
+mkdir -p "$BUNDLED_DIR" "$SYSTEM_DIR"
 
-cp -a "$APP_IMAGE" "$WORK_DIR/FuoEvolve"
-tar -C "$WORK_DIR" -czf "$WORK_DIR/FuoEvolve.tar.gz" FuoEvolve
-rm -rf "$WORK_DIR/FuoEvolve"
-cp "$ICON" "$WORK_DIR/fuoevolve.png"
-cat > "$WORK_DIR/fuoevolve.desktop" <<'DESKTOP'
+write_common_files() {
+  local target_dir="$1"
+  cp "$ICON" "$target_dir/fuoevolve.png"
+  cat > "$target_dir/fuoevolve.desktop" <<'DESKTOP'
 [Desktop Entry]
 Type=Application
 Name=FuoEvolve
 Comment=A cross-platform multi-source music player based on FeelUOwn
-Exec=/opt/fuoevolve/bin/FuoEvolve %U
+Exec=/usr/bin/fuoevolve %U
 Icon=fuoevolve
 Terminal=false
 Categories=AudioVideo;Audio;Player;
 StartupNotify=true
 DESKTOP
+}
 
-APP_SHA="$(sha256sum "$WORK_DIR/FuoEvolve.tar.gz" | awk '{print $1}')"
-DESKTOP_SHA="$(sha256sum "$WORK_DIR/fuoevolve.desktop" | awk '{print $1}')"
-ICON_SHA="$(sha256sum "$WORK_DIR/fuoevolve.png" | awk '{print $1}')"
+write_common_files "$BUNDLED_DIR"
+write_common_files "$SYSTEM_DIR"
 
-cat > "$WORK_DIR/PKGBUILD" <<EOF
+# Default Arch package: keep the Compose-generated launcher and its bundled JBR runtime.
+cp -a "$APP_IMAGE" "$BUNDLED_DIR/FuoEvolve"
+tar -C "$BUNDLED_DIR" -czf "$BUNDLED_DIR/FuoEvolve.tar.gz" FuoEvolve
+rm -rf "$BUNDLED_DIR/FuoEvolve"
+
+BUNDLED_APP_SHA="$(sha256sum "$BUNDLED_DIR/FuoEvolve.tar.gz" | awk '{print $1}')"
+BUNDLED_DESKTOP_SHA="$(sha256sum "$BUNDLED_DIR/fuoevolve.desktop" | awk '{print $1}')"
+BUNDLED_ICON_SHA="$(sha256sum "$BUNDLED_DIR/fuoevolve.png" | awk '{print $1}')"
+
+cat > "$BUNDLED_DIR/PKGBUILD" <<EOF
 pkgname=fuoevolve
 pkgver=$VERSION
 pkgrel=1
-pkgdesc='A cross-platform multi-source music player based on FeelUOwn'
+pkgdesc='A cross-platform multi-source music player based on FeelUOwn (bundled JVM)'
 arch=('x86_64')
 url='https://github.com/feeluown/FuoEvolve'
 license=('GPL-3.0-only')
 depends=('mpv' 'libsecret' 'webkit2gtk-4.1')
+conflicts=('fuoevolve-system-jvm')
 options=('!strip')
 source=('FuoEvolve.tar.gz' 'fuoevolve.desktop' 'fuoevolve.png')
-sha256sums=('$APP_SHA' '$DESKTOP_SHA' '$ICON_SHA')
+sha256sums=('$BUNDLED_APP_SHA' '$BUNDLED_DESKTOP_SHA' '$BUNDLED_ICON_SHA')
 
 package() {
   install -d "\$pkgdir/opt/fuoevolve"
@@ -72,10 +88,118 @@ package() {
 }
 EOF
 
-# makepkg intentionally runs as a non-root user; the package itself retains distro-managed
-# dependencies on mpv/libsecret/WebKitGTK while the Compose app image keeps its bundled JBR runtime.
-# The bind-mounted work directory must be returned to the host runner's numeric ownership before
-# Docker exits, otherwise chown-ing it to the container-only builder user makes host cleanup fail.
+# System-JVM Arch package: retain the optimized application image, native resources and JARs,
+# but drop the jpackage launcher/runtime pair and use a distro-aware launcher instead.
+cp -a "$APP_IMAGE" "$SYSTEM_DIR/FuoEvolve"
+rm -rf "$SYSTEM_DIR/FuoEvolve/bin" "$SYSTEM_DIR/FuoEvolve/runtime"
+if [[ ! -d "$SYSTEM_DIR/FuoEvolve/lib/app" ]] || ! find "$SYSTEM_DIR/FuoEvolve/lib/app" -maxdepth 1 -type f -name '*.jar' -print -quit | grep -q .; then
+  echo "system-JVM package staging lost application JARs" >&2
+  exit 1
+fi
+if find "$SYSTEM_DIR/FuoEvolve" -path '*/runtime/*' -print -quit | grep -q .; then
+  echo "system-JVM package staging still contains a bundled runtime" >&2
+  exit 1
+fi
+
+tar -C "$SYSTEM_DIR" -czf "$SYSTEM_DIR/FuoEvolve.tar.gz" FuoEvolve
+rm -rf "$SYSTEM_DIR/FuoEvolve"
+
+cat > "$SYSTEM_DIR/fuoevolve" <<'LAUNCHER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MIN_JAVA_MAJOR=21
+readonly APPDIR=/usr/lib/fuoevolve/lib/app
+readonly MAIN_CLASS=org.feeluown.mobile.desktop.MainKt
+
+java_major() {
+  local java_bin="$1"
+  local spec
+  spec="$("$java_bin" -XshowSettings:properties -version 2>&1 |
+    awk -F'= ' '/^[[:space:]]*java\.specification\.version =/ { print $2; exit }')"
+  [[ -n "$spec" ]] || return 1
+  if [[ "$spec" == 1.* ]]; then
+    spec="${spec#1.}"
+  fi
+  spec="${spec%%.*}"
+  [[ "$spec" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$spec"
+}
+
+if [[ -n "${FUOEVOLVE_JAVA_HOME:-}" ]]; then
+  JAVA_BIN="$FUOEVOLVE_JAVA_HOME/bin/java"
+  if [[ ! -x "$JAVA_BIN" ]]; then
+    echo "FUOEVOLVE_JAVA_HOME does not contain an executable Java runtime: $JAVA_BIN" >&2
+    exit 1
+  fi
+  JAVA_MAJOR="$(java_major "$JAVA_BIN" || true)"
+  if [[ -z "$JAVA_MAJOR" || "$JAVA_MAJOR" -lt "$MIN_JAVA_MAJOR" ]]; then
+    echo "FuoEvolve requires Java $MIN_JAVA_MAJOR or later; FUOEVOLVE_JAVA_HOME points to Java ${JAVA_MAJOR:-unknown}." >&2
+    exit 1
+  fi
+else
+  JAVA_BIN=""
+  BEST_MAJOR=""
+  for candidate in /usr/lib/jvm/default-runtime/bin/java /usr/lib/jvm/*/bin/java; do
+    [[ -x "$candidate" ]] || continue
+    candidate="$(readlink -f "$candidate")"
+    major="$(java_major "$candidate" || true)"
+    [[ "$major" =~ ^[0-9]+$ ]] || continue
+    (( major >= MIN_JAVA_MAJOR )) || continue
+    if [[ -z "$BEST_MAJOR" || "$major" -lt "$BEST_MAJOR" ]]; then
+      JAVA_BIN="$candidate"
+      BEST_MAJOR="$major"
+    fi
+  done
+  if [[ -z "$JAVA_BIN" ]]; then
+    echo "FuoEvolve requires an installed Java runtime version $MIN_JAVA_MAJOR or later." >&2
+    echo "Install a package that provides java-runtime>=$MIN_JAVA_MAJOR or set FUOEVOLVE_JAVA_HOME." >&2
+    exit 1
+  fi
+fi
+
+readonly JNA_LIBRARY_PATH="$APPDIR/resources/native/mpv:$APPDIR/resources/native/bridges"
+exec "$JAVA_BIN" \
+  "-Dfuoevolve.appdir=$APPDIR" \
+  "-Djna.library.path=$JNA_LIBRARY_PATH" \
+  -cp "$APPDIR/*" \
+  "$MAIN_CLASS" \
+  "$@"
+LAUNCHER
+chmod 755 "$SYSTEM_DIR/fuoevolve"
+
+SYSTEM_APP_SHA="$(sha256sum "$SYSTEM_DIR/FuoEvolve.tar.gz" | awk '{print $1}')"
+SYSTEM_DESKTOP_SHA="$(sha256sum "$SYSTEM_DIR/fuoevolve.desktop" | awk '{print $1}')"
+SYSTEM_ICON_SHA="$(sha256sum "$SYSTEM_DIR/fuoevolve.png" | awk '{print $1}')"
+SYSTEM_LAUNCHER_SHA="$(sha256sum "$SYSTEM_DIR/fuoevolve" | awk '{print $1}')"
+
+cat > "$SYSTEM_DIR/PKGBUILD" <<EOF
+pkgname=fuoevolve-system-jvm
+pkgver=$VERSION
+pkgrel=1
+pkgdesc='A cross-platform multi-source music player based on FeelUOwn (system JVM)'
+arch=('x86_64')
+url='https://github.com/feeluown/FuoEvolve'
+license=('GPL-3.0-only')
+depends=('java-runtime>=21' 'mpv' 'libsecret' 'webkit2gtk-4.1')
+provides=("fuoevolve=\$pkgver")
+conflicts=('fuoevolve')
+options=('!strip')
+source=('FuoEvolve.tar.gz' 'fuoevolve.desktop' 'fuoevolve.png' 'fuoevolve')
+sha256sums=('$SYSTEM_APP_SHA' '$SYSTEM_DESKTOP_SHA' '$SYSTEM_ICON_SHA' '$SYSTEM_LAUNCHER_SHA')
+
+package() {
+  install -d "\$pkgdir/usr/lib/fuoevolve"
+  cp -a "\$srcdir/FuoEvolve/." "\$pkgdir/usr/lib/fuoevolve/"
+  install -Dm755 "\$srcdir/fuoevolve" "\$pkgdir/usr/bin/fuoevolve"
+  install -Dm644 "\$srcdir/fuoevolve.desktop" "\$pkgdir/usr/share/applications/fuoevolve.desktop"
+  install -Dm644 "\$srcdir/fuoevolve.png" "\$pkgdir/usr/share/icons/hicolor/192x192/apps/fuoevolve.png"
+}
+EOF
+
+# Build both packages in one clean Arch container so the second variant adds little CI overhead.
+# makepkg intentionally runs as a non-root user. Return the bind-mounted work directory to the
+# host runner's numeric ownership before Docker exits so host cleanup and artifact upload work.
 HOST_UID="$(id -u)"
 HOST_GID="$(id -g)"
 docker run --rm \
@@ -91,15 +215,21 @@ docker run --rm \
   pacman -Syu --noconfirm --needed base-devel namcap
   useradd -m builder
   chown -R builder:builder /work
-  su builder -c "cd /work && makepkg --nodeps --noconfirm --cleanbuild"
-  namcap /work/*.pkg.tar.zst || true
-  chmod a+r /work/*.pkg.tar.zst
+  su builder -c "cd /work/bundled && makepkg --nodeps --noconfirm --cleanbuild"
+  su builder -c "cd /work/system-jvm && makepkg --nodeps --noconfirm --cleanbuild"
+  namcap /work/bundled/*.pkg.tar.zst /work/system-jvm/*.pkg.tar.zst || true
+  chmod a+r /work/bundled/*.pkg.tar.zst /work/system-jvm/*.pkg.tar.zst
 '
 
-PACKAGE_FILE="$(find "$WORK_DIR" -maxdepth 1 -type f -name 'fuoevolve-*.pkg.tar.zst' -print -quit)"
-if [[ -z "$PACKAGE_FILE" ]]; then
-  echo "Arch package was not produced" >&2
+BUNDLED_PACKAGE="$(find "$BUNDLED_DIR" -maxdepth 1 -type f -name 'fuoevolve-*.pkg.tar.zst' -print -quit)"
+SYSTEM_PACKAGE="$(find "$SYSTEM_DIR" -maxdepth 1 -type f -name 'fuoevolve-system-jvm-*.pkg.tar.zst' -print -quit)"
+if [[ -z "$BUNDLED_PACKAGE" || -z "$SYSTEM_PACKAGE" ]]; then
+  echo "Arch packages were not both produced" >&2
+  find "$WORK_DIR" -maxdepth 2 -type f -name '*.pkg.tar.zst' -print >&2
   exit 1
 fi
-cp "$PACKAGE_FILE" "$OUTPUT_DIR/"
-printf 'Built Arch package: %s\n' "$OUTPUT_DIR/$(basename "$PACKAGE_FILE")"
+
+cp "$BUNDLED_PACKAGE" "$OUTPUT_DIR/"
+cp "$SYSTEM_PACKAGE" "$OUTPUT_DIR/"
+printf 'Built Arch bundled-JVM package: %s\n' "$OUTPUT_DIR/$(basename "$BUNDLED_PACKAGE")"
+printf 'Built Arch system-JVM package: %s\n' "$OUTPUT_DIR/$(basename "$SYSTEM_PACKAGE")"

--- a/docs/desktop-packaging.md
+++ b/docs/desktop-packaging.md
@@ -11,10 +11,13 @@ This document defines the installable desktop artifact matrix and native depende
 | macOS x64 | DMG + PKG | bundled JetBrains Runtime | bundled relocatable libmpv + Now Playing Rust bridge |
 | Debian / Ubuntu x64 | DEB | bundled JetBrains Runtime | distribution `libmpv2` + `libsecret-1-0`; Linux tray bridge bundled |
 | RPM x64 | RPM | bundled JetBrains Runtime | distribution providers of `libmpv.so.2` + `libsecret-1.so.0`; Linux tray bridge bundled |
-| Arch Linux x64 | `.pkg.tar.zst` | bundled JetBrains Runtime | distribution `mpv` + `libsecret`; Linux tray bridge bundled |
+| Arch Linux x64 | `fuoevolve-*.pkg.tar.zst` | bundled JetBrains Runtime | distribution `mpv`, `libsecret` and WebKitGTK; Linux tray bridge bundled |
+| Arch Linux x64 | `fuoevolve-system-jvm-*.pkg.tar.zst` | system `java-runtime>=21` | distribution JVM, `mpv`, `libsecret` and WebKitGTK; Linux tray bridge bundled |
 | Portable Linux x64 | AppImage | bundled JetBrains Runtime | bundled libmpv/libsecret client dependency closures + Linux tray bridge |
 
-The JVM is intentionally bundled for every platform, including distribution-native Linux packages. This keeps the Compose/AWT runtime under application control and is required for the native-Wayland runtime baseline. Linux package managers are used for native libraries where they provide a stable ABI and dependency resolution.
+The self-contained desktop artifacts keep the Compose/AWT runtime under application control. Arch Linux additionally provides a system-JVM package for users who prefer distro-managed Java. The two Arch packages conflict with each other and install the same `fuoevolve` command and desktop entry.
+
+The system-JVM Arch launcher does not rely on the JVM selected globally by `archlinux-java`. It searches installed runtimes under `/usr/lib/jvm`, rejects versions below Java 21, and prefers the lowest installed compatible major version so Java 21 wins over newer runtimes when both are present. `FUOEVOLVE_JAVA_HOME` can explicitly select a Java 21+ runtime without changing the system-wide default.
 
 ## Packaging profiles
 
@@ -24,6 +27,8 @@ The JVM is intentionally bundled for every platform, including distribution-nati
 - `system`: stage the Linux Rust tray bridge only. libmpv and libsecret are resolved from the target distribution. This profile is Linux-only.
 
 Bundled packaging requires `FUOEVOLVE_PACKAGE_LIBMPV_DIR` or `-Pfuoevolve.packageLibmpvDir=<path>`. The directory must contain a loadable libmpv library and all non-system native dependencies needed by that build.
+
+The Arch JVM choice is separate from the native-dependency packaging profile. CI creates one optimized Linux `system` app image, then `package-arch.sh` produces both Arch variants from it: the default package retains the generated JetBrains Runtime and launcher, while `fuoevolve-system-jvm` removes them and installs a system-JVM launcher.
 
 ## Native inputs
 
@@ -40,10 +45,10 @@ Immutable externally downloaded packaging tools are recorded in `desktopApp/pack
 
 1. Windows x64 builds the Rust SMTC bridge, prepares pinned libmpv, then runs Compose `packageMsi` and `packageExe`.
 2. macOS arm64 and Intel jobs build the Now Playing bridge, create a relocatable libmpv bundle, then run `packageDmg` and `packagePkg`.
-3. Ubuntu 24.04 creates a `system` Compose app image and repackages it as DEB/RPM; the same app image is passed to a clean Arch container for `makepkg`.
+3. Ubuntu 24.04 creates a `system` Compose app image and repackages it as DEB/RPM; the same app image is passed to one clean Arch container, which builds both the bundled-JVM and system-JVM `.pkg.tar.zst` variants.
 4. Ubuntu 22.04 creates a lower-glibc-baseline app image and converts it to an AppImage with bundled libmpv/libsecret client libraries.
 
-Each job validates package output and dependency policy instead of treating a successful `jpackage` invocation as sufficient.
+Each job validates package output and dependency policy instead of treating a successful `jpackage` invocation as sufficient. Arch validation additionally checks that the bundled package contains its runtime, while the system-JVM package contains no bundled runtime and declares `java-runtime>=21`.
 
 ## Signing and release
 
@@ -57,4 +62,6 @@ Unsigned PR artifacts must not be presented as production-ready downloads.
 
 ## Linux Wayland
 
-Distribution and AppImage packaging must keep the Linux application window on the JetBrains Runtime Wayland toolkit and must never introduce an AWT/X11 tray fallback. Linux tray integration remains StatusNotifierItem/D-Bus. A later packaging smoke step must launch the packaged application under a native Wayland compositor and fail if it resolves to XWayland.
+Bundled-JVM distribution packages and AppImage must keep the Linux application window on the JetBrains Runtime Wayland toolkit and must never introduce an AWT/X11 tray fallback. Linux tray integration remains StatusNotifierItem/D-Bus. A later packaging smoke step must launch those packaged artifacts under a native Wayland compositor and fail if they resolve to XWayland.
+
+The Arch system-JVM variant intentionally does not guarantee native Wayland because its AWT/Compose window backend follows the selected system runtime. This trade-off is explicit: it prioritizes a distro-managed JVM and smaller package over a controlled JetBrains Runtime.


### PR DESCRIPTION
## Summary
- keep `fuoevolve` as the default Arch package with bundled JetBrains Runtime
- add `fuoevolve-system-jvm` using distro-provided `java-runtime>=21`
- make the system launcher select the lowest compatible installed Java major (preferring 21 when available) without changing `archlinux-java`
- build both Arch variants in the same clean Arch container
- validate and upload the two `.pkg.tar.zst` artifacts separately
- document the system-JVM trade-off and `FUOEVOLVE_JAVA_HOME` override

## Package behavior
- `fuoevolve`: installs under `/opt/fuoevolve` and retains the Compose/jpackage launcher + bundled JBR
- `fuoevolve-system-jvm`: installs application files under `/usr/lib/fuoevolve`, contains no bundled runtime, and installs `/usr/bin/fuoevolve`
- the two packages conflict with each other; the system-JVM variant provides `fuoevolve`

## Validation
- `package-arch.sh` and the generated launcher pass Bash syntax validation
- synthetic packaging with a fake Compose app image produces both expected package variants and confirms the system archive excludes `runtime/`
- launcher rejects an explicit Java 17 runtime and correctly forwards classpath/native paths/main class through an explicit Java 21 runtime
- packaging CI metadata checks verify bundled/runtime and system/no-runtime policies plus `java-runtime>=21`