### PR TITLE
[feat] Configure desktop application icons across platforms

### DIFF
--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -19,6 +19,12 @@ kotlin {
 private val desktopAppIcon = rootProject.file(
     "androidApp/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
 )
+private val desktopWindowsIcon = rootProject.file(
+    "desktopApp/packaging/icons/fuoevolve.ico",
+)
+private val desktopMacIcon = rootProject.file(
+    "desktopApp/packaging/icons/fuoevolve.icns",
+)
 
 sourceSets {
     named("main") {
@@ -357,18 +363,21 @@ nucleus.application {
 
         windows {
             packageName = "FuoEvolve"
+            iconFile.set(desktopWindowsIcon)
         }
         macOS {
             packageName = "FuoEvolve"
             // Preserve the existing desktop bundle identity across the JVM -> Nucleus migration.
             bundleID = "org.feeluown.mobile.desktop"
             appCategory = "public.app-category.music"
+            iconFile.set(desktopMacIcon)
         }
         linux {
             packageName = "fuoevolve"
             shortcut = true
             appCategory = "AudioVideo"
             menuGroup = "AudioVideo"
+            iconFile.set(desktopAppIcon)
             debMaintainer = "FuoEvolve Maintainers <6873988+BruceZhang1993@users.noreply.github.com>"
             pacmanDepends = listOf(
                 "gtk3",

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -106,6 +106,7 @@ fun main(args: Array<String>) {
         enableSingleInstance = false,
     ) {
         val uiScope = rememberCoroutineScope()
+        val appIcon = painterResource("ic_launcher.png")
         var windowVisible by remember { mutableStateOf(true) }
         var activationRequest by remember { mutableStateOf(0L) }
         val trayAvailable = remember(smokeMode, playbackSmokeFile) {
@@ -147,7 +148,7 @@ fun main(args: Array<String>) {
 
         if (trayAvailable) {
             Tray(
-                icon = painterResource("ic_launcher.png"),
+                icon = appIcon,
                 tooltip = "FuoEvolve",
                 primaryAction = { uiScope.launch { showWindow() } },
             ) {
@@ -171,6 +172,7 @@ fun main(args: Array<String>) {
             state = rememberWindowState(size = DpSize(1280.dp, 800.dp)),
             minimumSize = DpSize(900.dp, 600.dp),
             title = "FuoEvolve",
+            icon = appIcon,
         ) {
             val clipboardManager = LocalClipboardManager.current
             DisposableEffect(oauthDeviceCodeAssistant, clipboardManager) {


### PR DESCRIPTION
## Summary

- Configure Windows, macOS, and Linux package icons for the desktop Nucleus app
- Reuse the loaded launcher icon for both the system tray and application window

## Testing

Not run (not requested)