### PR TITLE
fix(nucleus): register credential storage JNA proxies

### DIFF
--- a/desktopNucleusPoc/src/main/resources/META-INF/native-image/org.feeluown/fuoevolve/reachability-metadata.json
+++ b/desktopNucleusPoc/src/main/resources/META-INF/native-image/org.feeluown/fuoevolve/reachability-metadata.json
@@ -1,0 +1,25 @@
+{
+  "reflection": [
+    {
+      "type": {
+        "proxy": [
+          "com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretLibrary"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "com.microsoft.credentialstorage.implementation.posix.internal.GLibLibrary"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "com.microsoft.credentialstorage.implementation.windows.CredAdvapi32"
+        ]
+      }
+    }
+  ]
+}

--- a/desktopNucleusPoc/src/test/kotlin/org/feeluown/mobile/nucleus/NativeImageReachabilityMetadataTest.kt
+++ b/desktopNucleusPoc/src/test/kotlin/org/feeluown/mobile/nucleus/NativeImageReachabilityMetadataTest.kt
@@ -1,0 +1,28 @@
+package org.feeluown.mobile.nucleus
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NativeImageReachabilityMetadataTest {
+    @Test
+    fun credentialStorageJnaProxiesAreRegistered() {
+        val resourcePath =
+            "META-INF/native-image/org.feeluown/fuoevolve/reachability-metadata.json"
+        val stream = assertNotNull(javaClass.classLoader.getResourceAsStream(resourcePath))
+        val metadata = stream.bufferedReader().use { it.readText() }
+
+        val requiredProxyInterfaces = listOf(
+            "com.microsoft.credentialstorage.implementation.posix.libsecret.LibSecretLibrary",
+            "com.microsoft.credentialstorage.implementation.posix.internal.GLibLibrary",
+            "com.microsoft.credentialstorage.implementation.windows.CredAdvapi32",
+        )
+
+        requiredProxyInterfaces.forEach { interfaceName ->
+            assertTrue(
+                metadata.contains("\"$interfaceName\""),
+                "Missing Native Image proxy metadata for $interfaceName",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 问题

GraalVM Native Image 下首次读取桌面安全凭据时，`credential-secure-storage` 通过 JNA `Native.load(...)` 创建接口代理，但 Nucleus uber JAR 没有对应 reachability metadata，导致 Linux 抛出 `MissingReflectionRegistrationError`，Provider session 无法恢复登录态。

## 修复

- 为 Linux `LibSecretLibrary` 注册 Native Image 动态代理元数据。
- 同时注册 Linux 后续读写必经的 `GLibLibrary`，避免修完第一处后继续在实际凭据访问时失败。
- 同时注册 Windows `CredAdvapi32`，它使用相同的 JNA 动态代理模式，避免 Windows Nucleus 包出现同类问题。
- 增加测试，确保三个平台相关代理条目不会被误删。

## 说明

日志中的 `androidx.datastore.preferences.protobuf.UnsafeUtil` / `sun.misc.Unsafe::arrayBaseOffset` 是 JDK 25 的终止弃用告警，与本次 credential storage 初始化失败不是同一个问题，本 PR 不混入 DataStore 升级或替换。
