### PR TITLE
fix(ci): finalize macOS Native Image Mach-O packaging

### DIFF
--- a/.github/gradle/macos-native-image-workaround.init.gradle
+++ b/.github/gradle/macos-native-image-workaround.init.gradle
@@ -15,7 +15,7 @@ gradle.beforeProject { project ->
 
         def preflight = project.tasks.register('verifyGraalvmMachOPreflight', Exec) { task ->
             task.group = 'verification'
-            task.description = 'Probe the raw macOS Native Image with Apple Mach-O mutation tools.'
+            task.description = 'Require the raw macOS Native Image to support Apple Mach-O mutation tools.'
             task.dependsOn('nativeImageCompile')
 
             def binary = project.layout.buildDirectory
@@ -34,9 +34,19 @@ gradle.beforeProject { project ->
             task.dependsOn(preflight)
         }
 
-        // Nucleus 2.5.15 already mutates dylibs through a temporary copy, but the main executable
-        // still uses in-place Exec tasks. Redirect those two operations through the same safety
-        // model: mutate a sibling copy, validate it with otool, then atomically replace on success.
+        // Nucleus 2.5.15 rewrites LC_BUILD_VERSION with vtool after native-image has produced a
+        // healthy executable. With Xcode 26 that rewrite leaves the main Mach-O in a state that
+        // strip/install_name_tool reject because __LINKEDIT no longer fills the segment. The raw
+        // GraalVM 25 executable is already linked by the selected Xcode 26 toolchain, so keep its
+        // linker-produced build version instead of rewriting the packaged image in place.
+        project.tasks.matching { it.name == 'patchGraalvmBuildVersion' }.configureEach { task ->
+            task.enabled = false
+            project.logger.lifecycle('FuoEvolve macOS Native Image: disabled Nucleus LC_BUILD_VERSION patch')
+        }
+
+        // Keep the temporary-copy mutation model so a failed Apple tool never corrupts the package,
+        // but failures are now fatal. With the Nucleus build-version patch disabled, rpath and strip
+        // are expected to work exactly as they do in the raw preflight.
         def safeMutationScript = project.rootProject
             .file('desktopApp/packaging/macos/safe-macho-mutate.sh')
             .absolutePath
@@ -52,6 +62,30 @@ gradle.beforeProject { project ->
                 def operation = task.name == 'fixGraalvmRpath' ? 'rpath' : 'strip'
                 task.commandLine('bash', safeMutationScript, operation, binary)
             }
+        }
+
+        // Do not allow a successful DMG to hide a missing main-executable rpath. Validate the exact
+        // binary Nucleus stripped before codesigning starts.
+        def verifyExecutableScript = project.rootProject
+            .file('desktopApp/packaging/macos/verify-macho-executable.sh')
+            .absolutePath
+        def verifyExecutable = project.tasks.register('verifyGraalvmExecutableMachO', Exec) { task ->
+            task.group = 'verification'
+            task.description = 'Verify the packaged GraalVM executable Mach-O layout and rpath.'
+            task.dependsOn('stripGraalvmBinary')
+            task.doFirst {
+                def stripTask = project.tasks.named('stripGraalvmBinary', Exec).get()
+                def stripCommand = stripTask.commandLine as List
+                if (!stripCommand) {
+                    throw new GradleException("${stripTask.path} has no configured command line")
+                }
+                def binary = stripCommand[-1].toString()
+                task.commandLine('bash', verifyExecutableScript, binary)
+            }
+        }
+
+        project.tasks.matching { it.name == 'codesignGraalvmBundle' }.configureEach { task ->
+            task.dependsOn(verifyExecutable)
         }
     }
 }

