### PR TITLE
feat(desktop): add isolated Nucleus Tao PoC

### DIFF
--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -34,10 +34,17 @@ jobs:
         with:
           add-job-summary: never
 
-      - name: Install Tao smoke-test runtime
+      - name: Install Tao headful runtime
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb libgtk-3-0 libxkbcommon-x11-0
+          sudo apt-get install -y \
+            xvfb \
+            openbox \
+            mesa-utils \
+            libegl1 \
+            libgl1-mesa-dri \
+            libgtk-3-0 \
+            libxkbcommon-x11-0
 
       - name: Compile isolated Nucleus module
         run: >-
@@ -50,10 +57,17 @@ jobs:
       - name: Start Tao window and compose existing UI
         env:
           FUOEVOLVE_NUCLEUS_POC_SMOKE: "1"
-        run: >-
-          timeout 90s xvfb-run -a
-          ./gradlew
-          --no-configuration-cache
-          --warning-mode all
-          -PenableNucleusDesktopPoc=true
-          :desktopNucleusPoc:run
+        run: |
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1600x1200x24 &
+          for i in $(seq 1 50); do
+            xdpyinfo -display :99 >/dev/null 2>&1 && break
+            sleep 0.2
+          done
+          openbox &
+          sleep 1
+          timeout 90s ./gradlew \
+            --no-configuration-cache \
+            --warning-mode all \
+            -PenableNucleusDesktopPoc=true \
+            :desktopNucleusPoc:run

--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -1,0 +1,59 @@
+name: Nucleus Desktop PoC
+
+"on":
+  pull_request:
+    paths:
+      - "desktopNucleusPoc/**"
+      - "settings.gradle.kts"
+      - ".github/workflows/nucleus-desktop-poc.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux-tao:
+    name: Linux Tao compile and window smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          add-job-summary: never
+
+      - name: Install Tao smoke-test runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libgtk-3-0 libxkbcommon-x11-0
+
+      - name: Compile isolated Nucleus module
+        run: >-
+          ./gradlew
+          --no-configuration-cache
+          --warning-mode all
+          -PenableNucleusDesktopPoc=true
+          :desktopNucleusPoc:compileKotlin
+
+      - name: Start Tao window and compose existing UI
+        env:
+          FUOEVOLVE_NUCLEUS_POC_SMOKE: "1"
+        run: >-
+          timeout 90s xvfb-run -a
+          ./gradlew
+          --no-configuration-cache
+          --warning-mode all
+          -PenableNucleusDesktopPoc=true
+          :desktopNucleusPoc:run

--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -13,9 +13,9 @@ permissions:
 
 jobs:
   linux-tao:
-    name: Linux Tao compile and window smoke
+    name: Linux Tao JVM and GraalVM smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -34,10 +34,12 @@ jobs:
         with:
           add-job-summary: never
 
-      - name: Install Tao headful runtime
+      - name: Install Tao and Native Image runtime
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            build-essential \
+            patchelf \
             xvfb \
             openbox \
             mesa-utils \
@@ -54,12 +56,14 @@ jobs:
           -PenableNucleusDesktopPoc=true
           :desktopNucleusPoc:compileKotlin
 
-      - name: Start Tao window and compose existing UI
+      - name: Start Tao JVM window and compose existing UI
         env:
           FUOEVOLVE_NUCLEUS_POC_SMOKE: "1"
         run: |
           export DISPLAY=:99
           Xvfb :99 -screen 0 1600x1200x24 &
+          xvfb_pid=$!
+          trap 'kill "$xvfb_pid" 2>/dev/null || true' EXIT
           for i in $(seq 1 50); do
             xdpyinfo -display :99 >/dev/null 2>&1 && break
             sleep 0.2
@@ -71,3 +75,23 @@ jobs:
             --warning-mode all \
             -PenableNucleusDesktopPoc=true \
             :desktopNucleusPoc:run
