### PR TITLE
ci: fix Arch package verification output directory

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -410,6 +410,7 @@ jobs:
             exit 1
           fi
           package="${artifacts[0]}"
+          mkdir -p build
           bsdtar -xOf "$package" .PKGINFO | tee build/arch-pkginfo.txt
           grep -Eq '^depend = mpv($|[<>=])' build/arch-pkginfo.txt
           grep -Eq '^depend = libsecret($|[<>=])' build/arch-pkginfo.txt


### PR DESCRIPTION
## Summary

- create the root `build` directory before writing `build/arch-pkginfo.txt`
- keep the existing Arch package dependency and payload verification unchanged

## Why

The Arch package itself is generated successfully, but the verification step fails at `tee build/arch-pkginfo.txt` because the root `build` directory does not exist yet. This makes the job exit with code 1 before the dependency checks run.