### PR TITLE
fix(linux): restore system dependencies for distro packages

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -248,9 +248,21 @@ jobs:
           if-no-files-found: error
 
   linux-x64:
-    name: Linux x64 AppImage + DEB + Arch
+    name: Linux x64 ${{ matrix.label }}
     runs-on: ubuntu-26.04
     timeout-minutes: 110
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: appimage
+            label: AppImage
+            bundle_runtime: "true"
+            gradle_tasks: ":desktopApp:packageGraalvmAppImage"
+          - variant: distro
+            label: DEB + Arch
+            bundle_runtime: "false"
+            gradle_tasks: ":desktopApp:packageGraalvmDeb :desktopApp:packageGraalvmPacman"
 
     steps:
       - name: Checkout
@@ -263,7 +275,7 @@ jobs:
           . /etc/os-release
           test "$ID" = "ubuntu"
           test "$VERSION_ID" = "26.04"
-          echo "Building Linux packages against Ubuntu $VERSION_ID LTS baseline"
+          echo "Building Linux ${{ matrix.label }} against Ubuntu $VERSION_ID LTS baseline"
 
       - name: Prepare Git refs for versioning
         run: |
@@ -290,8 +302,9 @@ jobs:
             ~/.cargo/git
             desktopApp/native/web-login/target
             desktopApp/native/audio-capture/target
-          key: nucleus-native-linux-ubuntu26.04-x64-rust-1.98.1-${{ hashFiles('desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/Cargo.lock', 'desktopApp/native/web-login/src/**', 'desktopApp/native/audio-capture/Cargo.toml', 'desktopApp/native/audio-capture/Cargo.lock', 'desktopApp/native/audio-capture/src/**') }}
+          key: nucleus-native-linux-ubuntu26.04-x64-${{ matrix.variant }}-rust-1.98.1-${{ hashFiles('desktopApp/native/web-login/Cargo.toml', 'desktopApp/native/web-login/Cargo.lock', 'desktopApp/native/web-login/src/**', 'desktopApp/native/audio-capture/Cargo.toml', 'desktopApp/native/audio-capture/Cargo.lock', 'desktopApp/native/audio-capture/src/**') }}
           restore-keys: |
+            nucleus-native-linux-ubuntu26.04-x64-${{ matrix.variant }}-rust-1.98.1-
             nucleus-native-linux-ubuntu26.04-x64-rust-1.98.1-
 
       - name: Install Linux native dependencies
@@ -311,7 +324,7 @@ jobs:
             patchelf \
             pax-utils
 