--- a/.github/gradle/macos-native-image-workaround.init.gradle
+++ b/.github/gradle/macos-native-image-workaround.init.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import org.gradle.api.tasks.Exec
 
 gradle.beforeProject { project ->
@@ -34,19 +36,68 @@ gradle.beforeProject { project ->
             task.dependsOn(preflight)
         }
 
-        // Nucleus 2.5.15 rewrites LC_BUILD_VERSION with vtool after native-image has produced a
-        // healthy executable. With Xcode 26 that rewrite leaves the main Mach-O in a state that
-        // strip/install_name_tool reject because __LINKEDIT no longer fills the segment. The raw
-        // GraalVM 25 executable is already linked by the selected Xcode 26 toolchain, so keep its
-        // linker-produced build version instead of rewriting the packaged image in place.
+        def packagedMainBinary = {
+            def rpathTask = project.tasks.named('fixGraalvmRpath', Exec).get()
+            def command = rpathTask.commandLine as List
+            if (!command) {
+                throw new GradleException("${rpathTask.path} has no configured command line")
+            }
+            project.file(command[-1].toString())
+        }
+
+        // Nucleus 2.5.15 patches LC_BUILD_VERSION for every Mach-O in the app bundle. Keep that
+        // normalization for companion dylibs/helpers so they retain the configured macOS minimum,
+        // but preserve the raw native-image executable: Xcode 26's vtool rewrite makes that one
+        // binary fail later strip/install_name_tool operations with an invalid __LINKEDIT layout.
+        // The backup intentionally lives outside the app bundle so Nucleus's recursive patch scan
+        // cannot patch the backup itself.
         project.tasks.matching { it.name == 'patchGraalvmBuildVersion' }.configureEach { task ->
-            task.enabled = false
-            project.logger.lifecycle('FuoEvolve macOS Native Image: disabled Nucleus LC_BUILD_VERSION patch')
+            task.doFirst {
+                def binary = packagedMainBinary()
+                if (!binary.isFile()) {
+                    throw new GradleException("GraalVM main executable not found before build-version patch: ${binary}")
+                }
+                def backup = project.layout.buildDirectory
+                    .file('tmp/fuoevolve-macos-native-image/fuoevolve.before-build-version-patch')
+                    .get()
+                    .asFile
+                backup.parentFile.mkdirs()
+                Files.copy(
+                    binary.toPath(),
+                    backup.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.COPY_ATTRIBUTES,
+                )
+                task.extensions.extraProperties.set('fuoevolveMainBinary', binary.absolutePath)
+                task.extensions.extraProperties.set('fuoevolveMainBackup', backup.absolutePath)
+                project.logger.lifecycle(
+                    'FuoEvolve macOS Native Image: preserving raw main executable while Nucleus patches companion Mach-O files',
+                )
+            }
+            task.doLast {
+                def binary = project.file(
+                    task.extensions.extraProperties.get('fuoevolveMainBinary').toString(),
+                )
+                def backup = project.file(
+                    task.extensions.extraProperties.get('fuoevolveMainBackup').toString(),
+                )
+                if (!backup.isFile()) {
+                    throw new GradleException("GraalVM main executable backup missing after build-version patch: ${backup}")
+                }
+                Files.move(
+                    backup.toPath(),
+                    binary.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+                project.logger.lifecycle(
+                    'FuoEvolve macOS Native Image: restored unpatched main executable; companion Mach-O patches retained',
+                )
+            }
         }
 
         // Keep the temporary-copy mutation model so a failed Apple tool never corrupts the package,
-        // but failures are now fatal. With the Nucleus build-version patch disabled, rpath and strip
-        // are expected to work exactly as they do in the raw preflight.
+        // but failures are fatal. The restored raw main executable is expected to support rpath and
+        // strip exactly as it did in the preflight.
         def safeMutationScript = project.rootProject
             .file('desktopApp/packaging/macos/safe-macho-mutate.sh')
             .absolutePath

--- a/desktopApp/native/mpv-jni/fuoevolve_mpv_jni.c
+++ b/desktopApp/native/mpv-jni/fuoevolve_mpv_jni.c
@@ -84,17 +84,23 @@ static jstring utf8_to_jstring(JNIEnv *env, const char *value) {
         if (first < 0x80u) {
             codepoint = first;
         } else if ((first & 0xE0u) == 0xC0u && in < byte_length) {
+            unsigned char second = (unsigned char)value[in++];
             codepoint = ((uint32_t)(first & 0x1Fu) << 6u) |
-                        ((uint32_t)value[in++] & 0x3Fu);
+                        ((uint32_t)second & 0x3Fu);
         } else if ((first & 0xF0u) == 0xE0u && in + 1u < byte_length) {
+            unsigned char second = (unsigned char)value[in++];
+            unsigned char third = (unsigned char)value[in++];
             codepoint = ((uint32_t)(first & 0x0Fu) << 12u) |
-                        (((uint32_t)value[in++] & 0x3Fu) << 6u) |
-                        ((uint32_t)value[in++] & 0x3Fu);
+                        (((uint32_t)second & 0x3Fu) << 6u) |
+                        ((uint32_t)third & 0x3Fu);
         } else if ((first & 0xF8u) == 0xF0u && in + 2u < byte_length) {
+            unsigned char second = (unsigned char)value[in++];
+            unsigned char third = (unsigned char)value[in++];
+            unsigned char fourth = (unsigned char)value[in++];
             codepoint = ((uint32_t)(first & 0x07u) << 18u) |
-                        (((uint32_t)value[in++] & 0x3Fu) << 12u) |
-                        (((uint32_t)value[in++] & 0x3Fu) << 6u) |
-                        ((uint32_t)value[in++] & 0x3Fu);
+                        (((uint32_t)second & 0x3Fu) << 12u) |
+                        (((uint32_t)third & 0x3Fu) << 6u) |
+                        ((uint32_t)fourth & 0x3Fu);
         } else {
             codepoint = 0xFFFDu;
         }

--- a/desktopApp/packaging/macos/macho-preflight.sh
+++ b/desktopApp/packaging/macos/macho-preflight.sh
@@ -15,25 +15,36 @@ echo "xcode-select=$(xcode-select -p)"
 echo "strip=$(xcrun --find strip)"
 echo "install_name_tool=$(xcrun --find install_name_tool)"
 
-# A malformed Mach-O should still fail fast. The mutation probes below are diagnostic only:
-# packaging can keep the original binary when Apple's rewriting tools reject GraalVM's layout.
+# The selected GraalVM/Xcode pair must produce a Mach-O that Apple's packaging tools can safely
+# mutate. This intentionally fails early now that macOS Native Image is pinned to the compatible
+# LTS toolchain instead of deferring a broken executable to the packaging phase.
 xcrun otool -l "$binary" >/dev/null
+
+echo "Mach-O preflight: raw LC_BUILD_VERSION"
+xcrun otool -l "$binary" | awk '
+  $1 == "cmd" && $2 == "LC_BUILD_VERSION" { active=1; print "  cmd LC_BUILD_VERSION"; next }
+  active && ($1 == "platform" || $1 == "minos" || $1 == "sdk" || $1 == "ntools") {
+    print "  " $0
+    if ($1 == "ntools") exit
+  }
+'
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/fuoevolve-macho-preflight.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 
 strip_copy="$tmpdir/fuoevolve-strip"
 cp -p "$binary" "$strip_copy"
-if xcrun strip -x "$strip_copy"; then
-  echo "Mach-O preflight: raw native-image binary accepts strip -x"
-else
-  echo "::warning::Mach-O preflight: raw native-image binary rejects strip -x; packaging will keep the original executable"
+if ! xcrun strip -x "$strip_copy"; then
+  echo "::error::Mach-O preflight: raw native-image binary rejects strip -x" >&2
+  exit 1
 fi
+echo "Mach-O preflight: raw native-image binary accepts strip -x"
 
 rpath_copy="$tmpdir/fuoevolve-rpath"
 cp -p "$binary" "$rpath_copy"
-if xcrun install_name_tool -add_rpath '@executable_path/.' "$rpath_copy"; then
-  echo "Mach-O preflight: raw native-image binary accepts install_name_tool -add_rpath"
-else
-  echo "::warning::Mach-O preflight: raw native-image binary rejects install_name_tool; packaging will keep the original executable"
+if ! xcrun install_name_tool -add_rpath '@executable_path/.' "$rpath_copy"; then
+  echo "::error::Mach-O preflight: raw native-image binary rejects install_name_tool -add_rpath" >&2
+  exit 1
 fi
+xcrun otool -l "$rpath_copy" >/dev/null
+echo "Mach-O preflight: raw native-image binary accepts install_name_tool -add_rpath"

--- a/desktopApp/packaging/macos/safe-macho-mutate.sh
+++ b/desktopApp/packaging/macos/safe-macho-mutate.sh
@@ -33,13 +33,13 @@ case "$operation" in
 esac
 
 if ! "${command[@]}"; then
-  echo "::warning::Safe Mach-O $operation rejected for $base; original executable kept"
-  exit 0
+  echo "::error::Safe Mach-O $operation rejected for $base; original executable kept" >&2
+  exit 1
 fi
 
 if ! xcrun otool -l "$tmp" >/dev/null; then
-  echo "::warning::Safe Mach-O $operation produced an unreadable file for $base; original executable kept"
-  exit 0
+  echo "::error::Safe Mach-O $operation produced an unreadable file for $base; original executable kept" >&2
+  exit 1
 fi
 
 mv -f "$tmp" "$binary"

--- a/desktopApp/packaging/macos/verify-macho-executable.sh
+++ b/desktopApp/packaging/macos/verify-macho-executable.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+binary="${1:?usage: verify-macho-executable.sh <packaged-native-image-binary>}"
+expected_rpath='@executable_path/.'
+
+if [[ ! -f "$binary" ]]; then
+  echo "Packaged Mach-O verification: executable not found: $binary" >&2
+  exit 1
+fi
+
+echo "Packaged Mach-O verification: $binary"
+file "$binary"
+load_commands="$(xcrun otool -l "$binary")"
+
+rpath_count="$(printf '%s\n' "$load_commands" | awk -v expected="$expected_rpath" '
+  $1 == "cmd" && $2 == "LC_RPATH" { in_rpath=1; next }
+  in_rpath && $1 == "path" {
+    if ($2 == expected) count++
+    in_rpath=0
+  }
+  END { print count+0 }
+')"
+
+if [[ "$rpath_count" -ne 1 ]]; then
+  echo "::error::Expected exactly one LC_RPATH '$expected_rpath' in $binary, found $rpath_count" >&2
+  exit 1
+fi
+
+echo "Packaged Mach-O verification: LC_BUILD_VERSION"
+printf '%s\n' "$load_commands" | awk '
+  $1 == "cmd" && $2 == "LC_BUILD_VERSION" { active=1; print "  cmd LC_BUILD_VERSION"; next }
+  active && ($1 == "platform" || $1 == "minos" || $1 == "sdk" || $1 == "ntools") {
+    print "  " $0
+    if ($1 == "ntools") exit
+  }
+'
+
+echo "Packaged Mach-O verification: required LC_RPATH present exactly once"


### PR DESCRIPTION
## Summary
- keep Nucleus 2.5.15 `patchGraalvmBuildVersion` enabled for companion Mach-O binaries so dylibs/helpers retain the configured macOS minimum deployment target
- preserve and restore only the raw `fuoevolve` executable around that task because the successful A/B run showed the raw GraalVM 25 executable accepts `strip`/`install_name_tool`, while the post-`vtool` main executable does not
- make raw Mach-O preflight failures fatal instead of diagnostic-only
- keep copy-before-mutate safety for the main executable, but fail packaging if rpath/strip fails
- add a pre-codesign verification task that requires exactly one `@executable_path/.` LC_RPATH and prints the retained LC_BUILD_VERSION
- remove the JNI UTF-8 decoder's unsequenced `in++` expressions by reading continuation bytes in explicit order

## Why
The successful macOS arm64 packaging run isolated the main-executable failure to Nucleus's LC_BUILD_VERSION rewrite: the raw executable is healthy, then the `vtool` patch makes later Apple Mach-O mutations fail with the `__LINKEDIT` layout error. However, the Nucleus patch task also normalizes companion Mach-O files, so disabling the whole task would regress macOS 12–14 compatibility for binaries built on the macOS 15/Xcode 26 runner.

The workaround now backs up the main executable outside the app bundle, lets Nucleus patch companion dylibs/helpers normally, then restores only the raw main executable before rpath/strip.

The same run also exposed Clang `-Wunsequenced` warnings in `utf8_to_jstring`; those expressions modified `in` multiple times in one C expression, so they are now sequenced explicitly without changing the decoder's output.

## Validation target
The next macOS arm64 package run should show:
- raw preflight accepts both `strip -x` and `install_name_tool`
- Nucleus still patches companion Mach-O files
- the raw main executable is restored immediately after `patchGraalvmBuildVersion`
- safe rpath and strip both apply successfully to the restored main executable
- `verifyGraalvmExecutableMachO` sees exactly one `@executable_path/.` LC_RPATH
- no `-Wunsequenced` warning from `fuoevolve_mpv_jni.c`
- codesign/DMG packaging completes normally