### PR TITLE
feat(desktop): use Nucleus native OAuth shell services

### DIFF
--- a/desktopNucleusPoc/README.md
+++ b/desktopNucleusPoc/README.md
@@ -65,10 +65,12 @@ The Nucleus path includes:
 - Nucleus single-instance locking plus URI and `.fuo` file activation forwarding;
 - `fuo://` protocol and `.fuo` file-association packaging;
 - FileKit OS-native Open/Save dialogs instead of Swing file choosers;
+- Nucleus native notifications for YouTube Music OAuth device codes, with dismissable notification handles;
+- Tao/Compose clipboard integration for device-code copying, including the native GTK/Wayland clipboard bridge on Linux;
 - stale-event correlation for rapid source replacement;
 - GraalVM Native Image compilation and native installer packaging.
 
-Remaining desktop parity work is intentionally separate: video rendering, native OAuth device-code clipboard/notification assistance, desktop app updates, and dedicated Native Image runtime validation for microphone capture/audio recognition.
+Remaining desktop parity work is intentionally separate: video rendering, desktop app updates, and dedicated Native Image runtime validation for microphone capture/audio recognition.
 
 ## CI
 

--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -284,6 +284,7 @@ dependencies {
     implementation("dev.nucleusframework:nucleus.decorated-window-tao:2.5.15")
     implementation("dev.nucleusframework:nucleus.graalvm-runtime:2.5.15")
     implementation("dev.nucleusframework:nucleus.media-control:2.5.15")
+    implementation("dev.nucleusframework:nucleus.notification-common:2.5.15")
     implementation("dev.nucleusframework:composenativetray:2.1.6")
 
     testImplementation(kotlin("test"))

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -1,12 +1,15 @@
 package org.feeluown.mobile.nucleus
 
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.rememberWindowState
@@ -41,16 +44,20 @@ import org.feeluown.mobile.installDesktopPlaybackEngineFactory
 import org.feeluown.mobile.installDesktopPlaybackSessionIntegrationFactory
 import org.feeluown.mobile.installDesktopProviderCredentialStoreFactory
 import org.feeluown.mobile.installDesktopTextFileDialogProviderFactory
+import org.feeluown.mobile.installFallbackOAuthDeviceCodeAssistant
 
 private const val SMOKE_ENV = "FUOEVOLVE_NUCLEUS_POC_SMOKE"
 private const val PLAYBACK_SMOKE_ENV = "FUOEVOLVE_NUCLEUS_PLAYBACK_SMOKE"
 private const val LINUX_TRAY_PROBE_TIMEOUT_SECONDS = 1L
 
+@Suppress("DEPRECATION")
 fun main(args: Array<String>) {
     configurePackagedNativeRuntime()
     installDesktopAppLogger()
 
     val activation = NucleusExternalActivation.open(args) ?: return
+    val oauthDeviceCodeAssistant = NucleusOAuthDeviceCodeAssistant()
+    installFallbackOAuthDeviceCodeAssistant(oauthDeviceCodeAssistant)
     installDesktopProviderCredentialStoreFactory(::createDesktopSecureProviderCredentialStore)
     installDesktopListeningHistorySinkFactory(::createDesktopRuntimeListeningHistorySink)
     installDesktopLocalMusicRepositoryFactory(::createDesktopRuntimeLocalMusicRepository)
@@ -143,6 +150,20 @@ fun main(args: Array<String>) {
             minimumSize = DpSize(900.dp, 600.dp),
             title = "FuoEvolve",
         ) {
+            val clipboardManager = LocalClipboardManager.current
+            DisposableEffect(oauthDeviceCodeAssistant, clipboardManager) {
+                val clipboardWriter: (String) -> Unit = { value ->
+                    uiScope.launch {
+                        clipboardManager.setText(AnnotatedString(value))
+                    }
+                }
+                oauthDeviceCodeAssistant.bindClipboardWriter(clipboardWriter)
+                onDispose {
+                    oauthDeviceCodeAssistant.unbindClipboardWriter(clipboardWriter)
+                    oauthDeviceCodeAssistant.clearUserCodeNotification()
+                }
+            }
+
             LaunchedEffect(activationRequest) {
                 if (activationRequest > 0L) {
                     nucleusWindow.show()

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -154,7 +154,9 @@ fun main(args: Array<String>) {
             DisposableEffect(oauthDeviceCodeAssistant, clipboardManager) {
                 val clipboardWriter: (String) -> Unit = { value ->
                     uiScope.launch {
-                        clipboardManager.setText(AnnotatedString(value))
+                        runCatching {
+                            clipboardManager.setText(AnnotatedString(value))
+                        }
                     }
                 }
                 oauthDeviceCodeAssistant.bindClipboardWriter(clipboardWriter)

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistant.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistant.kt
@@ -1,0 +1,76 @@
+package org.feeluown.mobile.nucleus
+
+import dev.nucleusframework.notification.common.NotificationManager
+import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.notification
+import java.util.concurrent.atomic.AtomicReference
+import org.feeluown.mobile.OAuthDeviceCodeAssistant
+
+internal fun interface NucleusNotificationHandle {
+    fun dismiss()
+}
+
+/**
+ * Nucleus/Tao implementation of the desktop OAuth device-code shell UX.
+ *
+ * Notifications are delivered by Nucleus' native per-platform backends. Clipboard access is bound
+ * from the active DecoratedWindow composition so Tao can supply its native clipboard implementation
+ * (including the GTK/Wayland bridge on Linux) without pulling AWT Toolkit into this runtime path.
+ */
+internal class NucleusOAuthDeviceCodeAssistant(
+    private val notificationSender: (String, () -> Unit) -> NucleusNotificationHandle? =
+        ::sendNativeOAuthDeviceCodeNotification,
+) : OAuthDeviceCodeAssistant {
+    private val clipboardWriter = AtomicReference<((String) -> Unit)?>(null)
+    private val activeNotification = AtomicReference<NucleusNotificationHandle?>(null)
+
+    fun bindClipboardWriter(writer: (String) -> Unit) {
+        clipboardWriter.set(writer)
+    }
+
+    fun unbindClipboardWriter(writer: (String) -> Unit) {
+        clipboardWriter.compareAndSet(writer, null)
+    }
+
+    override fun copyUserCode(userCode: String) {
+        clipboardWriter.get()?.let { writer ->
+            runCatching { writer(userCode) }
+        }
+    }
+
+    override fun showUserCodeNotification(userCode: String) {
+        activeNotification.getAndSet(null)?.dismissSafely()
+        val handle = runCatching {
+            notificationSender(userCode) { copyUserCode(userCode) }
+        }.getOrNull()
+        activeNotification.set(handle)
+    }
+
+    override fun clearUserCodeNotification() {
+        activeNotification.getAndSet(null)?.dismissSafely()
+    }
+}
+
+private fun NucleusNotificationHandle.dismissSafely() {
+    runCatching(::dismiss)
+}
+
+private fun sendNativeOAuthDeviceCodeNotification(
+    userCode: String,
+    copyUserCode: () -> Unit,
+): NucleusNotificationHandle? {
+    if (!NotificationManager.isAvailable()) return null
+
+    return when (
+        val result = notification(
+            title = "FuoEvolve",
+            message = "YouTube Music 验证码：$userCode",
+            onActivated = copyUserCode,
+        ) {
+            button("复制验证码", copyUserCode)
+        }.send()
+    ) {
+        is NotificationResult.Success -> NucleusNotificationHandle { result.handle.dismiss() }
+        is NotificationResult.Failure -> null
+    }
+}

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistant.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistant.kt
@@ -1,5 +1,7 @@
 package org.feeluown.mobile.nucleus
 
+import dev.nucleusframework.notification.AuthorizationOption
+import dev.nucleusframework.notification.NotificationCenter
 import dev.nucleusframework.notification.common.NotificationManager
 import dev.nucleusframework.notification.common.NotificationResult
 import dev.nucleusframework.notification.common.notification
@@ -51,6 +53,34 @@ internal class NucleusOAuthDeviceCodeAssistant(
     }
 }
 
+private class DeferredNucleusNotificationHandle : NucleusNotificationHandle {
+    private val lock = Any()
+    private var dismissed = false
+    private var delegate: NucleusNotificationHandle? = null
+
+    fun attach(handle: NucleusNotificationHandle?) {
+        if (handle == null) return
+        val dismissImmediately = synchronized(lock) {
+            if (dismissed) {
+                true
+            } else {
+                delegate?.dismissSafely()
+                delegate = handle
+                false
+            }
+        }
+        if (dismissImmediately) handle.dismissSafely()
+    }
+
+    override fun dismiss() {
+        val handle = synchronized(lock) {
+            dismissed = true
+            delegate.also { delegate = null }
+        }
+        handle?.dismissSafely()
+    }
+}
+
 private fun NucleusNotificationHandle.dismissSafely() {
     runCatching(::dismiss)
 }
@@ -59,8 +89,24 @@ private fun sendNativeOAuthDeviceCodeNotification(
     userCode: String,
     copyUserCode: () -> Unit,
 ): NucleusNotificationHandle? {
-    if (!NotificationManager.isAvailable()) return null
+    if (isMacOs()) {
+        if (!NotificationCenter.isAvailable) return null
+        val pending = DeferredNucleusNotificationHandle()
+        NotificationCenter.requestAuthorization(setOf(AuthorizationOption.ALERT)) { granted, _ ->
+            if (granted) {
+                pending.attach(sendCommonOAuthDeviceCodeNotification(userCode, copyUserCode))
+            }
+        }
+        return pending
+    }
+    return sendCommonOAuthDeviceCodeNotification(userCode, copyUserCode)
+}
 
+private fun sendCommonOAuthDeviceCodeNotification(
+    userCode: String,
+    copyUserCode: () -> Unit,
+): NucleusNotificationHandle? {
+    if (!NotificationManager.isAvailable()) return null
     return when (
         val result = notification(
             title = "FuoEvolve",
@@ -73,4 +119,9 @@ private fun sendNativeOAuthDeviceCodeNotification(
         is NotificationResult.Success -> NucleusNotificationHandle { result.handle.dismiss() }
         is NotificationResult.Failure -> null
     }
+}
+
+private fun isMacOs(): Boolean {
+    val osName = System.getProperty("os.name").orEmpty()
+    return osName.contains("mac", ignoreCase = true) || osName.contains("darwin", ignoreCase = true)
 }

--- a/desktopNucleusPoc/src/test/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistantTest.kt
+++ b/desktopNucleusPoc/src/test/kotlin/org/feeluown/mobile/nucleus/NucleusOAuthDeviceCodeAssistantTest.kt
@@ -1,0 +1,55 @@
+package org.feeluown.mobile.nucleus
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class NucleusOAuthDeviceCodeAssistantTest {
+    @Test
+    fun copyUsesCurrentlyBoundClipboardWriter() {
+        val copied = mutableListOf<String>()
+        val assistant = NucleusOAuthDeviceCodeAssistant(notificationSender = { _, _ -> null })
+        val firstWriter: (String) -> Unit = { copied += "first:$it" }
+        val secondWriter: (String) -> Unit = { copied += "second:$it" }
+
+        assistant.bindClipboardWriter(firstWriter)
+        assistant.bindClipboardWriter(secondWriter)
+        assistant.unbindClipboardWriter(firstWriter)
+        assistant.copyUserCode("ABCD-EFGH")
+
+        assertEquals(listOf("second:ABCD-EFGH"), copied)
+    }
+
+    @Test
+    fun notificationActionCopiesCodeAndClearDismissesIt() {
+        var action: (() -> Unit)? = null
+        var dismissed = 0
+        val assistant = NucleusOAuthDeviceCodeAssistant { _, onCopy ->
+            action = onCopy
+            NucleusNotificationHandle { dismissed += 1 }
+        }
+        val copied = mutableListOf<String>()
+        assistant.bindClipboardWriter { copied += it }
+
+        assistant.showUserCodeNotification("CODE-1234")
+        assertNotNull(action).invoke()
+        assistant.clearUserCodeNotification()
+
+        assertEquals(listOf("CODE-1234"), copied)
+        assertEquals(1, dismissed)
+    }
+
+    @Test
+    fun replacingNotificationDismissesPreviousHandle() {
+        val dismissed = mutableListOf<String>()
+        val assistant = NucleusOAuthDeviceCodeAssistant { code, _ ->
+            NucleusNotificationHandle { dismissed += code }
+        }
+
+        assistant.showUserCodeNotification("FIRST")
+        assistant.showUserCodeNotification("SECOND")
+        assistant.clearUserCodeNotification()
+
+        assertEquals(listOf("FIRST", "SECOND"), dismissed)
+    }
+}


### PR DESCRIPTION
## Summary

- replace the Nucleus desktop OAuth device-code shell fallback with Nucleus native notifications
- bind device-code copy to the active Tao/Compose clipboard instead of `java.awt.Toolkit`
- use the Nucleus notification handle to dismiss stale/completed OAuth code notifications
- keep the legacy JVM host unchanged behind the existing `OAuthDeviceCodeAssistant` boundary
- add unit coverage for clipboard rebinding, notification actions, replacement and dismissal

## Native integration

- notifications: `nucleus.notification-common` 2.5.15, dispatching to WinRT Toast / macOS User Notifications / Freedesktop D-Bus notifications
- clipboard: captured from the active `DecoratedWindow`; on Linux Tao this uses Nucleus' GTK/Wayland clipboard bridge

## Scope

This PR intentionally focuses on the low-risk shell-service parity item. Desktop in-app updates are next: Nucleus already generates the required `latest*.yml`, but FuoEvolve's release/Canary workflows must publish desktop installers and those manifests persistently before the updater can be enabled end-to-end.