### PR TITLE
fix(ci): harden macOS Native Image Mach-O packaging

### DIFF
--- a/.github/actions/setup-nucleus/action.yml
+++ b/.github/actions/setup-nucleus/action.yml
@@ -23,9 +23,13 @@ inputs:
     required: false
     default: 'false'
   graalvm-version:
-    description: GraalVM toolchain version cache-key component
+    description: GraalVM toolchain version used on Windows and Linux
     required: false
     default: '25i3'
+  macos-graalvm-version:
+    description: GraalVM toolchain version used on macOS; keep separate for Native Image Mach-O A/B testing
+    required: false
+    default: '25'
   graalvm-distribution:
     description: GraalVM distribution cache-key component
     required: false
@@ -56,10 +60,44 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
-    - name: Select Xcode 26
+    - name: Resolve GraalVM toolchain version
+      if: inputs.graalvm == 'true'
+      id: graalvm-version
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          resolved="${{ inputs.macos-graalvm-version }}"
+          echo "FUOEVOLVE_GRAALVM_VERSION=$resolved" >> "$GITHUB_ENV"
+        else
+          resolved="${{ inputs.graalvm-version }}"
+        fi
+        echo "version=$resolved" >> "$GITHUB_OUTPUT"
+        echo "Resolved GraalVM toolchain version: $resolved"
+
+    - name: Select and pin Xcode 26 toolchain
       if: runner.os == 'macOS' && inputs.graalvm == 'true'
       shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
+      run: |
+        set -euo pipefail
+        developer_dir=/Applications/Xcode_26.0.app/Contents/Developer
+        test -d "$developer_dir"
+        sudo xcode-select -s "$developer_dir"
+        export DEVELOPER_DIR="$developer_dir"
+        echo "DEVELOPER_DIR=$developer_dir" >> "$GITHUB_ENV"
+
+        echo "Pinned Xcode toolchain:"
+        xcodebuild -version
+        echo "xcode-select=$(xcode-select -p)"
+        for tool in strip install_name_tool otool vtool; do
+          tool_path="$(xcrun --find "$tool")"
+          echo "$tool=$tool_path"
+          echo "$(dirname "$tool_path")" >> "$GITHUB_PATH"
+        done
+
+        mkdir -p "$HOME/.gradle/init.d"
+        cp "$GITHUB_WORKSPACE/.github/gradle/macos-native-image-workaround.init.gradle" \
+          "$HOME/.gradle/init.d/fuoevolve-macos-native-image-workaround.gradle"
 
     # Keep the MSVC setup free of JavaScript actions so it cannot inherit an old Node runtime.
     # Capture the environment produced by VsDevCmd.bat and persist it for later Gradle/native-image steps.
@@ -97,7 +135,7 @@ runs:
       uses: actions/cache@v6
       with:
         path: ~/.gradle/nucleus/graalvm
-        key: graalvm-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ inputs.graalvm-distribution }}-${{ inputs.graalvm-version }}
+        key: graalvm-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ inputs.graalvm-distribution }}-${{ steps.graalvm-version.outputs.version }}
 
     - name: Set java-home output
       id: set-java-home

--- a/.github/gradle/macos-native-image-workaround.init.gradle
+++ b/.github/gradle/macos-native-image-workaround.init.gradle
@@ -34,26 +34,23 @@ gradle.beforeProject { project ->
             task.dependsOn(preflight)
         }
 
