### PR TITLE
ci: normalize release artifact packaging

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -104,7 +104,6 @@ jobs:
         with:
           name: FuoEvolve-windows-x64-nsis
           path: build/artifacts/FuoEvolve-windows-x64.exe
-          archive: false
           retention-days: 14
           if-no-files-found: error
 
@@ -243,7 +242,6 @@ jobs:
         with:
           name: FuoEvolve-macos-${{ matrix.arch }}-dmg
           path: build/artifacts/FuoEvolve-macos-${{ matrix.arch }}.dmg
-          archive: false
           retention-days: 14
           if-no-files-found: error
 
@@ -435,7 +433,6 @@ jobs:
         with:
           name: FuoEvolve-linux-x64-appimage
           path: build/artifacts/FuoEvolve-linux-x64.AppImage
-          archive: false
           retention-days: 14
           if-no-files-found: error
 
@@ -445,7 +442,6 @@ jobs:
         with:
           name: FuoEvolve-linux-x64-deb
           path: build/artifacts/FuoEvolve-linux-x64.deb
-          archive: false
           retention-days: 14
           if-no-files-found: error
 
@@ -455,6 +451,5 @@ jobs:
         with:
           name: FuoEvolve-linux-x64-arch
           path: build/artifacts/FuoEvolve-linux-x64.pkg.tar.zst
-          archive: false
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           name: fuo-evolve-android-release
           path: ${{ steps.asset.outputs.path }}
-          archive: false
           if-no-files-found: error
 
   build-desktop-release:
@@ -239,6 +238,7 @@ jobs:
           SUMMARY_OUTCOME: ${{ steps.release_summary.outcome }}
           SUMMARY_FILE: ${{ steps.release_summary.outputs.response-file }}
         run: |
+          mkdir -p build
           : > build/release-intro.md
           if [ "$SUMMARY_OUTCOME" = "success" ] && [ -n "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
             {


### PR DESCRIPTION
Superseded by a narrower fix that keeps `archive: false` for direct artifact downloads. The replacement only changes the Android download name to match the actual raw artifact filename and keeps the release-intro directory guard.