### PR TITLE
fix: sign bundled macOS libmpv runtime

### DIFF
--- a/desktopApp/packaging/macos/prepare-libmpv.sh
+++ b/desktopApp/packaging/macos/prepare-libmpv.sh
@@ -80,6 +80,15 @@ while IFS= read -r dylib; do
   fi
 done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.dylib' -print)
 
+# dylibbundler and install_name_tool rewrite Mach-O load commands and invalidate any existing code
+# signature. Apple Silicon requires arm64 Mach-O code to carry a valid signature, so re-sign the
+# final relocatable dependency closure only after every binary rewrite has completed. Ad-hoc signing
+# keeps unsigned CI/development packages loadable; production app signing can replace these later.
+while IFS= read -r dylib; do
+  codesign --force --sign - --timestamp=none "$dylib"
+  codesign --verify --strict --verbose=2 "$dylib"
+done < <(find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.dylib' -print | sort)
+
 {
   echo "Source: Homebrew mpv $INSTALLED_MPV_VERSION"
   echo "Pinned version key: $MPV_VERSION_KEY"


### PR DESCRIPTION
## Summary
- re-sign every dylib in the bundled macOS libmpv dependency closure after `dylibbundler` and `install_name_tool` finish rewriting Mach-O metadata
- use ad-hoc signing so unsigned CI/development packages remain loadable on Apple Silicon
- verify each final dylib immediately with `codesign --verify --strict`

## Why
Rewriting Mach-O load commands invalidates existing code signatures. Apple Silicon requires arm64 Mach-O code to carry a valid signature, so the packaged libmpv runtime can otherwise fail to load even when the original Homebrew library works.

The signing step intentionally runs only after all binary rewrites are complete. A future production Developer ID signing/notarization pass can replace these ad-hoc signatures.