+
+      - name: Build and start GraalVM Native Image
+        env:
+          FUOEVOLVE_NUCLEUS_POC_SMOKE: "1"
+        run: |
+          export DISPLAY=:100
+          Xvfb :100 -screen 0 1600x1200x24 &
+          xvfb_pid=$!
+          trap 'kill "$xvfb_pid" 2>/dev/null || true' EXIT
+          for i in $(seq 1 50); do
+            xdpyinfo -display :100 >/dev/null 2>&1 && break
+            sleep 0.2
+          done
+          openbox &
+          sleep 1
+          timeout 1200s ./gradlew \
+            --no-configuration-cache \
+            --warning-mode all \
+            -PenableNucleusDesktopPoc=true \
+            :desktopNucleusPoc:runGraalvmNative

--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -97,7 +97,7 @@ jobs:
           echo "app dir: $APPDIR"
           test -n "$APPDIR" && test -d "$APPDIR"
 
-          BIN=$(find "$APPDIR" -maxdepth 1 -type f -perm -111 ! -name '*.so*' | head -1)
+          BIN=$(find "$APPDIR" -type f -name 'fuoevolve-nucleus-poc' -perm -111 | head -1)
           echo "native binary: $BIN"
           test -n "$BIN" && test -x "$BIN"
           file "$BIN"

--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -11,6 +11,10 @@ name: Nucleus Desktop PoC
 permissions:
   contents: read
 
+concurrency:
+  group: nucleus-desktop-poc-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-tao:
     name: Linux Tao JVM and GraalVM smoke
@@ -113,3 +117,11 @@ jobs:
           openbox &
           sleep 1
           timeout 90s "$BIN"