-        // Nucleus 2.5.15 already treats dylib strip failures as non-fatal, but the main executable
-        // still uses strict Exec tasks. Keep the original Native Image executable when Apple's
-        // cctools reject its __LINKEDIT layout, matching Nucleus' safe dylib behavior.
+        // Nucleus 2.5.15 already mutates dylibs through a temporary copy, but the main executable
+        // still uses in-place Exec tasks. Redirect those two operations through the same safety
+        // model: mutate a sibling copy, validate it with otool, then atomically replace on success.
+        def safeMutationScript = project.rootProject
+            .file('desktopApp/packaging/macos/safe-macho-mutate.sh')
+            .absolutePath
         project.tasks.withType(Exec).matching {
             it.name == 'fixGraalvmRpath' || it.name == 'stripGraalvmBinary'
         }.configureEach { task ->
-            task.ignoreExitValue = true
             task.doFirst {
-                def command = task.commandLine as List
-                if (command && command[0] != 'xcrun') {
-                    task.commandLine((['xcrun'] + command) as List)
+                def originalCommand = task.commandLine as List
+                if (!originalCommand) {
+                    throw new GradleException("${task.path} has no configured command line")
                 }
-            }
-            task.doLast {
-                def result = task.executionResult.orNull
-                if (result != null && result.exitValue != 0) {
-                    project.logger.warn(
-                        "${task.path} failed with exit ${result.exitValue}; keeping the original Mach-O executable.",
-                    )
-                }
+                def binary = originalCommand[-1].toString()
+                def operation = task.name == 'fixGraalvmRpath' ? 'rpath' : 'strip'
+                task.commandLine('bash', safeMutationScript, operation, binary)
             }
         }
     }

