### PR TITLE
feat(desktop): add Native Image video playback

### DIFF
--- a/desktopApp/packaging/native-deps.lock
+++ b/desktopApp/packaging/native-deps.lock
@@ -7,6 +7,7 @@ macos.arm64.mpv.version=0.41.0_9
 macos.x64.mpv.version=0.41.0_8
 
 # shinchiro/mpv-winbuild-cmake development archive contains the libmpv DLL + development runtime.
+# Cache schema v2 stages the complete public mpv header set for the GPU render API.
 windows.x64.libmpv.url=https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260902/mpv-dev-x86_64-20260902-git-174b638f29.7z
 windows.x64.libmpv.sha256=f23fbdee1864958df65886b56b1d640a319a4430df89aaa4417473d9d581c57f
 

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_iosurface.inc
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_iosurface.inc
@@ -1,0 +1,641 @@
+/* macOS IOSurface producer for the Nucleus TextureView path.
+ *
+ * Kept as an include next to the portable JNI bridge so Windows/Linux keep compiling the same
+ * translation unit without linking Apple frameworks. All Apple APIs are loaded dynamically.
+ */
+#if defined(__APPLE__)
+
+typedef struct fuo_mac_gpu_api {
+    void *open_gl_module;
+    void *io_surface_module;
+    void *core_foundation_module;
+
+    int (*cgl_choose_pixel_format)(const int *, void **, int *);
+    int (*cgl_create_context)(void *, void *, void **);
+    int (*cgl_destroy_pixel_format)(void *);
+    int (*cgl_destroy_context)(void *);
+    int (*cgl_set_current_context)(void *);
+    void *(*cgl_get_current_context)(void);
+    int (*cgl_tex_image_io_surface_2d)(
+        void *, fuo_gl_enum, fuo_gl_enum, fuo_gl_sizei, fuo_gl_sizei,
+        fuo_gl_enum, fuo_gl_enum, void *, fuo_gl_uint
+    );
+
+    void *(*io_surface_create)(const void *);
+    size_t (*io_surface_align_property)(const void *, size_t);
+
+    void *(*cf_number_create)(const void *, long, const void *);
+    void *(*cf_dictionary_create)(
+        const void *, const void **, const void **, long, const void *, const void *
+    );
+    void (*cf_release)(const void *);
+
+    const void *key_width;
+    const void *key_height;
+    const void *key_bytes_per_element;
+    const void *key_bytes_per_row;
+    const void *key_alloc_size;
+    const void *key_pixel_format;
+} fuo_mac_gpu_api;
+
+typedef struct fuo_mac_render_context {
+    mpv_render_context *mpv;
+    void *cgl;
+} fuo_mac_render_context;
+
+typedef struct fuo_mac_surface_target {
+    void *surface;
+    fuo_gl_uint texture;
+    fuo_gl_uint framebuffer;
+    int width;
+    int height;
+    int rendered_once;
+} fuo_mac_surface_target;
+
+static fuo_mac_gpu_api global_mac_gpu_api;
+static int global_mac_gpu_api_loaded = 0;
+
+#define FUO_CGL_PFA_ACCELERATED 73
+#define FUO_CGL_PFA_OPENGL_PROFILE 99
+#define FUO_CGL_OGLP_VERSION_3_2_CORE 0x3200
+#define FUO_CF_NUMBER_SINT64_TYPE 4
+#define FUO_GL_TEXTURE_RECTANGLE 0x84F5u
+#define FUO_GL_TEXTURE_BINDING_RECTANGLE 0x84F6u
+#define FUO_GL_RGBA8 0x8058u
+#define FUO_GL_BGRA 0x80E1u
+#define FUO_GL_UNSIGNED_INT_8_8_8_8_REV 0x8367u
+#define FUO_PIXEL_FORMAT_BGRA 0x42475241u
+
+static void *fuo_dlsym_required(void *module, const char *name) {
+    if (module == NULL) return NULL;
+    return dlsym(module, name);
+}
+
+static const void *fuo_load_exported_cf_value(void *module, const char *name) {
+    const void **slot = (const void **)fuo_dlsym_required(module, name);
+    return slot == NULL ? NULL : *slot;
+}
+
+#define LOAD_MAC_PROC(field, type, module, name) \
+    do { \
+        global_mac_gpu_api.field = (type)(intptr_t)fuo_dlsym_required(module, name); \
+        if (global_mac_gpu_api.field == NULL) return 0; \
+    } while (0)
+
+static int ensure_mac_gpu_api(void) {
+    if (global_mac_gpu_api_loaded) return 1;
+
+    global_mac_gpu_api.open_gl_module = dlopen(
+        "/System/Library/Frameworks/OpenGL.framework/OpenGL",
+        RTLD_LAZY | RTLD_GLOBAL
+    );
+    global_mac_gpu_api.io_surface_module = dlopen(
+        "/System/Library/Frameworks/IOSurface.framework/IOSurface",
+        RTLD_LAZY | RTLD_LOCAL
+    );
+    global_mac_gpu_api.core_foundation_module = dlopen(
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+        RTLD_LAZY | RTLD_LOCAL
+    );
+    if (global_mac_gpu_api.open_gl_module == NULL ||
+        global_mac_gpu_api.io_surface_module == NULL ||
+        global_mac_gpu_api.core_foundation_module == NULL) {
+        return 0;
+    }
+
+    LOAD_MAC_PROC(
+        cgl_choose_pixel_format,
+        int (*)(const int *, void **, int *),
+        global_mac_gpu_api.open_gl_module,
+        "CGLChoosePixelFormat"
+    );
+    LOAD_MAC_PROC(
+        cgl_create_context,
+        int (*)(void *, void *, void **),
+        global_mac_gpu_api.open_gl_module,
+        "CGLCreateContext"
+    );
+    LOAD_MAC_PROC(
+        cgl_destroy_pixel_format,
+        int (*)(void *),
+        global_mac_gpu_api.open_gl_module,
+        "CGLDestroyPixelFormat"
+    );
+    LOAD_MAC_PROC(
+        cgl_destroy_context,
+        int (*)(void *),
+        global_mac_gpu_api.open_gl_module,
+        "CGLDestroyContext"
+    );
+    LOAD_MAC_PROC(
+        cgl_set_current_context,
+        int (*)(void *),
+        global_mac_gpu_api.open_gl_module,
+        "CGLSetCurrentContext"
+    );
+    LOAD_MAC_PROC(
+        cgl_get_current_context,
+        void *(*)(void),
+        global_mac_gpu_api.open_gl_module,
+        "CGLGetCurrentContext"
+    );
+    LOAD_MAC_PROC(
+        cgl_tex_image_io_surface_2d,
+        int (*)(
+            void *, fuo_gl_enum, fuo_gl_enum, fuo_gl_sizei, fuo_gl_sizei,
+            fuo_gl_enum, fuo_gl_enum, void *, fuo_gl_uint
+        ),
+        global_mac_gpu_api.open_gl_module,
+        "CGLTexImageIOSurface2D"
+    );
+
+    LOAD_MAC_PROC(
+        io_surface_create,
+        void *(*)(const void *),
+        global_mac_gpu_api.io_surface_module,
+        "IOSurfaceCreate"
+    );
+    LOAD_MAC_PROC(
+        io_surface_align_property,
+        size_t (*)(const void *, size_t),
+        global_mac_gpu_api.io_surface_module,
+        "IOSurfaceAlignProperty"
+    );
+    LOAD_MAC_PROC(
+        cf_number_create,
+        void *(*)(const void *, long, const void *),
+        global_mac_gpu_api.core_foundation_module,
+        "CFNumberCreate"
+    );
+    LOAD_MAC_PROC(
+        cf_dictionary_create,
+        void *(*)(const void *, const void **, const void **, long, const void *, const void *),
+        global_mac_gpu_api.core_foundation_module,
+        "CFDictionaryCreate"
+    );
+    LOAD_MAC_PROC(
+        cf_release,
+        void (*)(const void *),
+        global_mac_gpu_api.core_foundation_module,
+        "CFRelease"
+    );
+
+    global_mac_gpu_api.key_width = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfaceWidth"
+    );
+    global_mac_gpu_api.key_height = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfaceHeight"
+    );
+    global_mac_gpu_api.key_bytes_per_element = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfaceBytesPerElement"
+    );
+    global_mac_gpu_api.key_bytes_per_row = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfaceBytesPerRow"
+    );
+    global_mac_gpu_api.key_alloc_size = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfaceAllocSize"
+    );
+    global_mac_gpu_api.key_pixel_format = fuo_load_exported_cf_value(
+        global_mac_gpu_api.io_surface_module,
+        "kIOSurfacePixelFormat"
+    );
+    if (global_mac_gpu_api.key_width == NULL ||
+        global_mac_gpu_api.key_height == NULL ||
+        global_mac_gpu_api.key_bytes_per_element == NULL ||
+        global_mac_gpu_api.key_bytes_per_row == NULL ||
+        global_mac_gpu_api.key_alloc_size == NULL ||
+        global_mac_gpu_api.key_pixel_format == NULL) {
+        return 0;
+    }
+
+    /* Loading OpenGL globally above makes the GL entry points visible to resolve_gl_proc(). */
+    if (!ensure_gl_api()) return 0;
+
+    global_mac_gpu_api_loaded = 1;
+    return 1;
+}
+
+static void *create_mac_io_surface(int width, int height) {
+    if (!ensure_mac_gpu_api() || width <= 0 || height <= 0) return NULL;
+
+    size_t bytes_per_row = global_mac_gpu_api.io_surface_align_property(
+        global_mac_gpu_api.key_bytes_per_row,
+        (size_t)width * 4u
+    );
+    size_t alloc_size = global_mac_gpu_api.io_surface_align_property(
+        global_mac_gpu_api.key_alloc_size,
+        bytes_per_row * (size_t)height
+    );
+    if (bytes_per_row == 0u || alloc_size == 0u) return NULL;
+
+    int64_t raw_values[6] = {
+        width,
+        height,
+        4,
+        (int64_t)bytes_per_row,
+        (int64_t)alloc_size,
+        FUO_PIXEL_FORMAT_BGRA,
+    };
+    const void *keys[6] = {
+        global_mac_gpu_api.key_width,
+        global_mac_gpu_api.key_height,
+        global_mac_gpu_api.key_bytes_per_element,
+        global_mac_gpu_api.key_bytes_per_row,
+        global_mac_gpu_api.key_alloc_size,
+        global_mac_gpu_api.key_pixel_format,
+    };
+    void *numbers[6] = {NULL, NULL, NULL, NULL, NULL, NULL};
+    const void *values[6] = {NULL, NULL, NULL, NULL, NULL, NULL};
+
+    for (int i = 0; i < 6; ++i) {
+        numbers[i] = global_mac_gpu_api.cf_number_create(
+            NULL,
+            FUO_CF_NUMBER_SINT64_TYPE,
+            &raw_values[i]
+        );
+        if (numbers[i] == NULL) goto cleanup;
+        values[i] = numbers[i];
+    }
+
+    void *dictionary = global_mac_gpu_api.cf_dictionary_create(
+        NULL,
+        keys,
+        values,
+        6,
+        NULL,
+        NULL
+    );
+    if (dictionary == NULL) goto cleanup;
+    void *surface = global_mac_gpu_api.io_surface_create(dictionary);
+    global_mac_gpu_api.cf_release(dictionary);
+    for (int i = 0; i < 6; ++i) global_mac_gpu_api.cf_release(numbers[i]);
+    return surface;
+
+cleanup:
+    for (int i = 0; i < 6; ++i) {
+        if (numbers[i] != NULL) global_mac_gpu_api.cf_release(numbers[i]);
+    }
+    return NULL;
+}
+
+static int with_mac_context(fuo_mac_render_context *renderer, void **previous) {
+    if (renderer == NULL || renderer->cgl == NULL || !ensure_mac_gpu_api()) return 0;
+    *previous = global_mac_gpu_api.cgl_get_current_context();
+    return global_mac_gpu_api.cgl_set_current_context(renderer->cgl) == 0;
+}
+
+static void restore_mac_context(void *previous) {
+    if (global_mac_gpu_api_loaded) {
+        global_mac_gpu_api.cgl_set_current_context(previous);
+    }
+}
+
+static void destroy_mac_surface_target(
+    fuo_mac_render_context *renderer,
+    fuo_mac_surface_target *target
+) {
+    if (target == NULL) return;
+    void *previous = NULL;
+    if (renderer != NULL && with_mac_context(renderer, &previous)) {
+        if (target->framebuffer != 0u) {
+            global_gl_api.delete_framebuffers(1, &target->framebuffer);
+            target->framebuffer = 0u;
+        }
+        if (target->texture != 0u) {
+            global_gl_api.delete_textures(1, &target->texture);
+            target->texture = 0u;
+        }
+        restore_mac_context(previous);
+    }
+    if (target->surface != NULL) {
+        global_mac_gpu_api.cf_release(target->surface);
+        target->surface = NULL;
+    }
+    free(target);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateIoSurfaceRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong handle_value
+) {
+    (void)env;
+    (void)self;
+    mpv_handle *handle = handle_from_jlong(handle_value);
+    if (handle == NULL || !ensure_mac_gpu_api()) return 0;
+
+    int attributes[] = {
+        FUO_CGL_PFA_OPENGL_PROFILE,
+        FUO_CGL_OGLP_VERSION_3_2_CORE,
+        FUO_CGL_PFA_ACCELERATED,
+        0,
+    };
+    void *pixel_format = NULL;
+    int pixel_format_count = 0;
+    if (global_mac_gpu_api.cgl_choose_pixel_format(
+            attributes,
+            &pixel_format,
+            &pixel_format_count
+        ) != 0 || pixel_format == NULL || pixel_format_count <= 0) {
+        return 0;
+    }
+
+    void *cgl = NULL;
+    int create_result = global_mac_gpu_api.cgl_create_context(pixel_format, NULL, &cgl);
+    global_mac_gpu_api.cgl_destroy_pixel_format(pixel_format);
+    if (create_result != 0 || cgl == NULL) return 0;
+
+    fuo_mac_render_context *renderer =
+        (fuo_mac_render_context *)calloc(1u, sizeof(fuo_mac_render_context));
+    if (renderer == NULL) {
+        global_mac_gpu_api.cgl_destroy_context(cgl);
+        return 0;
+    }
+    renderer->cgl = cgl;
+
+    void *previous = global_mac_gpu_api.cgl_get_current_context();
+    if (global_mac_gpu_api.cgl_set_current_context(cgl) != 0) goto failure;
+
+    mpv_opengl_init_params gl_init = {
+        .get_proc_address = resolve_gl_proc,
+        .get_proc_address_ctx = NULL,
+    };
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_OPENGL},
+        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    int mpv_result = mpv_render_context_create(&renderer->mpv, handle, params);
+    restore_mac_context(previous);
+    if (mpv_result < 0 || renderer->mpv == NULL) goto failure_without_current;
+    return (jlong)(intptr_t)renderer;
+
+failure:
+    restore_mac_context(previous);
+failure_without_current:
+    if (renderer->mpv != NULL) mpv_render_context_free(renderer->mpv);
+    global_mac_gpu_api.cgl_destroy_context(renderer->cgl);
+    free(renderer);
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateIoSurfaceRenderTarget(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value,
+    jint width,
+    jint height
+) {
+    (void)env;
+    (void)self;
+    fuo_mac_render_context *renderer =
+        (fuo_mac_render_context *)(intptr_t)render_context_value;
+    if (renderer == NULL || width <= 0 || height <= 0) return 0;
+
+    void *previous = NULL;
+    if (!with_mac_context(renderer, &previous)) return 0;
+
+    fuo_gl_int previous_framebuffer = 0;
+    fuo_gl_int previous_texture = 0;
+    global_gl_api.get_integerv(FUO_GL_FRAMEBUFFER_BINDING, &previous_framebuffer);
+    global_gl_api.get_integerv(FUO_GL_TEXTURE_BINDING_RECTANGLE, &previous_texture);
+
+    fuo_mac_surface_target *target =
+        (fuo_mac_surface_target *)calloc(1u, sizeof(fuo_mac_surface_target));
+    if (target == NULL) goto failure_no_target;
+    target->width = width;
+    target->height = height;
+    target->surface = create_mac_io_surface(width, height);
+    if (target->surface == NULL) goto failure;
+
+    global_gl_api.gen_textures(1, &target->texture);
+    if (target->texture == 0u) goto failure;
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_RECTANGLE, target->texture);
+    global_gl_api.tex_parameteri(
+        FUO_GL_TEXTURE_RECTANGLE,
+        FUO_GL_TEXTURE_MIN_FILTER,
+        FUO_GL_LINEAR
+    );
+    global_gl_api.tex_parameteri(
+        FUO_GL_TEXTURE_RECTANGLE,
+        FUO_GL_TEXTURE_MAG_FILTER,
+        FUO_GL_LINEAR
+    );
+    global_gl_api.tex_parameteri(
+        FUO_GL_TEXTURE_RECTANGLE,
+        FUO_GL_TEXTURE_WRAP_S,
+        FUO_GL_CLAMP_TO_EDGE
+    );
+    global_gl_api.tex_parameteri(
+        FUO_GL_TEXTURE_RECTANGLE,
+        FUO_GL_TEXTURE_WRAP_T,
+        FUO_GL_CLAMP_TO_EDGE
+    );
+
+    if (global_mac_gpu_api.cgl_tex_image_io_surface_2d(
+            renderer->cgl,
+            FUO_GL_TEXTURE_RECTANGLE,
+            FUO_GL_RGBA8,
+            width,
+            height,
+            FUO_GL_BGRA,
+            FUO_GL_UNSIGNED_INT_8_8_8_8_REV,
+            target->surface,
+            0u
+        ) != 0) {
+        goto failure;
+    }
+
+    global_gl_api.gen_framebuffers(1, &target->framebuffer);
+    if (target->framebuffer == 0u) goto failure;
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, target->framebuffer);
+    global_gl_api.framebuffer_texture_2d(
+        FUO_GL_FRAMEBUFFER,
+        FUO_GL_COLOR_ATTACHMENT0,
+        FUO_GL_TEXTURE_RECTANGLE,
+        target->texture,
+        0
+    );
+    if (global_gl_api.check_framebuffer_status(FUO_GL_FRAMEBUFFER) != FUO_GL_FRAMEBUFFER_COMPLETE) {
+        goto failure;
+    }
+
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, (fuo_gl_uint)previous_framebuffer);
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_RECTANGLE, (fuo_gl_uint)previous_texture);
+    restore_mac_context(previous);
+    return (jlong)(intptr_t)target;
+
+failure:
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, (fuo_gl_uint)previous_framebuffer);
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_RECTANGLE, (fuo_gl_uint)previous_texture);
+    restore_mac_context(previous);
+    destroy_mac_surface_target(renderer, target);
+    return 0;
+
+failure_no_target:
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, (fuo_gl_uint)previous_framebuffer);
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_RECTANGLE, (fuo_gl_uint)previous_texture);
+    restore_mac_context(previous);
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeIoSurfaceRenderTargetPointer(
+    JNIEnv *env,
+    jobject self,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    fuo_mac_surface_target *target =
+        (fuo_mac_surface_target *)(intptr_t)render_target_value;
+    return target == NULL ? 0 : (jlong)(intptr_t)target->surface;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderIoSurface(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    fuo_mac_render_context *renderer =
+        (fuo_mac_render_context *)(intptr_t)render_context_value;
+    fuo_mac_surface_target *target =
+        (fuo_mac_surface_target *)(intptr_t)render_target_value;
+    if (renderer == NULL || renderer->mpv == NULL || target == NULL) return JNI_FALSE;
+
+    void *previous = NULL;
+    if (!with_mac_context(renderer, &previous)) return JNI_FALSE;
+
+    uint64_t updates = mpv_render_context_update(renderer->mpv);
+    if (target->rendered_once && (updates & MPV_RENDER_UPDATE_FRAME) == 0u) {
+        restore_mac_context(previous);
+        return JNI_FALSE;
+    }
+
+    mpv_opengl_fbo fbo = {
+        .fbo = (int)target->framebuffer,
+        .w = target->width,
+        .h = target->height,
+        .internal_format = 0,
+    };
+    int flip_y = 1;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    mpv_render_context_render(renderer->mpv, params);
+    global_gl_api.flush();
+    mpv_render_context_report_swap(renderer->mpv);
+    target->rendered_once = 1;
+    restore_mac_context(previous);
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeDestroyIoSurfaceRenderTarget(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    fuo_mac_render_context *renderer =
+        (fuo_mac_render_context *)(intptr_t)render_context_value;
+    fuo_mac_surface_target *target =
+        (fuo_mac_surface_target *)(intptr_t)render_target_value;
+    destroy_mac_surface_target(renderer, target);
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeFreeIoSurfaceRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value
+) {
+    (void)env;
+    (void)self;
+    fuo_mac_render_context *renderer =
+        (fuo_mac_render_context *)(intptr_t)render_context_value;
+    if (renderer == NULL) return;
+
+    void *previous = NULL;
+    if (with_mac_context(renderer, &previous)) {
+        if (renderer->mpv != NULL) {
+            mpv_render_context_free(renderer->mpv);
+            renderer->mpv = NULL;
+        }
+        restore_mac_context(previous);
+    } else if (renderer->mpv != NULL) {
+        /* mpv teardown is still preferable to leaking if CGL already became unavailable. */
+        mpv_render_context_free(renderer->mpv);
+        renderer->mpv = NULL;
+    }
+    if (renderer->cgl != NULL) {
+        global_mac_gpu_api.cgl_destroy_context(renderer->cgl);
+        renderer->cgl = NULL;
+    }
+    free(renderer);
+}
+
+#else
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateIoSurfaceRenderContext(
+    JNIEnv *env, jobject self, jlong handle_value
+) {
+    (void)env; (void)self; (void)handle_value;
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateIoSurfaceRenderTarget(
+    JNIEnv *env, jobject self, jlong render_context_value, jint width, jint height
+) {
+    (void)env; (void)self; (void)render_context_value; (void)width; (void)height;
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeIoSurfaceRenderTargetPointer(
+    JNIEnv *env, jobject self, jlong render_target_value
+) {
+    (void)env; (void)self; (void)render_target_value;
+    return 0;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderIoSurface(
+    JNIEnv *env, jobject self, jlong render_context_value, jlong render_target_value
+) {
+    (void)env; (void)self; (void)render_context_value; (void)render_target_value;
+    return JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeDestroyIoSurfaceRenderTarget(
+    JNIEnv *env, jobject self, jlong render_context_value, jlong render_target_value
+) {
+    (void)env; (void)self; (void)render_context_value; (void)render_target_value;
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeFreeIoSurfaceRenderContext(
+    JNIEnv *env, jobject self, jlong render_context_value
+) {
+    (void)env; (void)self; (void)render_context_value;
+}
+
+#endif

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -2,10 +2,18 @@
 #include <locale.h>
 #include <mpv/client.h>
 #include <mpv/render.h>
+#include <mpv/render_gl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 static mpv_handle *handle_from_jlong(jlong value) {
     return (mpv_handle *)(intptr_t)value;
@@ -386,6 +394,189 @@ Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeErrorString(
     return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeErrorString(env, self, error);
 }
 
+/* Minimal dynamically-resolved GLES surface used by the Tao OpenGL path. We deliberately avoid
+ * linking another GL implementation into the JNI bridge: on Windows Tao owns ANGLE, and on Linux
+ * it owns the active EGL/GLES implementation. Resolving against that current context guarantees
+ * libmpv and Skia operate on the same GPU device/context. */
+#if defined(_WIN32)
+#define FUO_GL_APIENTRY APIENTRY
+#else
+#define FUO_GL_APIENTRY
+#endif
+
+typedef unsigned int fuo_gl_enum;
+typedef unsigned int fuo_gl_uint;
+typedef int fuo_gl_int;
+typedef int fuo_gl_sizei;
+
+typedef void (FUO_GL_APIENTRY *fuo_gl_gen_textures_fn)(fuo_gl_sizei, fuo_gl_uint *);
+typedef void (FUO_GL_APIENTRY *fuo_gl_delete_textures_fn)(fuo_gl_sizei, const fuo_gl_uint *);
+typedef void (FUO_GL_APIENTRY *fuo_gl_bind_texture_fn)(fuo_gl_enum, fuo_gl_uint);
+typedef void (FUO_GL_APIENTRY *fuo_gl_tex_parameteri_fn)(fuo_gl_enum, fuo_gl_enum, fuo_gl_int);
+typedef void (FUO_GL_APIENTRY *fuo_gl_tex_image_2d_fn)(
+    fuo_gl_enum, fuo_gl_int, fuo_gl_int, fuo_gl_sizei, fuo_gl_sizei,
+    fuo_gl_int, fuo_gl_enum, fuo_gl_enum, const void *
+);
+typedef void (FUO_GL_APIENTRY *fuo_gl_gen_framebuffers_fn)(fuo_gl_sizei, fuo_gl_uint *);
+typedef void (FUO_GL_APIENTRY *fuo_gl_delete_framebuffers_fn)(fuo_gl_sizei, const fuo_gl_uint *);
+typedef void (FUO_GL_APIENTRY *fuo_gl_bind_framebuffer_fn)(fuo_gl_enum, fuo_gl_uint);
+typedef void (FUO_GL_APIENTRY *fuo_gl_framebuffer_texture_2d_fn)(
+    fuo_gl_enum, fuo_gl_enum, fuo_gl_enum, fuo_gl_uint, fuo_gl_int
+);
+typedef fuo_gl_enum (FUO_GL_APIENTRY *fuo_gl_check_framebuffer_status_fn)(fuo_gl_enum);
+typedef void (FUO_GL_APIENTRY *fuo_gl_get_integerv_fn)(fuo_gl_enum, fuo_gl_int *);
+typedef void (FUO_GL_APIENTRY *fuo_gl_flush_fn)(void);
+
+typedef struct fuo_gl_api {
+    fuo_gl_gen_textures_fn gen_textures;
+    fuo_gl_delete_textures_fn delete_textures;
+    fuo_gl_bind_texture_fn bind_texture;
+    fuo_gl_tex_parameteri_fn tex_parameteri;
+    fuo_gl_tex_image_2d_fn tex_image_2d;
+    fuo_gl_gen_framebuffers_fn gen_framebuffers;
+    fuo_gl_delete_framebuffers_fn delete_framebuffers;
+    fuo_gl_bind_framebuffer_fn bind_framebuffer;
+    fuo_gl_framebuffer_texture_2d_fn framebuffer_texture_2d;
+    fuo_gl_check_framebuffer_status_fn check_framebuffer_status;
+    fuo_gl_get_integerv_fn get_integerv;
+    fuo_gl_flush_fn flush;
+} fuo_gl_api;
+
+typedef struct fuo_gl_target {
+    fuo_gl_uint texture;
+    fuo_gl_uint framebuffer;
+    int width;
+    int height;
+} fuo_gl_target;
+
+static fuo_gl_api global_gl_api;
+static int global_gl_api_loaded = 0;
+
+#define FUO_GL_TEXTURE_2D 0x0DE1u
+#define FUO_GL_RGBA 0x1908u
+#define FUO_GL_UNSIGNED_BYTE 0x1401u
+#define FUO_GL_TEXTURE_MIN_FILTER 0x2801u
+#define FUO_GL_TEXTURE_MAG_FILTER 0x2800u
+#define FUO_GL_TEXTURE_WRAP_S 0x2802u
+#define FUO_GL_TEXTURE_WRAP_T 0x2803u
+#define FUO_GL_LINEAR 0x2601u
+#define FUO_GL_CLAMP_TO_EDGE 0x812Fu
+#define FUO_GL_FRAMEBUFFER 0x8D40u
+#define FUO_GL_FRAMEBUFFER_BINDING 0x8CA6u
+#define FUO_GL_TEXTURE_BINDING_2D 0x8069u
+#define FUO_GL_COLOR_ATTACHMENT0 0x8CE0u
+#define FUO_GL_FRAMEBUFFER_COMPLETE 0x8CD5u
+
+#if defined(_WIN32)
+typedef void *(WINAPI *fuo_egl_get_proc_address_fn)(const char *);
+
+static void *resolve_gl_proc(void *context, const char *name) {
+    (void)context;
+    static HMODULE egl_module = NULL;
+    static HMODULE gles_module = NULL;
+    static fuo_egl_get_proc_address_fn egl_get_proc_address = NULL;
+
+    if (egl_module == NULL) {
+        egl_module = GetModuleHandleA("libEGL.dll");
+        if (egl_module == NULL) egl_module = LoadLibraryA("libEGL.dll");
+        if (egl_module != NULL) {
+            egl_get_proc_address = (fuo_egl_get_proc_address_fn)(intptr_t)
+                GetProcAddress(egl_module, "eglGetProcAddress");
+        }
+    }
+    if (gles_module == NULL) {
+        gles_module = GetModuleHandleA("libGLESv2.dll");
+        if (gles_module == NULL) gles_module = LoadLibraryA("libGLESv2.dll");
+    }
+
+    if (egl_get_proc_address != NULL) {
+        void *resolved = egl_get_proc_address(name);
+        if (resolved != NULL) return resolved;
+    }
+    if (gles_module != NULL) {
+        FARPROC resolved = GetProcAddress(gles_module, name);
+        if (resolved != NULL) return (void *)(intptr_t)resolved;
+    }
+    return NULL;
+}
+#else
+typedef void *(*fuo_egl_get_proc_address_fn)(const char *);
+
+static void *resolve_gl_proc(void *context, const char *name) {
+    (void)context;
+    void *resolved = dlsym(RTLD_DEFAULT, name);
+    if (resolved != NULL) return resolved;
+
+#if !defined(__APPLE__)
+    static void *egl_module = NULL;
+    static void *gles_module = NULL;
+    static fuo_egl_get_proc_address_fn egl_get_proc_address = NULL;
+    if (egl_module == NULL) {
+        egl_module = dlopen("libEGL.so.1", RTLD_LAZY | RTLD_LOCAL);
+        if (egl_module != NULL) {
+            egl_get_proc_address = (fuo_egl_get_proc_address_fn)dlsym(
+                egl_module,
+                "eglGetProcAddress"
+            );
+        }
+    }
+    if (gles_module == NULL) {
+        gles_module = dlopen("libGLESv2.so.2", RTLD_LAZY | RTLD_LOCAL);
+    }
+    if (egl_get_proc_address != NULL) {
+        resolved = egl_get_proc_address(name);
+        if (resolved != NULL) return resolved;
+    }
+    if (gles_module != NULL) return dlsym(gles_module, name);
+#endif
+    return NULL;
+}
+#endif
+
+#define LOAD_GL_PROC(field, type, name) \
+    do { \
+        global_gl_api.field = (type)(intptr_t)resolve_gl_proc(NULL, name); \
+        if (global_gl_api.field == NULL) return 0; \
+    } while (0)
+
+static int ensure_gl_api(void) {
+    if (global_gl_api_loaded) return 1;
+    LOAD_GL_PROC(gen_textures, fuo_gl_gen_textures_fn, "glGenTextures");
+    LOAD_GL_PROC(delete_textures, fuo_gl_delete_textures_fn, "glDeleteTextures");
+    LOAD_GL_PROC(bind_texture, fuo_gl_bind_texture_fn, "glBindTexture");
+    LOAD_GL_PROC(tex_parameteri, fuo_gl_tex_parameteri_fn, "glTexParameteri");
+    LOAD_GL_PROC(tex_image_2d, fuo_gl_tex_image_2d_fn, "glTexImage2D");
+    LOAD_GL_PROC(gen_framebuffers, fuo_gl_gen_framebuffers_fn, "glGenFramebuffers");
+    LOAD_GL_PROC(delete_framebuffers, fuo_gl_delete_framebuffers_fn, "glDeleteFramebuffers");
+    LOAD_GL_PROC(bind_framebuffer, fuo_gl_bind_framebuffer_fn, "glBindFramebuffer");
+    LOAD_GL_PROC(
+        framebuffer_texture_2d,
+        fuo_gl_framebuffer_texture_2d_fn,
+        "glFramebufferTexture2D"
+    );
+    LOAD_GL_PROC(
+        check_framebuffer_status,
+        fuo_gl_check_framebuffer_status_fn,
+        "glCheckFramebufferStatus"
+    );
+    LOAD_GL_PROC(get_integerv, fuo_gl_get_integerv_fn, "glGetIntegerv");
+    LOAD_GL_PROC(flush, fuo_gl_flush_fn, "glFlush");
+    global_gl_api_loaded = 1;
+    return 1;
+}
+
+static void destroy_gl_target(fuo_gl_target *target) {
+    if (target == NULL || !ensure_gl_api()) return;
+    if (target->framebuffer != 0u) {
+        global_gl_api.delete_framebuffers(1, &target->framebuffer);
+        target->framebuffer = 0u;
+    }
+    if (target->texture != 0u) {
+        global_gl_api.delete_textures(1, &target->texture);
+        target->texture = 0u;
+    }
+}
+
 JNIEXPORT jlong JNICALL
 Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateSoftwareRenderContext(
     JNIEnv *env,
@@ -405,6 +596,177 @@ Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateSoftwareRenderContext
     int result = mpv_render_context_create(&context, handle, params);
     if (result < 0 || context == NULL) return 0;
     return (jlong)(intptr_t)context;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateOpenGlRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong handle_value
+) {
+    (void)env;
+    (void)self;
+    mpv_handle *handle = handle_from_jlong(handle_value);
+    if (handle == NULL) return 0;
+
+    mpv_opengl_init_params gl_init = {
+        .get_proc_address = resolve_gl_proc,
+        .get_proc_address_ctx = NULL,
+    };
+    mpv_render_context *context = NULL;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_OPENGL},
+        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    int result = mpv_render_context_create(&context, handle, params);
+    if (result < 0 || context == NULL) return 0;
+    return (jlong)(intptr_t)context;
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeUpdateRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value
+) {
+    (void)env;
+    (void)self;
+    mpv_render_context *context = render_context_from_jlong(render_context_value);
+    return context == NULL ? 0 : (jlong)mpv_render_context_update(context);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateOpenGlRenderTarget(
+    JNIEnv *env,
+    jobject self,
+    jint width,
+    jint height
+) {
+    (void)env;
+    (void)self;
+    if (width <= 0 || height <= 0 || !ensure_gl_api()) return 0;
+
+    fuo_gl_int previous_framebuffer = 0;
+    fuo_gl_int previous_texture = 0;
+    global_gl_api.get_integerv(FUO_GL_FRAMEBUFFER_BINDING, &previous_framebuffer);
+    global_gl_api.get_integerv(FUO_GL_TEXTURE_BINDING_2D, &previous_texture);
+
+    fuo_gl_target *target = (fuo_gl_target *)calloc(1u, sizeof(fuo_gl_target));
+    if (target == NULL) return 0;
+    target->width = width;
+    target->height = height;
+
+    global_gl_api.gen_textures(1, &target->texture);
+    if (target->texture == 0u) goto failure;
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_2D, target->texture);
+    global_gl_api.tex_parameteri(FUO_GL_TEXTURE_2D, FUO_GL_TEXTURE_MIN_FILTER, FUO_GL_LINEAR);
+    global_gl_api.tex_parameteri(FUO_GL_TEXTURE_2D, FUO_GL_TEXTURE_MAG_FILTER, FUO_GL_LINEAR);
+    global_gl_api.tex_parameteri(FUO_GL_TEXTURE_2D, FUO_GL_TEXTURE_WRAP_S, FUO_GL_CLAMP_TO_EDGE);
+    global_gl_api.tex_parameteri(FUO_GL_TEXTURE_2D, FUO_GL_TEXTURE_WRAP_T, FUO_GL_CLAMP_TO_EDGE);
+    global_gl_api.tex_image_2d(
+        FUO_GL_TEXTURE_2D,
+        0,
+        FUO_GL_RGBA,
+        width,
+        height,
+        0,
+        FUO_GL_RGBA,
+        FUO_GL_UNSIGNED_BYTE,
+        NULL
+    );
+
+    global_gl_api.gen_framebuffers(1, &target->framebuffer);
+    if (target->framebuffer == 0u) goto failure;
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, target->framebuffer);
+    global_gl_api.framebuffer_texture_2d(
+        FUO_GL_FRAMEBUFFER,
+        FUO_GL_COLOR_ATTACHMENT0,
+        FUO_GL_TEXTURE_2D,
+        target->texture,
+        0
+    );
+    if (global_gl_api.check_framebuffer_status(FUO_GL_FRAMEBUFFER) != FUO_GL_FRAMEBUFFER_COMPLETE) {
+        goto failure;
+    }
+
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, (fuo_gl_uint)previous_framebuffer);
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_2D, (fuo_gl_uint)previous_texture);
+    return (jlong)(intptr_t)target;
+
+failure:
+    global_gl_api.bind_framebuffer(FUO_GL_FRAMEBUFFER, (fuo_gl_uint)previous_framebuffer);
+    global_gl_api.bind_texture(FUO_GL_TEXTURE_2D, (fuo_gl_uint)previous_texture);
+    destroy_gl_target(target);
+    free(target);
+    return 0;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeOpenGlRenderTargetFramebuffer(
+    JNIEnv *env,
+    jobject self,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    fuo_gl_target *target = (fuo_gl_target *)(intptr_t)render_target_value;
+    return target == NULL ? 0 : (jint)target->framebuffer;
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderOpenGl(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    mpv_render_context *context = render_context_from_jlong(render_context_value);
+    fuo_gl_target *target = (fuo_gl_target *)(intptr_t)render_target_value;
+    if (context == NULL || target == NULL) return;
+
+    mpv_opengl_fbo fbo = {
+        .fbo = (int)target->framebuffer,
+        .w = target->width,
+        .h = target->height,
+        .internal_format = 0,
+    };
+    int flip_y = 0;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+        {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    mpv_render_context_render(context, params);
+    if (ensure_gl_api()) global_gl_api.flush();
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeReportSwap(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value
+) {
+    (void)env;
+    (void)self;
+    mpv_render_context *context = render_context_from_jlong(render_context_value);
+    if (context != NULL) mpv_render_context_report_swap(context);
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeDestroyOpenGlRenderTarget(
+    JNIEnv *env,
+    jobject self,
+    jlong render_target_value
+) {
+    (void)env;
+    (void)self;
+    fuo_gl_target *target = (fuo_gl_target *)(intptr_t)render_target_value;
+    if (target == NULL) return;
+    destroy_gl_target(target);
+    free(target);
 }
 
 JNIEXPORT jint JNICALL

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -350,7 +350,7 @@ JNIEXPORT jstring JNICALL
 Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeGetProperty(
     JNIEnv *env, jobject self, jlong handle_value, jstring name_value
 ) {
-    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeGetProperty(
+    return Java_org_feeluown_mobile_nucleus_JniMpvVideoApi_nativeGetProperty(
         env, self, handle_value, name_value
     );
 }
@@ -819,3 +819,5 @@ Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeFreeRenderContext(
     mpv_render_context *context = render_context_from_jlong(render_context_value);
     if (context != NULL) mpv_render_context_free(context);
 }
+
+#include "fuoevolve_mpv_iosurface.inc"

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -350,7 +350,7 @@ JNIEXPORT jstring JNICALL
 Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeGetProperty(
     JNIEnv *env, jobject self, jlong handle_value, jstring name_value
 ) {
-    return Java_org_feeluown_mobile_nucleus_JniMpvVideoApi_nativeGetProperty(
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeGetProperty(
         env, self, handle_value, name_value
     );
 }

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <locale.h>
 #include <mpv/client.h>
+#include <mpv/render.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,6 +9,10 @@
 
 static mpv_handle *handle_from_jlong(jlong value) {
     return (mpv_handle *)(intptr_t)value;
+}
+
+static mpv_render_context *render_context_from_jlong(jlong value) {
+    return (mpv_render_context *)(intptr_t)value;
 }
 
 static char *jstring_to_utf8(JNIEnv *env, jstring value) {
@@ -299,4 +304,155 @@ Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeErrorString(
 ) {
     (void)self;
     return utf8_to_jstring(env, mpv_error_string(error));
+}
+
+/* Shared desktop video controller aliases the existing client API so the audio and video
+ * implementations stay on the same JNI bridge and libmpv runtime. */
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreate(JNIEnv *env, jobject self) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeCreate(env, self);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeInitialize(
+    JNIEnv *env, jobject self, jlong handle_value
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeInitialize(env, self, handle_value);
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeSetOption(
+    JNIEnv *env, jobject self, jlong handle_value, jstring name_value, jstring data_value
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeSetOption(
+        env, self, handle_value, name_value, data_value
+    );
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeSetProperty(
+    JNIEnv *env, jobject self, jlong handle_value, jstring name_value, jstring data_value
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeSetProperty(
+        env, self, handle_value, name_value, data_value
+    );
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeGetProperty(
+    JNIEnv *env, jobject self, jlong handle_value, jstring name_value
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeGetProperty(
+        env, self, handle_value, name_value
+    );
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCommand(
+    JNIEnv *env, jobject self, jlong handle_value, jobjectArray args_value
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeCommand(
+        env, self, handle_value, args_value
+    );
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeWaitEvent(
+    JNIEnv *env, jobject self, jlong handle_value, jdouble timeout_seconds
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeWaitEvent(
+        env, self, handle_value, timeout_seconds
+    );
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeWakeup(
+    JNIEnv *env, jobject self, jlong handle_value
+) {
+    Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeWakeup(env, self, handle_value);
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeDestroy(
+    JNIEnv *env, jobject self, jlong handle_value
+) {
+    Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeDestroy(env, self, handle_value);
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeErrorString(
+    JNIEnv *env, jobject self, jint error
+) {
+    return Java_org_feeluown_mobile_nucleus_JniMpvApi_nativeErrorString(env, self, error);
+}
+
+JNIEXPORT jlong JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeCreateSoftwareRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong handle_value
+) {
+    (void)env;
+    (void)self;
+    mpv_handle *handle = handle_from_jlong(handle_value);
+    if (handle == NULL) return 0;
+
+    mpv_render_context *context = NULL;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_SW},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    int result = mpv_render_context_create(&context, handle, params);
+    if (result < 0 || context == NULL) return 0;
+    return (jlong)(intptr_t)context;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderSoftware(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value,
+    jint width,
+    jint height,
+    jint stride,
+    jbyteArray pixels_value
+) {
+    (void)self;
+    mpv_render_context *context = render_context_from_jlong(render_context_value);
+    if (context == NULL || width <= 0 || height <= 0 || stride <= 0 || pixels_value == NULL) {
+        return MPV_ERROR_INVALID_PARAMETER;
+    }
+
+    jsize pixel_length = (*env)->GetArrayLength(env, pixels_value);
+    int64_t required = (int64_t)stride * (int64_t)height;
+    if (required <= 0 || required > pixel_length) return MPV_ERROR_INVALID_PARAMETER;
+
+    jbyte *pixels = (*env)->GetPrimitiveArrayCritical(env, pixels_value, NULL);
+    if (pixels == NULL) return MPV_ERROR_NOMEM;
+
+    int size[2] = {width, height};
+    const char *format = "bgr0";
+    size_t native_stride = (size_t)stride;
+    mpv_render_param params[] = {
+        {MPV_RENDER_PARAM_SW_SIZE, size},
+        {MPV_RENDER_PARAM_SW_FORMAT, (void *)format},
+        {MPV_RENDER_PARAM_SW_STRIDE, &native_stride},
+        {MPV_RENDER_PARAM_SW_POINTER, pixels},
+        {MPV_RENDER_PARAM_INVALID, NULL},
+    };
+    int result = mpv_render_context_render(context, params);
+    (*env)->ReleasePrimitiveArrayCritical(env, pixels_value, pixels, 0);
+    return result;
+}
+
+JNIEXPORT void JNICALL
+Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeFreeRenderContext(
+    JNIEnv *env,
+    jobject self,
+    jlong render_context_value
+) {
+    (void)env;
+    (void)self;
+    mpv_render_context *context = render_context_from_jlong(render_context_value);
+    if (context != NULL) mpv_render_context_free(context);
 }

--- a/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopNucleusPoc/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -427,7 +427,8 @@ Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderSoftware(
     int64_t required = (int64_t)stride * (int64_t)height;
     if (required <= 0 || required > pixel_length) return MPV_ERROR_INVALID_PARAMETER;
 
-    jbyte *pixels = (*env)->GetPrimitiveArrayCritical(env, pixels_value, NULL);
+    jboolean is_copy = JNI_FALSE;
+    jbyte *pixels = (*env)->GetByteArrayElements(env, pixels_value, &is_copy);
     if (pixels == NULL) return MPV_ERROR_NOMEM;
 
     int size[2] = {width, height};
@@ -440,9 +441,9 @@ Java_org_feeluown_mobile_DesktopJniMpvVideoApi_nativeRenderSoftware(
         {MPV_RENDER_PARAM_SW_POINTER, pixels},
         {MPV_RENDER_PARAM_INVALID, NULL},
     };
-    int result = mpv_render_context_render(context, params);
-    (*env)->ReleasePrimitiveArrayCritical(env, pixels_value, pixels, 0);
-    return result;
+    mpv_render_context_render(context, params);
+    (*env)->ReleaseByteArrayElements(env, pixels_value, pixels, 0);
+    return 0;
 }
 
 JNIEXPORT void JNICALL

--- a/desktopNucleusPoc/packaging/windows/prepare-libmpv-dev.ps1
+++ b/desktopNucleusPoc/packaging/windows/prepare-libmpv-dev.ps1
@@ -52,12 +52,20 @@ try {
     if (-not $importLibrary) { throw "Pinned Windows libmpv archive does not contain libmpv.dll.a" }
     if (-not $dlls) { throw "Pinned Windows libmpv archive does not contain libmpv runtime DLLs" }
 
+    # client.h sits in include/mpv. Copy the complete public mpv header set from that same
+    # directory; render.h and render_gl.h are required by the Native video GPU bridge.
+    $mpvHeaderDir = $clientHeader.Directory.FullName
+    $publicHeaders = Get-ChildItem -Path $mpvHeaderDir -File -Filter "*.h"
+    $requiredHeaders = @("client.h", "render.h", "render_gl.h")
+    foreach ($requiredHeader in $requiredHeaders) {
+        if (-not ($publicHeaders | Where-Object { $_.Name -eq $requiredHeader })) {
+            throw "Pinned Windows libmpv archive does not contain include/mpv/$requiredHeader"
+        }
+    }
+
     Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
     New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "include\mpv") | Out-Null
-    Copy-Item -Path $clientHeader.FullName -Destination (Join-Path $OutputDir "include\mpv\client.h")
-
-    $headerRoot = $clientHeader.Directory.Parent.FullName
-    Get-ChildItem -Path $headerRoot -File -Filter "*.h" | ForEach-Object {
+    $publicHeaders | ForEach-Object {
         Copy-Item -Path $_.FullName -Destination (Join-Path $OutputDir "include\mpv\$($_.Name)") -Force
     }
 

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -60,6 +60,7 @@ import org.feeluown.mobile.desktop.createDesktopRuntimeLocalMusicRepository
 import org.feeluown.mobile.desktop.createDesktopSecureProviderCredentialStore
 import org.feeluown.mobile.desktop.createPersistentDesktopPlaybackEngine
 import org.feeluown.mobile.installDesktopAppLogger
+import org.feeluown.mobile.installDesktopJniMpvVideoControllerFactory
 import org.feeluown.mobile.installDesktopListeningHistorySinkFactory
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
 import org.feeluown.mobile.installDesktopPlaybackEngineFactory
@@ -83,6 +84,7 @@ fun main(args: Array<String>) {
     installDesktopProviderCredentialStoreFactory(::createDesktopSecureProviderCredentialStore)
     installDesktopListeningHistorySinkFactory(::createDesktopRuntimeListeningHistorySink)
     installDesktopLocalMusicRepositoryFactory(::createDesktopRuntimeLocalMusicRepository)
+    installDesktopJniMpvVideoControllerFactory()
     installDesktopTextFileDialogProviderFactory {
         createDesktopNativeTextFileDialogProvider(requireNativeLinuxPortal = true)
     }

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMain.kt
@@ -63,6 +63,7 @@ import org.feeluown.mobile.installDesktopAppLogger
 import org.feeluown.mobile.installDesktopJniMpvVideoControllerFactory
 import org.feeluown.mobile.installDesktopListeningHistorySinkFactory
 import org.feeluown.mobile.installDesktopLocalMusicRepositoryFactory
+import org.feeluown.mobile.installDesktopPlatformVideoSurface
 import org.feeluown.mobile.installDesktopPlaybackEngineFactory
 import org.feeluown.mobile.installDesktopPlaybackSessionIntegrationFactory
 import org.feeluown.mobile.installDesktopProviderCredentialStoreFactory
@@ -85,6 +86,7 @@ fun main(args: Array<String>) {
     installDesktopListeningHistorySinkFactory(::createDesktopRuntimeListeningHistorySink)
     installDesktopLocalMusicRepositoryFactory(::createDesktopRuntimeLocalMusicRepository)
     installDesktopJniMpvVideoControllerFactory()
+    installDesktopPlatformVideoSurface(NucleusMpvVideoSurface)
     installDesktopTextFileDialogProviderFactory {
         createDesktopNativeTextFileDialogProvider(requireNativeLinuxPortal = true)
     }

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMpvVideoSurface.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMpvVideoSurface.kt
@@ -13,14 +13,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import dev.nucleusframework.window.tao.TaoMetalRenderContext
 import dev.nucleusframework.window.tao.TaoOpenGlRenderContext
+import dev.nucleusframework.window.tao.TextureView
+import dev.nucleusframework.window.tao.nucleusIOSurfaceTextureSource
 import dev.nucleusframework.window.tao.rememberTaoGpuRenderContext
+import dev.nucleusframework.window.tao.rememberTextureViewController
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 import org.feeluown.mobile.AppLogger
+import org.feeluown.mobile.DesktopIoSurfaceVideoController
 import org.feeluown.mobile.DesktopOpenGlVideoController
 import org.feeluown.mobile.DesktopPlatformVideoController
 import org.feeluown.mobile.DesktopPlatformVideoSurface
@@ -38,10 +46,10 @@ import org.jetbrains.skia.SurfaceOrigin
 /**
  * Native/Nucleus video presentation surface.
  *
- * Windows and Linux render libmpv directly into an FBO allocated on Tao's current ANGLE/EGL
- * context. Skia wraps that FBO on the same DirectContext, so video never round-trips through a
- * CPU ByteArray. macOS currently uses the existing software fallback until the IOSurface/Metal
- * import path is wired.
+ * Windows/Linux render libmpv directly into an FBO on Tao's ANGLE/EGL context and let the same
+ * Skia DirectContext sample it. macOS renders libmpv into an IOSurface-backed CGL FBO which
+ * Nucleus imports into its Metal scene through TextureView. Neither GPU path performs a CPU frame
+ * readback; the software ImageBitmap path remains the last-resort fallback.
  */
 internal object NucleusMpvVideoSurface : DesktopPlatformVideoSurface {
     @Composable
@@ -50,14 +58,16 @@ internal object NucleusMpvVideoSurface : DesktopPlatformVideoSurface {
         payload: VideoPlaybackPayload?,
         modifier: Modifier,
     ) {
-        val gpuController = controller as? DesktopOpenGlVideoController
+        val openGlController = controller as? DesktopOpenGlVideoController
+        val ioSurfaceController = controller as? DesktopIoSurfaceVideoController
         val taoContext = rememberTaoGpuRenderContext()
         val openGlContext = taoContext as? TaoOpenGlRenderContext
-        var gpuDisabled by remember(controller, openGlContext) { mutableStateOf(false) }
+        val metalContext = taoContext as? TaoMetalRenderContext
+        var gpuDisabled by remember(controller, taoContext) { mutableStateOf(false) }
 
-        if (gpuController != null && openGlContext != null && !gpuDisabled) {
-            val rendererResult = remember(gpuController, openGlContext) {
-                runCatching { NucleusOpenGlMpvVideoRenderer(gpuController, openGlContext) }
+        if (openGlController != null && openGlContext != null && !gpuDisabled) {
+            val rendererResult = remember(openGlController, openGlContext) {
+                runCatching { NucleusOpenGlMpvVideoRenderer(openGlController, openGlContext) }
                     .onFailure { throwable ->
                         AppLogger.w(
                             "DesktopVideo",
@@ -83,9 +93,36 @@ internal object NucleusMpvVideoSurface : DesktopPlatformVideoSurface {
             }
         }
 
+        if (ioSurfaceController != null && metalContext != null && !gpuDisabled) {
+            val rendererResult = remember(ioSurfaceController, metalContext) {
+                runCatching { NucleusIoSurfaceMpvVideoRenderer(ioSurfaceController) }
+                    .onFailure { throwable ->
+                        AppLogger.w(
+                            "DesktopVideo",
+                            "macOS IOSurface video setup failed; falling back to software: ${throwable.message}",
+                        )
+                    }
+            }
+            val renderer = rendererResult.getOrNull()
+            if (renderer != null) {
+                DisposableEffect(renderer) {
+                    onDispose(renderer::close)
+                }
+                NucleusIoSurfaceVideoContent(
+                    renderer = renderer,
+                    modifier = modifier,
+                    onFailure = { throwable ->
+                        AppLogger.e("DesktopVideo", "macOS IOSurface video rendering failed", throwable)
+                        gpuDisabled = true
+                    },
+                )
+                return
+            }
+        }
+
         NucleusSoftwareVideoContent(
             controller = controller,
-            gpuController = gpuController,
+            gpuController = openGlController,
             contentDescription = payload?.video?.title,
             modifier = modifier,
         )
@@ -153,6 +190,81 @@ private fun NucleusGpuVideoContent(
             )
         }
     }
+}
+
+@Composable
+private fun NucleusIoSurfaceVideoContent(
+    renderer: NucleusIoSurfaceMpvVideoRenderer,
+    modifier: Modifier,
+    onFailure: (Throwable) -> Unit,
+) {
+    val textureController = rememberTextureViewController()
+    var width by remember(renderer) { mutableStateOf(0) }
+    var height by remember(renderer) { mutableStateOf(0) }
+    var target by remember(renderer) { mutableStateOf<IoSurfaceVideoTarget?>(null) }
+
+    LaunchedEffect(renderer, width, height) {
+        if (width <= 0 || height <= 0) return@LaunchedEffect
+        try {
+            val next = withContext(Dispatchers.Default) {
+                renderer.createTarget(width = width, height = height)
+            }
+            val previous = target
+            target = next
+            if (previous != null) {
+                // Let Compose publish/import the new source before retiring the old IOSurface.
+                withFrameNanos { }
+                withContext(Dispatchers.Default) { previous.close() }
+            }
+        } catch (throwable: Throwable) {
+            onFailure(throwable)
+        }
+    }
+
+    val activeTarget = target
+    LaunchedEffect(renderer, activeTarget, textureController) {
+        val renderTarget = activeTarget ?: return@LaunchedEffect
+        try {
+            while (isActive) {
+                withFrameNanos { }
+                val rendered = withContext(Dispatchers.Default) {
+                    renderer.render(renderTarget)
+                }
+                if (rendered) textureController.markFrameAvailable()
+            }
+        } catch (throwable: Throwable) {
+            onFailure(throwable)
+        }
+    }
+
+    DisposableEffect(renderer) {
+        onDispose {
+            target?.close()
+            target = null
+        }
+    }
+
+    val source = remember(activeTarget) {
+        activeTarget?.let { renderTarget ->
+            nucleusIOSurfaceTextureSource(
+                ioSurface = renderTarget.ioSurface,
+                widthPx = renderTarget.width,
+                heightPx = renderTarget.height,
+            )
+        }
+    }
+    TextureView(
+        source = source,
+        controller = textureController,
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { size ->
+                width = size.width
+                height = size.height
+            },
+        contentScale = ContentScale.Fit,
+        filterQuality = FilterQuality.Low,
+    )
 }
 
 @Composable
@@ -293,6 +405,67 @@ private class NucleusOpenGlMpvVideoRenderer(
             destroyTarget()
             controller.destroyOpenGlRenderContext(mpvRenderContext)
         }
+    }
+}
+
+private class NucleusIoSurfaceMpvVideoRenderer(
+    private val controller: DesktopIoSurfaceVideoController,
+) : AutoCloseable {
+    private val lock = Any()
+    private val renderContext = controller.createIoSurfaceRenderContext()
+    private val targets = mutableSetOf<Long>()
+    private var closed = false
+
+    fun createTarget(width: Int, height: Int): IoSurfaceVideoTarget = synchronized(lock) {
+        check(!closed) { "IOSurface video renderer is closed" }
+        val handle = controller.createIoSurfaceRenderTarget(renderContext, width, height)
+        targets += handle
+        IoSurfaceVideoTarget(
+            owner = this,
+            handle = handle,
+            ioSurface = controller.ioSurfaceRenderTargetPointer(handle),
+            width = width,
+            height = height,
+        ).also {
+            AppLogger.i("DesktopVideo", "IOSurface video target ${width}x$height attached to Tao/Metal")
+        }
+    }
+
+    fun render(target: IoSurfaceVideoTarget): Boolean = synchronized(lock) {
+        if (closed || target.handle !in targets) return@synchronized false
+        controller.renderIoSurface(renderContext, target.handle)
+    }
+
+    fun release(handle: Long) = synchronized(lock) {
+        if (handle !in targets) return@synchronized
+        targets.remove(handle)
+        if (!closed) controller.destroyIoSurfaceRenderTarget(renderContext, handle)
+    }
+
+    override fun close() = synchronized(lock) {
+        if (closed) return@synchronized
+        targets.toList().forEach { handle ->
+            controller.destroyIoSurfaceRenderTarget(renderContext, handle)
+        }
+        targets.clear()
+        controller.destroyIoSurfaceRenderContext(renderContext)
+        closed = true
+    }
+}
+
+private class IoSurfaceVideoTarget(
+    private val owner: NucleusIoSurfaceMpvVideoRenderer,
+    val handle: Long,
+    val ioSurface: Long,
+    val width: Int,
+    val height: Int,
+) : AutoCloseable {
+    private var closed = false
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        owner.release(handle)
     }
 }
 

--- a/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMpvVideoSurface.kt
+++ b/desktopNucleusPoc/src/main/kotlin/org/feeluown/mobile/nucleus/NucleusMpvVideoSurface.kt
@@ -1,0 +1,299 @@
+package org.feeluown.mobile.nucleus
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import dev.nucleusframework.window.tao.TaoOpenGlRenderContext
+import dev.nucleusframework.window.tao.rememberTaoGpuRenderContext
+import kotlinx.coroutines.isActive
+import org.feeluown.mobile.AppLogger
+import org.feeluown.mobile.DesktopOpenGlVideoController
+import org.feeluown.mobile.DesktopPlatformVideoController
+import org.feeluown.mobile.DesktopPlatformVideoSurface
+import org.feeluown.mobile.VideoPlaybackPayload
+import org.jetbrains.skia.BackendRenderTarget
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ContentChangeMode
+import org.jetbrains.skia.FramebufferFormat
+import org.jetbrains.skia.Image as SkiaImage
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.Surface
+import org.jetbrains.skia.SurfaceColorFormat
+import org.jetbrains.skia.SurfaceOrigin
+
+/**
+ * Native/Nucleus video presentation surface.
+ *
+ * Windows and Linux render libmpv directly into an FBO allocated on Tao's current ANGLE/EGL
+ * context. Skia wraps that FBO on the same DirectContext, so video never round-trips through a
+ * CPU ByteArray. macOS currently uses the existing software fallback until the IOSurface/Metal
+ * import path is wired.
+ */
+internal object NucleusMpvVideoSurface : DesktopPlatformVideoSurface {
+    @Composable
+    override fun Content(
+        controller: DesktopPlatformVideoController,
+        payload: VideoPlaybackPayload?,
+        modifier: Modifier,
+    ) {
+        val gpuController = controller as? DesktopOpenGlVideoController
+        val taoContext = rememberTaoGpuRenderContext()
+        val openGlContext = taoContext as? TaoOpenGlRenderContext
+        var gpuDisabled by remember(controller, openGlContext) { mutableStateOf(false) }
+
+        if (gpuController != null && openGlContext != null && !gpuDisabled) {
+            val rendererResult = remember(gpuController, openGlContext) {
+                runCatching { NucleusOpenGlMpvVideoRenderer(gpuController, openGlContext) }
+                    .onFailure { throwable ->
+                        AppLogger.w(
+                            "DesktopVideo",
+                            "Tao OpenGL video setup failed; falling back to software: ${throwable.message}",
+                        )
+                    }
+            }
+            val renderer = rendererResult.getOrNull()
+            if (renderer != null) {
+                DisposableEffect(renderer) {
+                    onDispose(renderer::close)
+                }
+                NucleusGpuVideoContent(
+                    renderer = renderer,
+                    contentDescription = payload?.video?.title,
+                    modifier = modifier,
+                    onFailure = { throwable ->
+                        AppLogger.e("DesktopVideo", "Tao OpenGL video rendering failed", throwable)
+                        gpuDisabled = true
+                    },
+                )
+                return
+            }
+        }
+
+        NucleusSoftwareVideoContent(
+            controller = controller,
+            gpuController = gpuController,
+            contentDescription = payload?.video?.title,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun NucleusGpuVideoContent(
+    renderer: NucleusOpenGlMpvVideoRenderer,
+    contentDescription: String?,
+    modifier: Modifier,
+    onFailure: (Throwable) -> Unit,
+) {
+    var width by remember(renderer) { mutableStateOf(0) }
+    var height by remember(renderer) { mutableStateOf(0) }
+    var frame by remember(renderer) { mutableStateOf<SkiaImage?>(null) }
+
+    LaunchedEffect(renderer, width, height) {
+        if (width <= 0 || height <= 0) return@LaunchedEffect
+        try {
+            while (isActive) {
+                val next = withFrameNanos {
+                    renderer.renderFrame(width = width, height = height)
+                }
+                if (next != null) {
+                    frame?.let(renderer::retire)
+                    frame = next
+                }
+            }
+        } catch (throwable: Throwable) {
+            onFailure(throwable)
+        }
+    }
+
+    DisposableEffect(renderer) {
+        onDispose {
+            frame?.let(renderer::retire)
+            frame = null
+        }
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { size ->
+                width = size.width
+                height = size.height
+            },
+    ) {
+        val image = frame ?: return@Canvas
+        drawIntoCanvas { canvas ->
+            val sourceWidth = image.width.toFloat()
+            val sourceHeight = image.height.toFloat()
+            if (sourceWidth <= 0f || sourceHeight <= 0f || size.width <= 0f || size.height <= 0f) {
+                return@drawIntoCanvas
+            }
+            val scale = minOf(size.width / sourceWidth, size.height / sourceHeight)
+            val drawWidth = sourceWidth * scale
+            val drawHeight = sourceHeight * scale
+            val left = (size.width - drawWidth) / 2f
+            val top = (size.height - drawHeight) / 2f
+            canvas.nativeCanvas.drawImageRect(
+                image,
+                Rect.makeXYWH(left, top, drawWidth, drawHeight),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NucleusSoftwareVideoContent(
+    controller: DesktopPlatformVideoController,
+    gpuController: DesktopOpenGlVideoController?,
+    contentDescription: String?,
+    modifier: Modifier,
+) {
+    DisposableEffect(controller, gpuController) {
+        runCatching { gpuController?.enableSoftwareRendering() }
+            .onFailure { throwable ->
+                AppLogger.e("DesktopVideo", "software video fallback setup failed", throwable)
+            }
+        onDispose { }
+    }
+    val frame by controller.frame.collectAsState()
+    frame?.let { bitmap ->
+        Image(
+            bitmap = bitmap,
+            contentDescription = contentDescription,
+            modifier = modifier.fillMaxSize(),
+            contentScale = ContentScale.Fit,
+        )
+    }
+}
+
+private class NucleusOpenGlMpvVideoRenderer(
+    private val controller: DesktopOpenGlVideoController,
+    private val renderContext: TaoOpenGlRenderContext,
+) : AutoCloseable {
+    private val mpvRenderContext: Long = renderContext.withContextCurrent {
+        controller.createOpenGlRenderContext()
+    } ?: error("Tao OpenGL context is not available")
+
+    private var target: Long = 0L
+    private var backendTarget: BackendRenderTarget? = null
+    private var surface: Surface? = null
+    private var targetWidth = 0
+    private var targetHeight = 0
+    private var targetNeedsInitialFrame = true
+    private val retired = ArrayDeque<SkiaImage>()
+    private var closed = false
+
+    fun renderFrame(width: Int, height: Int): SkiaImage? {
+        if (closed || width <= 0 || height <= 0) return null
+        return renderContext.withContextCurrent {
+            ensureTarget(width, height)
+            val currentSurface = checkNotNull(surface)
+            val shouldRender = targetNeedsInitialFrame || controller.updateOpenGlRenderContext(mpvRenderContext)
+            if (!shouldRender) {
+                retireOldSnapshots()
+                return@withContextCurrent null
+            }
+
+            // Tell Skia an external producer is about to overwrite the wrapped FBO. This preserves
+            // snapshot immutability with a GPU-side copy-on-write when a previous frame is in flight.
+            currentSurface.notifyContentWillChange(ContentChangeMode.DISCARD)
+            controller.renderOpenGl(mpvRenderContext, target)
+            renderContext.skiaContext.resetGLAll()
+            val next = currentSurface.makeImageSnapshot()
+            controller.reportOpenGlSwap(mpvRenderContext)
+            targetNeedsInitialFrame = false
+            retireOldSnapshots()
+            next
+        }
+    }
+
+    fun retire(image: SkiaImage) {
+        retired.addLast(image)
+    }
+
+    private fun ensureTarget(width: Int, height: Int) {
+        if (target != 0L && targetWidth == width && targetHeight == height) return
+        destroyTarget()
+
+        val nextTarget = controller.createOpenGlRenderTarget(width, height)
+        var nextBackendTarget: BackendRenderTarget? = null
+        var nextSurface: Surface? = null
+        try {
+            val framebuffer = controller.openGlRenderTargetFramebuffer(nextTarget)
+            nextBackendTarget = BackendRenderTarget.makeGL(
+                width = width,
+                height = height,
+                sampleCnt = 0,
+                stencilBits = 0,
+                fbId = framebuffer,
+                fbFormat = FramebufferFormat.GR_GL_RGBA8,
+            )
+            nextSurface = Surface.makeFromBackendRenderTarget(
+                context = renderContext.skiaContext,
+                rt = nextBackendTarget,
+                origin = SurfaceOrigin.BOTTOM_LEFT,
+                colorFormat = SurfaceColorFormat.RGBA_8888,
+                colorSpace = ColorSpace.sRGB,
+            ) ?: error("Skia could not wrap the libmpv OpenGL framebuffer")
+        } catch (throwable: Throwable) {
+            nextSurface?.close()
+            nextBackendTarget?.close()
+            controller.destroyOpenGlRenderTarget(nextTarget)
+            throw throwable
+        }
+
+        target = nextTarget
+        backendTarget = nextBackendTarget
+        surface = nextSurface
+        targetWidth = width
+        targetHeight = height
+        targetNeedsInitialFrame = true
+        AppLogger.i("DesktopVideo", "GPU video target ${width}x$height attached to Tao/Skia")
+    }
+
+    private fun retireOldSnapshots() {
+        while (retired.size > SNAPSHOT_RETIRE_DELAY_FRAMES) {
+            retired.removeFirst().close()
+        }
+    }
+
+    private fun destroyTarget() {
+        surface?.close()
+        surface = null
+        backendTarget?.close()
+        backendTarget = null
+        if (target != 0L) {
+            controller.destroyOpenGlRenderTarget(target)
+            target = 0L
+        }
+        targetWidth = 0
+        targetHeight = 0
+        targetNeedsInitialFrame = true
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        renderContext.withContextCurrent {
+            while (retired.isNotEmpty()) retired.removeFirst().close()
+            destroyTarget()
+            controller.destroyOpenGlRenderContext(mpvRenderContext)
+        }
+    }
+}
+
+private const val SNAPSHOT_RETIRE_DELAY_FRAMES = 2

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
@@ -149,13 +149,13 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
                         }
                         event.startsWith("end:") -> {
                             playbackActive = false
-                            val fields = event.split(':', limit = 3)
-                            val reason = fields.getOrNull(1)?.toIntOrNull()
-                            val error = fields.getOrNull(2)?.toIntOrNull() ?: 0
+                            val endEvent = parseDesktopJniVideoEndEvent(event)
                             mutableState.value = mutableState.value.copy(
                                 isPlaying = false,
-                                errorMessage = if (reason == MPV_END_FILE_REASON_ERROR && error < 0) {
-                                    DesktopJniMpvVideoApi.nativeErrorString(error)
+                                errorMessage = if (
+                                    endEvent?.reason == MPV_END_FILE_REASON_ERROR && endEvent.error < 0
+                                ) {
+                                    DesktopJniMpvVideoApi.nativeErrorString(endEvent.error)
                                         ?.let { "视频播放失败：$it" }
                                         ?: "视频播放失败"
                                 } else {
@@ -257,6 +257,21 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
     private fun ensureOpen() {
         check(!closed.get()) { "libmpv video controller is closed" }
     }
+}
+
+internal data class DesktopJniVideoEndEvent(
+    val reason: Int,
+    val error: Int,
+)
+
+internal fun parseDesktopJniVideoEndEvent(encoded: String): DesktopJniVideoEndEvent? {
+    val fields = encoded.split(':', limit = 4)
+    if (fields.size != 4 || fields[0] != "end") return null
+    if (fields[1].toLongOrNull() == null) return null
+    return DesktopJniVideoEndEvent(
+        reason = fields[2].toIntOrNull() ?: return null,
+        error = fields[3].toIntOrNull() ?: return null,
+    )
 }
 
 internal fun boundedDesktopJniVideoRenderSize(width: Int, height: Int): Pair<Int, Int> {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
@@ -1,0 +1,385 @@
+package org.feeluown.mobile
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.math.sqrt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+
+/**
+ * GraalVM-friendly desktop video controller backed by the same libmpv JNI bridge packaged by the
+ * Nucleus desktop runtime. The legacy JVM host installs its JNA controller explicitly, so this
+ * controller is only used when no host-specific factory overrides the desktop default.
+ */
+internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
+    private val closed = AtomicBoolean(false)
+    private val mutableState = MutableStateFlow(PlatformVideoPlaybackState())
+    override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
+    private val mutableFrame = MutableStateFlow<ImageBitmap?>(null)
+    override val frame: StateFlow<ImageBitmap?> = mutableFrame.asStateFlow()
+
+    private val handle: Long
+    private val renderContext: Long
+    private val eventThread: Thread
+    private val renderThread: Thread
+
+    @Volatile private var viewportWidth = 0
+    @Volatile private var viewportHeight = 0
+    @Volatile private var playbackActive = false
+
+    init {
+        DesktopJniMpvVideoBridgeLoader.ensureLoaded()
+        handle = DesktopJniMpvVideoApi.nativeCreate()
+        check(handle != 0L) { "libmpv mpv_create() returned null for video" }
+        var createdRenderContext = 0L
+        try {
+            setOption("config", "no")
+            setOption("terminal", "no")
+            setOption("input-default-bindings", "no")
+            setOption("ytdl", "no")
+            setOption("vo", "libmpv")
+            setOption("hwdec", "no")
+            setOption("audio-display", "no")
+            checkMpv(DesktopJniMpvVideoApi.nativeInitialize(handle), "mpv_initialize video")
+            createdRenderContext = DesktopJniMpvVideoApi.nativeCreateSoftwareRenderContext(handle)
+            check(createdRenderContext != 0L) { "libmpv software video render context creation failed" }
+        } catch (throwable: Throwable) {
+            if (createdRenderContext != 0L) {
+                DesktopJniMpvVideoApi.nativeFreeRenderContext(createdRenderContext)
+            }
+            DesktopJniMpvVideoApi.nativeDestroy(handle)
+            throw throwable
+        }
+        renderContext = createdRenderContext
+        eventThread = thread(
+            start = true,
+            isDaemon = true,
+            name = "fuoevolve-jni-libmpv-video-events",
+            block = ::eventLoop,
+        )
+        renderThread = thread(
+            start = true,
+            isDaemon = true,
+            name = "fuoevolve-jni-libmpv-video-render",
+            block = ::renderLoop,
+        )
+    }
+
+    override fun setPayload(payload: VideoPlaybackPayload?) {
+        ensureOpen()
+        mutableFrame.value = null
+        if (payload == null) {
+            playbackActive = false
+            command("stop")
+            mutableState.value = PlatformVideoPlaybackState()
+            return
+        }
+
+        val mainUrl = payload.url.takeIf(String::isNotBlank)
+            ?: payload.videoUrl.takeIf(String::isNotBlank)
+        if (mainUrl == null) {
+            playbackActive = false
+            mutableState.value = PlatformVideoPlaybackState(errorMessage = "当前视频没有可播放地址")
+            return
+        }
+
+        val externalAudio = if (payload.url.isBlank()) payload.audioUrl.takeIf(String::isNotBlank) else null
+        val options = encodeDesktopJniVideoLoadfileOptions(payload.headers, externalAudio)
+        mutableState.value = PlatformVideoPlaybackState()
+        playbackActive = true
+        if (options.isBlank()) {
+            command("loadfile", mainUrl, "replace")
+        } else {
+            command("loadfile", mainUrl, "replace", "-1", options)
+        }
+    }
+
+    override fun setViewportSize(width: Int, height: Int) {
+        viewportWidth = width.coerceAtLeast(0)
+        viewportHeight = height.coerceAtLeast(0)
+    }
+
+    override fun play() {
+        ensureOpen()
+        setProperty("pause", "no")
+    }
+
+    override fun pause() {
+        ensureOpen()
+        setProperty("pause", "yes")
+    }
+
+    override fun seekTo(positionMs: Long) {
+        ensureOpen()
+        command("seek", (positionMs.coerceAtLeast(0L) / 1000.0).toString(), "absolute")
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        playbackActive = false
+        DesktopJniMpvVideoApi.nativeWakeup(handle)
+        if (Thread.currentThread() !== eventThread) runCatching { eventThread.join(2_000) }
+        if (Thread.currentThread() !== renderThread) runCatching { renderThread.join(2_000) }
+        DesktopJniMpvVideoApi.nativeFreeRenderContext(renderContext)
+        DesktopJniMpvVideoApi.nativeDestroy(handle)
+        mutableFrame.value = null
+    }
+
+    private fun eventLoop() {
+        try {
+            var nextPollAtNanos = System.nanoTime()
+            while (!closed.get()) {
+                DesktopJniMpvVideoApi.nativeWaitEvent(handle, EVENT_WAIT_SECONDS)?.let { event ->
+                    when {
+                        event == "shutdown" -> return
+                        event == "loaded" || event == "restart" -> {
+                            playbackActive = true
+                            mutableState.value = mutableState.value.copy(
+                                isPlaying = getProperty("pause") != "yes",
+                                errorMessage = null,
+                            )
+                        }
+                        event.startsWith("end:") -> {
+                            playbackActive = false
+                            val fields = event.split(':', limit = 3)
+                            val reason = fields.getOrNull(1)?.toIntOrNull()
+                            val error = fields.getOrNull(2)?.toIntOrNull() ?: 0
+                            mutableState.value = mutableState.value.copy(
+                                isPlaying = false,
+                                errorMessage = if (reason == MPV_END_FILE_REASON_ERROR && error < 0) {
+                                    DesktopJniMpvVideoApi.nativeErrorString(error)
+                                        ?.let { "视频播放失败：$it" }
+                                        ?: "视频播放失败"
+                                } else {
+                                    null
+                                },
+                            )
+                        }
+                    }
+                }
+
+                val now = System.nanoTime()
+                if (playbackActive && now >= nextPollAtNanos) {
+                    publishPolledState()
+                    nextPollAtNanos = now + STATE_POLL_INTERVAL_NANOS
+                }
+            }
+        } catch (throwable: Throwable) {
+            if (!closed.get()) {
+                mutableState.value = mutableState.value.copy(
+                    isPlaying = false,
+                    errorMessage = throwable.message ?: "libmpv 视频事件处理失败",
+                )
+            }
+        }
+    }
+
+    private fun publishPolledState() {
+        val current = mutableState.value
+        val duration = getProperty("duration").secondsToMsOrNull() ?: current.durationMs
+        val buffered = getProperty("demuxer-cache-time").secondsToMsOrNull() ?: current.bufferedMs
+        mutableState.value = current.copy(
+            isPlaying = getProperty("pause")?.let { it != "yes" && it != "true" } ?: current.isPlaying,
+            positionMs = getProperty("time-pos").secondsToMsOrNull()?.coerceAtLeast(0L) ?: current.positionMs,
+            durationMs = duration.coerceAtLeast(0L),
+            bufferedMs = if (duration > 0L) buffered.coerceIn(0L, duration) else buffered.coerceAtLeast(0L),
+            videoWidth = getProperty("video-params/w")?.toIntOrNull()?.coerceAtLeast(0) ?: current.videoWidth,
+            videoHeight = getProperty("video-params/h")?.toIntOrNull()?.coerceAtLeast(0) ?: current.videoHeight,
+        )
+    }
+
+    private fun renderLoop() {
+        while (!closed.get()) {
+            val (width, height) = boundedDesktopJniVideoRenderSize(viewportWidth, viewportHeight)
+            if (!playbackActive || width <= 0 || height <= 0) {
+                Thread.sleep(if (playbackActive) 30L else 80L)
+                continue
+            }
+
+            try {
+                val stride = alignTo64(width * BYTES_PER_PIXEL)
+                val pixels = ByteArray(stride * height)
+                checkMpv(
+                    DesktopJniMpvVideoApi.nativeRenderSoftware(
+                        renderContext = renderContext,
+                        width = width,
+                        height = height,
+                        stride = stride,
+                        pixels = pixels,
+                    ),
+                    "render software video frame",
+                )
+                val imageInfo = ImageInfo.makeN32(width, height, ColorAlphaType.OPAQUE)
+                mutableFrame.value = Image.makeRaster(imageInfo, pixels, stride).toComposeImageBitmap()
+            } catch (throwable: Throwable) {
+                if (!closed.get()) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = throwable.message ?: "视频画面渲染失败",
+                    )
+                }
+                Thread.sleep(100L)
+            }
+            Thread.sleep(VIDEO_RENDER_INTERVAL_MS)
+        }
+    }
+
+    private fun setOption(name: String, value: String) {
+        checkMpv(DesktopJniMpvVideoApi.nativeSetOption(handle, name, value), "set video option $name")
+    }
+
+    private fun setProperty(name: String, value: String) {
+        checkMpv(DesktopJniMpvVideoApi.nativeSetProperty(handle, name, value), "set video property $name")
+    }
+
+    private fun getProperty(name: String): String? = DesktopJniMpvVideoApi.nativeGetProperty(handle, name)
+
+    private fun command(vararg args: String) {
+        checkMpv(
+            DesktopJniMpvVideoApi.nativeCommand(handle, args),
+            "video command ${args.firstOrNull().orEmpty()}",
+        )
+    }
+
+    private fun checkMpv(result: Int, operation: String) {
+        if (result >= 0) return
+        val detail = DesktopJniMpvVideoApi.nativeErrorString(result) ?: "error $result"
+        throw IllegalStateException("libmpv $operation failed: $detail")
+    }
+
+    private fun ensureOpen() {
+        check(!closed.get()) { "libmpv video controller is closed" }
+    }
+}
+
+internal fun boundedDesktopJniVideoRenderSize(width: Int, height: Int): Pair<Int, Int> {
+    if (width <= 0 || height <= 0) return 0 to 0
+    val pixels = width.toLong() * height.toLong()
+    if (pixels <= MAX_SOFTWARE_RENDER_PIXELS) return width to height
+    val scale = sqrt(MAX_SOFTWARE_RENDER_PIXELS.toDouble() / pixels.toDouble())
+    return (width * scale).toInt().coerceAtLeast(1) to (height * scale).toInt().coerceAtLeast(1)
+}
+
+internal fun encodeDesktopJniVideoLoadfileOptions(
+    headers: Map<String, String>,
+    externalAudioUrl: String?,
+): String = buildList {
+    encodeDesktopJniHttpOptions(headers).takeIf(String::isNotBlank)?.let(::add)
+    externalAudioUrl?.takeIf(String::isNotBlank)?.let { url ->
+        add("audio-files-append=${desktopJniMpvFixedLength(url)}")
+    }
+}.joinToString(",")
+
+private fun encodeDesktopJniHttpOptions(headers: Map<String, String>): String {
+    val sanitized = headers.mapNotNull { (name, value) ->
+        if (name.isBlank() || name.any(::isHeaderLineBreak) || value.any(::isHeaderLineBreak)) null
+        else name to value
+    }
+    if (sanitized.isEmpty()) return ""
+
+    val userAgent = sanitized
+        .firstOrNull { (name, _) -> name.equals("User-Agent", ignoreCase = true) }
+        ?.second
+    val headerFields = sanitized
+        .filterNot { (name, _) -> name.equals("User-Agent", ignoreCase = true) }
+        .map { (name, value) -> escapeMpvStringListItem("$name: $value") }
+        .joinToString(",")
+
+    return buildList {
+        userAgent?.let { add("user-agent=${desktopJniMpvFixedLength(it)}") }
+        if (headerFields.isNotEmpty()) add("http-header-fields=${desktopJniMpvFixedLength(headerFields)}")
+    }.joinToString(",")
+}
+
+private fun escapeMpvStringListItem(value: String): String = buildString(value.length) {
+    value.forEach { char ->
+        when (char) {
+            '\\' -> append("\\\\")
+            ',' -> append("\\,")
+            else -> append(char)
+        }
+    }
+}
+
+private fun desktopJniMpvFixedLength(value: String): String =
+    "%${value.toByteArray(StandardCharsets.UTF_8).size}%$value"
+
+private fun isHeaderLineBreak(char: Char): Boolean = char == '\r' || char == '\n'
+
+private fun String?.secondsToMsOrNull(): Long? =
+    this?.toDoubleOrNull()?.takeIf(Double::isFinite)?.let { (it * 1000.0).toLong() }
+
+private fun alignTo64(value: Int): Int = ((value + 63) / 64) * 64
+
+private object DesktopJniMpvVideoApi {
+    external fun nativeCreate(): Long
+    external fun nativeInitialize(handle: Long): Int
+    external fun nativeSetOption(handle: Long, name: String, value: String): Int
+    external fun nativeSetProperty(handle: Long, name: String, value: String): Int
+    external fun nativeGetProperty(handle: Long, name: String): String?
+    external fun nativeCommand(handle: Long, args: Array<out String>): Int
+    external fun nativeWaitEvent(handle: Long, timeoutSeconds: Double): String?
+    external fun nativeWakeup(handle: Long)
+    external fun nativeDestroy(handle: Long)
+    external fun nativeErrorString(error: Int): String?
+    external fun nativeCreateSoftwareRenderContext(handle: Long): Long
+    external fun nativeRenderSoftware(
+        renderContext: Long,
+        width: Int,
+        height: Int,
+        stride: Int,
+        pixels: ByteArray,
+    ): Int
+    external fun nativeFreeRenderContext(renderContext: Long)
+}
+
+private object DesktopJniMpvVideoBridgeLoader {
+    @Volatile private var loaded = false
+
+    fun ensureLoaded() {
+        if (loaded) return
+        synchronized(this) {
+            if (loaded) return
+            val bridge = resolveDesktopJniMpvVideoBridge()
+                ?: throw UnsatisfiedLinkError(
+                    "Nucleus libmpv JNI bridge not found in packaged resources or development build output",
+                )
+            System.load(bridge.absolutePath)
+            loaded = true
+            AppLogger.i("DesktopVideo", "loaded JNI video bridge ${bridge.absolutePath}")
+        }
+    }
+}
+
+private fun resolveDesktopJniMpvVideoBridge(): File? {
+    val osName = System.getProperty("os.name").orEmpty()
+    val libraryName = when {
+        osName.contains("windows", ignoreCase = true) -> "fuoevolve_mpv_jni.dll"
+        osName.contains("mac", ignoreCase = true) || osName.contains("darwin", ignoreCase = true) ->
+            "libfuoevolve_mpv_jni.dylib"
+        else -> "libfuoevolve_mpv_jni.so"
+    }
+    val resourcesDir = System.getProperty("compose.application.resources.dir")
+        ?.takeIf(String::isNotBlank)
+        ?.let(::File)
+    val userDir = File(System.getProperty("user.dir").orEmpty().ifBlank { "." })
+    return buildList {
+        resourcesDir?.let { add(File(it, "native/lib/$libraryName")) }
+        add(File(userDir, "desktopNucleusPoc/build/native/mpv-jni/$libraryName"))
+        add(File(userDir, "build/native/mpv-jni/$libraryName"))
+    }.firstOrNull(File::isFile)
+}
+
+private const val EVENT_WAIT_SECONDS = 0.05
+private const val STATE_POLL_INTERVAL_NANOS = 100_000_000L
+private const val MPV_END_FILE_REASON_ERROR = 4
+private const val BYTES_PER_PIXEL = 4
+private const val VIDEO_RENDER_INTERVAL_MS = 33L
+private const val MAX_SOFTWARE_RENDER_PIXELS = 1920L * 1080L

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
@@ -43,6 +43,20 @@ interface DesktopIoSurfaceVideoController {
     fun destroyIoSurfaceRenderContext(renderContext: Long)
 }
 
+internal data class DesktopJniVideoSourceCandidate(
+    val url: String = "",
+    val videoUrl: String = "",
+    val audioUrl: String = "",
+) {
+    val mainUrl: String
+        get() = url.ifBlank { videoUrl }
+
+    val externalAudioUrl: String?
+        get() = if (url.isBlank()) audioUrl.takeIf(String::isNotBlank) else null
+
+    fun debugDescription(): String = if (url.isNotBlank()) "combined" else "split-dash"
+}
+
 /**
  * GraalVM-friendly desktop video controller backed by the same libmpv JNI bridge packaged by the
  * Nucleus desktop runtime. The legacy JVM host installs its JNA controller explicitly, so this
@@ -70,6 +84,13 @@ internal class DesktopJniMpvVideoController :
     @Volatile private var viewportWidth = 0
     @Volatile private var viewportHeight = 0
     @Volatile private var playbackActive = false
+    @Volatile private var playWhenReady = false
+    @Volatile private var reachedEof = false
+    @Volatile private var softwareFrameDirty = false
+    @Volatile private var activePayload: VideoPlaybackPayload? = null
+    @Volatile private var activeCandidates: List<DesktopJniVideoSourceCandidate> = emptyList()
+    @Volatile private var activeCandidateIndex = -1
+    @Volatile private var activePlaylistEntryId: Long? = null
     @Volatile private var softwareRenderContext = 0L
     @Volatile private var openGlRenderContext = 0L
     @Volatile private var ioSurfaceRenderContext = 0L
@@ -112,50 +133,90 @@ internal class DesktopJniMpvVideoController :
         ensureOpen()
         mutableFrame.value = null
         lastPipelineDescription = null
+        activePlaylistEntryId = null
+        reachedEof = false
+        softwareFrameDirty = true
+
         if (payload == null) {
+            activePayload = null
+            activeCandidates = emptyList()
+            activeCandidateIndex = -1
             playbackActive = false
+            playWhenReady = false
             command("stop")
             mutableState.value = PlatformVideoPlaybackState()
             return
         }
 
-        val mainUrl = payload.url.takeIf(String::isNotBlank)
-            ?: payload.videoUrl.takeIf(String::isNotBlank)
-        if (mainUrl == null) {
+        val candidates = desktopJniVideoSourceCandidates(payload)
+        if (candidates.isEmpty()) {
+            activePayload = null
+            activeCandidates = emptyList()
+            activeCandidateIndex = -1
             playbackActive = false
+            playWhenReady = false
             mutableState.value = PlatformVideoPlaybackState(errorMessage = "当前视频没有可播放地址")
             return
         }
 
-        val externalAudio = if (payload.url.isBlank()) payload.audioUrl.takeIf(String::isNotBlank) else null
-        val options = encodeDesktopJniVideoLoadfileOptions(payload.headers, externalAudio)
+        activePayload = payload
+        activeCandidates = candidates
+        activeCandidateIndex = 0
         mutableState.value = PlatformVideoPlaybackState()
-        playbackActive = true
-        if (options.isBlank()) {
-            command("loadfile", mainUrl, "replace")
-        } else {
-            command("loadfile", mainUrl, "replace", "-1", options)
-        }
+        prepareCandidate(index = 0, positionMs = 0L, shouldPlay = true)
     }
 
     override fun setViewportSize(width: Int, height: Int) {
-        viewportWidth = width.coerceAtLeast(0)
-        viewportHeight = height.coerceAtLeast(0)
+        val newWidth = width.coerceAtLeast(0)
+        val newHeight = height.coerceAtLeast(0)
+        if (newWidth != viewportWidth || newHeight != viewportHeight) {
+            softwareFrameDirty = true
+        }
+        viewportWidth = newWidth
+        viewportHeight = newHeight
     }
 
     override fun play() {
         ensureOpen()
+        playWhenReady = true
+        softwareFrameDirty = true
+        val current = mutableState.value
+        if (
+            activeCandidateIndex in activeCandidates.indices &&
+            shouldRestartDesktopJniVideoPlayback(
+                reachedEof = reachedEof,
+                playbackActive = playbackActive,
+                positionMs = current.positionMs,
+                durationMs = current.durationMs,
+            )
+        ) {
+            val restartPosition = if (reachedEof) 0L else current.positionMs.coerceAtLeast(0L)
+            prepareCandidate(activeCandidateIndex, restartPosition, shouldPlay = true)
+            return
+        }
         setProperty("pause", "no")
     }
 
     override fun pause() {
         ensureOpen()
+        playWhenReady = false
         setProperty("pause", "yes")
     }
 
     override fun seekTo(positionMs: Long) {
         ensureOpen()
-        command("seek", (positionMs.coerceAtLeast(0L) / 1000.0).toString(), "absolute")
+        val duration = mutableState.value.durationMs
+        val target = if (duration > 0L) {
+            positionMs.coerceIn(0L, duration)
+        } else {
+            positionMs.coerceAtLeast(0L)
+        }
+        softwareFrameDirty = true
+        if (!playbackActive && activeCandidateIndex in activeCandidates.indices) {
+            prepareCandidate(activeCandidateIndex, target, shouldPlay = playWhenReady)
+        } else {
+            command("seek", (target / 1000.0).toString(), "absolute")
+        }
     }
 
     override fun createOpenGlRenderContext(): Long = synchronized(renderContextLock) {
@@ -277,6 +338,7 @@ internal class DesktopJniMpvVideoController :
             val context = DesktopJniMpvVideoApi.nativeCreateSoftwareRenderContext(handle)
             check(context != 0L) { "libmpv software video render context creation failed" }
             softwareRenderContext = context
+            softwareFrameDirty = true
             AppLogger.w("DesktopVideo", "using software video rendering fallback")
         }
     }
@@ -320,35 +382,9 @@ internal class DesktopJniMpvVideoController :
         try {
             var nextPollAtNanos = System.nanoTime()
             while (!closed.get()) {
-                DesktopJniMpvVideoApi.nativeWaitEvent(handle, EVENT_WAIT_SECONDS)?.let { event ->
-                    when {
-                        event == "shutdown" -> return
-                        event == "loaded" || event == "restart" -> {
-                            playbackActive = true
-                            mutableState.value = mutableState.value.copy(
-                                isPlaying = getProperty("pause") != "yes",
-                                errorMessage = null,
-                            )
-                            publishPipelineIfChanged()
-                        }
-                        event.startsWith("end:") -> {
-                            playbackActive = false
-                            val endEvent = parseDesktopJniVideoEndEvent(event)
-                            mutableState.value = mutableState.value.copy(
-                                isPlaying = false,
-                                errorMessage = if (
-                                    endEvent?.reason == MPV_END_FILE_REASON_ERROR && endEvent.error < 0
-                                ) {
-                                    DesktopJniMpvVideoApi.nativeErrorString(endEvent.error)
-                                        ?.let { "视频播放失败：$it" }
-                                        ?: "视频播放失败"
-                                } else {
-                                    null
-                                },
-                            )
-                        }
-                    }
-                }
+                val event = DesktopJniMpvVideoApi.nativeWaitEvent(handle, EVENT_WAIT_SECONDS)
+                if (event == "shutdown") return
+                if (event != null) handleEvent(event)
 
                 val now = System.nanoTime()
                 if (playbackActive && now >= nextPollAtNanos) {
@@ -364,6 +400,113 @@ internal class DesktopJniMpvVideoController :
                 )
             }
         }
+    }
+
+    private fun handleEvent(event: String) {
+        when {
+            event.startsWith("start:") -> {
+                activePlaylistEntryId = parseDesktopJniVideoStartEvent(event)
+                softwareFrameDirty = true
+            }
+            event == "loaded" || event == "restart" -> {
+                playbackActive = true
+                reachedEof = false
+                softwareFrameDirty = true
+                mutableState.value = mutableState.value.copy(
+                    isPlaying = getProperty("pause") != "yes",
+                    errorMessage = null,
+                )
+                publishPipelineIfChanged()
+            }
+            event.startsWith("end:") -> handleEndEvent(event)
+        }
+    }
+
+    private fun handleEndEvent(encoded: String) {
+        val endEvent = parseDesktopJniVideoEndEvent(encoded) ?: return
+        // loadfile replace and payload/source switches can deliver END_FILE for the previous
+        // playlist entry after a new load was already requested. Never let a stale event stop or
+        // retry the current source.
+        if (activePlaylistEntryId == null || endEvent.playlistEntryId != activePlaylistEntryId) {
+            return
+        }
+        activePlaylistEntryId = null
+
+        if (
+            endEvent.reason == MPV_END_FILE_REASON_ERROR &&
+            endEvent.error < 0 &&
+            retryNextCandidate()
+        ) {
+            return
+        }
+
+        playbackActive = false
+        reachedEof = endEvent.reason == MPV_END_FILE_REASON_EOF
+        playWhenReady = false
+        softwareFrameDirty = reachedEof
+        val errorMessage = if (
+            endEvent.reason == MPV_END_FILE_REASON_ERROR && endEvent.error < 0
+        ) {
+            DesktopJniMpvVideoApi.nativeErrorString(endEvent.error)
+                ?.let { "视频播放失败：$it" }
+                ?: "视频播放失败"
+        } else {
+            null
+        }
+        val current = mutableState.value
+        mutableState.value = current.copy(
+            isPlaying = false,
+            positionMs = if (reachedEof && current.durationMs > 0L) current.durationMs else current.positionMs,
+            errorMessage = errorMessage,
+        )
+    }
+
+    private fun retryNextCandidate(): Boolean {
+        val nextIndex = activeCandidateIndex + 1
+        if (nextIndex !in activeCandidates.indices) return false
+        val current = mutableState.value
+        val shouldPlay = playWhenReady
+        AppLogger.w(
+            "DesktopVideo",
+            "retrying source ${nextIndex + 1}/${activeCandidates.size} " +
+                "(${activeCandidates[nextIndex].debugDescription()}) after playback error",
+        )
+        return prepareCandidate(
+            index = nextIndex,
+            positionMs = current.positionMs.coerceAtLeast(0L),
+            shouldPlay = shouldPlay,
+        )
+    }
+
+    private fun prepareCandidate(index: Int, positionMs: Long, shouldPlay: Boolean): Boolean {
+        val payload = activePayload ?: return false
+        val candidate = activeCandidates.getOrNull(index) ?: return false
+        if (candidate.mainUrl.isBlank()) return false
+
+        activeCandidateIndex = index
+        activePlaylistEntryId = null
+        reachedEof = false
+        playbackActive = true
+        playWhenReady = shouldPlay
+        softwareFrameDirty = true
+        lastPipelineDescription = null
+        mutableState.value = mutableState.value.copy(
+            isPlaying = false,
+            positionMs = positionMs.coerceAtLeast(0L),
+            errorMessage = null,
+        )
+
+        setProperty("pause", if (shouldPlay) "no" else "yes")
+        val options = encodeDesktopJniVideoLoadfileOptions(payload.headers, candidate.externalAudioUrl)
+        if (options.isBlank()) {
+            command("loadfile", candidate.mainUrl, "replace")
+        } else {
+            command("loadfile", candidate.mainUrl, "replace", "-1", options)
+        }
+        if (positionMs > 0L) {
+            command("seek", (positionMs / 1000.0).toString(), "absolute")
+        }
+        return true
     }
 
     private fun publishPolledState() {
@@ -399,6 +542,11 @@ internal class DesktopJniMpvVideoController :
     }
 
     private fun renderLoop() {
+        var pixels = ByteArray(0)
+        var bufferWidth = 0
+        var bufferHeight = 0
+        var bufferStride = 0
+
         while (!closed.get()) {
             val renderContext = softwareRenderContext
             if (renderContext == 0L) {
@@ -411,9 +559,26 @@ internal class DesktopJniMpvVideoController :
                 continue
             }
 
+            val currentlyPlaying = mutableState.value.isPlaying
+            if (!currentlyPlaying && !softwareFrameDirty) {
+                Thread.sleep(PAUSED_RENDER_IDLE_MS)
+                continue
+            }
+
             try {
                 val stride = alignTo64(width * BYTES_PER_PIXEL)
-                val pixels = ByteArray(stride * height)
+                val requiredBytes = stride * height
+                if (
+                    pixels.size != requiredBytes ||
+                    bufferWidth != width ||
+                    bufferHeight != height ||
+                    bufferStride != stride
+                ) {
+                    pixels = ByteArray(requiredBytes)
+                    bufferWidth = width
+                    bufferHeight = height
+                    bufferStride = stride
+                }
                 checkMpv(
                     DesktopJniMpvVideoApi.nativeRenderSoftware(
                         renderContext = renderContext,
@@ -426,6 +591,7 @@ internal class DesktopJniMpvVideoController :
                 )
                 val imageInfo = ImageInfo.makeN32(width, height, ColorAlphaType.OPAQUE)
                 mutableFrame.value = Image.makeRaster(imageInfo, pixels, stride).toComposeImageBitmap()
+                softwareFrameDirty = false
             } catch (throwable: Throwable) {
                 if (!closed.get()) {
                     mutableState.value = mutableState.value.copy(
@@ -434,7 +600,7 @@ internal class DesktopJniMpvVideoController :
                 }
                 Thread.sleep(100L)
             }
-            Thread.sleep(VIDEO_RENDER_INTERVAL_MS)
+            Thread.sleep(if (currentlyPlaying) VIDEO_RENDER_INTERVAL_MS else PAUSED_RENDER_IDLE_MS)
         }
     }
 
@@ -481,19 +647,81 @@ internal class DesktopJniMpvVideoController :
 }
 
 internal data class DesktopJniVideoEndEvent(
+    val playlistEntryId: Long,
     val reason: Int,
     val error: Int,
 )
 
+internal fun parseDesktopJniVideoStartEvent(encoded: String): Long? {
+    if (!encoded.startsWith("start:")) return null
+    return encoded.substringAfter(':').toLongOrNull()
+}
+
 internal fun parseDesktopJniVideoEndEvent(encoded: String): DesktopJniVideoEndEvent? {
     val fields = encoded.split(':', limit = 4)
     if (fields.size != 4 || fields[0] != "end") return null
-    if (fields[1].toLongOrNull() == null) return null
     return DesktopJniVideoEndEvent(
+        playlistEntryId = fields[1].toLongOrNull() ?: return null,
         reason = fields[2].toIntOrNull() ?: return null,
         error = fields[3].toIntOrNull() ?: return null,
     )
 }
+
+internal fun desktopJniVideoSourceCandidates(
+    payload: VideoPlaybackPayload,
+): List<DesktopJniVideoSourceCandidate> {
+    val candidates = mutableListOf<DesktopJniVideoSourceCandidate>()
+    (listOf(payload.url) + payload.fallbackUrls)
+        .filter(String::isNotBlank)
+        .distinct()
+        .forEach { mediaUrl -> candidates += DesktopJniVideoSourceCandidate(url = mediaUrl) }
+
+    if (payload.videoUrl.isNotBlank() && payload.audioUrl.isNotBlank()) {
+        val videos = (listOf(payload.videoUrl) + payload.fallbackVideoUrls)
+            .filter(String::isNotBlank)
+            .distinct()
+        val audios = (listOf(payload.audioUrl) + payload.fallbackAudioUrls)
+            .filter(String::isNotBlank)
+            .distinct()
+        if (videos.isNotEmpty() && audios.isNotEmpty()) {
+            candidates += DesktopJniVideoSourceCandidate(
+                videoUrl = videos.first(),
+                audioUrl = audios.first(),
+            )
+            videos.drop(1).forEach { fallbackVideo ->
+                candidates += DesktopJniVideoSourceCandidate(
+                    videoUrl = fallbackVideo,
+                    audioUrl = audios.first(),
+                )
+            }
+            audios.drop(1).forEach { fallbackAudio ->
+                candidates += DesktopJniVideoSourceCandidate(
+                    videoUrl = videos.first(),
+                    audioUrl = fallbackAudio,
+                )
+            }
+            videos.drop(1).forEach { fallbackVideo ->
+                audios.drop(1).forEach { fallbackAudio ->
+                    candidates += DesktopJniVideoSourceCandidate(
+                        videoUrl = fallbackVideo,
+                        audioUrl = fallbackAudio,
+                    )
+                }
+            }
+        }
+    }
+
+    return candidates.distinct().take(MAX_VIDEO_SOURCE_CANDIDATES)
+}
+
+internal fun shouldRestartDesktopJniVideoPlayback(
+    reachedEof: Boolean,
+    playbackActive: Boolean,
+    positionMs: Long,
+    durationMs: Long,
+): Boolean = reachedEof ||
+    !playbackActive ||
+    (durationMs > 0L && positionMs >= (durationMs - RESTART_NEAR_END_THRESHOLD_MS).coerceAtLeast(0L))
 
 internal fun boundedDesktopJniVideoRenderSize(width: Int, height: Int): Pair<Int, Int> {
     if (width <= 0 || height <= 0) return 0 to 0
@@ -628,8 +856,12 @@ private fun resolveDesktopJniMpvVideoBridge(): File? {
 
 private const val EVENT_WAIT_SECONDS = 0.05
 private const val STATE_POLL_INTERVAL_NANOS = 100_000_000L
+private const val MPV_END_FILE_REASON_EOF = 0
 private const val MPV_END_FILE_REASON_ERROR = 4
 private const val MPV_RENDER_UPDATE_FRAME = 1L
 private const val BYTES_PER_PIXEL = 4
 private const val VIDEO_RENDER_INTERVAL_MS = 33L
+private const val PAUSED_RENDER_IDLE_MS = 100L
+private const val RESTART_NEAR_END_THRESHOLD_MS = 500L
+private const val MAX_VIDEO_SOURCE_CANDIDATES = 24
 private const val MAX_SOFTWARE_RENDER_PIXELS = 1920L * 1080L

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
@@ -15,50 +15,69 @@ import org.jetbrains.skia.Image
 import org.jetbrains.skia.ImageInfo
 
 /**
+ * GPU-facing extension used by the Nucleus/Tao host. The host owns the GL context lifetime and
+ * calls these methods only while Tao has made that context current.
+ */
+interface DesktopOpenGlVideoController {
+    fun createOpenGlRenderContext(): Long
+    fun updateOpenGlRenderContext(renderContext: Long): Boolean
+    fun createOpenGlRenderTarget(width: Int, height: Int): Long
+    fun openGlRenderTargetFramebuffer(renderTarget: Long): Int
+    fun renderOpenGl(renderContext: Long, renderTarget: Long)
+    fun reportOpenGlSwap(renderContext: Long)
+    fun destroyOpenGlRenderTarget(renderTarget: Long)
+    fun destroyOpenGlRenderContext(renderContext: Long)
+    fun enableSoftwareRendering()
+}
+
+/**
  * GraalVM-friendly desktop video controller backed by the same libmpv JNI bridge packaged by the
  * Nucleus desktop runtime. The legacy JVM host installs its JNA controller explicitly, so this
- * controller is only used when no host-specific factory overrides the desktop default.
+ * controller is only used by the Native/Nucleus host.
+ *
+ * A render context is intentionally created lazily. Windows/Linux attach libmpv to Tao's active
+ * OpenGL/ANGLE context. macOS and any failed GPU setup explicitly enable the software fallback.
  */
-internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
+internal class DesktopJniMpvVideoController :
+    DesktopPlatformVideoController,
+    DesktopOpenGlVideoController {
     private val closed = AtomicBoolean(false)
+    private val renderContextLock = Any()
     private val mutableState = MutableStateFlow(PlatformVideoPlaybackState())
     override val state: StateFlow<PlatformVideoPlaybackState> = mutableState.asStateFlow()
     private val mutableFrame = MutableStateFlow<ImageBitmap?>(null)
     override val frame: StateFlow<ImageBitmap?> = mutableFrame.asStateFlow()
 
     private val handle: Long
-    private val renderContext: Long
     private val eventThread: Thread
     private val renderThread: Thread
 
     @Volatile private var viewportWidth = 0
     @Volatile private var viewportHeight = 0
     @Volatile private var playbackActive = false
+    @Volatile private var softwareRenderContext = 0L
+    @Volatile private var openGlRenderContext = 0L
+    @Volatile private var lastPipelineDescription: String? = null
 
     init {
         DesktopJniMpvVideoBridgeLoader.ensureLoaded()
         handle = DesktopJniMpvVideoApi.nativeCreate()
         check(handle != 0L) { "libmpv mpv_create() returned null for video" }
-        var createdRenderContext = 0L
         try {
             setOption("config", "no")
             setOption("terminal", "no")
             setOption("input-default-bindings", "no")
             setOption("ytdl", "no")
             setOption("vo", "libmpv")
-            setOption("hwdec", "no")
+            // Prefer the OS hardware decoder. libmpv automatically falls back to software when
+            // the codec, device, driver, or GPU interop path cannot satisfy the request.
+            setOption("hwdec", "auto")
             setOption("audio-display", "no")
             checkMpv(DesktopJniMpvVideoApi.nativeInitialize(handle), "mpv_initialize video")
-            createdRenderContext = DesktopJniMpvVideoApi.nativeCreateSoftwareRenderContext(handle)
-            check(createdRenderContext != 0L) { "libmpv software video render context creation failed" }
         } catch (throwable: Throwable) {
-            if (createdRenderContext != 0L) {
-                DesktopJniMpvVideoApi.nativeFreeRenderContext(createdRenderContext)
-            }
             DesktopJniMpvVideoApi.nativeDestroy(handle)
             throw throwable
         }
-        renderContext = createdRenderContext
         eventThread = thread(
             start = true,
             isDaemon = true,
@@ -76,6 +95,7 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
     override fun setPayload(payload: VideoPlaybackPayload?) {
         ensureOpen()
         mutableFrame.value = null
+        lastPipelineDescription = null
         if (payload == null) {
             playbackActive = false
             command("stop")
@@ -122,13 +142,106 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
         command("seek", (positionMs.coerceAtLeast(0L) / 1000.0).toString(), "absolute")
     }
 
+    override fun createOpenGlRenderContext(): Long = synchronized(renderContextLock) {
+        ensureOpen()
+        check(softwareRenderContext == 0L) {
+            "software libmpv video renderer is already active"
+        }
+        if (openGlRenderContext != 0L) return@synchronized openGlRenderContext
+        val context = DesktopJniMpvVideoApi.nativeCreateOpenGlRenderContext(handle)
+        check(context != 0L) { "libmpv OpenGL video render context creation failed" }
+        openGlRenderContext = context
+        AppLogger.i("DesktopVideo", "attached libmpv OpenGL renderer with hwdec=auto")
+        context
+    }
+
+    override fun updateOpenGlRenderContext(renderContext: Long): Boolean {
+        ensureOpenGlContext(renderContext)
+        return DesktopJniMpvVideoApi.nativeUpdateRenderContext(renderContext) and
+            MPV_RENDER_UPDATE_FRAME != 0L
+    }
+
+    override fun createOpenGlRenderTarget(width: Int, height: Int): Long {
+        ensureOpen()
+        require(width > 0 && height > 0) { "OpenGL video render target must have positive dimensions" }
+        val target = DesktopJniMpvVideoApi.nativeCreateOpenGlRenderTarget(width, height)
+        check(target != 0L) { "OpenGL video render target creation failed" }
+        return target
+    }
+
+    override fun openGlRenderTargetFramebuffer(renderTarget: Long): Int {
+        ensureOpen()
+        val framebuffer = DesktopJniMpvVideoApi.nativeOpenGlRenderTargetFramebuffer(renderTarget)
+        check(framebuffer > 0) { "OpenGL video render target has no framebuffer" }
+        return framebuffer
+    }
+
+    override fun renderOpenGl(renderContext: Long, renderTarget: Long) {
+        ensureOpenGlContext(renderContext)
+        check(renderTarget != 0L) { "OpenGL video render target is closed" }
+        DesktopJniMpvVideoApi.nativeRenderOpenGl(renderContext, renderTarget)
+    }
+
+    override fun reportOpenGlSwap(renderContext: Long) {
+        ensureOpenGlContext(renderContext)
+        DesktopJniMpvVideoApi.nativeReportSwap(renderContext)
+    }
+
+    override fun destroyOpenGlRenderTarget(renderTarget: Long) {
+        if (renderTarget != 0L) DesktopJniMpvVideoApi.nativeDestroyOpenGlRenderTarget(renderTarget)
+    }
+
+    override fun destroyOpenGlRenderContext(renderContext: Long) {
+        if (renderContext == 0L) return
+        synchronized(renderContextLock) {
+            if (openGlRenderContext != renderContext) return
+            DesktopJniMpvVideoApi.nativeFreeRenderContext(renderContext)
+            openGlRenderContext = 0L
+            lastPipelineDescription = null
+        }
+    }
+
+    override fun enableSoftwareRendering() {
+        synchronized(renderContextLock) {
+            ensureOpen()
+            if (softwareRenderContext != 0L) return
+            check(openGlRenderContext == 0L) {
+                "OpenGL libmpv video renderer is already active"
+            }
+            val context = DesktopJniMpvVideoApi.nativeCreateSoftwareRenderContext(handle)
+            check(context != 0L) { "libmpv software video render context creation failed" }
+            softwareRenderContext = context
+            AppLogger.w("DesktopVideo", "using software video rendering fallback")
+        }
+    }
+
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         playbackActive = false
         DesktopJniMpvVideoApi.nativeWakeup(handle)
         if (Thread.currentThread() !== eventThread) runCatching { eventThread.join(2_000) }
         if (Thread.currentThread() !== renderThread) runCatching { renderThread.join(2_000) }
-        DesktopJniMpvVideoApi.nativeFreeRenderContext(renderContext)
+
+        val gpuContextStillAttached = synchronized(renderContextLock) {
+            softwareRenderContext.takeIf { it != 0L }?.let { context ->
+                DesktopJniMpvVideoApi.nativeFreeRenderContext(context)
+                softwareRenderContext = 0L
+            }
+            openGlRenderContext != 0L
+        }
+        if (gpuContextStillAttached) {
+            // The normal Compose lifecycle disposes the host GPU surface first, while its GL
+            // context can still be made current. Do not attempt OpenGL teardown without that
+            // context here; leaking only on an abnormal disposal order is safer than a driver
+            // crash. The process will reclaim it on exit.
+            AppLogger.w(
+                "DesktopVideo",
+                "OpenGL video surface still attached during controller close; deferring native teardown",
+            )
+            mutableFrame.value = null
+            return
+        }
+
         DesktopJniMpvVideoApi.nativeDestroy(handle)
         mutableFrame.value = null
     }
@@ -146,6 +259,7 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
                                 isPlaying = getProperty("pause") != "yes",
                                 errorMessage = null,
                             )
+                            publishPipelineIfChanged()
                         }
                         event.startsWith("end:") -> {
                             playbackActive = false
@@ -194,10 +308,32 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
             videoWidth = getProperty("video-params/w")?.toIntOrNull()?.coerceAtLeast(0) ?: current.videoWidth,
             videoHeight = getProperty("video-params/h")?.toIntOrNull()?.coerceAtLeast(0) ?: current.videoHeight,
         )
+        publishPipelineIfChanged()
+    }
+
+    private fun publishPipelineIfChanged() {
+        val renderer = when {
+            openGlRenderContext != 0L -> "opengl-gpu"
+            softwareRenderContext != 0L -> "software"
+            else -> "pending"
+        }
+        val hwdec = getProperty("hwdec-current")
+            ?.takeIf { it.isNotBlank() && !it.equals("no", ignoreCase = true) }
+            ?: "software"
+        val codec = getProperty("video-codec")?.takeIf(String::isNotBlank) ?: "unknown"
+        val description = "decoder=$hwdec renderer=$renderer codec=$codec"
+        if (description == lastPipelineDescription) return
+        lastPipelineDescription = description
+        AppLogger.i("DesktopVideo", description)
     }
 
     private fun renderLoop() {
         while (!closed.get()) {
+            val renderContext = softwareRenderContext
+            if (renderContext == 0L) {
+                Thread.sleep(80L)
+                continue
+            }
             val (width, height) = boundedDesktopJniVideoRenderSize(viewportWidth, viewportHeight)
             if (!playbackActive || width <= 0 || height <= 0) {
                 Thread.sleep(if (playbackActive) 30L else 80L)
@@ -228,6 +364,13 @@ internal class DesktopJniMpvVideoController : DesktopPlatformVideoController {
                 Thread.sleep(100L)
             }
             Thread.sleep(VIDEO_RENDER_INTERVAL_MS)
+        }
+    }
+
+    private fun ensureOpenGlContext(renderContext: Long) {
+        ensureOpen()
+        check(renderContext != 0L && renderContext == openGlRenderContext) {
+            "OpenGL libmpv video render context is not active"
         }
     }
 
@@ -345,6 +488,13 @@ private object DesktopJniMpvVideoApi {
     external fun nativeDestroy(handle: Long)
     external fun nativeErrorString(error: Int): String?
     external fun nativeCreateSoftwareRenderContext(handle: Long): Long
+    external fun nativeCreateOpenGlRenderContext(handle: Long): Long
+    external fun nativeUpdateRenderContext(renderContext: Long): Long
+    external fun nativeCreateOpenGlRenderTarget(width: Int, height: Int): Long
+    external fun nativeOpenGlRenderTargetFramebuffer(renderTarget: Long): Int
+    external fun nativeRenderOpenGl(renderContext: Long, renderTarget: Long)
+    external fun nativeReportSwap(renderContext: Long)
+    external fun nativeDestroyOpenGlRenderTarget(renderTarget: Long)
     external fun nativeRenderSoftware(
         renderContext: Long,
         width: Int,
@@ -395,6 +545,7 @@ private fun resolveDesktopJniMpvVideoBridge(): File? {
 private const val EVENT_WAIT_SECONDS = 0.05
 private const val STATE_POLL_INTERVAL_NANOS = 100_000_000L
 private const val MPV_END_FILE_REASON_ERROR = 4
+private const val MPV_RENDER_UPDATE_FRAME = 1L
 private const val BYTES_PER_PIXEL = 4
 private const val VIDEO_RENDER_INTERVAL_MS = 33L
 private const val MAX_SOFTWARE_RENDER_PIXELS = 1920L * 1080L

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoController.kt
@@ -31,16 +31,31 @@ interface DesktopOpenGlVideoController {
 }
 
 /**
+ * macOS GPU extension. libmpv renders on a private accelerated CGL context into an
+ * IOSurface-backed FBO; Nucleus imports that IOSurface into its Metal scene via TextureView.
+ */
+interface DesktopIoSurfaceVideoController {
+    fun createIoSurfaceRenderContext(): Long
+    fun createIoSurfaceRenderTarget(renderContext: Long, width: Int, height: Int): Long
+    fun ioSurfaceRenderTargetPointer(renderTarget: Long): Long
+    fun renderIoSurface(renderContext: Long, renderTarget: Long): Boolean
+    fun destroyIoSurfaceRenderTarget(renderContext: Long, renderTarget: Long)
+    fun destroyIoSurfaceRenderContext(renderContext: Long)
+}
+
+/**
  * GraalVM-friendly desktop video controller backed by the same libmpv JNI bridge packaged by the
  * Nucleus desktop runtime. The legacy JVM host installs its JNA controller explicitly, so this
  * controller is only used by the Native/Nucleus host.
  *
  * A render context is intentionally created lazily. Windows/Linux attach libmpv to Tao's active
- * OpenGL/ANGLE context. macOS and any failed GPU setup explicitly enable the software fallback.
+ * OpenGL/ANGLE context. macOS renders into IOSurface on a private CGL context and lets Tao/Metal
+ * import the surface. Any failed GPU setup can explicitly enable the software fallback.
  */
 internal class DesktopJniMpvVideoController :
     DesktopPlatformVideoController,
-    DesktopOpenGlVideoController {
+    DesktopOpenGlVideoController,
+    DesktopIoSurfaceVideoController {
     private val closed = AtomicBoolean(false)
     private val renderContextLock = Any()
     private val mutableState = MutableStateFlow(PlatformVideoPlaybackState())
@@ -57,6 +72,7 @@ internal class DesktopJniMpvVideoController :
     @Volatile private var playbackActive = false
     @Volatile private var softwareRenderContext = 0L
     @Volatile private var openGlRenderContext = 0L
+    @Volatile private var ioSurfaceRenderContext = 0L
     @Volatile private var lastPipelineDescription: String? = null
 
     init {
@@ -144,8 +160,8 @@ internal class DesktopJniMpvVideoController :
 
     override fun createOpenGlRenderContext(): Long = synchronized(renderContextLock) {
         ensureOpen()
-        check(softwareRenderContext == 0L) {
-            "software libmpv video renderer is already active"
+        check(softwareRenderContext == 0L && ioSurfaceRenderContext == 0L) {
+            "another libmpv video renderer is already active"
         }
         if (openGlRenderContext != 0L) return@synchronized openGlRenderContext
         val context = DesktopJniMpvVideoApi.nativeCreateOpenGlRenderContext(handle)
@@ -201,12 +217,62 @@ internal class DesktopJniMpvVideoController :
         }
     }
 
+    override fun createIoSurfaceRenderContext(): Long = synchronized(renderContextLock) {
+        ensureOpen()
+        check(softwareRenderContext == 0L && openGlRenderContext == 0L) {
+            "another libmpv video renderer is already active"
+        }
+        if (ioSurfaceRenderContext != 0L) return@synchronized ioSurfaceRenderContext
+        val context = DesktopJniMpvVideoApi.nativeCreateIoSurfaceRenderContext(handle)
+        check(context != 0L) { "libmpv macOS IOSurface render context creation failed" }
+        ioSurfaceRenderContext = context
+        AppLogger.i("DesktopVideo", "attached libmpv IOSurface renderer with hwdec=auto")
+        context
+    }
+
+    override fun createIoSurfaceRenderTarget(renderContext: Long, width: Int, height: Int): Long {
+        ensureIoSurfaceContext(renderContext)
+        require(width > 0 && height > 0) { "IOSurface video target must have positive dimensions" }
+        val target = DesktopJniMpvVideoApi.nativeCreateIoSurfaceRenderTarget(renderContext, width, height)
+        check(target != 0L) { "macOS IOSurface video target creation failed" }
+        return target
+    }
+
+    override fun ioSurfaceRenderTargetPointer(renderTarget: Long): Long {
+        ensureOpen()
+        val surface = DesktopJniMpvVideoApi.nativeIoSurfaceRenderTargetPointer(renderTarget)
+        check(surface != 0L) { "macOS video target has no IOSurface" }
+        return surface
+    }
+
+    override fun renderIoSurface(renderContext: Long, renderTarget: Long): Boolean {
+        ensureIoSurfaceContext(renderContext)
+        check(renderTarget != 0L) { "IOSurface video render target is closed" }
+        return DesktopJniMpvVideoApi.nativeRenderIoSurface(renderContext, renderTarget)
+    }
+
+    override fun destroyIoSurfaceRenderTarget(renderContext: Long, renderTarget: Long) {
+        if (renderTarget == 0L) return
+        ensureIoSurfaceContext(renderContext)
+        DesktopJniMpvVideoApi.nativeDestroyIoSurfaceRenderTarget(renderContext, renderTarget)
+    }
+
+    override fun destroyIoSurfaceRenderContext(renderContext: Long) {
+        if (renderContext == 0L) return
+        synchronized(renderContextLock) {
+            if (ioSurfaceRenderContext != renderContext) return
+            DesktopJniMpvVideoApi.nativeFreeIoSurfaceRenderContext(renderContext)
+            ioSurfaceRenderContext = 0L
+            lastPipelineDescription = null
+        }
+    }
+
     override fun enableSoftwareRendering() {
         synchronized(renderContextLock) {
             ensureOpen()
             if (softwareRenderContext != 0L) return
-            check(openGlRenderContext == 0L) {
-                "OpenGL libmpv video renderer is already active"
+            check(openGlRenderContext == 0L && ioSurfaceRenderContext == 0L) {
+                "GPU libmpv video renderer is already active"
             }
             val context = DesktopJniMpvVideoApi.nativeCreateSoftwareRenderContext(handle)
             check(context != 0L) { "libmpv software video render context creation failed" }
@@ -226,6 +292,10 @@ internal class DesktopJniMpvVideoController :
             softwareRenderContext.takeIf { it != 0L }?.let { context ->
                 DesktopJniMpvVideoApi.nativeFreeRenderContext(context)
                 softwareRenderContext = 0L
+            }
+            ioSurfaceRenderContext.takeIf { it != 0L }?.let { context ->
+                DesktopJniMpvVideoApi.nativeFreeIoSurfaceRenderContext(context)
+                ioSurfaceRenderContext = 0L
             }
             openGlRenderContext != 0L
         }
@@ -313,6 +383,7 @@ internal class DesktopJniMpvVideoController :
 
     private fun publishPipelineIfChanged() {
         val renderer = when {
+            ioSurfaceRenderContext != 0L -> "iosurface-metal"
             openGlRenderContext != 0L -> "opengl-gpu"
             softwareRenderContext != 0L -> "software"
             else -> "pending"
@@ -371,6 +442,13 @@ internal class DesktopJniMpvVideoController :
         ensureOpen()
         check(renderContext != 0L && renderContext == openGlRenderContext) {
             "OpenGL libmpv video render context is not active"
+        }
+    }
+
+    private fun ensureIoSurfaceContext(renderContext: Long) {
+        ensureOpen()
+        check(renderContext != 0L && renderContext == ioSurfaceRenderContext) {
+            "IOSurface libmpv video render context is not active"
         }
     }
 
@@ -495,6 +573,12 @@ private object DesktopJniMpvVideoApi {
     external fun nativeRenderOpenGl(renderContext: Long, renderTarget: Long)
     external fun nativeReportSwap(renderContext: Long)
     external fun nativeDestroyOpenGlRenderTarget(renderTarget: Long)
+    external fun nativeCreateIoSurfaceRenderContext(handle: Long): Long
+    external fun nativeCreateIoSurfaceRenderTarget(renderContext: Long, width: Int, height: Int): Long
+    external fun nativeIoSurfaceRenderTargetPointer(renderTarget: Long): Long
+    external fun nativeRenderIoSurface(renderContext: Long, renderTarget: Long): Boolean
+    external fun nativeDestroyIoSurfaceRenderTarget(renderContext: Long, renderTarget: Long)
+    external fun nativeFreeIoSurfaceRenderContext(renderContext: Long)
     external fun nativeRenderSoftware(
         renderContext: Long,
         width: Int,

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoIntegration.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/DesktopJniMpvVideoIntegration.kt
@@ -1,0 +1,6 @@
+package org.feeluown.mobile
+
+/** Installs the GraalVM-friendly libmpv JNI video controller for the Native/Nucleus desktop host. */
+fun installDesktopJniMpvVideoControllerFactory() {
+    installDesktopPlatformVideoControllerFactory(::DesktopJniMpvVideoController)
+}

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -25,12 +25,31 @@ interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseabl
     fun setViewportSize(width: Int, height: Int)
 }
 
+/**
+ * Optional host-owned video surface. Native desktop hosts can render directly into their GPU
+ * scene while the legacy JVM host keeps consuming [DesktopPlatformVideoController.frame].
+ */
+interface DesktopPlatformVideoSurface {
+    @Composable
+    fun Content(
+        controller: DesktopPlatformVideoController,
+        payload: VideoPlaybackPayload?,
+        modifier: Modifier,
+    )
+}
+
 private var desktopPlatformVideoControllerFactory: () -> DesktopPlatformVideoController = {
     UnsupportedDesktopPlatformVideoController("桌面视频播放组件未初始化")
 }
 
+private var desktopPlatformVideoSurface: DesktopPlatformVideoSurface? = null
+
 fun installDesktopPlatformVideoControllerFactory(factory: () -> DesktopPlatformVideoController) {
     desktopPlatformVideoControllerFactory = factory
+}
+
+fun installDesktopPlatformVideoSurface(surface: DesktopPlatformVideoSurface?) {
+    desktopPlatformVideoSurface = surface
 }
 
 private class UnsupportedDesktopPlatformVideoController(
@@ -73,12 +92,6 @@ actual fun PlatformVideoPlayer(
     LaunchedEffect(desktopController, payload) {
         desktopController?.setPayload(payload)
     }
-    val frame = if (desktopController != null) {
-        val value by desktopController.frame.collectAsState()
-        value
-    } else {
-        null
-    }
 
     Box(
         modifier = modifier.onSizeChanged { size ->
@@ -86,13 +99,28 @@ actual fun PlatformVideoPlayer(
         },
         contentAlignment = Alignment.Center,
     ) {
-        frame?.let { bitmap ->
-            Image(
-                bitmap = bitmap,
-                contentDescription = payload?.video?.title,
+        val hostSurface = desktopPlatformVideoSurface
+        if (desktopController != null && hostSurface != null) {
+            hostSurface.Content(
+                controller = desktopController,
+                payload = payload,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Fit,
             )
+        } else {
+            val frame = if (desktopController != null) {
+                val value by desktopController.frame.collectAsState()
+                value
+            } else {
+                null
+            }
+            frame?.let { bitmap ->
+                Image(
+                    bitmap = bitmap,
+                    contentDescription = payload?.video?.title,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit,
+                )
+            }
         }
     }
 }

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -26,7 +26,7 @@ interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseabl
 }
 
 private var desktopPlatformVideoControllerFactory: () -> DesktopPlatformVideoController = {
-    DesktopJniMpvVideoController()
+    UnsupportedDesktopPlatformVideoController("桌面视频播放组件未初始化")
 }
 
 fun installDesktopPlatformVideoControllerFactory(factory: () -> DesktopPlatformVideoController) {

--- a/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
+++ b/shared/src/desktopMain/kotlin/org/feeluown/mobile/PlatformVideoPlayer.desktop.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-/** Desktop-only bridge implemented by the host module that owns libmpv/JNA. */
+/** Desktop-only bridge implemented by the active desktop host/runtime. */
 interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseable {
     val frame: StateFlow<ImageBitmap?>
     fun setPayload(payload: VideoPlaybackPayload?)
@@ -26,7 +26,7 @@ interface DesktopPlatformVideoController : PlatformVideoController, AutoCloseabl
 }
 
 private var desktopPlatformVideoControllerFactory: () -> DesktopPlatformVideoController = {
-    UnsupportedDesktopPlatformVideoController("桌面视频播放组件未初始化")
+    DesktopJniMpvVideoController()
 }
 
 fun installDesktopPlatformVideoControllerFactory(factory: () -> DesktopPlatformVideoController) {

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopJniMpvVideoControllerTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopJniMpvVideoControllerTest.kt
@@ -2,6 +2,7 @@ package org.feeluown.mobile
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -31,10 +32,85 @@ class DesktopJniMpvVideoControllerTest {
     }
 
     @Test
-    fun endEventParserUsesReasonAndErrorAfterPlaylistEntryId() {
+    fun sourceCandidatesRetryCombinedThenSplitFallbacks() {
+        val payload = VideoPlaybackPayload(
+            video = ProviderVideo(
+                id = "video-1",
+                title = "Video",
+                providerId = "bilibili",
+                providerName = "Bilibili",
+            ),
+            url = "https://cdn.test/combined-primary.mp4",
+            fallbackUrls = listOf(
+                "https://cdn.test/combined-backup.mp4",
+                "https://cdn.test/combined-primary.mp4",
+            ),
+            videoUrl = "https://cdn.test/video-primary.m4s",
+            audioUrl = "https://cdn.test/audio-primary.m4s",
+            fallbackVideoUrls = listOf("https://cdn.test/video-backup.m4s"),
+            fallbackAudioUrls = listOf("https://cdn.test/audio-backup.m4s"),
+        )
+
+        val candidates = desktopJniVideoSourceCandidates(payload)
+
+        assertEquals(6, candidates.size)
+        assertEquals("https://cdn.test/combined-primary.mp4", candidates[0].url)
+        assertEquals("https://cdn.test/combined-backup.mp4", candidates[1].url)
+        assertEquals("https://cdn.test/video-primary.m4s", candidates[2].videoUrl)
+        assertEquals("https://cdn.test/audio-primary.m4s", candidates[2].audioUrl)
+        assertEquals("https://cdn.test/video-backup.m4s", candidates[3].videoUrl)
+        assertEquals("https://cdn.test/audio-primary.m4s", candidates[3].audioUrl)
+        assertEquals("https://cdn.test/video-primary.m4s", candidates[4].videoUrl)
+        assertEquals("https://cdn.test/audio-backup.m4s", candidates[4].audioUrl)
+        assertEquals("https://cdn.test/video-backup.m4s", candidates[5].videoUrl)
+        assertEquals("https://cdn.test/audio-backup.m4s", candidates[5].audioUrl)
+    }
+
+    @Test
+    fun endEventParserUsesPlaylistEntryReasonAndError() {
+        assertEquals(42L, parseDesktopJniVideoStartEvent("start:42"))
+        assertEquals(null, parseDesktopJniVideoStartEvent("start:broken"))
+
         val event = assertNotNull(parseDesktopJniVideoEndEvent("end:42:4:-13"))
+        assertEquals(42L, event.playlistEntryId)
         assertEquals(4, event.reason)
         assertEquals(-13, event.error)
         assertEquals(null, parseDesktopJniVideoEndEvent("end:broken"))
+    }
+
+    @Test
+    fun playbackRestartCoversEofIdleAndNearEnd() {
+        assertTrue(
+            shouldRestartDesktopJniVideoPlayback(
+                reachedEof = true,
+                playbackActive = false,
+                positionMs = 10_000,
+                durationMs = 10_000,
+            ),
+        )
+        assertTrue(
+            shouldRestartDesktopJniVideoPlayback(
+                reachedEof = false,
+                playbackActive = false,
+                positionMs = 3_000,
+                durationMs = 10_000,
+            ),
+        )
+        assertTrue(
+            shouldRestartDesktopJniVideoPlayback(
+                reachedEof = false,
+                playbackActive = true,
+                positionMs = 9_600,
+                durationMs = 10_000,
+            ),
+        )
+        assertFalse(
+            shouldRestartDesktopJniVideoPlayback(
+                reachedEof = false,
+                playbackActive = true,
+                positionMs = 5_000,
+                durationMs = 10_000,
+            ),
+        )
     }
 }

--- a/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopJniMpvVideoControllerTest.kt
+++ b/shared/src/desktopTest/kotlin/org/feeluown/mobile/DesktopJniMpvVideoControllerTest.kt
@@ -1,0 +1,40 @@
+package org.feeluown.mobile
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DesktopJniMpvVideoControllerTest {
+    @Test
+    fun softwareRenderSizeCaps4kAt1080p() {
+        assertEquals(1920 to 1080, boundedDesktopJniVideoRenderSize(3840, 2160))
+        assertEquals(1280 to 720, boundedDesktopJniVideoRenderSize(1280, 720))
+        assertEquals(0 to 0, boundedDesktopJniVideoRenderSize(0, 720))
+    }
+
+    @Test
+    fun splitDashPayloadAddsExternalAudioAndRequestHeaders() {
+        val options = encodeDesktopJniVideoLoadfileOptions(
+            headers = mapOf(
+                "Referer" to "https://www.bilibili.com/",
+                "User-Agent" to "FuoEvolve",
+            ),
+            externalAudioUrl = "https://example.test/audio.m4s",
+        )
+
+        assertTrue(options.contains("user-agent="))
+        assertTrue(options.contains("http-header-fields="))
+        assertTrue(options.contains("Referer"))
+        assertTrue(options.contains("audio-files-append="))
+        assertTrue(options.contains("https://example.test/audio.m4s"))
+    }
+
+    @Test
+    fun endEventParserUsesReasonAndErrorAfterPlaylistEntryId() {
+        val event = assertNotNull(parseDesktopJniVideoEndEvent("end:42:4:-13"))
+        assertEquals(4, event.reason)
+        assertEquals(-13, event.error)
+        assertEquals(null, parseDesktopJniVideoEndEvent("end:broken"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a GraalVM-friendly desktop video controller backed by the packaged libmpv JNI bridge
- extend the JNI bridge with libmpv software render-context support and frame transfer to Compose
- explicitly install the JNI video controller from the Nucleus host while keeping the legacy JVM/JNA host unchanged
- preserve split DASH external-audio and HTTP-header handling
- add desktop tests for render sizing, loadfile options, and end-event parsing

## Design
The shared desktop video contract keeps its unsupported fallback. `desktopNucleusPoc` now explicitly installs the new JNI/libmpv controller during host initialization, matching the existing playback/local-music/service injection pattern. The legacy JVM host continues to install `DesktopMpvVideoController`, so the two runtimes stay isolated.

## Validation
PR CI exercises shared desktop tests plus Linux, Windows, and macOS Nucleus runtime compilation/resource staging, including compilation of the expanded JNI bridge.