-      - name: Build Linux Native Image once and package all formats
+      - name: Build Linux Native Image and package ${{ matrix.label }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -321,12 +334,11 @@ jobs:
             --warning-mode all \
             --stacktrace \
             -PnativeMarch=compatibility \
-            -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
-            :desktopApp:packageGraalvmAppImage \
-            :desktopApp:packageGraalvmDeb \
-            :desktopApp:packageGraalvmPacman
+            -Pfuoevolve.nucleus.bundleLinuxRuntime=${{ matrix.bundle_runtime }} \
+            ${{ matrix.gradle_tasks }}
 
-      - name: Prepare and verify Linux artifacts
+      - name: Prepare and verify AppImage
+        if: matrix.variant == 'appimage'
         run: |
           mapfile -t appimages < <(find desktopApp/build -type f -iname '*.AppImage' -print)
           if [[ "${#appimages[@]}" -ne 1 ]]; then
@@ -335,6 +347,27 @@ jobs:
             exit 1
           fi
 
+          mkdir -p build/artifacts build/appimage-verify
+          cp "${appimages[0]}" build/artifacts/FuoEvolve-linux-x64.AppImage
+          chmod +x build/artifacts/FuoEvolve-linux-x64.AppImage
+
+          (
+            cd build/appimage-verify
+            ../artifacts/FuoEvolve-linux-x64.AppImage --appimage-extract >/dev/null
+            ROOT=squashfs-root
+            find "$ROOT" -type f -name libfuoevolve_mpv_jni.so -print -quit | grep -q .
+            find "$ROOT" -type f -name libfuoevolve_audio_capture.so -print -quit | grep -q .
+            find "$ROOT" -type f -name 'libmpv.so*' -print -quit | grep -q .
+            find "$ROOT" -type f -name fuoevolve-web-login -print -quit | grep -q .
+            find "$ROOT" -type f -name WebKitNetworkProcess -print -quit | grep -q .
+            find "$ROOT" -type f -name libgiognutls.so -print -quit | grep -q .
+          )
+
+          du -h build/artifacts/FuoEvolve-linux-x64.AppImage
+
+      - name: Prepare and verify DEB and Arch packages
+        if: matrix.variant == 'distro'
+        run: |
           mapfile -t deb_packages < <(find desktopApp/build -type f -name '*.deb' -print)
           if [[ "${#deb_packages[@]}" -ne 1 ]]; then
             echo "Expected exactly one DEB package, found ${#deb_packages[@]}" >&2
@@ -349,28 +382,34 @@ jobs:
             exit 1
           fi
 
-          mkdir -p build/artifacts build/appimage-verify
-          cp "${appimages[0]}" build/artifacts/FuoEvolve-linux-x64.AppImage
-          chmod +x build/artifacts/FuoEvolve-linux-x64.AppImage
+          mkdir -p build/artifacts
           cp "${deb_packages[0]}" build/artifacts/FuoEvolve-linux-x64.deb
           cp "${arch_packages[0]}" build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
-          (
-            cd build/appimage-verify
-            ../artifacts/FuoEvolve-linux-x64.AppImage --appimage-extract >/dev/null
-            ROOT=squashfs-root
-            find "$ROOT" -type f -name libfuoevolve_mpv_jni.so -print -quit | grep -q .
-            find "$ROOT" -type f -name libfuoevolve_audio_capture.so -print -quit | grep -q .
-            find "$ROOT" -type f -name 'libmpv.so*' -print -quit | grep -q .
-            find "$ROOT" -type f -name fuoevolve-web-login -print -quit | grep -q .
-            find "$ROOT" -type f -name WebKitNetworkProcess -print -quit | grep -q .
-            find "$ROOT" -type f -name libgiognutls.so -print -quit | grep -q .
-          )
-
           test "$(dpkg-deb -f build/artifacts/FuoEvolve-linux-x64.deb Package)" = "fuoevolve"
+          dpkg-deb -f build/artifacts/FuoEvolve-linux-x64.deb Depends | tee build/deb-depends.txt
+          for dep in \
+            libgtk-3-0t64 \
+            libx11-6 \
+            libxkbcommon0 \
+            libsecret-1-0 \
+            libmpv2 \
+            libwebkit2gtk-4.1-0 \
+            libasound2t64 \
+            libpipewire-0.3-0t64 \
+            libpulse0; do
+            grep -Fq "$dep" build/deb-depends.txt || {
+              echo "DEB dependency metadata is missing $dep" >&2
+              exit 1
+            }
+          done
           dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep -E 'libfuoevolve_mpv_jni\.so$' >/dev/null
           dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep -E 'libfuoevolve_audio_capture\.so$' >/dev/null
           dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep 'fuoevolve-web-login' >/dev/null
+          if dpkg-deb -c build/artifacts/FuoEvolve-linux-x64.deb | grep -E '(^|/)libmpv\.so([.0-9]*)?$|WebKitNetworkProcess$|libwebkit2gtk-4\.1\.so'; then
+            echo "DEB unexpectedly bundles portable Linux runtime libraries" >&2
+            exit 1
+          fi
 
           bsdtar -xOf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst .PKGINFO | tee build/arch-pkginfo.txt
           grep -Eq '^depend = mpv($|[<>=])' build/arch-pkginfo.txt
@@ -382,12 +421,16 @@ jobs:
           bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep -E 'libfuoevolve_mpv_jni\.(so|dll|dylib)$' >/dev/null
           bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep -E 'libfuoevolve_audio_capture\.so$' >/dev/null
           bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep 'fuoevolve-web-login' >/dev/null
+          if bsdtar -tf build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst | grep -E '(^|/)libmpv\.so([.0-9]*)?$|WebKitNetworkProcess$|libwebkit2gtk-4\.1\.so'; then
+            echo "Arch package unexpectedly bundles portable Linux runtime libraries" >&2
+            exit 1
+          fi
 
-          du -h build/artifacts/FuoEvolve-linux-x64.AppImage
           du -h build/artifacts/FuoEvolve-linux-x64.deb
           du -h build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
 
       - name: Upload Linux AppImage
+        if: matrix.variant == 'appimage'
         uses: actions/upload-artifact@v7
         with:
           name: FuoEvolve-linux-x64-appimage
@@ -397,6 +440,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Debian package
+        if: matrix.variant == 'distro'
         uses: actions/upload-artifact@v7
         with:
           name: FuoEvolve-linux-x64-deb
@@ -406,6 +450,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Arch Linux package
+        if: matrix.variant == 'distro'
         uses: actions/upload-artifact@v7
         with:
           name: FuoEvolve-linux-x64-arch

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -29,16 +29,21 @@ Nucleus exposes per-format Native Image packaging tasks. The release pipeline us
 # macOS
 ./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmDmg
 
-# Linux: one Gradle invocation, one shared Native Image compilation
+# Linux AppImage: portable/self-contained native runtime closure
 ./gradlew \
   -PnativeMarch=compatibility \
   -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
-  :desktopApp:packageGraalvmAppImage \
+  :desktopApp:packageGraalvmAppImage
+
+# Linux DEB + Pacman: distribution-managed native dependencies
+./gradlew \
+  -PnativeMarch=compatibility \
+  -Pfuoevolve.nucleus.bundleLinuxRuntime=false \
   :desktopApp:packageGraalvmDeb \
   :desktopApp:packageGraalvmPacman
 ```
 
-The three Linux packaging tasks share the same `packageGraalvmNative` dependency in one Gradle invocation, so AppImage, DEB, and Pacman do not trigger three full GraalVM compilations.
+CI runs the AppImage and distro-package branches in parallel. DEB and Pacman share one Native Image compilation inside the distro branch, while AppImage has its own compilation because it stages a different native runtime closure.
 
 ## Distribution matrix
 
@@ -47,8 +52,8 @@ The three Linux packaging tasks share the same `packageGraalvmNative` dependency
 | Windows x64 | NSIS `.exe` installer | JNI bridge, system-output capture library and pinned libmpv runtime bundled |
 | macOS arm64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | JNI bridge, system-output capture library and relocatable libmpv dylib closure bundled |
-| Debian/Ubuntu Linux x64 | DEB | Built from the shared Linux Native Image and packaged user-space closure |
-| Arch Linux x64 | Pacman/Arch package | Built from the shared Linux Native Image and packaged user-space closure; `pacmanDepends` remain as system compatibility dependencies |
+| Debian/Ubuntu Linux x64 | DEB | JNI bridge/helpers bundled; libmpv, Libsecret, WebKitGTK and audio libraries supplied by APT dependencies |
+| Arch Linux x64 | Pacman/Arch package | JNI bridge/helpers bundled; libmpv, Libsecret, WebKitGTK and audio libraries supplied by `pacmanDepends` |
 | Portable Linux x64 | AppImage | Native audio/libmpv/Libsecret/WebKitGTK/TLS closures bundled; built against the Ubuntu 26.04 LTS baseline |
 
 No desktop artifact bundles a JVM.
@@ -79,7 +84,7 @@ Release tags such as `1.2.3` are embedded as the desktop package version and dis
 ## CI and release
 
 - `.github/workflows/desktop-tests.yml` validates shared desktop/runtime tests and native resource staging on Linux, Windows and macOS.
-- `.github/workflows/desktop-packaging.yml` produces the Windows NSIS installer, both macOS DMGs, and Linux AppImage/DEB/Arch packages. All three Linux formats are emitted from one Ubuntu 26.04 LTS job and share a single Native Image compilation.
+- `.github/workflows/desktop-packaging.yml` produces the Windows NSIS installer, both macOS DMGs, and Linux AppImage/DEB/Arch packages. Linux AppImage and distro packages run in parallel on Ubuntu 26.04; DEB and Arch share one distro-package Native Image compilation.
 - `master-canary.yml` publishes preview artifacts from `master` after the matching platform test workflow succeeds. iOS remains test-only and does not produce a Canary artifact.
 - `release.yml` publishes the same desktop package matrix alongside Android for release tags and includes SHA-256 checksums.
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -472,6 +472,17 @@ nucleus.application {
             menuGroup = "AudioVideo"
             iconFile.set(desktopAppIcon)
             debMaintainer = "FuoEvolve Maintainers <6873988+BruceZhang1993@users.noreply.github.com>"
+            debDepends = listOf(
+                "libgtk-3-0t64",
+                "libx11-6",
+                "libxkbcommon0",
+                "libsecret-1-0",
+                "libmpv2",
+                "libwebkit2gtk-4.1-0",
+                "libasound2t64",
+                "libpipewire-0.3-0t64",
+                "libpulse0",
+            )
             pacmanDepends = listOf(
                 "gtk3",
                 "libx11",

--- a/docs/desktop-packaging.md
+++ b/docs/desktop-packaging.md
@@ -9,15 +9,15 @@
 | Windows x64 | NSIS `.exe` installer | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + pinned libmpv DLL runtime bundled |
 | macOS arm64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
 | macOS x64 | DMG | GraalVM Native Image | JNI libmpv bridge + native system-output capture library + relocatable libmpv dylib closure bundled |
-| Debian/Ubuntu Linux x64 | DEB | GraalVM Native Image | shares the Linux Native Image and packaged user-space closure |
-| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | shares the Linux Native Image and packaged user-space closure; `pacmanDepends` are retained as system compatibility dependencies |
+| Debian/Ubuntu Linux x64 | DEB | GraalVM Native Image | JNI bridge/helpers bundled; libmpv, Libsecret, WebKitGTK and audio libraries supplied by APT dependencies |
+| Arch Linux x64 | Pacman/Arch package | GraalVM Native Image | JNI bridge/helpers bundled; libmpv, Libsecret, WebKitGTK and audio libraries supplied by `pacmanDepends` |
 | Portable Linux x64 | AppImage | GraalVM Native Image | bundled system-output capture library/ELF closure plus libmpv/Libsecret/WebKitGTK/TLS native closures |
 
 No desktop artifact bundles a JVM.
 
 ## Nucleus packaging
 
-Nucleus 2.5.15 exposes one GraalVM packaging task per format. The release pipeline uses the direct tasks rather than branching the workflow with GitHub Actions conditions:
+Nucleus 2.5.15 exposes one GraalVM packaging task per format. Windows and macOS build one package branch each. Linux intentionally uses two independent branches because AppImage and distro packages have different native-dependency policies:
 
 ```bash
 # Windows
@@ -26,16 +26,21 @@ Nucleus 2.5.15 exposes one GraalVM packaging task per format. The release pipeli
 # macOS
 ./gradlew -PnativeMarch=compatibility :desktopApp:packageGraalvmDmg
 
-# Linux: all direct-distribution formats in one Gradle invocation
+# Linux AppImage: self-contained native runtime closure
 ./gradlew \
   -PnativeMarch=compatibility \
   -Pfuoevolve.nucleus.bundleLinuxRuntime=true \
-  :desktopApp:packageGraalvmAppImage \
+  :desktopApp:packageGraalvmAppImage
+
+# Linux DEB + Pacman: use distribution-managed native dependencies
+./gradlew \
+  -PnativeMarch=compatibility \
+  -Pfuoevolve.nucleus.bundleLinuxRuntime=false \
   :desktopApp:packageGraalvmDeb \
   :desktopApp:packageGraalvmPacman
 ```
 
-All three Linux packaging tasks depend on the same `packageGraalvmNative` task. Gradle executes that dependency once per invocation, so AppImage, DEB and Pacman reuse one full GraalVM Native Image compilation instead of compiling the application three times.
+The AppImage and distro branches run in parallel in GitHub Actions. DEB and Pacman are built together inside the distro branch and therefore share one `packageGraalvmNative` dependency there. AppImage performs a separate Native Image compilation because its staged native resources intentionally include the portable dependency closure.
 
 ## Versioning
 
@@ -53,16 +58,19 @@ Desktop self-update is intentionally not implemented yet. These version values a
 
 - Windows libmpv input pins live in `desktopApp/packaging/native-deps.lock`. CI verifies the pinned archive, stages the public headers/import library for JNI compilation, and bundles the runtime DLLs into the NSIS package.
 - macOS uses the architecture-specific pinned mpv input and `desktopApp/packaging/macos/prepare-libmpv.sh` to produce an `@loader_path`-relative dylib closure.
-- Linux AppImage, DEB and Arch packages are produced from the same staged portable user-space closure. The Arch package retains Nucleus `pacmanDepends` metadata for system-level compatibility even though runtime libraries used by the packaged helpers are staged with the application.
+- Linux AppImage stages the portable libmpv, Libsecret, WebKitGTK, TLS and audio-capture dependency closure into the application.
+- Linux DEB and Arch packages stage only the application-owned JNI bridge, audio-capture library and WebView helper. Their external native libraries are declared as package-manager dependencies instead of copied into the package.
 - Desktop system-audio recognition uses the CPAL/JNI library staged under `native/audio`; Windows and macOS capture the default output device, while Linux prefers PipeWire and falls back to a PulseAudio `.monitor` source.
 
 ## Linux LTS baseline
 
-The Linux Native Image build is pinned to the **latest Ubuntu LTS, currently Ubuntu 26.04 LTS**. The workflow uses the explicit `ubuntu-26.04` runner label and verifies `VERSION_ID=26.04` before building so the native executable and packaged user-space ELF closure cannot silently drift with `ubuntu-latest`.
+The Linux Native Image build is pinned to the **latest Ubuntu LTS, currently Ubuntu 26.04 LTS**. Both Linux workflow branches use the explicit `ubuntu-26.04` runner label and verify `VERSION_ID=26.04` before building so the native executable ABI cannot silently drift with `ubuntu-latest`.
 
-The Linux packaged closure includes libmpv, Libsecret client libraries, WebKitGTK subprocess/runtime libraries, GIO TLS support, the audio-capture closure, and their required user-space ELF dependencies. glibc and graphics-driver-facing libraries remain host ABI dependencies.
+The AppImage portable closure includes libmpv, Libsecret client libraries, WebKitGTK subprocess/runtime libraries, GIO TLS support, the audio-capture closure, and their required user-space ELF dependencies. glibc and graphics-driver-facing libraries remain host ABI dependencies.
 
-Ubuntu 26.04 is currently a public-preview GitHub-hosted runner image. This is intentional because the Linux Native Image policy is to track the newest released Ubuntu LTS rather than the `ubuntu-latest` alias. When a newer Ubuntu LTS becomes the target baseline, update the pinned runner, baseline verification, cache key, and this documentation in the same change.
+DEB packages instead declare the Ubuntu 26.04 runtime packages required by the application, including `libmpv2`, `libsecret-1-0`, `libwebkit2gtk-4.1-0`, ALSA, PipeWire and PulseAudio libraries. Arch packages declare the corresponding dependencies through `pacmanDepends`.
+
+Ubuntu 26.04 is currently a public-preview GitHub-hosted runner image. This is intentional because the Linux Native Image policy is to track the newest released Ubuntu LTS rather than the `ubuntu-latest` alias. When a newer Ubuntu LTS becomes the target baseline, update the pinned runner, baseline verification, package dependency names, cache keys, and this documentation in the same change.
 
 ## CI
 
@@ -74,7 +82,10 @@ Pull requests use runtime-level validation and do not build the full NSIS/DMG/Ap
 
 1. Windows x64 NSIS installer.
 2. macOS arm64 and x64 DMGs.
-3. Linux x64 AppImage, DEB and Arch/Pacman packages in one Ubuntu 26.04 LTS job with one Native Image compilation.
+3. Linux x64 AppImage in a portable-runtime branch.
+4. Linux x64 DEB and Arch/Pacman packages together in a system-dependency branch.
+
+The two Linux branches execute in parallel. This restores the separation used by the earlier desktop packaging pipeline while keeping the current Nucleus Native Image implementation.
 
 `master-canary.yml` invokes that workflow for preview builds after desktop tests complete. Android Canary packaging starts independently after Android tests; iOS remains test-only and no Canary application artifact is produced. `release.yml` invokes the same desktop workflow for release tags and publishes all six desktop assets alongside the Android APK. The release job renames assets with the release tag and publishes `SHA256SUMS.txt`.
 
@@ -87,4 +98,4 @@ Desktop release artifacts currently use the same unsigned package output as Cana
 
 ## Linux portability
 
-All three Linux package formats use the same Native Image and packaged user-space dependency closure. The AppImage remains the explicitly portable format; DEB and Arch integrate with their distribution package managers, while the Arch package additionally carries `pacmanDepends` metadata so the target system supplies the expected desktop ABI environment. `$ORIGIN`-relative loader paths keep packaged helper libraries self-contained, while glibc and graphics-driver-facing libraries stay host-managed. The WebView helper discovers the packaged WebKitGTK runtime from `compose.application.resources.dir`, while the credential layer and system-audio capture loader discover their packaged native libraries from the same desktop resource root.
+The AppImage is the explicitly portable Linux format and carries the application-managed native dependency closure. DEB and Arch integrate with their distribution package managers and do not duplicate libmpv, WebKitGTK, Libsecret or the Linux audio runtime closure inside the package. `$ORIGIN`-relative loader paths are still used for application-owned native libraries, while external runtime libraries are resolved from the host through package-manager dependencies. The WebView helper uses the system WebKitGTK runtime in distro packages and the staged WebKitGTK runtime in AppImage builds.


### PR DESCRIPTION
## Summary
- split Linux packaging into parallel AppImage and distro matrix jobs
- keep AppImage self-contained with `bundleLinuxRuntime=true`
- build DEB + Pacman together with `bundleLinuxRuntime=false`
- declare Debian/Ubuntu runtime dependencies through Nucleus `debDepends`
- verify DEB/Arch packages do not accidentally bundle libmpv/WebKitGTK portable runtime libraries
- update desktop packaging documentation to match the restored policy

## Expected result
DEB/Pacman should return to distribution-managed native dependencies and shrink substantially, while AppImage remains portable/self-contained.