### PR TITLE
fix(desktop): declare Native Image version resource dependency

### DIFF
--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -68,6 +68,14 @@ jobs:
             patchelf \
             pax-utils
 
+      - name: Validate Nucleus resource metadata task graph
+        run: |
+          ./gradlew \
+            --no-daemon \
+            --no-configuration-cache \
+            --warning-mode all \
+            :desktopApp:generateGraalvmProjectResourceMetadata
+
       - name: Test shared desktop and Nucleus runtime
         run: |
           ./gradlew \

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -94,6 +94,11 @@ sourceSets {
 tasks.named("processResources").configure {
     dependsOn(generateDesktopVersionInfo)
 }
+// Nucleus scans main source-set resources before native-image packaging instead of consuming
+// processResources, so wire the generated version resource into that task graph explicitly.
+tasks.matching { it.name == "generateGraalvmProjectResourceMetadata" }.configureEach {
+    dependsOn(generateDesktopVersionInfo)
+}
 
 val hostOs = System.getProperty("os.name").orEmpty().lowercase()
 val isWindowsHost = hostOs.contains("windows")


### PR DESCRIPTION
## Summary
- declare `generateDesktopVersionInfo` as an explicit dependency of Nucleus `generateGraalvmProjectResourceMetadata`
- fix Gradle 9.5 implicit-dependency validation that blocks all Native Image packaging jobs before AOT compilation

## Root cause
`generateGraalvmProjectResourceMetadata` scans the main source-set resources directly, including `build/generated/resources/desktopVersion`, but only `processResources` depended on `generateDesktopVersionInfo`. Gradle 9.5 therefore rejects the task graph as an undeclared producer/consumer relationship.

## Validation target
The failing CI path is expected to get past `:desktopApp:generateGraalvmProjectResourceMetadata`; normal PR checks should remain unchanged.