+
+      - name: Upload packaged native PoC
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuoevolve-nucleus-linux-poc
+          path: desktopNucleusPoc/build/compose/binaries/**/graalvm-app/**
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/nucleus-desktop-poc.yml
+++ b/.github/workflows/nucleus-desktop-poc.yml
@@ -15,7 +15,7 @@ jobs:
   linux-tao:
     name: Linux Tao JVM and GraalVM smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -76,10 +76,32 @@ jobs:
             -PenableNucleusDesktopPoc=true \
             :desktopNucleusPoc:run
 
-      - name: Build and start GraalVM Native Image
+      - name: Build packaged GraalVM Native Image
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          timeout 2400s ./gradlew \
+            --no-daemon \
+            --no-configuration-cache \
+            --warning-mode all \
+            --stacktrace \
+            -PenableNucleusDesktopPoc=true \
+            -PnativeMarch=compatibility \
+            :desktopNucleusPoc:packageGraalvmNative
+
+      - name: Start packaged native binary and compose existing UI
         env:
           FUOEVOLVE_NUCLEUS_POC_SMOKE: "1"
         run: |
+          APPDIR=$(find desktopNucleusPoc/build/compose/binaries -type d -name graalvm-app | head -1)
+          echo "app dir: $APPDIR"
+          test -n "$APPDIR" && test -d "$APPDIR"
+
+          BIN=$(find "$APPDIR" -maxdepth 1 -type f -perm -111 ! -name '*.so*' | head -1)
+          echo "native binary: $BIN"
+          test -n "$BIN" && test -x "$BIN"
+          file "$BIN"
+
           export DISPLAY=:100
           Xvfb :100 -screen 0 1600x1200x24 &
           xvfb_pid=$!
@@ -90,8 +112,4 @@ jobs:
           done
           openbox &
           sleep 1
-          timeout 1200s ./gradlew \
-            --no-configuration-cache \
-            --warning-mode all \
-            -PenableNucleusDesktopPoc=true \
-            :desktopNucleusPoc:runGraalvmNative
+          timeout 90s "$BIN"

--- a/desktopNucleusPoc/README.md
+++ b/desktopNucleusPoc/README.md
@@ -4,21 +4,52 @@ This module is an isolated experiment for running the existing FuoEvolve Compose
 
 It is deliberately excluded from the normal Gradle project graph. Existing `desktopApp` JVM builds, packaging and CI are unchanged unless the PoC is explicitly enabled.
 
-## Run
+## JVM / Tao run
 
 ```bash
 ./gradlew -PenableNucleusDesktopPoc=true :desktopNucleusPoc:run
 ```
 
-The PoC currently verifies only the phase-1 window/UI path:
+This uses Nucleus/Tao as the window host while still running on the regular JVM. It is useful for fast UI/runtime validation before paying the Native Image build cost.
 
-- Nucleus 2.5.15 runtime
+## GraalVM Native Image
+
+Build the packaged native application folder with:
+
+```bash
+./gradlew \
+  -PenableNucleusDesktopPoc=true \
+  -PnativeMarch=compatibility \
+  :desktopNucleusPoc:packageGraalvmNative
+```
+
+The packaged output is written below:
+
+```text
+desktopNucleusPoc/build/compose/binaries/**/graalvm-app/
+```
+
+The Linux executable is named `fuoevolve-nucleus-poc`. Use the packaged application folder rather than copying only the executable: Nucleus places the Skiko/AWT/native runtime sidecars required by the Compose desktop stack alongside it.
+
+## Phase-1 scope
+
+The PoC currently validates only the window/UI path:
+
+- Nucleus 2.5.15 application runtime
 - Tao native window backend
 - existing `shared` `DesktopAppHost` and Compose UI
+- GraalVM Native Image compilation and packaged native startup
 - existing desktop settings/provider implementations that do not require `desktopApp` host injection
 
 The regular desktop host integrations are intentionally not wired yet. Playback falls back to the shared unsupported engine, listening history is a no-op, local music is empty, and secure provider credential storage is not installed. Tray, system media integration, external activation and the current JNA/libmpv bridge remain owned by the existing JVM `desktopApp` path.
 
 ## CI smoke mode
 
-`FUOEVOLVE_NUCLEUS_POC_SMOKE=1` makes the application exit shortly after the existing UI reaches composition. The dedicated CI workflow uses this under Xvfb to validate that the Tao runtime actually starts a window instead of only compiling the module.
+`FUOEVOLVE_NUCLEUS_POC_SMOKE=1` makes the application exit shortly after the existing UI reaches composition.
+
+The dedicated CI workflow validates both paths on Linux under Xvfb + Openbox + Mesa:
+
+1. compile and start the Nucleus/Tao JVM host;
+2. build `packageGraalvmNative` with a compatibility CPU target;
+3. locate and execute the packaged native binary;
+4. mount the existing `DesktopAppHost` composition before exiting.

--- a/desktopNucleusPoc/README.md
+++ b/desktopNucleusPoc/README.md
@@ -1,0 +1,24 @@
+# Nucleus desktop PoC
+
+This module is an isolated experiment for running the existing FuoEvolve Compose UI on the Nucleus Tao desktop backend.
+
+It is deliberately excluded from the normal Gradle project graph. Existing `desktopApp` JVM builds, packaging and CI are unchanged unless the PoC is explicitly enabled.
+
+## Run
+
+```bash
+./gradlew -PenableNucleusDesktopPoc=true :desktopNucleusPoc:run
+```
+
+The PoC currently verifies only the phase-1 window/UI path:
+
+- Nucleus 2.5.15 runtime
+- Tao native window backend
+- existing `shared` `DesktopAppHost` and Compose UI
+- existing desktop settings/provider implementations that do not require `desktopApp` host injection
+
+The regular desktop host integrations are intentionally not wired yet. Playback falls back to the shared unsupported engine, listening history is a no-op, local music is empty, and secure provider credential storage is not installed. Tray, system media integration, external activation and the current JNA/libmpv bridge remain owned by the existing JVM `desktopApp` path.
+
+## CI smoke mode
+
+`FUOEVOLVE_NUCLEUS_POC_SMOKE=1` makes the application exit shortly after the existing UI reaches composition. The dedicated CI workflow uses this under Xvfb to validate that the Tao runtime actually starts a window instead of only compiling the module.

--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -17,8 +17,14 @@ dependencies {
 
     implementation("dev.nucleusframework:nucleus.nucleus-application:2.5.15")
     implementation("dev.nucleusframework:nucleus.decorated-window-tao:2.5.15")
+    implementation("dev.nucleusframework:nucleus.graalvm-runtime:2.5.15")
 }
 
 nucleus.application {
     mainClass = "org.feeluown.mobile.nucleus.NucleusMainKt"
+
+    graalvm {
+        isEnabled.set(true)
+        imageName.set("fuoevolve-nucleus-poc")
+    }
 }

--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    id("org.jetbrains.kotlin.jvm")
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     id("dev.nucleusframework") version "2.5.15"

--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+    id("dev.nucleusframework") version "2.5.15"
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    implementation(project(":shared"))
+    implementation(compose.desktop.currentOs)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.swing)
+
+    implementation("dev.nucleusframework:nucleus.nucleus-application:2.5.15")
+    implementation("dev.nucleusframework:nucleus.decorated-window-tao:2.5.15")
+}
+
+nucleus.application {
+    mainClass = "org.feeluown.mobile.nucleus.NucleusMainKt"
+}

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -1,0 +1,42 @@
+package org.feeluown.mobile.nucleus
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.application.DecoratedWindow
+import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.nucleusApplication
+import kotlinx.coroutines.delay
+import org.feeluown.mobile.DesktopAppHost
+import org.feeluown.mobile.installDesktopAppLogger
+
+private const val SMOKE_ENV = "FUOEVOLVE_NUCLEUS_POC_SMOKE"
+
+fun main() {
+    installDesktopAppLogger()
+    val smokeMode = System.getenv(SMOKE_ENV) == "1"
+
+    nucleusApplication(backend = NucleusBackend.Tao) {
+        val requestExit = { exitApplication() }
+
+        DecoratedWindow(
+            onCloseRequest = requestExit,
+            state = rememberWindowState(size = DpSize(1280.dp, 800.dp)),
+            minimumSize = DpSize(900.dp, 600.dp),
+            title = "FuoEvolve · Nucleus PoC",
+        ) {
+            if (smokeMode) {
+                LaunchedEffect(Unit) {
+                    // Reaching this effect means the Tao window and the existing FuoEvolve
+                    // composition both started successfully. Give one frame a short grace period
+                    // before exiting so CI validates the actual runtime path, not only compilation.
+                    delay(1_500)
+                    requestExit()
+                }
+            }
+
+            DesktopAppHost()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,3 +60,14 @@ include(":persistence:listening")
 include(":shared")
 include(":androidApp")
 include(":desktopApp")
+
+// Keep the experimental Nucleus/Tao desktop chain completely outside the normal project graph.
+// This guarantees the existing JVM desktop build/package tasks and CI do not resolve or apply
+// Nucleus unless a developer explicitly opts into the PoC.
+val enableNucleusDesktopPoc = providers.gradleProperty("enableNucleusDesktopPoc")
+    .orNull
+    ?.toBooleanStrictOrNull()
+    ?: false
+if (enableNucleusDesktopPoc) {
+    include(":desktopNucleusPoc")
+}


### PR DESCRIPTION
## Summary
- add an opt-in `desktopNucleusPoc` module using Nucleus 2.5.15 + Tao
- mount the existing `shared` `DesktopAppHost` in the Tao window so the PoC exercises real FuoEvolve UI
- add an independent GraalVM Native Image path and packaged native application folder
- keep the existing JVM `desktopApp`, packaging tasks and normal Gradle project graph unchanged unless `-PenableNucleusDesktopPoc=true` is explicitly set
- add dedicated Linux smoke coverage for both the Tao/JVM host and the packaged GraalVM native binary

## Phase 1 scope
This PR validates window startup and basic existing-UI compatibility only. The current `desktopApp` integrations for libmpv/JNA playback, secure credential storage, tray, external activation and system media controls remain on the existing JVM path and are intentionally not injected into the PoC.

The GraalVM output is a Native Image application folder rather than a single standalone ELF: Nucleus packages the Skiko/AWT/native runtime sidecars required by the Compose desktop stack alongside the executable. It does not require a separately installed JVM/JRE.

## Run
JVM/Tao fast path:
```bash
./gradlew -PenableNucleusDesktopPoc=true :desktopNucleusPoc:run
```

Packaged Native Image:
```bash
./gradlew \
  -PenableNucleusDesktopPoc=true \
  -PnativeMarch=compatibility \
  :desktopNucleusPoc:packageGraalvmNative
```

Output:
```text
desktopNucleusPoc/build/compose/binaries/**/graalvm-app/
```

## Isolation
Without `-PenableNucleusDesktopPoc=true`, `desktopNucleusPoc` is not included in the Gradle project graph. Existing desktop JVM commands, packaging and release logic remain unchanged.