### PR TITLE
[fix] Set Native Image compatibility march for macOS ARM64

### DIFF
--- a/desktopNucleusPoc/build.gradle.kts
+++ b/desktopNucleusPoc/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import java.io.File
 import java.util.zip.ZipFile
@@ -384,6 +385,7 @@ nucleus.application {
     graalvm {
         isEnabled.set(true)
         imageName.set("fuoevolve")
+        march.set(NativeImageMarch.COMPATIBILITY)
     }
 }
 


### PR DESCRIPTION
## Summary

- Configure the desktop Native Image build to use the compatibility instruction set.
- Improve runtime compatibility for macOS ARM64 targets.

## Testing

Not run (not requested)