### PR TITLE
ci(release): fix Android artifact download name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Download Android release asset
         uses: actions/download-artifact@v8
         with:
-          name: fuo-evolve-android-release
+          name: fuo-evolve-${{ github.ref_name }}-android-signed.apk
           path: build/android-release
 
       - name: Download desktop release assets
@@ -239,6 +239,7 @@ jobs:
           SUMMARY_OUTCOME: ${{ steps.release_summary.outcome }}
           SUMMARY_FILE: ${{ steps.release_summary.outputs.response-file }}
         run: |
+          mkdir -p build
           : > build/release-intro.md
           if [ "$SUMMARY_OUTCOME" = "success" ] && [ -n "$SUMMARY_FILE" ] && [ -s "$SUMMARY_FILE" ]; then
             {


### PR DESCRIPTION
## Summary
- keep `archive: false` for Android and desktop artifacts so artifacts remain directly downloadable
- change the release publish job to download the Android artifact by its actual raw filename: `fuo-evolve-${{ github.ref_name }}-android-signed.apk`
- keep the existing desktop artifact flow unchanged
- ensure `build/` exists before the always-running release intro fallback

## Why
With `actions/upload-artifact@v7` and `archive: false`, the Android artifact is exposed under the uploaded APK filename rather than the configured logical `name`. Release 1.6.0 therefore uploaded `fuo-evolve-1.6.0-android-signed.apk`, while the publish job tried to download `fuo-evolve-android-release`.

This fixes the mismatch without reintroducing ZIP-wrapped artifacts.