### PR TITLE
ci: speed up Native Image packaging

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -241,10 +241,10 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
-  linux-appimage:
-    name: Linux x64 AppImage (Ubuntu 26.04 LTS baseline)
+  linux-x64:
+    name: Linux x64 AppImage + Arch package
     runs-on: ubuntu-26.04
-    timeout-minutes: 100
+    timeout-minutes: 110
 
     steps:
       - name: Checkout
@@ -252,12 +252,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify AppImage LTS baseline
+      - name: Verify Linux LTS baseline
         run: |
           . /etc/os-release
           test "$ID" = "ubuntu"
           test "$VERSION_ID" = "26.04"
-          echo "Building AppImage against Ubuntu $VERSION_ID LTS baseline"
+          echo "Building Linux packages against Ubuntu $VERSION_ID LTS baseline"
 
       - name: Prepare Git refs for versioning
         run: |
@@ -288,7 +288,7 @@ jobs:
           restore-keys: |
             nucleus-native-linux-ubuntu26.04-x64-rust-1.98.1-
 
-      - name: Install portable Linux native dependencies
+      - name: Install Linux native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -301,10 +301,11 @@ jobs:
             libsecret-1-dev \
             libwebkit2gtk-4.1-dev \
             glib-networking \
+            libarchive-tools \
             patchelf \
             pax-utils
 
-      - name: Build Nucleus Native Image AppImage
+      - name: Build Linux Native Image once and package both formats
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -314,21 +315,31 @@ jobs:
             --warning-mode all \
             --stacktrace \
             -PnativeMarch=compatibility \
-            -Pfuoevolve.nucleus.targetFormat=appimage \
+            -Pfuoevolve.nucleus.targetFormat=all \
             -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
-            :desktopApp:packageGraalvmAppImage
+            :desktopApp:packageGraalvmNativeDistributionForCurrentOS
 
-      - name: Prepare and verify AppImage artifact
+      - name: Prepare and verify Linux artifacts
         run: |
-          mapfile -t artifacts < <(find desktopApp/build -type f -iname '*.AppImage' -print)
-          if [[ "${#artifacts[@]}" -ne 1 ]]; then
-            echo "Expected exactly one AppImage, found ${#artifacts[@]}" >&2
-            printf '%s\n' "${artifacts[@]}" >&2
+          mapfile -t appimages < <(find desktopApp/build -type f -iname '*.AppImage' -print)
+          if [[ "${#appimages[@]}" -ne 1 ]]; then
+            echo "Expected exactly one AppImage, found ${#appimages[@]}" >&2
+            printf '%s\n' "${appimages[@]}" >&2
             exit 1
           fi
+
+          mapfile -t arch_packages < <(find desktopApp/build -type f \( -name '*.pacman' -o -name '*.pkg.tar.zst' \) -print)
+          if [[ "${#arch_packages[@]}" -ne 1 ]]; then
+            echo "Expected exactly one Arch/pacman package, found ${#arch_packages[@]}" >&2
+            printf '%s\n' "${arch_packages[@]}" >&2
+            exit 1
+          fi
+
           mkdir -p build/artifacts build/appimage-verify
-          cp "${artifacts[0]}" build/artifacts/FuoEvolve-linux-x64.AppImage
+          cp "${appimages[0]}" build/artifacts/FuoEvolve-linux-x64.AppImage
           chmod +x build/artifacts/FuoEvolve-linux-x64.AppImage
+          cp "${arch_packages[0]}" build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
+
           (
             cd build/appimage-verify
             ../artifacts/FuoEvolve-linux-x64.AppImage --appimage-extract >/dev/null
@@ -340,7 +351,20 @@ jobs:
             find "$ROOT" -type f -name WebKitNetworkProcess -print -quit | grep -q .
             find "$ROOT" -type f -name libgiognutls.so -print -quit | grep -q .
           )
+
+          bsdtar -xOf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst .PKGINFO | tee build/arch-pkginfo.txt
+          grep -Eq '^depend = mpv($|[<>=])' build/arch-pkginfo.txt
+          grep -Eq '^depend = libsecret($|[<>=])' build/arch-pkginfo.txt
+          grep -Eq '^depend = webkit2gtk-4.1($|[<>=])' build/arch-pkginfo.txt
+          grep -Eq '^depend = alsa-lib($|[<>=])' build/arch-pkginfo.txt
+          grep -Eq '^depend = pipewire($|[<>=])' build/arch-pkginfo.txt
+          grep -Eq '^depend = libpulse($|[<>=])' build/arch-pkginfo.txt
+          bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep -E 'libfuoevolve_mpv_jni\.(so|dll|dylib)$' >/dev/null
+          bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep -E 'libfuoevolve_audio_capture\.so$' >/dev/null
+          bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep 'fuoevolve-web-login' >/dev/null
+
           du -h build/artifacts/FuoEvolve-linux-x64.AppImage
+          du -h build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
       - name: Upload Linux AppImage
         uses: actions/upload-artifact@v7
@@ -350,96 +374,6 @@ jobs:
           archive: false
           retention-days: 14
           if-no-files-found: error
-
-  linux-arch:
-    name: Linux x64 Arch package
-    runs-on: ubuntu-24.04
-    timeout-minutes: 90
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Prepare Git refs for versioning
-        run: |
-          if ! git show-ref --verify --quiet refs/heads/master; then
-            git branch master origin/master
-          fi
-
-      - name: Set up Nucleus GraalVM toolchain
-        uses: ./.github/actions/setup-nucleus
-        with:
-          java-version: "17"
-          graalvm: "true"
-          packaging-tools: "true"
-          setup-node: "true"
-
-      - name: Set up Rust 1.98.1
-        uses: dtolnay/rust-toolchain@1.98.1
-
-      - name: Cache Rust native helpers
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktopApp/native/web-login/target
-            desktopApp/native/audio-capture/target
-          key: nucleus-native-linux-ubuntu24.04-x64-rust-1.98.1-${{ hashFiles('desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/Cargo.lock', 'desktopApp/native/web-login/src/**', 'desktopApp/native/audio-capture/Cargo.toml', 'desktopApp/native/audio-capture/Cargo.lock', 'desktopApp/native/audio-capture/src/**') }}
-          restore-keys: |
-            nucleus-native-linux-ubuntu24.04-x64-rust-1.98.1-
-
-      - name: Install Linux native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            libasound2-dev \
-            libmpv-dev \
-            libpipewire-0.3-dev \
-            libpulse-dev \
-            libsecret-1-dev \
-            libwebkit2gtk-4.1-dev \
-            libarchive-tools
-
-      - name: Build Nucleus Native Image Arch package
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          ./gradlew \
-            --no-daemon \
-            --no-configuration-cache \
-            --warning-mode all \
-            --stacktrace \
-            -PnativeMarch=compatibility \
-            -Pfuoevolve.nucleus.targetFormat=pacman \
-            :desktopApp:packageGraalvmPacman
-
-      - name: Prepare and verify Arch artifact
-        run: |
-          mapfile -t artifacts < <(find desktopApp/build -type f \( -name '*.pacman' -o -name '*.pkg.tar.zst' \) -print)
-          if [[ "${#artifacts[@]}" -ne 1 ]]; then
-            echo "Expected exactly one Arch/pacman package, found ${#artifacts[@]}" >&2
-            printf '%s\n' "${artifacts[@]}" >&2
-            exit 1
-          fi
-          package="${artifacts[0]}"
-          mkdir -p build
-          bsdtar -xOf "$package" .PKGINFO | tee build/arch-pkginfo.txt
-          grep -Eq '^depend = mpv($|[<>=])' build/arch-pkginfo.txt
-          grep -Eq '^depend = libsecret($|[<>=])' build/arch-pkginfo.txt
-          grep -Eq '^depend = webkit2gtk-4.1($|[<>=])' build/arch-pkginfo.txt
-          grep -Eq '^depend = alsa-lib($|[<>=])' build/arch-pkginfo.txt
-          grep -Eq '^depend = pipewire($|[<>=])' build/arch-pkginfo.txt
-          grep -Eq '^depend = libpulse($|[<>=])' build/arch-pkginfo.txt
-          bsdtar -tf "$package" | grep -E 'libfuoevolve_mpv_jni\.(so|dll|dylib)$' >/dev/null
-          bsdtar -tf "$package" | grep -E 'libfuoevolve_audio_capture\.so$' >/dev/null
-          bsdtar -tf "$package" | grep 'fuoevolve-web-login' >/dev/null
-          mkdir -p build/artifacts
-          cp "$package" build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
-          du -h build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
       - name: Upload Arch Linux package
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -8,13 +8,12 @@ permissions:
 
 jobs:
   windows-x64:
-    name: Windows x64 MSI
+    name: Windows x64 NSIS
     runs-on: windows-latest
     timeout-minutes: 75
     env:
       FUOEVOLVE_NUCLEUS_LIBMPV_DEV_DIR: ${{ github.workspace }}\build\nucleus-native\windows\mpv
       FUOEVOLVE_NUCLEUS_LIBMPV_RUNTIME_DIR: ${{ github.workspace }}\build\nucleus-native\windows\mpv
-      FUOEVOLVE_NUCLEUS_TARGET_FORMAT: msi
 
     steps:
       - name: Checkout
@@ -61,13 +60,16 @@ jobs:
           key: nucleus-libmpv-windows-x64-${{ hashFiles('desktopApp/packaging/native-deps.lock') }}
 
       - name: Prepare pinned Windows libmpv development bundle
-        if: steps.windows-libmpv-cache.outputs.cache-hit != 'true'
         shell: pwsh
-        run: >-
-          ./desktopApp/packaging/windows/prepare-libmpv-dev.ps1
-          -OutputDir "$env:FUOEVOLVE_NUCLEUS_LIBMPV_DEV_DIR"
+        env:
+          LIBMPV_CACHE_HIT: ${{ steps.windows-libmpv-cache.outputs.cache-hit }}
+        run: |
+          if ($env:LIBMPV_CACHE_HIT -ne "true") {
+            ./desktopApp/packaging/windows/prepare-libmpv-dev.ps1 `
+              -OutputDir "$env:FUOEVOLVE_NUCLEUS_LIBMPV_DEV_DIR"
+          }
 
-      - name: Build Nucleus Native Image MSI
+      - name: Build Nucleus Native Image NSIS installer
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -80,27 +82,28 @@ jobs:
             --warning-mode all `
             --stacktrace `
             -PnativeMarch=compatibility `
-            :desktopApp:packageGraalvmMsi
+            :desktopApp:packageGraalvmNsis
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Prepare Windows artifact
         shell: pwsh
         run: |
-          $artifacts = Get-ChildItem -Path desktopApp\build -Recurse -File -Filter *.msi
+          $artifacts = Get-ChildItem -Path desktopApp\build\compose\binaries -Recurse -File -Filter *.exe |
+            Where-Object { $_.FullName -match '[\\/]graalvm-nsis[\\/]' }
           if ($artifacts.Count -ne 1) {
-            Write-Host "Expected exactly one MSI, found $($artifacts.Count)"
+            Write-Host "Expected exactly one NSIS installer, found $($artifacts.Count)"
             $artifacts | Select-Object FullName, Length
             exit 1
           }
           New-Item -ItemType Directory -Force -Path build\artifacts | Out-Null
-          Copy-Item $artifacts[0].FullName build\artifacts\FuoEvolve-windows-x64.msi
-          Get-Item build\artifacts\FuoEvolve-windows-x64.msi | Select-Object Name, Length
+          Copy-Item $artifacts[0].FullName build\artifacts\FuoEvolve-windows-x64.exe
+          Get-Item build\artifacts\FuoEvolve-windows-x64.exe | Select-Object Name, Length
 
-      - name: Upload Windows MSI
+      - name: Upload Windows NSIS installer
         uses: actions/upload-artifact@v7
         with:
-          name: FuoEvolve-windows-x64-msi
-          path: build/artifacts/FuoEvolve-windows-x64.msi
+          name: FuoEvolve-windows-x64-nsis
+          path: build/artifacts/FuoEvolve-windows-x64.exe
           archive: false
           retention-days: 14
           if-no-files-found: error
@@ -169,10 +172,13 @@ jobs:
           key: nucleus-libmpv-macos-${{ matrix.arch }}-${{ hashFiles('desktopApp/packaging/native-deps.lock', 'desktopApp/packaging/macos/prepare-libmpv.sh') }}
 
       - name: Prepare relocatable macOS libmpv runtime
-        if: steps.macos-libmpv-cache.outputs.cache-hit != 'true'
-        run: >-
-          bash desktopApp/packaging/macos/prepare-libmpv.sh
-          "${{ github.workspace }}/build/nucleus-native/macos/mpv"
+        env:
+          LIBMPV_CACHE_HIT: ${{ steps.macos-libmpv-cache.outputs.cache-hit }}
+        run: |
+          if [[ "$LIBMPV_CACHE_HIT" != "true" ]]; then
+            bash desktopApp/packaging/macos/prepare-libmpv.sh \
+              "${{ github.workspace }}/build/nucleus-native/macos/mpv"
+          fi
 
       - name: Verify cached macOS libmpv bundle
         run: |
@@ -242,7 +248,7 @@ jobs:
           if-no-files-found: error
 
   linux-x64:
-    name: Linux x64 AppImage + Arch package
+    name: Linux x64 AppImage + DEB + Arch
     runs-on: ubuntu-26.04
     timeout-minutes: 110
 
@@ -305,7 +311,7 @@ jobs:
             patchelf \
             pax-utils
 
-      - name: Build Linux Native Image once and package both formats
+      - name: Build Linux Native Image once and package all formats
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -315,9 +321,10 @@ jobs:
             --warning-mode all \
             --stacktrace \
             -PnativeMarch=compatibility \
-            -Pfuoevolve.nucleus.targetFormat=all \
             -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
-            :desktopApp:packageGraalvmNativeDistributionForCurrentOS
+            :desktopApp:packageGraalvmAppImage \
+            :desktopApp:packageGraalvmDeb \
+            :desktopApp:packageGraalvmPacman
 
       - name: Prepare and verify Linux artifacts
         run: |
@@ -325,6 +332,13 @@ jobs:
           if [[ "${#appimages[@]}" -ne 1 ]]; then
             echo "Expected exactly one AppImage, found ${#appimages[@]}" >&2
             printf '%s\n' "${appimages[@]}" >&2
+            exit 1
+          fi
+
+          mapfile -t deb_packages < <(find desktopApp/build -type f -name '*.deb' -print)
+          if [[ "${#deb_packages[@]}" -ne 1 ]]; then
+            echo "Expected exactly one DEB package, found ${#deb_packages[@]}" >&2
+            printf '%s\n' "${deb_packages[@]}" >&2
             exit 1
           fi
 
@@ -338,6 +352,7 @@ jobs:
           mkdir -p build/artifacts build/appimage-verify
           cp "${appimages[0]}" build/artifacts/FuoEvolve-linux-x64.AppImage
           chmod +x build/artifacts/FuoEvolve-linux-x64.AppImage
+          cp "${deb_packages[0]}" build/artifacts/FuoEvolve-linux-x64.deb
           cp "${arch_packages[0]}" build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
           (
@@ -352,6 +367,11 @@ jobs:
             find "$ROOT" -type f -name libgiognutls.so -print -quit | grep -q .
           )
 
+          test "$(dpkg-deb -f build/artifacts/FuoEvolve-linux-x64.deb Package)" = "fuoevolve"
+          dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep -E 'libfuoevolve_mpv_jni\.so$' >/dev/null
+          dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep -E 'libfuoevolve_audio_capture\.so$' >/dev/null
+          dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep 'fuoevolve-web-login' >/dev/null
+
           bsdtar -xOf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst .PKGINFO | tee build/arch-pkginfo.txt
           grep -Eq '^depend = mpv($|[<>=])' build/arch-pkginfo.txt
           grep -Eq '^depend = libsecret($|[<>=])' build/arch-pkginfo.txt
@@ -364,6 +384,7 @@ jobs:
           bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep 'fuoevolve-web-login' >/dev/null
 
           du -h build/artifacts/FuoEvolve-linux-x64.AppImage
+          du -h build/artifacts/FuoEvolve-linux-x64.deb
           du -h build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
       - name: Upload Linux AppImage
@@ -371,6 +392,15 @@ jobs:
         with:
           name: FuoEvolve-linux-x64-appimage
           path: build/artifacts/FuoEvolve-linux-x64.AppImage
+          archive: false
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v7
+        with:
+          name: FuoEvolve-linux-x64-deb
+          path: build/artifacts/FuoEvolve-linux-x64.deb
           archive: false
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/master-canary.yml
+++ b/.github/workflows/master-canary.yml
@@ -31,8 +31,6 @@ jobs:
     name: Build signed Android Canary APK
     needs:
       - android-tests
-      - desktop-tests
-      - ios-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -194,82 +192,5 @@ jobs:
   desktop-canary:
     name: Desktop Canary packages
     needs:
-      - android-tests
       - desktop-tests
-      - ios-tests
     uses: ./.github/workflows/desktop-packaging.yml
-
-  ios-canary:
-    name: Build iOS simulator Canary app
-    needs:
-      - android-tests
-      - desktop-tests
-      - ios-tests
-    runs-on: macos-26
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          build-scan-publish: true
-          build-scan-terms-of-use-url: https://gradle.com/terms-of-service
-          build-scan-terms-of-use-agree: "yes"
-          add-job-summary: never
-
-      - name: Cache Kotlin/Native toolchain
-        uses: actions/cache@v6
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-${{ runner.arch }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
-
-      - name: Resolve Swift package dependencies
-        run: |
-          defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
-          xcodebuild \
-            -resolvePackageDependencies \
-            -project iosApp/FuoEvolve.xcodeproj \
-            -scheme FuoEvolve \
-            -derivedDataPath build/ios-ci \
-            -clonedSourcePackagesDirPath build/ios-ci/SourcePackages
-
-      - name: Build debug simulator app
-        run: |
-          xcodebuild \
-            -project iosApp/FuoEvolve.xcodeproj \
-            -scheme FuoEvolve \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -derivedDataPath build/ios-ci \
-            -clonedSourcePackagesDirPath build/ios-ci/SourcePackages \
-            ARCHS=arm64 \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            build
-
-      - name: Package debug app bundle
-        run: |
-          mkdir -p build/artifacts
-          tar -cf build/artifacts/FuoEvolve-debug-ios-simulator.tar \
-            -C build/ios-ci/Build/Products/Debug-iphonesimulator \
-            FuoEvolve.app
-
-      - name: Upload iOS simulator Canary app
-        uses: actions/upload-artifact@v7
-        with:
-          name: FuoEvolve-debug-ios-simulator
-          path: build/artifacts/FuoEvolve-debug-ios-simulator.tar
-          archive: false
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,11 @@ jobs:
           cp "$android" build/artifacts/
 
           declare -A desktop_assets=(
-            ["FuoEvolve-windows-x64.msi"]="FuoEvolve-${tag}-windows-x64.msi"
+            ["FuoEvolve-windows-x64.exe"]="FuoEvolve-${tag}-windows-x64.exe"
             ["FuoEvolve-macos-arm64.dmg"]="FuoEvolve-${tag}-macos-arm64.dmg"
             ["FuoEvolve-macos-x64.dmg"]="FuoEvolve-${tag}-macos-x64.dmg"
             ["FuoEvolve-linux-x64.AppImage"]="FuoEvolve-${tag}-linux-x64.AppImage"
+            ["FuoEvolve-linux-x64.deb"]="FuoEvolve-${tag}-linux-x64.deb"
             ["FuoEvolve-linux-x64.pkg.tar.zst"]="FuoEvolve-${tag}-linux-x64.pkg.tar.zst"
           )
 
@@ -191,7 +192,7 @@ jobs:
             cp "$source_path" "build/artifacts/$target_name"
           done
 
-          expected_count=6
+          expected_count=7
           actual_count="$(find build/artifacts -maxdepth 1 -type f | wc -l | tr -d ' ')"
           if [ "$actual_count" -ne "$expected_count" ]; then
             echo "::error::Expected $expected_count release artifacts before checksums, found $actual_count"
@@ -257,57 +258,3 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           make_latest: true
-
-  publish-fdroid-pages:
-    name: Publish F-Droid repository to Pages
-    needs: publish-release
-    if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-      needs.publish-release.result == 'success')
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    concurrency:
-      group: fuoevolve-github-pages
-      cancel-in-progress: false
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      FUO_SIGNING_KEYSTORE_BASE64: ${{ secrets.FUO_SIGNING_KEYSTORE_BASE64 }}
-      FUO_SIGNING_STORE_PASSWORD: ${{ secrets.FUO_SIGNING_STORE_PASSWORD }}
-      FUO_SIGNING_KEY_ALIAS: ${{ secrets.FUO_SIGNING_KEY_ALIAS }}
-      FUO_SIGNING_KEY_PASSWORD: ${{ secrets.FUO_SIGNING_KEY_PASSWORD }}
-      GH_TOKEN: ${{ github.token }}
-      FDROID_DOCKER_IMAGE: registry.gitlab.com/fdroid/docker-executable-fdroidserver:master
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Build F-Droid repository and Pages site
-        run: |
-          docker pull "$FDROID_DOCKER_IMAGE"
-          bash scripts/build-fdroid-pages.sh
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: build/pages
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,3 +258,57 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           make_latest: true
+
+  publish-fdroid-pages:
+    name: Publish F-Droid repository to Pages
+    needs: publish-release
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+      needs.publish-release.result == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    concurrency:
+      group: fuoevolve-github-pages
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      FUO_SIGNING_KEYSTORE_BASE64: ${{ secrets.FUO_SIGNING_KEYSTORE_BASE64 }}
+      FUO_SIGNING_STORE_PASSWORD: ${{ secrets.FUO_SIGNING_STORE_PASSWORD }}
+      FUO_SIGNING_KEY_ALIAS: ${{ secrets.FUO_SIGNING_KEY_ALIAS }}
+      FUO_SIGNING_KEY_PASSWORD: ${{ secrets.FUO_SIGNING_KEY_PASSWORD }}
+      GH_TOKEN: ${{ github.token }}
+      FDROID_DOCKER_IMAGE: registry.gitlab.com/fdroid/docker-executable-fdroidserver:master
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Build F-Droid repository and Pages site
+        run: |
+          docker pull "$FDROID_DOCKER_IMAGE"
+          bash scripts/build-fdroid-pages.sh
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build/pages
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ FuoEvolve is an open-source, cross-platform music player built around the [FeelU
 | Platform | Stable | Canary / Preview |
 | --- | --- | --- |
 | **Android** | [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) · [F-Droid repository](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | [Latest master build](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
-| **Windows x64** | MSI from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | MSI from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **Windows x64** | NSIS installer from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | NSIS installer from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
 | **macOS arm64 / x64** | DMG from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | DMG from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
-| **Linux x64** | AppImage / Arch package from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | AppImage / Arch package from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
+| **Linux x64** | AppImage / DEB / Arch package from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | AppImage / DEB / Arch package from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
 
 > Desktop releases are GraalVM Native Image applications and do not bundle a JVM. Windows and macOS packages are not yet production-signed/notarized.
 
@@ -38,9 +38,9 @@ FuoEvolve is an open-source, cross-platform music player built around the [FeelU
 
 The desktop app shares the Compose experience with mobile and is available for Windows, macOS, and Linux. `desktopApp` is the only desktop host and is distributed through Nucleus/Tao + GraalVM Native Image; the legacy JVM desktop application has been removed.
 
-- **Windows:** SMTC system media controls and MSI packaging.
+- **Windows:** SMTC system media controls and NSIS packaging.
 - **macOS:** Now Playing / Remote Command Center integration with Apple Silicon and Intel DMGs.
-- **Linux:** MPRIS media controls, native Wayland/Tao support, AppImage and Arch packages. The portable AppImage is built against the pinned Ubuntu 26.04 LTS baseline.
+- **Linux:** MPRIS media controls, native Wayland/Tao support, AppImage, DEB and Arch packages. The Linux Native Image build uses the pinned Ubuntu 26.04 LTS baseline.
 - **Audio and video:** direct JNI libmpv playback with GPU video presentation and software fallback.
 - **Tray lifecycle:** closing the window keeps playback and downloads running; the tray/status item can restore or exit the app.
 - **Secure login storage:** Windows Credential Manager, macOS Keychain, and Linux Secret Service/Libsecret.
@@ -63,9 +63,9 @@ Available content depends on the source, region, login state, and upstream servi
 | Platform | Status | Notes |
 | --- | --- | --- |
 | Android | **Stable** | Signed APK and F-Droid distribution |
-| Windows | **Stable** | x64 Native Image MSI; production signing is pending |
+| Windows | **Stable** | x64 Native Image NSIS installer; production signing is pending |
 | macOS | **Stable** | Native Image DMGs for Apple Silicon and Intel; signing/notarization is pending |
-| Linux | **Stable** | Native Image AppImage and Arch package; AppImage baseline is Ubuntu 26.04 LTS |
+| Linux | **Stable** | Native Image AppImage, DEB and Arch package; build baseline is Ubuntu 26.04 LTS |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ FuoEvolve is an open-source, cross-platform music player built around the [FeelU
 | **Windows x64** | MSI from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | MSI from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
 | **macOS arm64 / x64** | DMG from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | DMG from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
 | **Linux x64** | AppImage / Arch package from [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) | AppImage / Arch package from [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
-| **iOS** | — | Experimental development builds only |
 
 > Desktop releases are GraalVM Native Image applications and do not bundle a JVM. Windows and macOS packages are not yet production-signed/notarized.
 
@@ -67,7 +66,6 @@ Available content depends on the source, region, login state, and upstream servi
 | Windows | **Stable** | x64 Native Image MSI; production signing is pending |
 | macOS | **Stable** | Native Image DMGs for Apple Silicon and Intel; signing/notarization is pending |
 | Linux | **Stable** | Native Image AppImage and Arch package; AppImage baseline is Ubuntu 26.04 LTS |
-| iOS | **Experimental** | Development and CI validation only |
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,6 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 | **Windows x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 MSI | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 MSI |
 | **macOS arm64 / x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 DMG | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 DMG |
 | **Linux x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 AppImage / Arch 包 | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 AppImage / Arch 包 |
-| **iOS** | — | 仅提供实验性开发构建 |
 
 > 桌面端正式版使用 GraalVM Native Image，不再捆绑 JVM。Windows 与 macOS 安装包目前尚未完成生产签名 / 公证。
 
@@ -67,7 +66,6 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 | Windows | **稳定版** | x64 Native Image MSI；生产签名后续补充 |
 | macOS | **稳定版** | Apple Silicon / Intel Native Image DMG；签名和公证后续补充 |
 | Linux | **稳定版** | Native Image AppImage 与 Arch 包；AppImage 基线为 Ubuntu 26.04 LTS |
-| iOS | **实验性** | 仅用于开发与 CI 验证 |
 
 ## 开发
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,9 +15,9 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 | 平台 | 正式版 | Canary / 预览版 |
 | --- | --- | --- |
 | **Android** | [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) · [F-Droid 仓库](https://feeluown.github.io/FuoEvolve/fdroid/repo?fingerprint=8D8BE45A04CF3242C13B43361C9FFA1CA8FB2F39D1A43CE35BEADFA8DBFEFB74) | [最新 master 构建](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) |
-| **Windows x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 MSI | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 MSI |
+| **Windows x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 NSIS 安装包 | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 NSIS 安装包 |
 | **macOS arm64 / x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 DMG | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 DMG |
-| **Linux x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 AppImage / Arch 包 | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 AppImage / Arch 包 |
+| **Linux x64** | 从 [GitHub Release](https://github.com/feeluown/FuoEvolve/releases/latest) 下载 AppImage / DEB / Arch 包 | 从 [Master Canary](https://github.com/feeluown/FuoEvolve/actions/workflows/master-canary.yml?query=branch%3Amaster) 下载 AppImage / DEB / Arch 包 |
 
 > 桌面端正式版使用 GraalVM Native Image，不再捆绑 JVM。Windows 与 macOS 安装包目前尚未完成生产签名 / 公证。
 
@@ -25,7 +25,7 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 
 - 🎵 **多音乐源**：在一个应用中使用网易云音乐、QQ 音乐、哔哩哔哩和 YouTube Music。
 - 🧭 **发现与搜索**：浏览推荐、排行榜、歌单、歌手、专辑和视频，并统一搜索已启用的音乐源。
-- ▶️ **音乐与视频播放**：支持播放队列、随机/循环、进度跳转、睡眠定时、MV / 视频和哔哩哔哩多分 P。
+- ▶️ **音乐和视频播放**：支持播放队列、随机/循环、进度跳转、睡眠定时、MV / 视频和哔哩哔哩多分 P。
 - 🎤 **丰富歌词**：支持同步歌词、翻译、罗马音、可用时的逐字歌词，以及手动匹配其他歌曲歌词。
 - 🔁 **智能换源**：当前歌曲无法播放时，自动从其他已启用来源寻找合适的替代资源。
 - 💽 **本地与离线音乐**：扫描本地音乐、编辑信息、创建本地歌单、下载在线歌曲并支持断点续传。
@@ -38,9 +38,9 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 
 桌面端与移动端共享 Compose 使用体验，支持 Windows、macOS 和 Linux。`desktopApp` 现在是唯一桌面宿主，使用 Nucleus/Tao + GraalVM Native Image 运行和发行，原 JVM 桌面应用已经移除。
 
-- **Windows**：支持 SMTC 系统媒体控制，正式发行 MSI。
+- **Windows**：支持 SMTC 系统媒体控制，使用 NSIS 安装包发行。
 - **macOS**：支持 Now Playing / Remote Command Center，提供 Apple Silicon 与 Intel DMG。
-- **Linux**：支持 MPRIS 与原生 Wayland/Tao，提供 AppImage 与 Arch 包；便携 AppImage 固定使用 Ubuntu 26.04 LTS 构建基线。
+- **Linux**：支持 MPRIS 与原生 Wayland/Tao，提供 AppImage、DEB 与 Arch 包；Linux Native Image 固定使用 Ubuntu 26.04 LTS 构建基线。
 - **音视频播放**：通过 JNI 直接接入 libmpv，视频优先使用 GPU 渲染并提供软件回退。
 - **托盘生命周期**：关闭窗口后继续播放和下载，可从托盘 / 状态栏图标恢复窗口或退出应用。
 - **安全登录存储**：使用 Windows Credential Manager、macOS Keychain 和 Linux Secret Service / Libsecret。
@@ -63,9 +63,9 @@ FuoEvolve 是一个围绕 [FeelUOwn](https://github.com/feeluown/FeelUOwn) 生�
 | 平台 | 状态 | 说明 |
 | --- | --- | --- |
 | Android | **稳定版** | 签名 APK 与 F-Droid 发行 |
-| Windows | **稳定版** | x64 Native Image MSI；生产签名后续补充 |
+| Windows | **稳定版** | x64 Native Image NSIS 安装包；生产签名后续补充 |
 | macOS | **稳定版** | Apple Silicon / Intel Native Image DMG；签名和公证后续补充 |
-| Linux | **稳定版** | Native Image AppImage 与 Arch 包；AppImage 基线为 Ubuntu 26.04 LTS |
+| Linux | **稳定版** | Native Image AppImage、DEB 与 Arch 包；构建基线为 Ubuntu 26.04 LTS |
 
 ## 开发
 

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -20,25 +20,35 @@ Build the native application image with:
   :desktopApp:packageGraalvmNative
 ```
 
-Create a user-facing package for the current OS with:
+Nucleus exposes per-format Native Image packaging tasks. The release pipeline uses:
 
 ```bash
+# Windows
+./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmNsis
+
+# macOS
+./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmDmg
+
+# Linux: one Gradle invocation, one shared Native Image compilation
 ./gradlew \
   -PnativeMarch=compatibility \
-  -Pfuoevolve.nucleus.targetFormat=<msi|dmg|appimage|pacman> \
-  :desktopApp:packageGraalvmNativeDistributionForCurrentOS
+  -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
+  :desktopApp:packageGraalvmAppImage \
+  :desktopApp:packageGraalvmDeb \
+  :desktopApp:packageGraalvmPacman
 ```
 
-Supported target formats are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias). Linux CI requests the full current-OS distribution task so AppImage and Pacman packaging share one `packageGraalvmNative` execution instead of compiling the Native Image twice.
+The three Linux packaging tasks share the same `packageGraalvmNative` dependency in one Gradle invocation, so AppImage, DEB, and Pacman do not trigger three full GraalVM compilations.
 
 ## Distribution matrix
 
 | Platform | Artifact | Native dependency policy |
 | --- | --- | --- |
-| Windows x64 | MSI | JNI bridge, system-output capture library and pinned libmpv runtime bundled |
+| Windows x64 | NSIS `.exe` installer | JNI bridge, system-output capture library and pinned libmpv runtime bundled |
 | macOS arm64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
-| Arch Linux x64 | Pacman/Arch package | Built from the same Native Image and packaged Linux user-space closure as AppImage; `pacmanDepends` remain as system compatibility dependencies |
+| Debian/Ubuntu Linux x64 | DEB | Built from the shared Linux Native Image and packaged user-space closure |
+| Arch Linux x64 | Pacman/Arch package | Built from the shared Linux Native Image and packaged user-space closure; `pacmanDepends` remain as system compatibility dependencies |
 | Portable Linux x64 | AppImage | Native audio/libmpv/Libsecret/WebKitGTK/TLS closures bundled; built against the Ubuntu 26.04 LTS baseline |
 
 No desktop artifact bundles a JVM.
@@ -69,8 +79,8 @@ Release tags such as `1.2.3` are embedded as the desktop package version and dis
 ## CI and release
 
 - `.github/workflows/desktop-tests.yml` validates shared desktop/runtime tests and native resource staging on Linux, Windows and macOS.
-- `.github/workflows/desktop-packaging.yml` produces MSI, both DMGs, AppImage and Arch packages. The two Linux formats are emitted from one Ubuntu 26.04 LTS job and share a single Native Image compilation.
-- `master-canary.yml` publishes preview artifacts from `master` after the matching platform test workflow succeeds.
+- `.github/workflows/desktop-packaging.yml` produces the Windows NSIS installer, both macOS DMGs, and Linux AppImage/DEB/Arch packages. All three Linux formats are emitted from one Ubuntu 26.04 LTS job and share a single Native Image compilation.
+- `master-canary.yml` publishes preview artifacts from `master` after the matching platform test workflow succeeds. iOS remains test-only and does not produce a Canary artifact.
 - `release.yml` publishes the same desktop package matrix alongside Android for release tags and includes SHA-256 checksums.
 
 Windows and macOS packages are currently published without production code signing/notarization; signing can be layered onto the same Native Image release pipeline later.

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -29,7 +29,7 @@ Create a user-facing package for the current OS with:
   :desktopApp:packageGraalvmNativeDistributionForCurrentOS
 ```
 
-Supported target formats are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias).
+Supported target formats are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias). Linux CI requests the full current-OS distribution task so AppImage and Pacman packaging share one `packageGraalvmNative` execution instead of compiling the Native Image twice.
 
 ## Distribution matrix
 
@@ -38,7 +38,7 @@ Supported target formats are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is a
 | Windows x64 | MSI | JNI bridge, system-output capture library and pinned libmpv runtime bundled |
 | macOS arm64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
-| Arch Linux x64 | Pacman/Arch package | Native capture library bundled; mpv, Libsecret, PipeWire/PulseAudio, WebKitGTK and UI ABI dependencies are distribution-managed |
+| Arch Linux x64 | Pacman/Arch package | Built from the same Native Image and packaged Linux user-space closure as AppImage; `pacmanDepends` remain as system compatibility dependencies |
 | Portable Linux x64 | AppImage | Native audio/libmpv/Libsecret/WebKitGTK/TLS closures bundled; built against the Ubuntu 26.04 LTS baseline |
 
 No desktop artifact bundles a JVM.
@@ -69,8 +69,8 @@ Release tags such as `1.2.3` are embedded as the desktop package version and dis
 ## CI and release
 
 - `.github/workflows/desktop-tests.yml` validates shared desktop/runtime tests and native resource staging on Linux, Windows and macOS.
-- `.github/workflows/desktop-packaging.yml` produces MSI, both DMGs, AppImage and Arch packages. AppImage uses the pinned Ubuntu 26.04 LTS runner baseline.
-- `master-canary.yml` publishes preview artifacts from `master`.
+- `.github/workflows/desktop-packaging.yml` produces MSI, both DMGs, AppImage and Arch packages. The two Linux formats are emitted from one Ubuntu 26.04 LTS job and share a single Native Image compilation.
+- `master-canary.yml` publishes preview artifacts from `master` after the matching platform test workflow succeeds.
 - `release.yml` publishes the same desktop package matrix alongside Android for release tags and includes SHA-256 checksums.
 
 Windows and macOS packages are currently published without production code signing/notarization; signing can be layered onto the same Native Image release pipeline later.

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -418,13 +418,15 @@ val requestedTargetFormat = providers.gradleProperty("fuoevolve.nucleus.targetFo
     ?.lowercase()
 val nucleusTargetFormats = when (requestedTargetFormat) {
     null, "all" -> arrayOf(
-        TargetFormat.Msi,
+        TargetFormat.Nsis,
         TargetFormat.Dmg,
+        TargetFormat.Deb,
         TargetFormat.AppImage,
         TargetFormat.Pacman,
     )
-    "msi" -> arrayOf(TargetFormat.Msi)
+    "nsis" -> arrayOf(TargetFormat.Nsis)
     "dmg" -> arrayOf(TargetFormat.Dmg)
+    "deb" -> arrayOf(TargetFormat.Deb)
     "appimage" -> arrayOf(TargetFormat.AppImage)
     "pacman", "arch" -> arrayOf(TargetFormat.Pacman)
     else -> throw GradleException("Unsupported Nucleus target format: $requestedTargetFormat")

--- a/docs/desktop-foundation.md
+++ b/docs/desktop-foundation.md
@@ -41,13 +41,14 @@ The Native Image host preserves the existing desktop data locations, bundle/appl
 
 Desktop packages are produced only from `desktopApp`:
 
-- Windows x64 MSI.
+- Windows x64 NSIS installer.
 - macOS arm64 DMG.
 - macOS x64 DMG.
 - Linux x64 AppImage.
+- Linux x64 DEB.
 - Linux x64 Arch/Pacman package.
 
-The Linux AppImage and Arch package are built together on the pinned Ubuntu 26.04 LTS baseline. They share one GraalVM Native Image compilation and the same packaged user-space native closure; the Arch package additionally retains system dependency metadata through `pacmanDepends`.
+The three Linux package formats are built together on the pinned Ubuntu 26.04 LTS baseline. They share one GraalVM Native Image compilation and the same packaged user-space native closure; the Arch package additionally retains system dependency metadata through `pacmanDepends`.
 
 No desktop package contains a bundled JVM.
 
@@ -62,7 +63,7 @@ Desktop CI runs on Linux, Windows, and macOS and validates:
 - packaged native-resource staging;
 - platform-specific libmpv runtime preparation.
 
-The reusable packaging workflow additionally verifies MSI/DMG/AppImage/Arch output and their required native package contents. The Linux packaging job verifies both outputs after one shared Native Image build. Release tags publish the same package matrix alongside Android.
+The reusable packaging workflow additionally verifies NSIS/DMG/AppImage/DEB/Arch output and their required native package contents. The Linux packaging job verifies all three Linux outputs after one shared Native Image build. Release tags publish the same package matrix alongside Android.
 
 ## Linux Wayland requirement
 

--- a/docs/desktop-foundation.md
+++ b/docs/desktop-foundation.md
@@ -47,7 +47,7 @@ Desktop packages are produced only from `desktopApp`:
 - Linux x64 AppImage.
 - Linux x64 Arch/Pacman package.
 
-The AppImage is built against the pinned Ubuntu 26.04 LTS baseline and bundles its portable user-space native closure. The Arch package intentionally relies on distribution-managed native dependencies.
+The Linux AppImage and Arch package are built together on the pinned Ubuntu 26.04 LTS baseline. They share one GraalVM Native Image compilation and the same packaged user-space native closure; the Arch package additionally retains system dependency metadata through `pacmanDepends`.
 
 No desktop package contains a bundled JVM.
 
@@ -62,13 +62,13 @@ Desktop CI runs on Linux, Windows, and macOS and validates:
 - packaged native-resource staging;
 - platform-specific libmpv runtime preparation.
 
-The reusable packaging workflow additionally verifies MSI/DMG/AppImage/Arch output and their required native package contents. Release tags publish the same package matrix alongside Android.
+The reusable packaging workflow additionally verifies MSI/DMG/AppImage/Arch output and their required native package contents. The Linux packaging job verifies both outputs after one shared Native Image build. Release tags publish the same package matrix alongside Android.
 
 ## Linux Wayland requirement
 
 Linux production packages must use native Wayland windowing when launched in a Wayland session and must not require XWayland for the main application window. Tao/Nucleus is the desktop window backend; WebKitGTK is isolated to the provider-login helper.
 
-The portable AppImage keeps graphics-driver-facing libraries host-managed while bundling the user-space dependency closure required by FuoEvolve.
+The packaged Linux user-space closure keeps graphics-driver-facing libraries host-managed while bundling the runtime dependencies required by FuoEvolve helpers and playback integration.
 
 ## Deferred work
 

--- a/docs/desktop-packaging.md
+++ b/docs/desktop-packaging.md
@@ -6,26 +6,36 @@
 
 | Target | Artifact | Runtime | Native dependency policy |
 | --- | --- | --- | --- |
-| Windows x64 | MSI | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + pinned libmpv DLL runtime bundled |
+| Windows x64 | NSIS `.exe` installer | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + pinned libmpv DLL runtime bundled |
 | macOS arm64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
-| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | shares the AppImage Native Image and packaged Linux user-space closure; `pacmanDepends` are retained as system compatibility dependencies |
+| Debian/Ubuntu Linux x64 | DEB | GraalVM Native Image | shares the Linux Native Image and packaged user-space closure |
+| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | shares the Linux Native Image and packaged user-space closure; `pacmanDepends` are retained as system compatibility dependencies |
 | Portable Linux x64 | AppImage | GraalVM Native Image | bundled system-output capture library/ELF closure plus libmpv/Libsecret/WebKitGTK/TLS native closures |
 
 No desktop artifact bundles a JVM.
 
 ## Nucleus packaging
 
-The host format is selected explicitly for single-format local builds:
+Nucleus 2.5.15 exposes one GraalVM packaging task per format. The release pipeline uses the direct tasks rather than branching the workflow with GitHub Actions conditions:
 
 ```bash
+# Windows
+./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmNsis
+
+# macOS
+./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmDmg
+
+# Linux: all direct-distribution formats in one Gradle invocation
 ./gradlew \
   -PnativeMarch=compatibility \
-  -Pfuoevolve.nucleus.targetFormat=appimage \
-  :desktopApp:packageGraalvmNativeDistributionForCurrentOS
+  -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
+  :desktopApp:packageGraalvmAppImage \
+  :desktopApp:packageGraalvmDeb \
+  :desktopApp:packageGraalvmPacman
 ```
 
-Supported `fuoevolve.nucleus.targetFormat` values are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias). In Linux CI the target format remains `all` and `packageGraalvmNativeDistributionForCurrentOS` emits both AppImage and Pacman packages from the same `packageGraalvmNative` dependency. This keeps one full GraalVM Native Image compilation per Linux workflow run rather than one per installer format.
+All three Linux packaging tasks depend on the same `packageGraalvmNative` task. Gradle executes that dependency once per invocation, so AppImage, DEB and Pacman reuse one full GraalVM Native Image compilation instead of compiling the application three times.
 
 ## Versioning
 
@@ -41,9 +51,9 @@ Desktop self-update is intentionally not implemented yet. These version values a
 
 ## Native inputs
 
-- Windows libmpv input pins live in `desktopApp/packaging/native-deps.lock`. CI verifies the pinned archive, stages the public headers/import library for JNI compilation, and bundles the runtime DLLs.
+- Windows libmpv input pins live in `desktopApp/packaging/native-deps.lock`. CI verifies the pinned archive, stages the public headers/import library for JNI compilation, and bundles the runtime DLLs into the NSIS package.
 - macOS uses the architecture-specific pinned mpv input and `desktopApp/packaging/macos/prepare-libmpv.sh` to produce an `@loader_path`-relative dylib closure.
-- Linux AppImage and Arch packages are produced from the same staged portable user-space closure. The Arch package retains Nucleus `pacmanDepends` metadata for system-level compatibility even though runtime libraries used by the packaged helpers are staged with the application.
+- Linux AppImage, DEB and Arch packages are produced from the same staged portable user-space closure. The Arch package retains Nucleus `pacmanDepends` metadata for system-level compatibility even though runtime libraries used by the packaged helpers are staged with the application.
 - Desktop system-audio recognition uses the CPAL/JNI library staged under `native/audio`; Windows and macOS capture the default output device, while Linux prefers PipeWire and falls back to a PulseAudio `.monitor` source.
 
 ## Linux LTS baseline
@@ -58,23 +68,23 @@ Ubuntu 26.04 is currently a public-preview GitHub-hosted runner image. This is i
 
 `.github/workflows/desktop-tests.yml` runs shared desktop tests plus `desktopRuntime` and `desktopApp` tests on Linux, Windows and macOS, then compiles the platform JNI bridge and stages desktop native resources.
 
-Pull requests use runtime-level validation and do not build the full MSI/DMG/AppImage/Pacman matrix.
+Pull requests use runtime-level validation and do not build the full NSIS/DMG/AppImage/DEB/Pacman matrix.
 
 `.github/workflows/desktop-packaging.yml` is the single reusable desktop packaging workflow. It builds:
 
-1. Windows x64 MSI.
+1. Windows x64 NSIS installer.
 2. macOS arm64 and x64 DMGs.
-3. Linux x64 AppImage and Arch/Pacman packages in one Ubuntu 26.04 LTS job with one Native Image compilation.
+3. Linux x64 AppImage, DEB and Arch/Pacman packages in one Ubuntu 26.04 LTS job with one Native Image compilation.
 
-`master-canary.yml` invokes that workflow for preview builds after desktop tests complete. Android Canary packaging starts independently after Android tests; iOS remains test-only and no Canary application artifact is produced. `release.yml` invokes the same desktop workflow for release tags and publishes all five desktop assets alongside the Android APK. The release job renames assets with the release tag and publishes `SHA256SUMS.txt`.
+`master-canary.yml` invokes that workflow for preview builds after desktop tests complete. Android Canary packaging starts independently after Android tests; iOS remains test-only and no Canary application artifact is produced. `release.yml` invokes the same desktop workflow for release tags and publishes all six desktop assets alongside the Android APK. The release job renames assets with the release tag and publishes `SHA256SUMS.txt`.
 
 ## Signing
 
 Desktop release artifacts currently use the same unsigned package output as Canary. Production signing/notarization remains a separate follow-up and does not require reintroducing JVM packaging:
 
-- Windows Authenticode for the Native Image executable, JNI/native DLLs, and MSI.
+- Windows Authenticode for the Native Image executable, JNI/native DLLs, and NSIS installer.
 - macOS Developer ID signing, hardened runtime, notarization, and stapling for both architectures.
 
 ## Linux portability
 
-Both Linux package formats use the same Native Image and packaged user-space dependency closure. The AppImage remains the explicitly portable format; the Arch package additionally carries `pacmanDepends` metadata so the target system supplies the expected desktop ABI environment. `$ORIGIN`-relative loader paths keep packaged helper libraries self-contained, while glibc and graphics-driver-facing libraries stay host-managed. The WebView helper discovers the packaged WebKitGTK runtime from `compose.application.resources.dir`, while the credential layer and system-audio capture loader discover their packaged native libraries from the same desktop resource root.
+All three Linux package formats use the same Native Image and packaged user-space dependency closure. The AppImage remains the explicitly portable format; DEB and Arch integrate with their distribution package managers, while the Arch package additionally carries `pacmanDepends` metadata so the target system supplies the expected desktop ABI environment. `$ORIGIN`-relative loader paths keep packaged helper libraries self-contained, while glibc and graphics-driver-facing libraries stay host-managed. The WebView helper discovers the packaged WebKitGTK runtime from `compose.application.resources.dir`, while the credential layer and system-audio capture loader discover their packaged native libraries from the same desktop resource root.

--- a/docs/desktop-packaging.md
+++ b/docs/desktop-packaging.md
@@ -9,14 +9,14 @@
 | Windows x64 | MSI | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + pinned libmpv DLL runtime bundled |
 | macOS arm64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
-| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | system-output capture library bundled; `mpv`, `libsecret`, PipeWire/PulseAudio, WebKitGTK and desktop UI dependencies are distro-managed |
+| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | shares the AppImage Native Image and packaged Linux user-space closure; `pacmanDepends` are retained as system compatibility dependencies |
 | Portable Linux x64 | AppImage | GraalVM Native Image | bundled system-output capture library/ELF closure plus libmpv/Libsecret/WebKitGTK/TLS native closures |
 
 No desktop artifact bundles a JVM.
 
 ## Nucleus packaging
 
-The host format is selected explicitly so each CI job emits only its requested installer:
+The host format is selected explicitly for single-format local builds:
 
 ```bash
 ./gradlew \
@@ -25,7 +25,7 @@ The host format is selected explicitly so each CI job emits only its requested i
   :desktopApp:packageGraalvmNativeDistributionForCurrentOS
 ```
 
-Supported `fuoevolve.nucleus.targetFormat` values are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias).
+Supported `fuoevolve.nucleus.targetFormat` values are `msi`, `dmg`, `appimage`, and `pacman` (`arch` is accepted as an alias). In Linux CI the target format remains `all` and `packageGraalvmNativeDistributionForCurrentOS` emits both AppImage and Pacman packages from the same `packageGraalvmNative` dependency. This keeps one full GraalVM Native Image compilation per Linux workflow run rather than one per installer format.
 
 ## Versioning
 
@@ -43,16 +43,16 @@ Desktop self-update is intentionally not implemented yet. These version values a
 
 - Windows libmpv input pins live in `desktopApp/packaging/native-deps.lock`. CI verifies the pinned archive, stages the public headers/import library for JNI compilation, and bundles the runtime DLLs.
 - macOS uses the architecture-specific pinned mpv input and `desktopApp/packaging/macos/prepare-libmpv.sh` to produce an `@loader_path`-relative dylib closure.
-- Arch packages keep native libraries distribution-managed through Nucleus `pacmanDepends` metadata.
+- Linux AppImage and Arch packages are produced from the same staged portable user-space closure. The Arch package retains Nucleus `pacmanDepends` metadata for system-level compatibility even though runtime libraries used by the packaged helpers are staged with the application.
 - Desktop system-audio recognition uses the CPAL/JNI library staged under `native/audio`; Windows and macOS capture the default output device, while Linux prefers PipeWire and falls back to a PulseAudio `.monitor` source.
 
-## AppImage LTS baseline
+## Linux LTS baseline
 
-The portable Linux build is pinned to the **latest Ubuntu LTS, currently Ubuntu 26.04 LTS**. The workflow uses the explicit `ubuntu-26.04` runner label and verifies `VERSION_ID=26.04` before building so the native executable and bundled user-space ELF closure cannot silently drift with `ubuntu-latest`.
+The Linux Native Image build is pinned to the **latest Ubuntu LTS, currently Ubuntu 26.04 LTS**. The workflow uses the explicit `ubuntu-26.04` runner label and verifies `VERSION_ID=26.04` before building so the native executable and packaged user-space ELF closure cannot silently drift with `ubuntu-latest`.
 
-The AppImage bundles libmpv, Libsecret client libraries, WebKitGTK subprocess/runtime libraries, GIO TLS support, the audio-capture closure, and their required user-space ELF dependencies. glibc and graphics-driver-facing libraries remain host ABI dependencies.
+The Linux packaged closure includes libmpv, Libsecret client libraries, WebKitGTK subprocess/runtime libraries, GIO TLS support, the audio-capture closure, and their required user-space ELF dependencies. glibc and graphics-driver-facing libraries remain host ABI dependencies.
 
-Ubuntu 26.04 is currently a public-preview GitHub-hosted runner image. This is intentional because the AppImage policy is to track the newest released Ubuntu LTS rather than the `ubuntu-latest` alias. When a newer Ubuntu LTS becomes the target baseline, update the pinned runner, baseline verification, cache key, and this documentation in the same change.
+Ubuntu 26.04 is currently a public-preview GitHub-hosted runner image. This is intentional because the Linux Native Image policy is to track the newest released Ubuntu LTS rather than the `ubuntu-latest` alias. When a newer Ubuntu LTS becomes the target baseline, update the pinned runner, baseline verification, cache key, and this documentation in the same change.
 
 ## CI
 
@@ -64,10 +64,9 @@ Pull requests use runtime-level validation and do not build the full MSI/DMG/App
 
 1. Windows x64 MSI.
 2. macOS arm64 and x64 DMGs.
-3. Linux x64 AppImage against the pinned Ubuntu 26.04 LTS baseline.
-4. Linux x64 Arch/Pacman package with dependency metadata verification.
+3. Linux x64 AppImage and Arch/Pacman packages in one Ubuntu 26.04 LTS job with one Native Image compilation.
 
-`master-canary.yml` invokes that workflow for preview builds. `release.yml` invokes the same workflow for release tags and publishes all five desktop assets alongside the Android APK. The release job renames assets with the release tag and publishes `SHA256SUMS.txt`.
+`master-canary.yml` invokes that workflow for preview builds after desktop tests complete. Android Canary packaging starts independently after Android tests; iOS remains test-only and no Canary application artifact is produced. `release.yml` invokes the same desktop workflow for release tags and publishes all five desktop assets alongside the Android APK. The release job renames assets with the release tag and publishes `SHA256SUMS.txt`.
 
 ## Signing
 
@@ -78,4 +77,4 @@ Desktop release artifacts currently use the same unsigned package output as Cana
 
 ## Linux portability
 
-The Arch package intentionally relies on the target distribution package manager. The AppImage bundles its user-space native dependency closure and uses `$ORIGIN`-relative loader paths. The WebView helper discovers the packaged WebKitGTK runtime from `compose.application.resources.dir`, while the credential layer and system-audio capture loader discover their packaged native libraries from the same desktop resource root.
+Both Linux package formats use the same Native Image and packaged user-space dependency closure. The AppImage remains the explicitly portable format; the Arch package additionally carries `pacmanDepends` metadata so the target system supplies the expected desktop ABI environment. `$ORIGIN`-relative loader paths keep packaged helper libraries self-contained, while glibc and graphics-driver-facing libraries stay host-managed. The WebView helper discovers the packaged WebKitGTK runtime from `compose.application.resources.dir`, while the credential layer and system-audio capture loader discover their packaged native libraries from the same desktop resource root.


### PR DESCRIPTION
## Summary

- decouple Canary packaging so Android and desktop builds start as soon as their own test workflows finish
- keep iOS CI tests but remove the simulator Canary artifact build entirely
- remove iOS distribution/status entries from both root READMEs
- switch Windows desktop packaging from MSI to the Nucleus NSIS `.exe` installer
- add a Linux DEB artifact alongside AppImage and Arch/Pacman
- build AppImage, DEB and Pacman in one Ubuntu 26.04 job and one Gradle invocation so all three formats share the same `packageGraalvmNative` compilation
- keep AppImage closure validation, add DEB package-content validation, and retain Arch dependency/package validation
- publish NSIS, both DMGs, AppImage, DEB and Arch assets from tagged releases
- make NSIS and DEB first-class `desktopApp` target formats and update packaging docs accordingly

## Expected CI impact

The Linux packaging workflow no longer performs separate full Native Image compilations for distribution formats. Nucleus documents GraalVM native-image compilation as the long 5–15 minute step per platform; requesting AppImage, DEB and Pacman tasks in one Gradle invocation deduplicates their shared `packageGraalvmNative` dependency.

Desktop packaging does not use GitHub Actions step-level `if:` conditions for the new flow; cache-hit decisions are handled inside the platform scripts instead.