--- a/.github/gradle/macos-native-image-workaround.init.gradle
+++ b/.github/gradle/macos-native-image-workaround.init.gradle
@@ -1,0 +1,60 @@
+import org.gradle.api.tasks.Exec
+
+gradle.beforeProject { project ->
+    if (project.path != ':desktopApp') {
+        return
+    }
+
+    project.pluginManager.withPlugin('dev.nucleusframework') {
+        def requestedGraalvmVersion = System.getenv('FUOEVOLVE_GRAALVM_VERSION')?.trim()
+        if (requestedGraalvmVersion) {
+            def nucleus = project.extensions.getByName('nucleus')
+            nucleus.application.graalvm.toolchain.version.set(requestedGraalvmVersion)
+            project.logger.lifecycle("FuoEvolve macOS GraalVM toolchain override: ${requestedGraalvmVersion}")
+        }
+
+        def preflight = project.tasks.register('verifyGraalvmMachOPreflight', Exec) { task ->
+            task.group = 'verification'
+            task.description = 'Probe the raw macOS Native Image with Apple Mach-O mutation tools.'
+            task.dependsOn('nativeImageCompile')
+
+            def binary = project.layout.buildDirectory
+                .file('compose/tmp/main/graalvm/nativeCompile/fuoevolve')
+                .get()
+                .asFile
+            task.inputs.file(binary)
+            task.commandLine(
+                'bash',
+                project.rootProject.file('desktopApp/packaging/macos/macho-preflight.sh').absolutePath,
+                binary.absolutePath,
+            )
+        }
+
+        project.tasks.matching { it.name == 'copyGraalvmBinaryToApp' }.configureEach { task ->
+            task.dependsOn(preflight)
+        }
+
+        // Nucleus 2.5.15 already treats dylib strip failures as non-fatal, but the main executable
+        // still uses strict Exec tasks. Keep the original Native Image executable when Apple's
+        // cctools reject its __LINKEDIT layout, matching Nucleus' safe dylib behavior.
+        project.tasks.withType(Exec).matching {
+            it.name == 'fixGraalvmRpath' || it.name == 'stripGraalvmBinary'
+        }.configureEach { task ->
+            task.ignoreExitValue = true
+            task.doFirst {
+                def command = task.commandLine as List
+                if (command && command[0] != 'xcrun') {
+                    task.commandLine((['xcrun'] + command) as List)
+                }
+            }
+            task.doLast {
+                def result = task.executionResult.orNull
+                if (result != null && result.exitValue != 0) {
+                    project.logger.warn(
+                        "${task.path} failed with exit ${result.exitValue}; keeping the original Mach-O executable.",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/desktopApp/packaging/macos/macho-preflight.sh
+++ b/desktopApp/packaging/macos/macho-preflight.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${1:?usage: macho-preflight.sh <native-image-binary>}"
+
+if [[ ! -f "$binary" ]]; then
+  echo "Mach-O preflight: native image binary not found: $binary" >&2
+  exit 1
+fi
+
+echo "Mach-O preflight: $binary"
+file "$binary"
+echo "DEVELOPER_DIR=${DEVELOPER_DIR:-<unset>}"
+echo "xcode-select=$(xcode-select -p)"
+echo "strip=$(xcrun --find strip)"
+echo "install_name_tool=$(xcrun --find install_name_tool)"
+
+# A malformed Mach-O should still fail fast. The mutation probes below are diagnostic only:
+# packaging can keep the original binary when Apple's rewriting tools reject GraalVM's layout.
+xcrun otool -l "$binary" >/dev/null
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/fuoevolve-macho-preflight.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+strip_copy="$tmpdir/fuoevolve-strip"
+cp -p "$binary" "$strip_copy"
+if xcrun strip -x "$strip_copy"; then
+  echo "Mach-O preflight: raw native-image binary accepts strip -x"
+else
+  echo "::warning::Mach-O preflight: raw native-image binary rejects strip -x; packaging will keep the original executable"
+fi
+
+rpath_copy="$tmpdir/fuoevolve-rpath"
+cp -p "$binary" "$rpath_copy"
+if xcrun install_name_tool -add_rpath '@executable_path/.' "$rpath_copy"; then
+  echo "Mach-O preflight: raw native-image binary accepts install_name_tool -add_rpath"
+else
+  echo "::warning::Mach-O preflight: raw native-image binary rejects install_name_tool; packaging will keep the original executable"
+fi

--- a/desktopApp/packaging/macos/safe-macho-mutate.sh
+++ b/desktopApp/packaging/macos/safe-macho-mutate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+operation="${1:?usage: safe-macho-mutate.sh <strip|rpath> <binary>}"
+binary="${2:?usage: safe-macho-mutate.sh <strip|rpath> <binary>}"
+
+if [[ ! -f "$binary" ]]; then
+  echo "Safe Mach-O mutation: binary not found: $binary" >&2
+  exit 1
+fi
+
+dir="$(dirname "$binary")"
+base="$(basename "$binary")"
+tmp="$(mktemp "$dir/.${base}.fuoevolve-macho.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+cp -p "$binary" "$tmp"
+
+# The bundle is ad-hoc signed later. Removing an existing signature from the temporary copy keeps
+# Apple's mutation tools from preserving stale signature data if an upstream task starts signing earlier.
+xcrun codesign --remove-signature "$tmp" >/dev/null 2>&1 || true
+
+case "$operation" in
+  strip)
+    command=(xcrun strip -x "$tmp")
+    ;;
+  rpath)
+    command=(xcrun install_name_tool -add_rpath '@executable_path/.' "$tmp")
+    ;;
+  *)
+    echo "Safe Mach-O mutation: unsupported operation: $operation" >&2
+    exit 2
+    ;;
+esac
+
+if ! "${command[@]}"; then
+  echo "::warning::Safe Mach-O $operation rejected for $base; original executable kept"
+  exit 0
+fi
+
+if ! xcrun otool -l "$tmp" >/dev/null; then
+  echo "::warning::Safe Mach-O $operation produced an unreadable file for $base; original executable kept"
+  exit 0
+fi
+
+mv -f "$tmp" "$binary"
+trap - EXIT
+echo "Safe Mach-O $operation applied to $base"


### PR DESCRIPTION
## Summary

- add a preflight probe against the raw GraalVM Native Image executable before Nucleus mutates the app bundle
- pin `DEVELOPER_DIR` and resolve `strip` / `install_name_tool` / `otool` / `vtool` from the same Xcode 26.0 toolchain
- route Nucleus 2.5.15 main-executable rpath/strip mutations through a temporary copy + `otool` validation + atomic replacement; failed mutations keep the original Mach-O
- switch macOS Native Image builds to the GraalVM CE LTS `25` line for an A/B against the previous innovation `25i3`; Windows/Linux remain on `25i3`

## Diagnostics expected from the next macOS packaging run

The new `verifyGraalvmMachOPreflight` task tests copies of the raw Native Image executable with both `strip -x` and `install_name_tool -add_rpath`. This tells us whether the `__LINKEDIT` layout is already rejected directly after `native-image`, before Nucleus `LC_BUILD_VERSION` / rpath post-processing.

If Apple's tools still reject the raw executable, the safe mutation wrapper leaves the original executable untouched and packaging continues so we can see whether the resulting DMG passes closure/signing checks.