### PR TITLE
fix(ci): isolate macOS Native Image toolchains

### DIFF
--- a/.github/actions/setup-nucleus/action.yml
+++ b/.github/actions/setup-nucleus/action.yml
@@ -101,6 +101,19 @@ runs:
         # prepending XcodeDefault.xctoolchain/usr/bin bypasses the runner's /usr/bin developer-tool
         # shim and can lose SDK resolution. All FuoEvolve Mach-O workaround scripts use xcrun
         # explicitly, while DEVELOPER_DIR keeps native-image and Apple tools on the selected Xcode.
+        probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/fuoevolve-clang-probe.XXXXXX")"
+        trap 'rm -rf "$probe_dir"' EXIT
+        cat > "$probe_dir/nucleus-stub-probe.c" <<'EOF'
+        #include <dlfcn.h>
+        void *fuoevolve_nucleus_stub_probe(void) {
+            return dlsym(RTLD_DEFAULT, "InitializeEncoding");
+        }
+        EOF
+        clang -c "$probe_dir/nucleus-stub-probe.c" -o "$probe_dir/nucleus-stub-probe.o"
+        file "$probe_dir/nucleus-stub-probe.o"
+        rm -rf "$probe_dir"
+        trap - EXIT
+
         mkdir -p "$HOME/.gradle/init.d"
         cp "$GITHUB_WORKSPACE/.github/gradle/macos-native-image-workaround.init.gradle" \
           "$HOME/.gradle/init.d/fuoevolve-macos-native-image-workaround.gradle"

--- a/.github/actions/setup-nucleus/action.yml
+++ b/.github/actions/setup-nucleus/action.yml
@@ -75,7 +75,7 @@ runs:
         echo "version=$resolved" >> "$GITHUB_OUTPUT"
         echo "Resolved GraalVM toolchain version: $resolved"
 
-    - name: Select and pin Xcode 26 toolchain
+    - name: Select Xcode 26 runner toolchain
       if: runner.os == 'macOS' && inputs.graalvm == 'true'
       shell: bash
       run: |
@@ -86,15 +86,21 @@ runs:
         export DEVELOPER_DIR="$developer_dir"
         echo "DEVELOPER_DIR=$developer_dir" >> "$GITHUB_ENV"
 
-        echo "Pinned Xcode toolchain:"
+        echo "Selected Xcode toolchain:"
         xcodebuild -version
         echo "xcode-select=$(xcode-select -p)"
+        echo "developer-dir-real=$(cd "$developer_dir" && pwd -P)"
+        echo "path-clang=$(command -v clang)"
+        echo "xcrun-clang=$(xcrun --find clang)"
+        echo "macos-sdk=$(xcrun --sdk macosx --show-sdk-path)"
         for tool in strip install_name_tool otool vtool; do
-          tool_path="$(xcrun --find "$tool")"
-          echo "$tool=$tool_path"
-          echo "$(dirname "$tool_path")" >> "$GITHUB_PATH"
+          echo "$tool=$(xcrun --find "$tool")"
         done
 
+        # Keep the runner PATH intact. Nucleus compileGraalvmStubs invokes `clang` directly;
+        # prepending XcodeDefault.xctoolchain/usr/bin bypasses the runner's /usr/bin developer-tool
+        # shim and can lose SDK resolution. All FuoEvolve Mach-O workaround scripts use xcrun
+        # explicitly, while DEVELOPER_DIR keeps native-image and Apple tools on the selected Xcode.
         mkdir -p "$HOME/.gradle/init.d"
         cp "$GITHUB_WORKSPACE/.github/gradle/macos-native-image-workaround.init.gradle" \
           "$HOME/.gradle/init.d/fuoevolve-macos-native-image-workaround.gradle"
@@ -135,7 +141,9 @@ runs:
       uses: actions/cache@v6
       with:
         path: ~/.gradle/nucleus/graalvm
-        key: graalvm-toolchain-${{ runner.os }}-${{ runner.arch }}-${{ inputs.graalvm-distribution }}-${{ steps.graalvm-version.outputs.version }}
+        # Terminate the version token and use a new namespace so `25` cannot prefix-match the
+        # previous `25i3` cache. The macOS A/B must provision the requested LTS line cleanly.
+        key: graalvm-toolchain-v2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.graalvm-distribution }}-${{ steps.graalvm-version.outputs.version }}-exact
 
     - name: Set java-home output
       id: set-java-home


### PR DESCRIPTION
## Summary

- stop prepending XcodeDefault.xctoolchain/usr/bin to PATH on macOS; Nucleus `compileGraalvmStubs` invokes `clang` directly and should keep using the runner developer-tool shim
- keep `DEVELOPER_DIR` pinned and continue resolving Mach-O tools via `xcrun`, so the existing preflight/safe-mutation workaround still uses the selected Xcode
- add an early clang smoke compile using `<dlfcn.h>` to catch the same Nucleus stub SDK/toolchain failure during setup
- move the GraalVM cache to a new terminated version-key namespace so macOS LTS `25` cannot prefix-restore the previous `25i3` cache
- log the real selected Xcode path, PATH clang, xcrun clang, and macOS SDK for the next packaging run

## Why

The first macOS arm64 run after #232 failed before Native Image compilation at `:desktopApp:compileGraalvmStubs`. The prior run compiled the same Nucleus stub successfully; the material new difference was adding the raw Xcode toolchain `usr/bin` directory to `GITHUB_PATH`.

The log also showed `graalvm-toolchain-...-25` restoring the older `...-25i3` cache because `25` prefix-matched `25i3`, so the intended GraalVM A/B was not cleanly isolated.

The next macOS packaging run should now reach Native Image compilation and the existing Mach-O preflight, while producing enough toolchain diagnostics to distinguish GraalVM output from Nucleus post-processing.